### PR TITLE
fix: correct proxy worker dashboard title

### DIFF
--- a/apps/proxy-worker/src/index.ts
+++ b/apps/proxy-worker/src/index.ts
@@ -15,7 +15,7 @@ router.get('/', (request: Request, env: Env) => {
     <!DOCTYPE html>
     <html>
     <head>
-      <title>Cyrus Edge Proxy</title>
+      <title>Cyrus Proxy Worker</title>
       <style>
         body { font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px; }
         .endpoint { background: #f3f4f6; padding: 15px; margin: 10px 0; border-radius: 8px; }
@@ -25,7 +25,7 @@ router.get('/', (request: Request, env: Env) => {
       </style>
     </head>
     <body>
-      <h1>🚀 Cyrus Edge Proxy (Cloudflare Workers)</h1>
+      <h1>🚀 Cyrus Proxy Worker (Cloudflare Workers)</h1>
       <p>A distributed OAuth and webhook handler for Linear integration.</p>
       
       <h2>Available Endpoints:</h2>

--- a/apps/proxy-worker/src/index.ts
+++ b/apps/proxy-worker/src/index.ts
@@ -15,6 +15,7 @@ router.get('/', (request: Request, env: Env) => {
     <!DOCTYPE html>
     <html>
     <head>
+      <meta charset="utf-8">
       <title>Cyrus Proxy Worker</title>
       <style>
         body { font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px; }
@@ -61,7 +62,7 @@ router.get('/', (request: Request, env: Env) => {
     </html>
   `, {
     status: 200,
-    headers: { 'Content-Type': 'text/html' }
+    headers: { 'Content-Type': 'text/html; charset=utf-8' }
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixed incorrect title on proxy worker dashboard (/ route)
- Changed "Cyrus Edge Proxy" to "Cyrus Proxy Worker" in both HTML title and h1 heading
- Title now matches the correct application name as documented in the README

## Test plan
- [ ] Visit the proxy worker dashboard at the / route
- [ ] Verify the browser tab shows "Cyrus Proxy Worker" 
- [ ] Verify the page heading shows "🚀 Cyrus Proxy Worker (Cloudflare Workers)"

🤖 Generated with [Claude Code](https://claude.ai/code)