### PR TITLE
Fix port mapping bug and refactor callback URL logic

### DIFF
--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -71,6 +71,32 @@ class EdgeApp {
   private onOAuthComplete?: (credentials: LinearCredentials) => Promise<void>
 
   /**
+   * Get the OAuth callback URL with proper port handling
+   */
+  private static get CALLBACK_URL(): string {
+    const port = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10)
+    const baseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL
+    
+    if (baseUrl) {
+      // If custom base URL is provided, check if it already includes a port
+      // If not, and a port override is specified, use the override
+      try {
+        const url = new URL(baseUrl)
+        // If no port is specified in the URL and we have a port override, use it
+        if (!url.port && process.env.CYRUS_OAUTH_CALLBACK_PORT) {
+          url.port = port.toString()
+        }
+        return url.toString().replace(/\/$/, '') // Remove trailing slash
+      } catch {
+        // If URL parsing fails, fall back to localhost with port
+        return `http://localhost:${port}`
+      }
+    }
+    
+    return `http://localhost:${port}`
+  }
+
+  /**
    * Load edge configuration (credentials and repositories)
    * Note: Strips promptTemplatePath from all repositories to ensure built-in template is used
    */
@@ -289,8 +315,7 @@ class EdgeApp {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
-      const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
+      const authUrl = `${proxyUrl}/oauth/authorize?callback=${EdgeApp.CALLBACK_URL}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
       console.log(`If the browser doesn't open, visit: ${authUrl}`)
@@ -360,12 +385,11 @@ class EdgeApp {
       
       // Start OAuth server immediately for easy access
       const oauthPort = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10)
-      const oauthCallbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${oauthPort}`
       if (!this.oauthServer) {
         this.startOAuthServer(oauthPort)
         console.log(`\n🔐 OAuth server running on port ${oauthPort}`)
         console.log(`👉 To authorize Linear (new workspace or re-auth):`)
-        console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)
+        console.log(`   ${proxyUrl}/oauth/authorize?callback=${EdgeApp.CALLBACK_URL}/callback`)
         console.log('─'.repeat(70))
         
         // Set up handler for OAuth completions to automatically trigger repository setup


### PR DESCRIPTION
## Summary
- Fixed bug where `CYRUS_OAUTH_CALLBACK_PORT` override was ignored when `CYRUS_OAUTH_CALLBACK_BASE_URL` was specified
- Refactored duplicated callback URL logic into a private static getter `CALLBACK_URL`
- Enhanced port handling to respect port overrides even with custom base URLs

## Changes Made
1. **Bug Fix**: The original issue was in `apps/cli/app.ts` where when `CYRUS_OAUTH_CALLBACK_BASE_URL` was provided, the `CYRUS_OAUTH_CALLBACK_PORT` was completely ignored. Now when a custom base URL is provided without a port, it will automatically use the port override if specified.

2. **Refactoring**: Created a `private static get CALLBACK_URL()` method that:
   - Handles all callback URL logic in one place
   - Eliminates code duplication (was repeated in two locations)
   - Provides consistent behavior across the application
   - Includes proper error handling for invalid URLs

## Test Cases Covered
- Default behavior (no environment variables): `http://localhost:3457`
- Custom port only: `http://localhost:8080`  
- Custom base URL without port + port override: `http://example.com:9000` ✅ **This was the bug**
- Custom base URL with existing port: `http://example.com:5000` (respects existing port)
- Invalid base URL: Falls back to `http://localhost:${port}`

## Breaking Changes
None - this is a bug fix that maintains backward compatibility while fixing the port override issue.

🤖 Generated with [Claude Code](https://claude.ai/code)