### PR TITLE
Fix comment threading issues with Linear API compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to this project will be documented in this file.
   - Agent's first assignment comment is always a top-level comment
   - All subsequent agent messages are threaded under the first comment
   - When users comment, agent replies directly to their comments
+- Comment threading issues with Linear API
+  - Fixed session initialization to properly pass agentRootCommentId to Session constructor
+  - Fixed nested reply threading logic to find correct root comment ID when replying to threaded comments
+  - Ensures compliance with Linear API requirement that parentId must be a top-level comment
+  - Addresses CEA-57 threading scenarios: assignment response threading and nested reply errors
   - When replying in existing threads, agent uses the same parentId to maintain thread structure
   - Session tracking for agentRootCommentId and currentParentId
   - Tracks parent comment IDs from webhook notifications

--- a/src/adapters/LinearIssueService.mjs
+++ b/src/adapters/LinearIssueService.mjs
@@ -650,7 +650,7 @@ export class LinearIssueService extends IssueService {
           if (commentData.parentId) {
             // If the comment is already threaded, find the root of that thread
             // Linear API requires parentId to be a top-level comment
-            const rootCommentId = await this.findRootCommentId(issueId, commentData.parentId);
+            const rootCommentId = await this.findRootCommentId(issueId, commentData.id);
             session.currentParentId = rootCommentId || commentData.parentId;
           } else {
             // If it's a root comment from user, reply to this comment
@@ -746,7 +746,7 @@ export class LinearIssueService extends IssueService {
           if (data.comment?.parentId) {
             // If the mention is in a threaded comment, find the root of that thread
             // Linear API requires parentId to be a top-level comment
-            const rootCommentId = await this.findRootCommentId(issueId, data.comment.parentId);
+            const rootCommentId = await this.findRootCommentId(issueId, commentId);
             session.currentParentId = rootCommentId || data.comment.parentId;
           } else {
             // If it's a root comment mention, reply to this comment
@@ -868,7 +868,7 @@ export class LinearIssueService extends IssueService {
           if (data.comment?.parentId) {
             // If replying in a thread, find the root of that thread
             // Linear API requires parentId to be a top-level comment
-            const rootCommentId = await this.findRootCommentId(issueId, data.comment.parentId);
+            const rootCommentId = await this.findRootCommentId(issueId, commentId);
             session.currentParentId = rootCommentId || data.comment.parentId;
           } else {
             // If it's a root comment reply, reply to this comment

--- a/src/adapters/NodeClaudeService.mjs
+++ b/src/adapters/NodeClaudeService.mjs
@@ -608,7 +608,8 @@ history are preserved. Please continue your work on the issue.]
           issue,
           workspace,
           process: claudeProcess,
-          startedAt: new Date()
+          startedAt: new Date(),
+          agentRootCommentId
         });
         
         resolve(session);


### PR DESCRIPTION
## Summary
- Fixed session initialization to properly pass `agentRootCommentId` to Session constructor in `NodeClaudeService`
- Fixed nested reply threading logic to find correct root comment ID when replying to threaded comments in `LinearIssueService`
- Ensured compliance with Linear API requirement that `parentId` must be a top-level comment

## Test plan
- [x] All existing tests pass
- [x] Verified that session initialization properly sets `agentRootCommentId`
- [x] Verified that nested reply threading finds the correct root comment ID
- [x] Updated CHANGELOG.md with fix details

Fixes CEA-57: Resolves both scenarios where responses were not behaving as intended:
1. Agent assignment response threading - first generative message now threads properly under acknowledgment comment
2. Nested reply threading error - agent now correctly finds root comment ID to comply with Linear API requirements

🤖 Generated with [Claude Code](https://claude.ai/code)