### PR TITLE
Fix agent setting issues to 'In Review' instead of 'In Progress' on assignment

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -928,8 +928,11 @@ Please analyze this issue and help implement a solution.`
       
       const states = await teamStates.nodes
       
-      // Find the first state with type 'started'
-      const startedState = states.find((state: any) => state.type === 'started')
+      // Find the appropriate started state - prefer "In Progress" if available
+      const inProgressState = states.find((state: any) => 
+        state.type === 'started' && state.name === 'In Progress'
+      )
+      const startedState = inProgressState || states.find((state: any) => state.type === 'started')
       
       if (!startedState) {
         console.warn(`No 'started' state found for team ${team.name || 'unknown'}, skipping state update`)


### PR DESCRIPTION
## Summary
- Fixed issue where agent was incorrectly setting issue status to 'In Review' instead of 'In Progress' when assigned
- Modified `moveIssueToStartedState` function in EdgeWorker to prefer 'In Progress' state when available
- Maintains backward compatibility by falling back to first 'started' state if 'In Progress' doesn't exist

## Changes Made
- Updated `packages/edge-worker/src/EdgeWorker.ts:932-935` to implement smarter state selection logic
- The fix searches for 'In Progress' state specifically before falling back to any 'started' state

## Root Cause
The original code used `states.find()` to select the first workflow state with `type === 'started'`, which could return 'In Review' if it appeared before 'In Progress' in the Linear team's workflow configuration.

## Before (Problematic):
```typescript
// Find the first state with type 'started'
const startedState = states.find((state: any) => state.type === 'started')
```

## After (Fixed):
```typescript
// Find the appropriate started state - prefer "In Progress" if available
const inProgressState = states.find((state: any) => 
  state.type === 'started' && state.name === 'In Progress'
)
const startedState = inProgressState || states.find((state: any) => state.type === 'started')
```

## Test Plan
- [x] All existing tests pass (39/39)
- [x] TypeScript compilation succeeds
- [x] Verified fix addresses the root cause in `handleIssueAssigned` workflow
- [x] Maintains backward compatibility for teams without 'In Progress' state

🤖 Generated with [Claude Code](https://claude.ai/code)