### PR TITLE
Remove colored dots from TODO formatting in Linear posts

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1069,9 +1069,8 @@ Please analyze this issue and help implement a solution.`
   private formatTodosAsChecklist(todos: Array<{id: string, content: string, status: string, priority: string}>): string {
     return todos.map(todo => {
       const checkbox = todo.status === 'completed' ? '[x]' : '[ ]'
-      const priorityEmoji = todo.priority === 'high' ? '🔴' : todo.priority === 'medium' ? '🟡' : '🟢'
       const statusEmoji = todo.status === 'in_progress' ? ' 🔄' : ''
-      return `- ${checkbox} ${priorityEmoji} ${todo.content}${statusEmoji}`
+      return `- ${checkbox} ${todo.content}${statusEmoji}`
     }).join('\n')
   }
   


### PR DESCRIPTION
## Summary
- Removed priority emojis (🔴🟡🟢) from TODO checklist formatting in Linear posts
- Kept status indicators (🔄) and checkboxes for core functionality
- Simplified TODO display by removing visual priority indicators

## Details
The `formatTodosAsChecklist` method in `packages/edge-worker/src/EdgeWorker.ts` was adding colored dots based on priority levels:
- 🔴 Red dot for high priority
- 🟡 Yellow dot for medium priority  
- 🟢 Green dot for low/default priority

These visual indicators were removed per user request while maintaining the essential functionality of checkboxes and status emojis.

## Test plan
- [x] Verified TypeScript compilation passes
- [x] Confirmed build process succeeds
- [x] Maintained existing functionality (checkboxes, status indicators)
- [x] No breaking changes to the API

🤖 Generated with [Claude Code](https://claude.ai/code)