### PR TITLE
Add config options for OAuth callback hostname and port (CEA-122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - cyrus-ai@0.1.10
 
 ### Added
-- Added `OAUTH_CALLBACK_BASE_URL` environment variable to configure OAuth callback URL (defaults to `http://localhost:3457`)
+- Added `OAUTH_CALLBACK_BASE_URL` environment variable to configure OAuth callback URL (defaults to `http://localhost:3457`) ([#69](https://github.com/ceedaragents/cyrus/pull/69))
 - OAuth callback URL is now fully configurable for different deployment environments (Docker, remote development, custom domains)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### CLI
 - cyrus-ai@0.1.10
 
+### Added
+- Added `OAUTH_CALLBACK_BASE_URL` environment variable to configure OAuth callback URL (defaults to `http://localhost:3457`)
+- OAuth callback URL is now fully configurable for different deployment environments (Docker, remote development, custom domains)
+
 ### Changed
 - Renamed repository setup script from `secretagentsetup.sh` to `cyrus-setup.sh` for better naming consistency
 - Updated all references in codebase to use the new script name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable changes to this project will be documented in this file.
 - cyrus-ai@0.1.10
 
 ### Added
-- Added `OAUTH_CALLBACK_BASE_URL` environment variable to configure OAuth callback URL (defaults to `http://localhost:3457`) ([#69](https://github.com/ceedaragents/cyrus/pull/69))
+- Added `CYRUS_OAUTH_CALLBACK_BASE_URL` environment variable to configure OAuth callback URL (defaults to `http://localhost:3457`) ([#69](https://github.com/ceedaragents/cyrus/pull/69))
+- Added `CYRUS_OAUTH_CALLBACK_PORT` environment variable to configure OAuth callback port (defaults to `3457`)
 - OAuth callback URL is now fully configurable for different deployment environments (Docker, remote development, custom domains)
+- Supports `--env-file=path` option to load environment variables from custom file
 
 ### Changed
 - Renamed repository setup script from `secretagentsetup.sh` to `cyrus-setup.sh` for better naming consistency

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -226,7 +226,7 @@ class EdgeApp {
                 <p>You can close this window and return to the terminal.</p>
                 <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
                 <p style="margin-top: 30px;">
-                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=http://localhost:${port}/callback" 
+                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=http://${process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'}:${port}/callback" 
                      style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                     Connect Another Workspace
                   </a>
@@ -274,7 +274,7 @@ class EdgeApp {
    * Start OAuth flow to get Linear token
    */
   async startOAuthFlow(proxyUrl: string): Promise<LinearCredentials> {
-    const port = 3457 // Different from proxy port
+    const port = parseInt(process.env.OAUTH_CALLBACK_PORT || '3457', 10) // Different from proxy port
     
     // Ensure OAuth server is running
     if (!this.oauthServer) {
@@ -289,7 +289,8 @@ class EdgeApp {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const authUrl = `${proxyUrl}/oauth/authorize?callback=http://localhost:${port}/callback`
+      const hostname = process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'
+      const authUrl = `${proxyUrl}/oauth/authorize?callback=http://${hostname}:${port}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
       console.log(`If the browser doesn't open, visit: ${authUrl}`)
@@ -358,12 +359,13 @@ class EdgeApp {
       // No need to validate Claude CLI - using Claude TypeScript SDK now
       
       // Start OAuth server immediately for easy access
-      const oauthPort = 3457
+      const oauthPort = parseInt(process.env.OAUTH_CALLBACK_PORT || '3457', 10)
+      const oauthHostname = process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'
       if (!this.oauthServer) {
         this.startOAuthServer(oauthPort)
         console.log(`\n🔐 OAuth server running on port ${oauthPort}`)
         console.log(`👉 To authorize Linear (new workspace or re-auth):`)
-        console.log(`   ${proxyUrl}/oauth/authorize?callback=http://localhost:${oauthPort}/callback`)
+        console.log(`   ${proxyUrl}/oauth/authorize?callback=http://${oauthHostname}:${oauthPort}/callback`)
         console.log('─'.repeat(70))
         
         // Set up handler for OAuth completions to automatically trigger repository setup

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -226,7 +226,7 @@ class EdgeApp {
                 <p>You can close this window and return to the terminal.</p>
                 <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
                 <p style="margin-top: 30px;">
-                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`}/callback" 
+                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`}/callback" 
                      style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                     Connect Another Workspace
                   </a>
@@ -274,7 +274,7 @@ class EdgeApp {
    * Start OAuth flow to get Linear token
    */
   async startOAuthFlow(proxyUrl: string): Promise<LinearCredentials> {
-    const port = parseInt(process.env.OAUTH_CALLBACK_PORT || '3457', 10) // Different from proxy port
+    const port = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10) // Different from proxy port
     
     // Ensure OAuth server is running
     if (!this.oauthServer) {
@@ -289,7 +289,7 @@ class EdgeApp {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const callbackBaseUrl = process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
+      const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
       const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
@@ -359,8 +359,8 @@ class EdgeApp {
       // No need to validate Claude CLI - using Claude TypeScript SDK now
       
       // Start OAuth server immediately for easy access
-      const oauthPort = parseInt(process.env.OAUTH_CALLBACK_PORT || '3457', 10)
-      const oauthCallbackBaseUrl = process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${oauthPort}`
+      const oauthPort = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10)
+      const oauthCallbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${oauthPort}`
       if (!this.oauthServer) {
         this.startOAuthServer(oauthPort)
         console.log(`\n🔐 OAuth server running on port ${oauthPort}`)

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -226,7 +226,7 @@ class EdgeApp {
                 <p>You can close this window and return to the terminal.</p>
                 <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
                 <p style="margin-top: 30px;">
-                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=http://${process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'}:${port}/callback" 
+                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`}/callback" 
                      style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                     Connect Another Workspace
                   </a>
@@ -289,8 +289,8 @@ class EdgeApp {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const hostname = process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'
-      const authUrl = `${proxyUrl}/oauth/authorize?callback=http://${hostname}:${port}/callback`
+      const callbackBaseUrl = process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
+      const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
       console.log(`If the browser doesn't open, visit: ${authUrl}`)
@@ -360,12 +360,12 @@ class EdgeApp {
       
       // Start OAuth server immediately for easy access
       const oauthPort = parseInt(process.env.OAUTH_CALLBACK_PORT || '3457', 10)
-      const oauthHostname = process.env.OAUTH_CALLBACK_HOSTNAME || 'localhost'
+      const oauthCallbackBaseUrl = process.env.OAUTH_CALLBACK_BASE_URL || `http://localhost:${oauthPort}`
       if (!this.oauthServer) {
         this.startOAuthServer(oauthPort)
         console.log(`\n🔐 OAuth server running on port ${oauthPort}`)
         console.log(`👉 To authorize Linear (new workspace or re-auth):`)
-        console.log(`   ${proxyUrl}/oauth/authorize?callback=http://${oauthHostname}:${oauthPort}/callback`)
+        console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)
         console.log('─'.repeat(70))
         
         // Set up handler for OAuth completions to automatically trigger repository setup


### PR DESCRIPTION
## Summary
- Add `OAUTH_CALLBACK_BASE_URL` environment variable (defaults to 'http://localhost:3457')
- Replace hardcoded localhost:3457 references with configurable base URL
- Fixes issue where OAuth callback URL was hardcoded and couldn't be customized for different environments
- Provides full flexibility without assuming port format

## Changes
- Modified `apps/cli/app.ts` to use `OAUTH_CALLBACK_BASE_URL` environment variable
- Updated OAuth URL construction, console output, and HTML templates to use configurable base URL
- Maintains backward compatibility with existing defaults
- Allows users to specify complete URLs with or without ports

## Test plan
- [ ] Test with default values (should work exactly as before)
- [ ] Test with custom `OAUTH_CALLBACK_BASE_URL=https://my-domain.com`
- [ ] Test with custom `OAUTH_CALLBACK_BASE_URL=http://my-host:8080`
- [ ] Verify OAuth flow completes successfully with custom values
- [ ] Check that console output and HTML templates show correct URLs

## Usage
```bash
# Examples of different base URL configurations:
export OAUTH_CALLBACK_BASE_URL=https://my-domain.com
# OAuth callback will use: https://my-domain.com/callback

export OAUTH_CALLBACK_BASE_URL=http://my-host:8080  
# OAuth callback will use: http://my-host:8080/callback

# Default (no env var set):
# OAuth callback will use: http://localhost:3457/callback
```

This approach provides maximum flexibility - users can specify the complete base URL (with or without port, HTTP or HTTPS) and the system simply appends `/callback` to it.

Closes CEA-122

🤖 Generated with [Claude Code](https://claude.ai/code)