### PR TITLE
Fix context loss in comment continuations

### DIFF
--- a/packages/edge-worker/test/EdgeWorker.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.test.ts
@@ -357,8 +357,9 @@ describe('EdgeWorker', () => {
       const webhook = mockCommentWebhook({}, { body: '@cyrus please help with this' })
       await webhookHandler(webhook)
 
-      // Should start new session with comment as prompt
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('@cyrus please help with this')
+      // Should start new session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('@cyrus please help with this'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should handle issue unassignment', async () => {
@@ -613,8 +614,9 @@ describe('EdgeWorker', () => {
       })
       await webhookHandler(webhook)
 
-      // Should start Claude session since agent is mentioned
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @cyrus, can you help with this?')
+      // Should start Claude session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @cyrus, can you help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should trigger when agent is mentioned by display name', async () => {
@@ -628,8 +630,9 @@ describe('EdgeWorker', () => {
       })
       await webhookHandler(webhook)
 
-      // Should start Claude session since agent is mentioned
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @"Cyrus Agent", can you help with this?')
+      // Should start Claude session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @"Cyrus Agent", can you help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should trigger when agent is mentioned by user ID', async () => {
@@ -643,8 +646,9 @@ describe('EdgeWorker', () => {
       })
       await webhookHandler(webhook)
 
-      // Should start Claude session since agent is mentioned
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @cyrus-user-id, can you help with this?')
+      // Should start Claude session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @cyrus-user-id, can you help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should NOT trigger when only other users are mentioned', async () => {
@@ -688,8 +692,9 @@ describe('EdgeWorker', () => {
       })
       await webhookHandler(webhook)
 
-      // Should start Claude session since agent is mentioned (even with others)
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @john, @cyrus, and @jane, can you all help with this?')
+      // Should start Claude session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @john, @cyrus, and @jane, can you all help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should be case-insensitive when checking mentions by name', async () => {
@@ -703,8 +708,9 @@ describe('EdgeWorker', () => {
       })
       await webhookHandler(webhook)
 
-      // Should start Claude session since agent is mentioned (case-insensitive)
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @CYRUS, can you help with this?')
+      // Should start Claude session with continuation prompt
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @CYRUS, can you help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should still work when viewer information is unavailable', async () => {
@@ -722,7 +728,8 @@ describe('EdgeWorker', () => {
       await webhookHandler(webhook)
 
       // Should err on the side of caution and trigger when viewer info is unavailable
-      expect(mockClaudeRunner.start).toHaveBeenCalledWith('Hey @cyrus, can you help with this?')
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('Hey @cyrus, can you help with this?'))
+      expect(mockClaudeRunner.start).toHaveBeenCalledWith(expect.stringContaining('## Current Context'))
     })
 
     it('should NOT trigger when Linear client is unavailable', async () => {


### PR DESCRIPTION
## Summary
Fixes the core issue where Cyrus only responds properly to mentions at the beginning of Linear comments. The problem was that follow-up comment mentions were receiving only the raw comment text without proper context.

## Root Cause
When Cyrus processes follow-up comments (continuation flow), it was passing only `comment.body` to Claude Code instead of building a proper prompt with repository, issue, and working directory context. This meant mentions at the end of comments were detected correctly but lacked the context needed to respond appropriately.

## Changes Made
- **Fixed continuation prompt building**: Replace raw comment body with `buildContinuationPrompt()` method
- **Added proper context**: Continuation prompts now include repository name, issue details, state, working directory, and base branch
- **Updated tests**: Modified test expectations to match new continuation prompt format
- **Maintained backward compatibility**: Initial assignments still use full template, continuations use simplified context

## Before/After Comparison

**Before (context-less):**
```
can you open a pull request to ceedaragents/cyrus repo @cyrus
```

**After (with context):**
```
## Current Context

**Repository**: Test Repository
**Issue**: CEA-123 - Fix mention detection
**State**: In Progress
**Working Directory**: /path/to/workspace
**Base Branch**: main

## Latest Request

can you open a pull request to ceedaragents/cyrus repo @cyrus

Please continue working on this issue based on the request above.
```

## Test Plan
- [x] All 48 tests pass
- [x] TypeScript compilation succeeds
- [x] Build succeeds
- [x] Mention detection still works for all positions
- [x] Context is properly provided for continuation comments

🤖 Generated with [Claude Code](https://claude.ai/code)