### PR TITLE
Fix crash on issue unassignment by handling SIGTERM gracefully

### DIFF
--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -148,6 +148,10 @@ export class ClaudeRunner extends EventEmitter {
 
       if (error instanceof AbortError) {
         console.log('[ClaudeRunner] Session was aborted')
+      } else if (error instanceof Error && error.message.includes('Claude Code process exited with code 143')) {
+        // Exit code 143 is SIGTERM (128 + 15), which indicates graceful termination
+        // This is expected when the session is stopped during unassignment
+        console.log('[ClaudeRunner] Session was terminated gracefully (SIGTERM)')
       } else {
         this.emit('error', error instanceof Error ? error : new Error(String(error)))
       }

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -432,6 +432,20 @@ describe('ClaudeRunner', () => {
       expect(errorHandler).not.toHaveBeenCalled()
       expect(runner.isRunning()).toBe(false)
     })
+
+    it('should handle SIGTERM (exit code 143) gracefully', async () => {
+      const errorHandler = vi.fn()
+      runner.on('error', errorHandler)
+      
+      mockQuery.mockImplementation(async function* () {
+        throw new Error('Claude Code process exited with code 143')
+      })
+      
+      await runner.start('test')
+      
+      expect(errorHandler).not.toHaveBeenCalled()
+      expect(runner.isRunning()).toBe(false)
+    })
   })
 
   describe('Session Info', () => {


### PR DESCRIPTION
## Summary
- Fix crash when issues are unassigned during active Claude sessions
- Add graceful handling of SIGTERM (exit code 143) in ClaudeRunner
- Prevent EdgeWorker crashes during issue unassignment flow

## Problem
When an issue is unassigned while a Claude session is active, the EdgeWorker calls `runner.stop()` which sends SIGTERM to the Claude Code process. The process exits with code 143, but this expected termination was being treated as an error, causing the entire EdgeWorker to crash.

## Solution
Modified the ClaudeRunner error handling to specifically detect and handle "Claude Code process exited with code 143" as a graceful termination rather than an error. This prevents the error from being emitted and crashing the EdgeWorker.

## Changes
- **packages/claude-runner/src/ClaudeRunner.ts**: Added SIGTERM handling in error catch block
- **packages/claude-runner/test/ClaudeRunner.test.ts**: Added test case for SIGTERM handling

## Test Plan
- [x] All existing tests pass
- [x] New test verifies SIGTERM handling doesn't emit error events
- [x] Confirms session terminates gracefully with appropriate logging

🤖 Generated with [Claude Code](https://claude.ai/code)