### PR TITLE
Fix streaming comment duplication and implement chronological synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
   - Fixed tool call grouping logic that was causing duplication in JSON stream synthesis
   - Improved chronological processing to properly separate consecutive tool calls from intervening text messages
   - Tool calls are now grouped correctly and displayed once per consecutive sequence
+- Streaming comment duplication and weird formatting issue (CEA-64)
+  - Completely redesigned streaming synthesis to show chronological timeline of ALL messages without duplication
+  - Fixed text processing to create concise previews instead of extracting potentially repetitive "meaningful statements"
+  - Eliminated truncation to 8 items - now shows complete chronological synthesis of Claude's work
+  - Text snippets are now processed into short previews (first sentence or truncated at 80 chars) to maintain readability
 
 ### Added
 - Real-time streaming updates to Linear comments during Claude Code execution


### PR DESCRIPTION
## Summary
- Fixes CEA-64: weird streaming comments with duplicated content
- Completely redesigns the streaming synthesis to show a chronological timeline of ALL messages without duplication
- Eliminates the previous approach of extracting "meaningful statements" which caused repetition

## Changes Made
- **Redesigned text processing**: Instead of extracting potentially repetitive "meaningful statements", now creates concise previews (first sentence or 80-char truncation)
- **Removed arbitrary truncation**: Eliminated the 8-item limit to show complete chronological synthesis of Claude's work
- **Simplified narrative flow**: Raw text snippets are added to narrative and processed chronologically during synthesis
- **Maintains tool call grouping**: Preserves existing logic for grouping consecutive tool calls

## Technical Details
The core issue was in `Session.mjs:92-186` where:
1. `addTextSnippet()` was extracting "meaningful statements" from each text chunk
2. Multiple statements per update were being added to the narrative
3. Similar or repetitive content was appearing multiple times in the synthesis

The fix:
1. `addTextSnippet()` now adds raw text to narrative (one entry per update)
2. `extractTextPreview()` creates concise previews during synthesis
3. `updateStreamingSynthesis()` shows complete chronology without arbitrary limits

## Test Results
✅ All existing tests pass
✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)