### PR TITLE
fix: properly handle non-image attachments in Linear issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,11 @@ All notable changes to this project will be documented in this file.
   - Only responds to comments without @ mentions (general conversation)
   - Always responds when directly @ mentioned (someone needs the agent!)
   - Politely ignores when other users are @ mentioned but not the agent (respecting private conversations)
+
+### Fixed
+- Improved attachment handling to properly distinguish images from other file types
+  - Non-image attachments (e.g., .jsonl, .pdf, .csv) are now downloaded separately
+  - Fixed "Could not process image" error when non-image files were treated as images
+  - Attachment download failures are now non-fatal with warnings instead of blocking issue processing
+  - Updated regex to properly parse attachment URLs in markdown format (e.g., `[Link](url)`)
+  - Renamed `.linear-images` directory to `.linear-attachments` to reflect broader file type support

--- a/__tests__/unit/utils/ImageDownloader.test.mjs
+++ b/__tests__/unit/utils/ImageDownloader.test.mjs
@@ -40,7 +40,64 @@ describe('ImageDownloader', () => {
     imageDownloader = new ImageDownloader(mockLinearClient, mockFileSystem, mockOAuthHelper);
   });
 
-  describe('extractImageUrls', () => {
+  describe('extractAttachmentUrls', () => {
+    it('should separate image URLs from other attachment URLs', () => {
+      const text = `
+        Here is an image: https://uploads.linear.app/12345/image1.png
+        And a JSON file: https://uploads.linear.app/67890/data.jsonl
+        Another image: https://uploads.linear.app/abc/photo.jpg
+        A PDF: https://uploads.linear.app/def/document.pdf
+      `;
+
+      const result = imageDownloader.extractAttachmentUrls(text);
+
+      expect(result.imageUrls).toHaveLength(2);
+      expect(result.imageUrls).toContain('https://uploads.linear.app/12345/image1.png');
+      expect(result.imageUrls).toContain('https://uploads.linear.app/abc/photo.jpg');
+      
+      expect(result.otherAttachmentUrls).toHaveLength(2);
+      expect(result.otherAttachmentUrls).toContain('https://uploads.linear.app/67890/data.jsonl');
+      expect(result.otherAttachmentUrls).toContain('https://uploads.linear.app/def/document.pdf');
+    });
+
+    it('should handle various image extensions', () => {
+      const text = `
+        https://uploads.linear.app/1/image.jpg
+        https://uploads.linear.app/2/image.jpeg
+        https://uploads.linear.app/3/image.png
+        https://uploads.linear.app/4/image.gif
+        https://uploads.linear.app/5/image.webp
+        https://uploads.linear.app/6/image.svg
+        https://uploads.linear.app/7/image.bmp
+      `;
+
+      const result = imageDownloader.extractAttachmentUrls(text);
+
+      expect(result.imageUrls).toHaveLength(7);
+      expect(result.otherAttachmentUrls).toHaveLength(0);
+    });
+
+    it('should be case-insensitive for extensions', () => {
+      const text = `
+        https://uploads.linear.app/1/image.PNG
+        https://uploads.linear.app/2/image.JpG
+        https://uploads.linear.app/3/data.JSONL
+      `;
+
+      const result = imageDownloader.extractAttachmentUrls(text);
+
+      expect(result.imageUrls).toHaveLength(2);
+      expect(result.otherAttachmentUrls).toHaveLength(1);
+    });
+
+    it('should return empty arrays for null or empty text', () => {
+      expect(imageDownloader.extractAttachmentUrls(null)).toEqual({ imageUrls: [], otherAttachmentUrls: [] });
+      expect(imageDownloader.extractAttachmentUrls('')).toEqual({ imageUrls: [], otherAttachmentUrls: [] });
+      expect(imageDownloader.extractAttachmentUrls(undefined)).toEqual({ imageUrls: [], otherAttachmentUrls: [] });
+    });
+  });
+
+  describe('extractImageUrls (deprecated)', () => {
     it('should extract Linear upload URLs from text', () => {
       const text = `
         Here is some text with an image:
@@ -81,7 +138,8 @@ describe('ImageDownloader', () => {
       `;
 
       const urls = imageDownloader.extractImageUrls(text);
-      expect(urls).toHaveLength(2);
+      expect(urls).toHaveLength(1); // Only the PNG is an image
+      expect(urls[0]).toBe('https://uploads.linear.app/12345/screenshot.png');
     });
   });
 
@@ -184,7 +242,122 @@ describe('ImageDownloader', () => {
     });
   });
 
-  describe('downloadIssueImages', () => {
+  describe('downloadIssueAttachments', () => {
+    it('should download both images and other attachments', async () => {
+      const issue = new Issue({
+        id: 'issue-123',
+        identifier: 'TEST-123',
+        title: 'Test Issue',
+        description: 'Image: https://uploads.linear.app/12345/screenshot.png JSON: https://uploads.linear.app/67890/data.jsonl',
+        comments: { nodes: [] }
+      });
+
+      const mockBuffer = Buffer.from('fake-file-data');
+      fetch.mockImplementation(() => Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        buffer: jest.fn().mockResolvedValue(mockBuffer)
+      }));
+
+      const result = await imageDownloader.downloadIssueAttachments(issue, '/workspace');
+
+      expect(result.imagesDownloaded).toBe(1);
+      expect(result.otherAttachmentsDownloaded).toBe(1);
+      expect(result.totalImagesFound).toBe(1);
+      expect(result.totalOtherAttachmentsFound).toBe(1);
+      expect(result.failedDownloads).toHaveLength(0);
+      
+      expect(Object.keys(result.imageMap)).toHaveLength(1);
+      expect(Object.keys(result.otherAttachmentMap)).toHaveLength(1);
+      
+      expect(result.imageMap['https://uploads.linear.app/12345/screenshot.png']).toMatch(/\.linear-attachments\/image_1\.png$/);
+      expect(result.otherAttachmentMap['https://uploads.linear.app/67890/data.jsonl']).toMatch(/\.linear-attachments\/attachment_1\.jsonl$/);
+    });
+
+    it('should handle download failures gracefully and continue', async () => {
+      const issue = new Issue({
+        id: 'issue-123',
+        identifier: 'TEST-123',
+        title: 'Test Issue',
+        description: 'Image1: https://uploads.linear.app/1/image1.png Image2: https://uploads.linear.app/2/image2.png JSON: https://uploads.linear.app/3/data.jsonl',
+        comments: { nodes: [] }
+      });
+
+      // First download succeeds, second fails, third succeeds
+      fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          buffer: jest.fn().mockResolvedValue(Buffer.from('image1-data'))
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found'
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          buffer: jest.fn().mockResolvedValue(Buffer.from('json-data'))
+        });
+
+      const result = await imageDownloader.downloadIssueAttachments(issue, '/workspace');
+
+      expect(result.totalImagesFound).toBe(2);
+      expect(result.totalOtherAttachmentsFound).toBe(1);
+      expect(result.imagesDownloaded).toBe(1);
+      expect(result.otherAttachmentsDownloaded).toBe(1);
+      expect(result.failedDownloads).toHaveLength(1);
+      expect(result.failedDownloads[0]).toEqual({ 
+        url: 'https://uploads.linear.app/2/image2.png', 
+        type: 'image', 
+        reason: 'Download failed' 
+      });
+    });
+
+    it('should respect the image limit but download all other attachments', async () => {
+      // Create an issue with 15 images and 5 other attachments
+      const imageUrls = [];
+      for (let i = 1; i <= 15; i++) {
+        imageUrls.push(`https://uploads.linear.app/img${i}/image${i}.png`);
+      }
+      const otherUrls = [];
+      for (let i = 1; i <= 5; i++) {
+        otherUrls.push(`https://uploads.linear.app/file${i}/data${i}.jsonl`);
+      }
+
+      const issue = new Issue({
+        id: 'issue-123',
+        identifier: 'TEST-123',
+        title: 'Test Issue',
+        description: [...imageUrls, ...otherUrls].join(' '),
+        comments: { nodes: [] }
+      });
+
+      const mockBuffer = Buffer.from('fake-file-data');
+      fetch.mockImplementation(() => Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        buffer: jest.fn().mockResolvedValue(mockBuffer)
+      }));
+
+      const result = await imageDownloader.downloadIssueAttachments(issue, '/workspace', 10);
+
+      expect(result.totalImagesFound).toBe(15);
+      expect(result.totalOtherAttachmentsFound).toBe(5);
+      expect(result.imagesDownloaded).toBe(10); // Limited to 10
+      expect(result.otherAttachmentsDownloaded).toBe(5); // All other attachments downloaded
+      expect(result.imagesSkipped).toBe(5);
+      expect(Object.keys(result.imageMap)).toHaveLength(10);
+      expect(Object.keys(result.otherAttachmentMap)).toHaveLength(5);
+    });
+  });
+
+  describe('downloadIssueImages (deprecated)', () => {
     it('should download images from issue description and comments', async () => {
       const issue = new Issue({
         id: 'issue-123',
@@ -216,8 +389,8 @@ describe('ImageDownloader', () => {
       expect(result.totalFound).toBe(2);
       expect(result.skipped).toBe(0);
       expect(Object.keys(result.imageMap)).toHaveLength(2);
-      expect(result.imageMap['https://uploads.linear.app/12345/screenshot.png']).toMatch(/\.linear-images\/image_1\.png$/);
-      expect(result.imageMap['https://uploads.linear.app/67890/image.jpg']).toMatch(/\.linear-images\/image_2\.jpg$/);
+      expect(result.imageMap['https://uploads.linear.app/12345/screenshot.png']).toMatch(/\.linear-attachments\/image_1\.png$/);
+      expect(result.imageMap['https://uploads.linear.app/67890/image.jpg']).toMatch(/\.linear-attachments\/image_2\.jpg$/);
     });
 
     it('should respect the 10 image limit', async () => {
@@ -300,7 +473,80 @@ describe('ImageDownloader', () => {
     });
   });
 
-  describe('generateImageManifest', () => {
+  describe('generateAttachmentManifest', () => {
+    it('should generate manifest for images and other attachments', () => {
+      const downloadResult = {
+        imageMap: {
+          'https://uploads.linear.app/12345/screenshot.png': '/workspace/.linear-attachments/image_1.png'
+        },
+        otherAttachmentMap: {
+          'https://uploads.linear.app/67890/data.jsonl': '/workspace/.linear-attachments/attachment_1.jsonl',
+          'https://uploads.linear.app/abc/report.pdf': '/workspace/.linear-attachments/attachment_2.pdf'
+        },
+        totalImagesFound: 1,
+        totalOtherAttachmentsFound: 2,
+        imagesDownloaded: 1,
+        otherAttachmentsDownloaded: 2,
+        imagesSkipped: 0,
+        failedDownloads: []
+      };
+
+      const manifest = imageDownloader.generateAttachmentManifest(downloadResult);
+
+      expect(manifest).toContain('## Downloaded Attachments');
+      expect(manifest).toContain('Found 1 image(s). Downloaded 1');
+      expect(manifest).toContain('Found 2 other attachment(s). Downloaded 2');
+      expect(manifest).toContain('### Images');
+      expect(manifest).toContain('image_1.png');
+      expect(manifest).toContain('### Other Attachments');
+      expect(manifest).toContain('attachment_1.jsonl (JSON)');
+      expect(manifest).toContain('attachment_2.pdf (PDF)');
+    });
+
+    it('should include warnings for failed downloads', () => {
+      const downloadResult = {
+        imageMap: {
+          'https://uploads.linear.app/1/image1.png': '/workspace/.linear-attachments/image_1.png'
+        },
+        otherAttachmentMap: {},
+        totalImagesFound: 3,
+        totalOtherAttachmentsFound: 1,
+        imagesDownloaded: 1,
+        otherAttachmentsDownloaded: 0,
+        imagesSkipped: 0,
+        failedDownloads: [
+          { url: 'https://uploads.linear.app/2/image2.png', type: 'image', reason: 'Download failed' },
+          { url: 'https://uploads.linear.app/3/image3.png', type: 'image', reason: 'Download failed' },
+          { url: 'https://uploads.linear.app/4/data.csv', type: 'attachment', reason: 'Download failed' }
+        ]
+      };
+
+      const manifest = imageDownloader.generateAttachmentManifest(downloadResult);
+
+      expect(manifest).toContain('⚠️ Failed to download 3 file(s)');
+      expect(manifest).toContain('### Failed Downloads');
+      expect(manifest).toContain('The agent will continue processing but may not have complete context');
+    });
+
+    it('should handle case with no attachments', () => {
+      const downloadResult = {
+        imageMap: {},
+        otherAttachmentMap: {},
+        totalImagesFound: 0,
+        totalOtherAttachmentsFound: 0,
+        imagesDownloaded: 0,
+        otherAttachmentsDownloaded: 0,
+        imagesSkipped: 0,
+        failedDownloads: []
+      };
+
+      const manifest = imageDownloader.generateAttachmentManifest(downloadResult);
+
+      expect(manifest).toContain('No attachments were found in this issue');
+    });
+  });
+
+  describe('generateImageManifest (deprecated)', () => {
     it('should generate manifest for downloaded images', () => {
       const downloadResult = {
         imageMap: {
@@ -314,8 +560,8 @@ describe('ImageDownloader', () => {
 
       const manifest = imageDownloader.generateImageManifest(downloadResult);
 
-      expect(manifest).toContain('## Downloaded Images');
-      expect(manifest).toContain('Found 2 images. Downloaded 2');
+      expect(manifest).toContain('## Downloaded Attachments');
+      expect(manifest).toContain('Found 2 image(s). Downloaded 2');
       expect(manifest).toContain('image_1.png');
       expect(manifest).toContain('image_2.jpg');
       expect(manifest).toContain('You can use the Read tool to view these images');
@@ -334,7 +580,7 @@ describe('ImageDownloader', () => {
 
       const manifest = imageDownloader.generateImageManifest(downloadResult);
 
-      expect(manifest).toContain('Found 15 images. Downloaded 10 (skipped 5 due to 10 image limit)');
+      expect(manifest).toContain('Found 15 image(s). Downloaded 10 (skipped 5 due to 10 image limit)');
     });
 
     it('should handle case with no images', () => {
@@ -347,7 +593,7 @@ describe('ImageDownloader', () => {
 
       const manifest = imageDownloader.generateImageManifest(downloadResult);
 
-      expect(manifest).toContain('No images were found in this issue');
+      expect(manifest).toContain('No attachments were found in this issue');
     });
   });
 });

--- a/src/utils/ImageDownloader.mjs
+++ b/src/utils/ImageDownloader.mjs
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import path from 'path';
 
 /**
- * Utility class for downloading images from Linear with proper authentication
+ * Utility class for downloading attachments from Linear with proper authentication
  */
 export class ImageDownloader {
   /**
@@ -17,19 +17,48 @@ export class ImageDownloader {
   }
 
   /**
-   * Extract image URLs from text (issue description or comment)
-   * @param {string} text - The text to search for image URLs
-   * @returns {string[]} - Array of image URLs
+   * Extract attachment URLs from text (issue description or comment)
+   * @param {string} text - The text to search for attachment URLs
+   * @returns {Object} - Object with arrays of image URLs and other attachment URLs
    */
-  extractImageUrls(text) {
-    if (!text) return [];
+  extractAttachmentUrls(text) {
+    if (!text) return { imageUrls: [], otherAttachmentUrls: [] };
     
     // Match URLs that start with https://uploads.linear.app
-    const regex = /https:\/\/uploads\.linear\.app\/[^\s<>"]+/gi;
+    const regex = /https:\/\/uploads\.linear\.app\/[^\s<>"()]+/gi;
     const matches = text.match(regex) || [];
     
     // Remove duplicates
-    return [...new Set(matches)];
+    const uniqueUrls = [...new Set(matches)];
+    
+    // Separate images from other attachments
+    const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp'];
+    const imageUrls = [];
+    const otherAttachmentUrls = [];
+    
+    uniqueUrls.forEach(url => {
+      const lowerUrl = url.toLowerCase();
+      const isImage = imageExtensions.some(ext => lowerUrl.endsWith(ext));
+      
+      if (isImage) {
+        imageUrls.push(url);
+      } else {
+        otherAttachmentUrls.push(url);
+      }
+    });
+    
+    return { imageUrls, otherAttachmentUrls };
+  }
+  
+  /**
+   * Extract image URLs from text (issue description or comment)
+   * @param {string} text - The text to search for image URLs
+   * @returns {string[]} - Array of image URLs
+   * @deprecated Use extractAttachmentUrls instead
+   */
+  extractImageUrls(text) {
+    const { imageUrls } = this.extractAttachmentUrls(text);
+    return imageUrls;
   }
 
   /**
@@ -90,106 +119,249 @@ export class ImageDownloader {
   }
 
   /**
-   * Download all images from an issue and its comments
-   * @param {Issue} issue - The issue containing potential images
+   * Download all attachments from an issue and its comments
+   * @param {Issue} issue - The issue containing potential attachments
    * @param {string} workspacePath - The workspace directory
    * @param {number} maxImages - Maximum number of images to download (default: 10)
-   * @returns {Promise<Object>} - Map of original URLs to local file paths
+   * @returns {Promise<Object>} - Result object with downloaded files info
    */
-  async downloadIssueImages(issue, workspacePath, maxImages = 10) {
+  async downloadIssueAttachments(issue, workspacePath, maxImages = 10) {
     const imageMap = {};
+    const otherAttachmentMap = {};
     let imageCount = 0;
-    let skippedCount = 0;
+    let otherAttachmentCount = 0;
+    let skippedImageCount = 0;
+    let failedDownloads = [];
     
-    // Create images directory in workspace
-    const imagesDir = path.join(workspacePath, '.linear-images');
+    // Create attachments directory in workspace
+    const attachmentsDir = path.join(workspacePath, '.linear-attachments');
     
     // Extract URLs from issue description
-    const descriptionUrls = this.extractImageUrls(issue.description);
+    const descriptionAttachments = this.extractAttachmentUrls(issue.description);
     
     // Extract URLs from comments
-    const commentUrls = [];
+    const commentImageUrls = [];
+    const commentOtherUrls = [];
     if (issue.comments && issue.comments.nodes) {
       for (const comment of issue.comments.nodes) {
-        const urls = this.extractImageUrls(comment.body);
-        commentUrls.push(...urls);
+        const attachments = this.extractAttachmentUrls(comment.body);
+        commentImageUrls.push(...attachments.imageUrls);
+        commentOtherUrls.push(...attachments.otherAttachmentUrls);
       }
     }
     
     // Combine and deduplicate all URLs
-    const allUrls = [...new Set([...descriptionUrls, ...commentUrls])];
+    const allImageUrls = [...new Set([...descriptionAttachments.imageUrls, ...commentImageUrls])];
+    const allOtherUrls = [...new Set([...descriptionAttachments.otherAttachmentUrls, ...commentOtherUrls])];
     
-    console.log(`Found ${allUrls.length} unique image URLs in issue ${issue.identifier}`);
+    console.log(`Found ${allImageUrls.length} unique image URLs and ${allOtherUrls.length} other attachment URLs in issue ${issue.identifier}`);
     
-    if (allUrls.length > maxImages) {
-      console.warn(`Warning: Found ${allUrls.length} images but limiting to ${maxImages}. Skipping ${allUrls.length - maxImages} images.`);
+    if (allImageUrls.length > maxImages) {
+      console.warn(`Warning: Found ${allImageUrls.length} images but limiting to ${maxImages}. Skipping ${allImageUrls.length - maxImages} images.`);
     }
     
     // Download images up to the limit
-    for (const url of allUrls) {
+    for (const url of allImageUrls) {
       if (imageCount >= maxImages) {
-        skippedCount++;
+        skippedImageCount++;
         continue;
       }
       
       // Generate a filename based on the URL
       const urlPath = new URL(url).pathname;
       const filename = `image_${imageCount + 1}${path.extname(urlPath) || '.png'}`;
-      const localPath = path.join(imagesDir, filename);
+      const localPath = path.join(attachmentsDir, filename);
       
       const success = await this.downloadImage(url, localPath);
       
       if (success) {
         imageMap[url] = localPath;
         imageCount++;
+      } else {
+        failedDownloads.push({ url, type: 'image', reason: 'Download failed' });
       }
     }
     
-    if (skippedCount > 0) {
-      console.log(`Downloaded ${imageCount} images. Skipped ${skippedCount} due to limit.`);
+    // Download other attachments
+    for (const url of allOtherUrls) {
+      // Generate a filename based on the URL
+      const urlPath = new URL(url).pathname;
+      const filename = `attachment_${otherAttachmentCount + 1}${path.extname(urlPath) || ''}`;
+      const localPath = path.join(attachmentsDir, filename);
+      
+      const success = await this.downloadImage(url, localPath);
+      
+      if (success) {
+        otherAttachmentMap[url] = localPath;
+        otherAttachmentCount++;
+      } else {
+        failedDownloads.push({ url, type: 'attachment', reason: 'Download failed' });
+      }
+    }
+    
+    if (skippedImageCount > 0) {
+      console.log(`Downloaded ${imageCount} images. Skipped ${skippedImageCount} due to limit.`);
     } else {
       console.log(`Downloaded all ${imageCount} images.`);
     }
     
+    if (otherAttachmentCount > 0) {
+      console.log(`Downloaded ${otherAttachmentCount} other attachments.`);
+    }
+    
+    if (failedDownloads.length > 0) {
+      console.warn(`Warning: Failed to download ${failedDownloads.length} file(s):`);
+      failedDownloads.forEach(({ url, type }) => {
+        console.warn(`  - ${type}: ${url}`);
+      });
+    }
+    
     return {
       imageMap,
-      totalFound: allUrls.length,
-      downloaded: imageCount,
-      skipped: skippedCount
+      otherAttachmentMap,
+      totalImagesFound: allImageUrls.length,
+      totalOtherAttachmentsFound: allOtherUrls.length,
+      imagesDownloaded: imageCount,
+      otherAttachmentsDownloaded: otherAttachmentCount,
+      imagesSkipped: skippedImageCount,
+      failedDownloads
     };
   }
 
   /**
-   * Generate a markdown section describing downloaded images
-   * @param {Object} downloadResult - Result from downloadIssueImages
+   * Download all images from an issue and its comments
+   * @param {Issue} issue - The issue containing potential images
+   * @param {string} workspacePath - The workspace directory
+   * @param {number} maxImages - Maximum number of images to download (default: 10)
+   * @returns {Promise<Object>} - Map of original URLs to local file paths
+   * @deprecated Use downloadIssueAttachments instead
+   */
+  async downloadIssueImages(issue, workspacePath, maxImages = 10) {
+    const result = await this.downloadIssueAttachments(issue, workspacePath, maxImages);
+    // Return in the old format for backward compatibility
+    return {
+      imageMap: result.imageMap,
+      totalFound: result.totalImagesFound,
+      downloaded: result.imagesDownloaded,
+      skipped: result.imagesSkipped
+    };
+  }
+  
+  /**
+   * Generate a markdown section describing downloaded attachments
+   * @param {Object} downloadResult - Result from downloadIssueAttachments
    * @returns {string} - Markdown formatted string
    */
-  generateImageManifest(downloadResult) {
-    const { imageMap, totalFound, downloaded, skipped } = downloadResult;
+  generateAttachmentManifest(downloadResult) {
+    const { imageMap, otherAttachmentMap, totalImagesFound, totalOtherAttachmentsFound, 
+            imagesDownloaded, otherAttachmentsDownloaded, imagesSkipped, failedDownloads } = downloadResult;
     
-    let manifest = '\n## Downloaded Images\n\n';
+    let manifest = '\n## Downloaded Attachments\n\n';
     
-    if (Object.keys(imageMap).length === 0) {
-      manifest += 'No images were found in this issue.\n';
+    const hasImages = Object.keys(imageMap).length > 0;
+    const hasOtherAttachments = Object.keys(otherAttachmentMap).length > 0;
+    const hasFailures = failedDownloads.length > 0;
+    
+    if (!hasImages && !hasOtherAttachments && !hasFailures) {
+      manifest += 'No attachments were found in this issue.\n';
       return manifest;
     }
     
-    manifest += `Found ${totalFound} images. Downloaded ${downloaded}`;
-    if (skipped > 0) {
-      manifest += ` (skipped ${skipped} due to 10 image limit)`;
+    // Summary section
+    if (hasImages) {
+      manifest += `Found ${totalImagesFound} image(s). Downloaded ${imagesDownloaded}`;
+      if (imagesSkipped > 0) {
+        manifest += ` (skipped ${imagesSkipped} due to 10 image limit)`;
+      }
+      manifest += '.\n';
     }
-    manifest += '.\n\n';
     
-    manifest += 'Images have been downloaded to the `.linear-images` directory:\n\n';
+    if (hasOtherAttachments) {
+      manifest += `Found ${totalOtherAttachmentsFound} other attachment(s). Downloaded ${otherAttachmentsDownloaded}.\n`;
+    }
     
-    Object.entries(imageMap).forEach(([url, localPath], index) => {
-      const filename = path.basename(localPath);
-      manifest += `${index + 1}. ${filename} - Original URL: ${url}\n`;
-      manifest += `   Local path: ${localPath}\n\n`;
-    });
+    if (hasFailures) {
+      manifest += `\n⚠️ Failed to download ${failedDownloads.length} file(s). The agent will continue processing but may not have complete context.\n`;
+    }
     
-    manifest += 'You can use the Read tool to view these images.\n';
+    manifest += '\n';
+    
+    // Images section
+    if (hasImages) {
+      manifest += '### Images\n';
+      manifest += 'Images have been downloaded to the `.linear-attachments` directory:\n\n';
+      
+      Object.entries(imageMap).forEach(([url, localPath], index) => {
+        const filename = path.basename(localPath);
+        manifest += `${index + 1}. ${filename} - Original URL: ${url}\n`;
+        manifest += `   Local path: ${localPath}\n\n`;
+      });
+      
+      manifest += 'You can use the Read tool to view these images.\n\n';
+    }
+    
+    // Other attachments section
+    if (hasOtherAttachments) {
+      manifest += '### Other Attachments\n';
+      manifest += 'Non-image attachments have been downloaded to the `.linear-attachments` directory:\n\n';
+      
+      Object.entries(otherAttachmentMap).forEach(([url, localPath], index) => {
+        const filename = path.basename(localPath);
+        const ext = path.extname(filename).toLowerCase();
+        let fileType = 'File';
+        
+        // Identify common file types
+        if (ext === '.jsonl' || ext === '.json') fileType = 'JSON';
+        else if (ext === '.txt') fileType = 'Text';
+        else if (ext === '.csv') fileType = 'CSV';
+        else if (ext === '.pdf') fileType = 'PDF';
+        else if (ext === '.md') fileType = 'Markdown';
+        
+        manifest += `${index + 1}. ${filename} (${fileType}) - Original URL: ${url}\n`;
+        manifest += `   Local path: ${localPath}\n\n`;
+      });
+      
+      manifest += 'You can use the Read tool to view the contents of text-based attachments.\n\n';
+    }
+    
+    // Failed downloads section
+    if (hasFailures) {
+      manifest += '### Failed Downloads\n';
+      manifest += 'The following files could not be downloaded:\n\n';
+      
+      failedDownloads.forEach(({ url, type }, index) => {
+        manifest += `${index + 1}. ${type}: ${url}\n`;
+      });
+      
+      manifest += '\n';
+    }
     
     return manifest;
+  }
+  
+  /**
+   * Generate a markdown section describing downloaded images
+   * @param {Object} downloadResult - Result from downloadIssueImages or downloadIssueAttachments
+   * @returns {string} - Markdown formatted string
+   * @deprecated Use generateAttachmentManifest instead
+   */
+  generateImageManifest(downloadResult) {
+    // Handle both old and new result formats
+    if ('imageMap' in downloadResult && 'totalFound' in downloadResult) {
+      // Old format from downloadIssueImages
+      return this.generateAttachmentManifest({
+        imageMap: downloadResult.imageMap,
+        otherAttachmentMap: {},
+        totalImagesFound: downloadResult.totalFound,
+        totalOtherAttachmentsFound: 0,
+        imagesDownloaded: downloadResult.downloaded,
+        otherAttachmentsDownloaded: 0,
+        imagesSkipped: downloadResult.skipped,
+        failedDownloads: []
+      });
+    } else {
+      // New format, use directly
+      return this.generateAttachmentManifest(downloadResult);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Fix handling of non-image attachments (e.g., .jsonl, .pdf, .csv files) that were being incorrectly treated as images
- Make attachment download failures non-fatal so the agent continues processing with a warning
- Improve file type detection and separation of images from other attachments

## Problem
When uploading non-image files like `.jsonl` to a Linear issue, the agent would fail with:
```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}
```

This happened because:
1. All attachments from `uploads.linear.app` were being treated as images
2. Non-image files were being passed to Claude as images, causing the error

## Solution
- Added file type detection to separate images from other attachments
- Both types are downloaded but handled differently
- Non-image attachments are mentioned in the manifest but not sent as images to Claude
- Download failures now produce warnings instead of blocking the entire process
- Updated directory name from `.linear-images` to `.linear-attachments` to reflect broader support

## Test plan
- [x] Unit tests updated and passing for new attachment handling logic
- [x] Test coverage maintained for ImageDownloader module
- [ ] Manual testing with various attachment types (.jsonl, .pdf, .csv, images)
- [ ] Verify agent continues processing when some attachments fail to download
- [ ] Confirm no regression in image handling functionality

🤖 Generated with [Claude Code](https://claude.ai/code)