### PR TITLE
fix: agent now identifies itself using Linear username instead of Claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ All notable changes to this project will be documented in this file.
   - Fetches `branchName` property from Linear API
   - Respects workspace settings for branch naming conventions
   - Falls back to lowercase identifier if API value not available
-
-### Changed
 - All entry points now support custom environment file paths
 - Updated documentation to reflect new environment file behavior
 - NodeClaudeService now downloads images before starting Claude sessions
@@ -42,3 +40,9 @@ All notable changes to this project will be documented in this file.
   - Automatically detects actual file type (png, jpg, gif, etc.) from downloaded content
   - No longer relies on URL extensions which Linear doesn't provide
   - Falls back to .png if file type cannot be determined
+
+### Fixed
+- Agent now correctly identifies itself using its Linear username instead of "Claude"
+  - Prompt template now uses dynamic `{{agent_name}}` placeholder
+  - Agent name is fetched from Linear API and injected into prompts
+  - Fallback to "Linear Agent" if username is not available

--- a/agent-prompt-template.md
+++ b/agent-prompt-template.md
@@ -1,4 +1,4 @@
-You are Agent Slick (@agentslick), a masterful software engineer contributing to this project which integrates Linear issue management with Claude Code for automated software development.
+You are {{agent_name}}, a masterful software engineer contributing to this project which integrates Linear issue management with Claude Code for automated software development.
 
 YOU ARE IN 1 OF 2 SITUATIONS AND YOUR FIRST JOB IS TO FIGURE OUT WHICH ONE:
 

--- a/src/adapters/NodeClaudeService.mjs
+++ b/src/adapters/NodeClaudeService.mjs
@@ -104,6 +104,11 @@ export class NodeClaudeService extends ClaudeService {
     const linearComments = issue.formatComments();
     const branchName = issue.getBranchName();
     
+    // Get the agent name from the issueService (Linear username)
+    const agentName = this.issueService && this.issueService.username 
+      ? this.issueService.username 
+      : 'Linear Agent'; // Fallback if username not available
+    
     // Inject variables into the template
     let finalPrompt = this.promptTemplate;
     
@@ -129,6 +134,7 @@ history are preserved. Please continue your work on the issue.]
       finalPrompt = finalPrompt + '\n' + imageManifest;
     }
     
+    finalPrompt = finalPrompt.replace('{{agent_name}}', agentName);
     finalPrompt = finalPrompt.replace('{{issue_details}}', issueDetails);
     finalPrompt = finalPrompt.replace('{{linear_comments}}', linearComments);
     finalPrompt = finalPrompt.replace('{{branch_name}}', branchName);


### PR DESCRIPTION
## Summary
- Fixed SEC-38 where the agent incorrectly identified itself as "Claude" instead of using its Linear username
- Agent now dynamically uses its actual username from the Linear API

## Changes
- Updated `agent-prompt-template.md` to use `{{agent_name}}` placeholder instead of hardcoded "Agent Slick (@agentslick)"
- Modified `NodeClaudeService.buildInitialPrompt()` to inject the agent name from `issueService.username`
- Added fallback to "Linear Agent" if username is not available

## Test plan
- [x] All existing tests pass
- [ ] Manually test that agent identifies itself with its Linear username in responses
- [ ] Verify fallback behavior when username is not available

🤖 Generated with [Claude Code](https://claude.ai/code)