### PR TITLE
Fix nested reply threading issue with Linear API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,9 @@ All notable changes to this project will be documented in this file.
 - Fixed issue where all attachments were treated as images
   - Non-image attachments (like .jsonl files) no longer cause "Could not process image" errors
   - Attachment failures are now handled gracefully without stopping the agent
+- Fixed nested reply handling to comply with Linear API requirements
+  - When agent is mentioned in nested comments (replies to replies), the system now correctly finds the root comment of the thread
+  - Linear API requires parentId to point to a top-level comment, not another nested comment
+  - Added `findRootCommentId()` method to traverse comment hierarchies and locate thread roots
+  - Updated `handleAgentMention`, `handleAgentReply`, and `handleCommentEvent` to use root comment IDs for threading
+  - Prevents "Parent comment must be a top level comment" errors when replying to deeply nested comments

--- a/__tests__/unit/adapters/LinearIssueService.nestedReply.test.mjs
+++ b/__tests__/unit/adapters/LinearIssueService.nestedReply.test.mjs
@@ -1,0 +1,170 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { LinearIssueService } from '../../../src/adapters/LinearIssueService.mjs'
+
+describe('LinearIssueService - Nested Reply Handling', () => {
+  let issueService
+  let mockLinearClient
+  
+  beforeEach(() => {
+    // Mock Linear client with comment structure support
+    mockLinearClient = {
+      createComment: vi.fn().mockResolvedValue({ 
+        success: true,
+        comment: { id: 'new-comment-id' }
+      }),
+      issueComments: vi.fn().mockResolvedValue({
+        comments: {
+          nodes: [
+            // Root comment from Jane
+            {
+              id: 'jane-root-comment',
+              body: 'Original question about the feature',
+              user: { id: 'jane-id', name: 'Jane' },
+              parent: null
+            },
+            // Jimmy's reply to Jane's root comment
+            {
+              id: 'jimmy-reply-1',
+              body: 'I think this might be related to...',
+              user: { id: 'jimmy-id', name: 'Jimmy' },
+              parent: { id: 'jane-root-comment' }
+            },
+            // Jane's nested reply to Jimmy (this is where she mentions the agent)
+            {
+              id: 'jane-nested-reply',
+              body: '@agentslick can you help with this?',
+              user: { id: 'jane-id', name: 'Jane' },
+              parent: { id: 'jimmy-reply-1' }
+            }
+          ]
+        }
+      })
+    }
+    
+    // Create the service
+    issueService = new LinearIssueService(
+      mockLinearClient,
+      'agent-user-id',
+      null, // sessionManager
+      null, // claudeService  
+      null  // workspaceService
+    )
+  })
+  
+  describe('findRootCommentId', () => {
+    it('should return the same ID for a root comment', async () => {
+      const rootId = await issueService.findRootCommentId('issue-123', 'jane-root-comment')
+      expect(rootId).toBe('jane-root-comment')
+    })
+    
+    it('should find the root for a first-level reply', async () => {
+      const rootId = await issueService.findRootCommentId('issue-123', 'jimmy-reply-1')
+      expect(rootId).toBe('jane-root-comment')
+    })
+    
+    it('should find the root for a deeply nested reply', async () => {
+      const rootId = await issueService.findRootCommentId('issue-123', 'jane-nested-reply')
+      expect(rootId).toBe('jane-root-comment')
+    })
+    
+    it('should return null if comment not found', async () => {
+      const rootId = await issueService.findRootCommentId('issue-123', 'non-existent-comment')
+      expect(rootId).toBeNull()
+    })
+    
+    it('should handle empty comments list', async () => {
+      mockLinearClient.issueComments.mockResolvedValue({
+        comments: { nodes: [] }
+      })
+      
+      const rootId = await issueService.findRootCommentId('issue-123', 'any-comment')
+      expect(rootId).toBeNull()
+    })
+    
+    it('should handle API errors gracefully', async () => {
+      mockLinearClient.issueComments.mockRejectedValue(new Error('API Error'))
+      
+      const rootId = await issueService.findRootCommentId('issue-123', 'any-comment')
+      expect(rootId).toBeNull()
+    })
+    
+    it('should prevent infinite loops with circular references', async () => {
+      // Mock circular reference scenario (should not happen in real Linear but good to be safe)
+      mockLinearClient.issueComments.mockResolvedValue({
+        comments: {
+          nodes: [
+            {
+              id: 'comment-a',
+              parent: { id: 'comment-b' }
+            },
+            {
+              id: 'comment-b', 
+              parent: { id: 'comment-a' }
+            }
+          ]
+        }
+      })
+      
+      const rootId = await issueService.findRootCommentId('issue-123', 'comment-a')
+      // Should return one of the comments rather than hanging
+      expect(['comment-a', 'comment-b']).toContain(rootId)
+    })
+  })
+  
+  describe('nested reply scenario integration', () => {
+    it('should use root comment ID when agent is mentioned in nested reply', async () => {
+      // Simulate the scenario: Jane mentions agent in a nested reply
+      const mentionData = {
+        issueId: 'issue-123',
+        commentId: 'jane-nested-reply',
+        comment: {
+          body: '@agentslick can you help with this?',
+          parentId: 'jimmy-reply-1' // This is a nested reply, not a root comment
+        },
+        actor: { name: 'Jane' }
+      }
+      
+      // Mock session manager and Claude service
+      const mockSession = {
+        currentParentId: null,
+        lastCommentId: null,
+        conversationContext: null
+      }
+      
+      const mockSessionManager = {
+        hasSession: vi.fn().mockReturnValue(true),
+        getSession: vi.fn().mockReturnValue(mockSession),
+        updateSession: vi.fn()
+      }
+      
+      const mockClaudeService = {
+        sendComment: vi.fn().mockResolvedValue(mockSession)
+      }
+      
+      // Create service with mocked dependencies
+      const serviceWithMocks = new LinearIssueService(
+        mockLinearClient,
+        'agent-user-id',
+        mockSessionManager,
+        mockClaudeService,
+        null
+      )
+      
+      // Mock fetchIssue to return a valid issue
+      serviceWithMocks.fetchIssue = vi.fn().mockResolvedValue({
+        id: 'issue-123',
+        identifier: 'TEST-123',
+        assigneeId: 'agent-user-id'
+      })
+      
+      // Handle the agent mention
+      await serviceWithMocks.handleAgentMention(mentionData)
+      
+      // Verify that findRootCommentId was called and currentParentId was set to root
+      expect(mockLinearClient.issueComments).toHaveBeenCalledWith('issue-123')
+      expect(mockSession.currentParentId).toBe('jane-root-comment') // Should be root, not 'jimmy-reply-1'
+      expect(mockSession.lastCommentId).toBe('jane-nested-reply')
+      expect(mockSession.conversationContext).toBe('mention')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes issue where agent mentions in nested comment replies fail with "Parent comment must be a top level comment" error
- Adds proper root comment detection for Linear's threading requirements
- Maintains proper conversation threading when users mention the agent in deeply nested replies

## Technical Details
When users mention the agent in nested comment replies (comments that already have a parentId), the system was incorrectly using the immediate parent comment ID. Linear's API requires that parentId must point to a top-level comment only.

This fix adds a `findRootCommentId()` method that traverses the comment hierarchy to locate the root comment of any thread, ensuring all agent replies comply with Linear's threading requirements.

## Changes Made
- **New method**: `findRootCommentId()` in LinearIssueService to traverse comment hierarchies
- **Updated handlers**: `handleAgentMention`, `handleAgentReply`, and `handleCommentEvent` now use root comment IDs
- **Comprehensive tests**: Added test suite covering nested reply scenarios and edge cases
- **Documentation**: Updated CHANGELOG.md with detailed fix information

## Test Plan
- [x] Unit tests pass for new `findRootCommentId()` method
- [x] Integration tests verify proper threading behavior in nested scenarios  
- [x] Error handling tests confirm graceful failure modes
- [x] All existing tests continue to pass (no regressions)
- [x] Manual testing with actual nested comment scenarios

## Fixes
Resolves CEA-53: issue with sending nested reply

Previously, when a user mentioned the agent in a deeply nested comment thread, the agent would fail to respond with the error: "Parent comment must be a top level comment. When creating a reply the `parentId` should be set to the same value as the comment you're replying to."

Now, the agent correctly identifies the root comment of any thread and uses that as the parentId, allowing successful responses to nested mentions while maintaining proper conversation threading.

🤖 Generated with [Claude Code](https://claude.ai/code)