### PR TITLE
Handle blocked issue statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
   - Automatically detects file types and categorizes them as images or other attachments
   - Gracefully handles download failures with informative warnings
   - Replaces the previous ImageDownloader with a more comprehensive solution
+- Blocked issue handling to prevent work on issues that are blocked by other issues
+  - Automatically detects when an issue is blocked via Linear's issue relations
+  - Posts a comment asking for permission before proceeding with blocked issues
+  - Remembers permission once granted to avoid asking repeatedly
+  - Supports multiple blocking issues with clear messaging
 
 ### Removed
 - Coverage folder from git tracking (now properly ignored)

--- a/__tests__/unit/adapters/LinearIssueService.test.mjs
+++ b/__tests__/unit/adapters/LinearIssueService.test.mjs
@@ -1,0 +1,208 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import { LinearIssueService } from '../../../src/adapters/LinearIssueService.mjs'
+import { Issue } from '../../../src/core/Issue.mjs'
+
+describe('LinearIssueService', () => {
+  let service
+  let mockLinearClient
+  let mockSessionManager
+  let mockClaudeService
+  let mockWorkspaceService
+
+  beforeEach(() => {
+    mockLinearClient = {}
+    mockSessionManager = {
+      hasSession: jest.fn(),
+      addSession: jest.fn(),
+      getSession: jest.fn(),
+      removeSession: jest.fn()
+    }
+    mockClaudeService = {
+      startSession: jest.fn()
+    }
+    mockWorkspaceService = {
+      getWorkspaceForIssue: jest.fn(),
+      createWorkspace: jest.fn()
+    }
+
+    service = new LinearIssueService(
+      mockLinearClient,
+      'test-user-id',
+      mockSessionManager,
+      mockClaudeService,
+      mockWorkspaceService
+    )
+  })
+
+  describe('hasBlockedIssuePermission', () => {
+    it('should return false if no comments', () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        comments: { nodes: [] }
+      })
+
+      const result = service.hasBlockedIssuePermission(issue)
+      expect(result).toBe(false)
+    })
+
+    it('should return false if no permission keywords found', () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        comments: {
+          nodes: [
+            {
+              body: 'This is blocked by another issue',
+              userId: 'test-user-id',
+              createdAt: new Date('2024-01-01')
+            },
+            {
+              body: 'I will wait for the blocking issue',
+              userId: 'other-user',
+              createdAt: new Date('2024-01-02')
+            }
+          ]
+        }
+      })
+
+      const result = service.hasBlockedIssuePermission(issue)
+      expect(result).toBe(false)
+    })
+
+    it('should return true if permission keyword found after agent query', () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        comments: {
+          nodes: [
+            {
+              body: 'This issue is blocked. Should I proceed?',
+              userId: 'test-user-id',
+              createdAt: new Date('2024-01-01')
+            },
+            {
+              body: 'Yes, please proceed anyway',
+              userId: 'other-user',
+              createdAt: new Date('2024-01-02')
+            }
+          ]
+        }
+      })
+
+      const result = service.hasBlockedIssuePermission(issue)
+      expect(result).toBe(true)
+    })
+
+    it('should ignore permission before agent asked about blocked status', () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        comments: {
+          nodes: [
+            {
+              body: 'Please proceed with this',
+              userId: 'other-user',
+              createdAt: new Date('2024-01-01')
+            },
+            {
+              body: 'This issue is blocked. Should I proceed?',
+              userId: 'test-user-id',
+              createdAt: new Date('2024-01-02')
+            }
+          ]
+        }
+      })
+
+      const result = service.hasBlockedIssuePermission(issue)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('handleBlockedIssue', () => {
+    beforeEach(() => {
+      service.createComment = jest.fn().mockResolvedValue(true)
+    })
+
+    it('should return true if issue is not blocked', async () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        blockedByIssues: []
+      })
+
+      const result = await service.handleBlockedIssue(issue)
+      expect(result).toBe(true)
+      expect(service.createComment).not.toHaveBeenCalled()
+    })
+
+    it('should return true if permission already granted', async () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        blockedByIssues: [{ identifier: 'BLOCK-1' }],
+        comments: {
+          nodes: [
+            {
+              body: 'This issue is blocked. Should I proceed?',
+              userId: 'test-user-id',
+              createdAt: new Date('2024-01-01')
+            },
+            {
+              body: 'go ahead',
+              userId: 'other-user',
+              createdAt: new Date('2024-01-02')
+            }
+          ]
+        }
+      })
+
+      const result = await service.handleBlockedIssue(issue)
+      expect(result).toBe(true)
+      expect(service.createComment).not.toHaveBeenCalled()
+    })
+
+    it('should post comment and return false if blocked without permission', async () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        blockedByIssues: [{ identifier: 'BLOCK-1' }],
+        comments: { nodes: [] }
+      })
+
+      const result = await service.handleBlockedIssue(issue)
+      expect(result).toBe(false)
+      expect(service.createComment).toHaveBeenCalledWith(
+        'issue-1',
+        expect.stringContaining('blocked by issue BLOCK-1')
+      )
+    })
+
+    it('should handle multiple blocking issues', async () => {
+      const issue = new Issue({
+        id: 'issue-1',
+        identifier: 'TEST-1',
+        title: 'Test Issue',
+        blockedByIssues: [
+          { identifier: 'BLOCK-1' },
+          { identifier: 'BLOCK-2' }
+        ],
+        comments: { nodes: [] }
+      })
+
+      const result = await service.handleBlockedIssue(issue)
+      expect(result).toBe(false)
+      expect(service.createComment).toHaveBeenCalledWith(
+        'issue-1',
+        expect.stringContaining('blocked by issues BLOCK-1, BLOCK-2')
+      )
+    })
+  })
+})

--- a/src/core/Issue.mjs
+++ b/src/core/Issue.mjs
@@ -14,6 +14,7 @@ export class Issue {
     assigneeId,
     comments = { nodes: [] },
     branchName,
+    blockedByIssues = [],
   }) {
     this.id = id;
     this.identifier = identifier;
@@ -26,6 +27,7 @@ export class Issue {
     this.assigneeId = assigneeId;
     this.comments = comments;
     this.branchName = branchName;
+    this.blockedByIssues = blockedByIssues;
   }
 
   /**
@@ -84,5 +86,24 @@ export class Issue {
    */
   getBranchName() {
     return this.branchName || this.identifier.toLowerCase();
+  }
+
+  /**
+   * Check if the issue is blocked by other issues
+   * @returns {boolean} - True if the issue is blocked
+   */
+  isBlocked() {
+    return this.blockedByIssues && this.blockedByIssues.length > 0;
+  }
+
+  /**
+   * Get the list of blocking issue identifiers
+   * @returns {Array<string>} - Array of blocking issue identifiers
+   */
+  getBlockingIssueIdentifiers() {
+    if (!this.blockedByIssues || this.blockedByIssues.length === 0) {
+      return [];
+    }
+    return this.blockedByIssues.map(issue => issue.identifier || issue.id);
   }
 }


### PR DESCRIPTION
## Summary
- Implements automatic detection and handling of blocked issues in Linear
- Prevents the agent from working on blocked issues without explicit permission

## Implementation Details

This PR adds functionality to check if an issue is blocked by other issues before starting work. When a blocked issue is detected:

1. The agent posts a comment asking for permission to proceed
2. The comment lists all blocking issues for transparency
3. Once permission is granted, it's remembered to avoid repeated asks
4. Permission is detected through keywords like "proceed anyway", "go ahead", etc.

The implementation includes:
- Fetching blocking relations from Linear's GraphQL API (`inverseRelations`)
- Checking blocked status before initializing Claude sessions
- Parsing comment history to find existing permissions
- Comprehensive unit tests for all scenarios

## Test plan
- [x] Added unit tests for `hasBlockedIssuePermission` method
- [x] Added unit tests for `handleBlockedIssue` method
- [x] All existing tests still pass
- [ ] Manual testing with actual Linear issues that have blocking relations

🤖 Generated with [Claude Code](https://claude.ai/code)