### PR TITLE
Fix: Eliminate duplication in streaming comment updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Duplicate information in streaming comment updates
+  - Fixed tool call grouping logic that was causing duplication in JSON stream synthesis
+  - Improved chronological processing to properly separate consecutive tool calls from intervening text messages
+  - Tool calls are now grouped correctly and displayed once per consecutive sequence
+
 ### Added
 - Real-time streaming updates to Linear comments during Claude Code execution
   - Agent now immediately posts "Getting to work..." comment when starting a new session


### PR DESCRIPTION
## Summary
- Fixed tool call grouping logic that was causing duplicate information in JSON stream synthesis
- Improved chronological processing to properly separate consecutive tool calls from intervening text messages

This resolves the issue where streaming comments were showing repeated tool call information and not properly grouping consecutive tool calls together.

## Test plan
- [x] All existing tests pass
- [x] Updated CHANGELOG.md with fix description
- [x] Fix addresses the exact duplication pattern described in issue CEA-62

🤖 Generated with [Claude Code](https://claude.ai/code)