### PR TITLE
Update initial comment text to 'I'll get started right away'

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -968,7 +968,7 @@ Please analyze this issue and help implement a solution.`
    */
   private async postInitialComment(issueId: string, repositoryId: string): Promise<Comment | null> {
     try {
-      const body = "I've been assigned to this issue and am getting started right away. I'll update this comment with my plan shortly."
+      const body = "I'll get started right away. I'll update this comment with my plan shortly."
       
       // Get the Linear client for this repository
       const linearClient = this.linearClients.get(repositoryId)
@@ -1053,7 +1053,7 @@ Please analyze this issue and help implement a solution.`
 
       // Convert todos to Linear checklist format
       const checklist = this.formatTodosAsChecklist(todos)
-      const body = `I've been assigned to this issue and am getting started right away. Here's my plan:\n\n${checklist}`
+      const body = `I'll get started right away. Here's my plan:\n\n${checklist}`
 
       // Get the Linear client
       const linearClient = this.linearClients.get(repositoryId)

--- a/packages/edge-worker/test/EdgeWorker.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.test.ts
@@ -432,7 +432,7 @@ describe('EdgeWorker', () => {
       // The initial comment should be the only one posted
       expect(mockLinearClient.createComment).toHaveBeenCalledWith({
         issueId: 'issue-123',
-        body: "I've been assigned to this issue and am getting started right away. I'll update this comment with my plan shortly."
+        body: "I'll get started right away. I'll update this comment with my plan shortly."
       })
 
       // Should emit message events


### PR DESCRIPTION
## Summary
- Changed initial comment from "I've been assigned to this issue and am getting started right away" to "I'll get started right away"
- Updated corresponding test to match the new messaging
- More direct and concise messaging for Linear issue assignments

## Test plan
- [x] All existing tests pass
- [x] EdgeWorker.test.ts updated to match new text
- [x] No breaking changes to functionality

🤖 Generated with [Claude Code](https://claude.ai/code)