### PR TITLE
CEA-103: Fix CLI wizard to match config.ts tool definitions

### DIFF
--- a/apps/cli/app.mjs
+++ b/apps/cli/app.mjs
@@ -118,7 +118,7 @@ class EdgeApp {
       
       // Ask for allowed tools configuration
       console.log('\n🔧 Tool Configuration')
-      console.log('Available tools: Read,Write,Edit,MultiEdit,Glob,Grep,LS,Task,WebFetch,TodoRead,TodoWrite,NotebookRead,NotebookEdit,Batch')
+      console.log('Available tools: Read(**),Edit(**),Bash,Task,WebFetch,WebSearch,TodoRead,TodoWrite,NotebookRead,NotebookEdit,Batch')
       console.log('')
       console.log('⚠️  SECURITY NOTE: Bash tool requires special configuration for safety:')
       console.log('   • Use "Bash" for full access (not recommended in production)')


### PR DESCRIPTION
## Summary
- Fixed CLI wizard to show the correct tool names that match the actual configuration
- Updated apps/cli/app.mjs to display tools using the correct format from config.ts
- Removed tools from CLI display that don't exist in the backend configuration

## Problem
The CLI wizard was displaying incorrect tool names that didn't match the actual 
configuration in packages/claude-runner/src/config.ts:
- CLI showed: `Read,Write,Edit,MultiEdit,Glob,Grep,LS,Task,WebFetch,TodoRead,TodoWrite,NotebookRead,NotebookEdit,Batch`
- Config actually defines: `Read(**),Edit(**),Bash,Task,WebFetch,WebSearch,TodoRead,TodoWrite,NotebookRead,NotebookEdit,Batch`

## Solution
Updated the CLI wizard to show exactly what tools are defined in config.ts:
- Use `Read(**)` and `Edit(**)` format (not plain `Read`, `Write`, `Edit`)
- Remove non-existent tools: `Write`, `MultiEdit`, `Glob`, `Grep`, `LS`
- Include all actual tools from config.ts in the correct format

## Test plan
- ✅ CLI wizard now displays the exact tool list from config.ts
- ✅ Tool format matches backend configuration expectations
- ✅ No phantom tools that don't exist in the backend

🤖 Generated with [Claude Code](https://claude.ai/code)