### PR TITLE
feat: Consolidate OAuth and webhook servers into single port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Consolidated `CYRUS_OAUTH_CALLBACK_BASE_URL` and `CYRUS_WEBHOOK_BASE_URL` into single `CYRUS_WEBHOOK_BASE_URL` environment variable
+  - **Action Required**: Remove `CYRUS_OAUTH_CALLBACK_BASE_URL` from environment configuration
+  - **Action Required**: Use `CYRUS_WEBHOOK_BASE_URL` for both webhook and OAuth callback URLs since they run on the same server
+  - OAuth callbacks now use the same base URL as webhooks (both run on shared application server)
+
 ## [0.1.19] - 2025-01-04
 
 ### CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **BREAKING**: Consolidated `CYRUS_OAUTH_CALLBACK_BASE_URL` and `CYRUS_WEBHOOK_BASE_URL` into single `CYRUS_WEBHOOK_BASE_URL` environment variable
-  - **Action Required**: Remove `CYRUS_OAUTH_CALLBACK_BASE_URL` from environment configuration
-  - **Action Required**: Use `CYRUS_WEBHOOK_BASE_URL` for both webhook and OAuth callback URLs since they run on the same server
-  - OAuth callbacks now use the same base URL as webhooks (both run on shared application server)
+- **BREAKING**: Renamed `CYRUS_WEBHOOK_BASE_URL` to `CYRUS_BASE_URL` for clearer naming
+  - **Action Required**: Update environment configuration to use `CYRUS_BASE_URL` instead of `CYRUS_WEBHOOK_BASE_URL`
+  - **Legacy Support**: `CYRUS_WEBHOOK_BASE_URL` is still supported for backward compatibility but deprecated
+  - The variable serves both webhook and OAuth callback purposes since they run on the same server
 
 ## [0.1.19] - 2025-01-04
 
@@ -20,14 +20,14 @@ All notable changes to this project will be documented in this file.
 - Added `CYRUS_OAUTH_CALLBACK_PORT` environment variable to configure OAuth callback port (defaults to `3457`)
 - OAuth callback URL is now fully configurable for different deployment environments (Docker, remote development, custom domains)
 - Supports `--env-file=path` option to load environment variables from custom file
-- Added `CYRUS_WEBHOOK_BASE_URL` environment variable to configure webhook base URL for edge workers ([#74](https://github.com/ceedaragents/cyrus/pull/74))
+- Added `CYRUS_BASE_URL` environment variable to configure base URL for edge workers ([#74](https://github.com/ceedaragents/cyrus/pull/74))
 - Added `CYRUS_WEBHOOK_PORT` environment variable to configure webhook port (defaults to random port 3000-3999)
 - Implemented shared webhook server architecture to eliminate port conflicts between multiple Linear tokens
 
 ### Changed
 - **BREAKING**: Migrated from Server-Sent Events (SSE) to webhook-only architecture ([#74](https://github.com/ceedaragents/cyrus/pull/74))
   - **Action Required**: Edge workers now receive webhooks instead of SSE streams
-  - **Action Required**: Set `CYRUS_WEBHOOK_BASE_URL` environment variable if using custom deployment URLs (e.g., ngrok tunnel, server domain)
+  - **Action Required**: Set `CYRUS_BASE_URL` environment variable if using custom deployment URLs (e.g., ngrok tunnel, server domain)
   - **Action Required**: Set `CYRUS_WEBHOOK_PORT=3456` environment variable to ensure consistent webhook port
   - **Action Required**: Ensure edge workers can receive inbound HTTP requests on webhook ports
 - Renamed repository setup script from `secretagentsetup.sh` to `cyrus-setup.sh`

--- a/README.md
+++ b/README.md
@@ -95,12 +95,15 @@ claude
 
 ```bash
 CYRUS_OAUTH_CALLBACK_BASE_URL=<your domain here>
-# Include if not on default port
-CYRUS_OAUTH_CALLBACK_PORT=<port>
+# Server configuration (handles both webhooks and OAuth callbacks)
+CYRUS_SERVER_PORT=3456
 
 # Webhook configuration (required for Linear integration)
 CYRUS_WEBHOOK_BASE_URL=<your publicly accessible webhook URL>
-CYRUS_WEBHOOK_PORT=3456
+
+# Legacy environment variables (still supported for backward compatibility)
+# CYRUS_WEBHOOK_PORT=3456  # Use CYRUS_SERVER_PORT instead
+# CYRUS_OAUTH_CALLBACK_PORT=3457  # No longer used - OAuth runs on same port as webhooks
 ```
 
 ### Webhook Configuration Options
@@ -117,7 +120,7 @@ ngrok http 3456
 
 # Set the environment variables
 export CYRUS_WEBHOOK_BASE_URL=https://abc123.ngrok-free.app
-export CYRUS_WEBHOOK_PORT=3456
+export CYRUS_SERVER_PORT=3456
 ```
 
 **Option 2: Direct server with domain/IP**
@@ -126,14 +129,14 @@ export CYRUS_WEBHOOK_PORT=3456
 export CYRUS_WEBHOOK_BASE_URL=https://your-domain.com
 # or
 export CYRUS_WEBHOOK_BASE_URL=http://your-server-ip
-export CYRUS_WEBHOOK_PORT=3456
+export CYRUS_SERVER_PORT=3456
 ```
 
 **Option 3: Behind reverse proxy (nginx, caddy, etc.)**
 ```bash
-# Configure your reverse proxy to forward /webhook to localhost:3456
+# Configure your reverse proxy to forward /webhook and /callback to localhost:3456
 export CYRUS_WEBHOOK_BASE_URL=https://your-domain.com
-export CYRUS_WEBHOOK_PORT=3456
+export CYRUS_SERVER_PORT=3456
 ```
 
 8. Start the cyrus server

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ claude
 # Server configuration (handles both webhooks and OAuth callbacks)
 CYRUS_SERVER_PORT=3456
 
-# Webhook configuration (required for Linear integration)
-CYRUS_WEBHOOK_BASE_URL=<your publicly accessible webhook URL>
+# Base URL configuration (required for Linear integration - handles both webhooks and OAuth)
+CYRUS_BASE_URL=<your publicly accessible URL>
 
 # Legacy environment variables (still supported for backward compatibility)
+# CYRUS_WEBHOOK_BASE_URL=<url>  # Use CYRUS_BASE_URL instead
 # CYRUS_WEBHOOK_PORT=3456  # Use CYRUS_SERVER_PORT instead
 ```
 
@@ -117,23 +118,23 @@ ngrok http 3456
 # Ctrl+B then D to detach
 
 # Set the environment variables
-export CYRUS_WEBHOOK_BASE_URL=https://abc123.ngrok-free.app
+export CYRUS_BASE_URL=https://abc123.ngrok-free.app
 export CYRUS_SERVER_PORT=3456
 ```
 
 **Option 2: Direct server with domain/IP**
 ```bash
 # If your server has a public IP or domain
-export CYRUS_WEBHOOK_BASE_URL=https://your-domain.com
+export CYRUS_BASE_URL=https://your-domain.com
 # or
-export CYRUS_WEBHOOK_BASE_URL=http://your-server-ip
+export CYRUS_BASE_URL=http://your-server-ip
 export CYRUS_SERVER_PORT=3456
 ```
 
 **Option 3: Behind reverse proxy (nginx, caddy, etc.)**
 ```bash
 # Configure your reverse proxy to forward /webhook and /callback to localhost:3456
-export CYRUS_WEBHOOK_BASE_URL=https://your-domain.com
+export CYRUS_BASE_URL=https://your-domain.com
 export CYRUS_SERVER_PORT=3456
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ claude
 7. Configure an environment variable file to specify your domain and webhook settings
 
 ```bash
-CYRUS_OAUTH_CALLBACK_BASE_URL=<your domain here>
 # Server configuration (handles both webhooks and OAuth callbacks)
 CYRUS_SERVER_PORT=3456
 
@@ -103,7 +102,6 @@ CYRUS_WEBHOOK_BASE_URL=<your publicly accessible webhook URL>
 
 # Legacy environment variables (still supported for backward compatibility)
 # CYRUS_WEBHOOK_PORT=3456  # Use CYRUS_SERVER_PORT instead
-# CYRUS_OAUTH_CALLBACK_PORT=3457  # No longer used - OAuth runs on same port as webhooks
 ```
 
 ### Webhook Configuration Options

--- a/WEBHOOK_ARCHITECTURE_PROPOSAL.md
+++ b/WEBHOOK_ARCHITECTURE_PROPOSAL.md
@@ -253,7 +253,7 @@ class NdjsonClient extends EventEmitter {
 - **Complete SSE removal**: All flaky SSE transport code eliminated
 - **Webhook architecture**: Fully functional with HMAC-SHA256 security
 - **Transport abstraction**: `BaseTransport` and `WebhookTransport` classes implemented
-- **webhookBaseUrl support**: Added via `CYRUS_WEBHOOK_BASE_URL` environment variable
+- **baseUrl support**: Added via `CYRUS_BASE_URL` environment variable
 - **All tests passing**: 109 tests across all packages (15 new webhook tests)
 - **Build success**: All TypeScript compilation successful
 

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -6,11 +6,8 @@ import dotenv from 'dotenv'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { resolve, dirname, basename } from 'path'
 import { fileURLToPath } from 'url'
-import { createServer, type Server } from 'http'
-import { URL } from 'url'
 import open from 'open'
 import readline from 'readline'
-import type { IncomingMessage, ServerResponse } from 'http'
 
 // Parse command line arguments
 const args = process.argv.slice(2)
@@ -48,11 +45,6 @@ interface EdgeConfig {
   repositories: RepositoryConfig[]
 }
 
-interface OAuthCallback {
-  resolve: (credentials: LinearCredentials) => void
-  reject: (error: Error) => void
-  id: string
-}
 
 interface Workspace {
   path: string
@@ -66,9 +58,6 @@ interface Workspace {
 class EdgeApp {
   private edgeWorker: EdgeWorker | null = null
   private isShuttingDown = false
-  private oauthServer: Server | null = null
-  private oauthCallbacks: Map<string, OAuthCallback> = new Map()
-  private onOAuthComplete?: (credentials: LinearCredentials) => Promise<void>
 
   /**
    * Load edge configuration (credentials and repositories)
@@ -188,128 +177,33 @@ class EdgeApp {
     }
   }
   
-  /**
-   * Start OAuth server to handle callbacks
-   */
-  startOAuthServer(port: number): void {
-    if (this.oauthServer) return // Already running
-    
-    this.oauthCallbacks = new Map() // Store pending callbacks
-    
-    this.oauthServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-      const url = new URL(req.url!, `http://localhost:${port}`)
-      
-      if (url.pathname === '/callback') {
-        const token = url.searchParams.get('token')
-        const workspaceId = url.searchParams.get('workspaceId')
-        const workspaceName = url.searchParams.get('workspaceName')
-        
-        if (token && workspaceId && workspaceName) {
-          // Success! Return the Linear credentials (don't save yet)
-          const linearCredentials: LinearCredentials = { 
-            linearToken: token,
-            linearWorkspaceId: workspaceId,
-            linearWorkspaceName: workspaceName
-          }
-          
-          // Send success response
-          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-          res.end(`
-            <!DOCTYPE html>
-            <html>
-              <head>
-                <meta charset="UTF-8">
-                <title>Authorization Successful</title>
-              </head>
-              <body style="font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px;">
-                <h1>✅ Authorization Successful!</h1>
-                <p>You can close this window and return to the terminal.</p>
-                <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
-                <p style="margin-top: 30px;">
-                  <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`}/callback" 
-                     style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
-                    Connect Another Workspace
-                  </a>
-                </p>
-                <script>setTimeout(() => window.close(), 10000)</script>
-              </body>
-            </html>
-          `)
-          
-          // Emit event for any waiting promise
-          if (this.oauthCallbacks.size > 0) {
-            const callback = this.oauthCallbacks.values().next().value
-            if (callback) {
-              callback.resolve(linearCredentials)
-              this.oauthCallbacks.delete(callback.id)
-            }
-          }
-          
-          // Also emit event for edge app to handle
-          if (this.onOAuthComplete) {
-            this.onOAuthComplete(linearCredentials)
-          }
-        } else {
-          res.writeHead(400, { 'Content-Type': 'text/html' })
-          res.end('<h1>Error: No token received</h1>')
-          
-          // Reject any waiting promises
-          for (const [id, callback] of this.oauthCallbacks) {
-            callback.reject(new Error('No token received'))
-            this.oauthCallbacks.delete(id)
-          }
-        }
-      } else {
-        res.writeHead(404)
-        res.end('Not found')
-      }
-    })
-    
-    this.oauthServer.listen(port, () => {
-      console.log(`OAuth callback server listening on port ${port}`)
-    })
-  }
   
   /**
-   * Start OAuth flow to get Linear token
+   * Start OAuth flow to get Linear token using EdgeWorker's shared server
    */
   async startOAuthFlow(proxyUrl: string): Promise<LinearCredentials> {
-    const port = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10) // Different from proxy port
-    
-    // Ensure OAuth server is running
-    if (!this.oauthServer) {
-      this.startOAuthServer(port)
+    if (!this.edgeWorker) {
+      throw new Error('EdgeWorker not initialized')
     }
     
-    return new Promise<LinearCredentials>((resolve, reject) => {
-      // Generate unique ID for this flow
-      const flowId = Date.now().toString()
-      
-      // Store callback for this flow
-      this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
-      
-      // Construct OAuth URL with callback
-      const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
-      const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
-      
-      console.log(`\n👉 Opening your browser to authorize with Linear...`)
-      console.log(`If the browser doesn't open, visit: ${authUrl}`)
-      
-      open(authUrl).catch(() => {
-        console.log(`\n⚠️  Could not open browser automatically`)
-        console.log(`Please visit: ${authUrl}`)
-      })
-      
-      console.log(`\n⏳ Waiting for authorization...`)
-      
-      // Timeout after 5 minutes
-      setTimeout(() => {
-        if (this.oauthCallbacks.has(flowId)) {
-          this.oauthCallbacks.delete(flowId)
-          reject(new Error('OAuth timeout'))
-        }
-      }, 5 * 60 * 1000)
+    const port = this.edgeWorker.getServerPort()
+    
+    // Construct OAuth URL with callback
+    const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
+    const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
+    
+    console.log(`\n👉 Opening your browser to authorize with Linear...`)
+    console.log(`If the browser doesn't open, visit: ${authUrl}`)
+    
+    open(authUrl).catch(() => {
+      console.log(`\n⚠️  Could not open browser automatically`)
+      console.log(`Please visit: ${authUrl}`)
     })
+    
+    console.log(`\n⏳ Waiting for authorization...`)
+    
+    // Use EdgeWorker's OAuth flow
+    return this.edgeWorker.startOAuthFlow(proxyUrl)
   }
   
   /**
@@ -322,58 +216,26 @@ class EdgeApp {
       repositories,
       defaultAllowedTools: process.env.ALLOWED_TOOLS?.split(',').map(t => t.trim()) || [],
       webhookBaseUrl: process.env.CYRUS_WEBHOOK_BASE_URL,
+      webhookPort: process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : undefined,
+      serverPort: process.env.CYRUS_SERVER_PORT ? parseInt(process.env.CYRUS_SERVER_PORT, 10) : 
+                  process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : 3456,
       features: {
         enableContinuation: true
       },
       handlers: {
         createWorkspace: async (issue: Issue, repository: RepositoryConfig): Promise<Workspace> => {
           return this.createGitWorktree(issue, repository)
-        }
-      }
-    }
-    
-    // Create and start EdgeWorker
-    this.edgeWorker = new EdgeWorker(config)
-    
-    // Set up event handlers
-    this.setupEventHandlers()
-    
-    // Start the worker
-    await this.edgeWorker.start()
-    
-    console.log('\n✅ Edge worker started successfully')
-    console.log(`Connected to proxy: ${config.proxyUrl}`)
-    console.log(`Managing ${repositories.length} repositories:`)
-    repositories.forEach(repo => {
-      console.log(`  - ${repo.name} (${repo.repositoryPath})`)
-    })
-  }
-
-  /**
-   * Start the edge application
-   */
-  async start(): Promise<void> {
-    try {
-      // Set proxy URL with default
-      const proxyUrl = process.env.PROXY_URL || 'https://cyrus-proxy.ceedar.workers.dev'
-      
-      // No need to validate Claude CLI - using Claude TypeScript SDK now
-      
-      // Start OAuth server immediately for easy access
-      const oauthPort = parseInt(process.env.CYRUS_OAUTH_CALLBACK_PORT || '3457', 10)
-      const oauthCallbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${oauthPort}`
-      if (!this.oauthServer) {
-        this.startOAuthServer(oauthPort)
-        console.log(`\n🔐 OAuth server running on port ${oauthPort}`)
-        console.log(`👉 To authorize Linear (new workspace or re-auth):`)
-        console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)
-        console.log('─'.repeat(70))
-        
-        // Set up handler for OAuth completions to automatically trigger repository setup
-        this.onOAuthComplete = async (linearCredentials: LinearCredentials): Promise<void> => {
+        },
+        onOAuthCallback: async (token: string, workspaceId: string, workspaceName: string): Promise<void> => {
+          const linearCredentials: LinearCredentials = {
+            linearToken: token,
+            linearWorkspaceId: workspaceId,
+            linearWorkspaceName: workspaceName
+          }
+          
+          // Handle OAuth completion for repository setup
           if (this.edgeWorker) {
-            // If edge worker is already running, just set up a new repository
-            console.log('\n📋 Setting up new repository for workspace:', linearCredentials.linearWorkspaceName)
+            console.log('\n📋 Setting up new repository for workspace:', workspaceName)
             console.log('─'.repeat(50))
             
             try {
@@ -401,7 +263,6 @@ class EdgeApp {
               const updatedConfig = this.loadEdgeConfig()
               console.log(`\n🔄 Reloading with ${updatedConfig.repositories?.length || 0} repositories from config file`)
               
-              const proxyUrl = process.env.PROXY_URL || 'https://cyrus-proxy.ceedar.workers.dev'
               return this.startEdgeWorker({ 
                 proxyUrl, 
                 repositories: updatedConfig.repositories || [] 
@@ -413,6 +274,35 @@ class EdgeApp {
           }
         }
       }
+    }
+    
+    // Create and start EdgeWorker
+    this.edgeWorker = new EdgeWorker(config)
+    
+    // Set up event handlers
+    this.setupEventHandlers()
+    
+    // Start the worker
+    await this.edgeWorker.start()
+    
+    console.log('\n✅ Edge worker started successfully')
+    console.log(`Configured proxy URL: ${config.proxyUrl}`)
+    console.log(`Managing ${repositories.length} repositories:`)
+    repositories.forEach(repo => {
+      console.log(`  - ${repo.name} (${repo.repositoryPath})`)
+    })
+  }
+
+  /**
+   * Start the edge application
+   */
+  async start(): Promise<void> {
+    try {
+      // Set proxy URL with default
+      const proxyUrl = process.env.PROXY_URL || 'https://cyrus-proxy.ceedar.workers.dev'
+      
+      // No need to validate Claude CLI - using Claude TypeScript SDK now
+      
       
       // Load edge configuration
       let edgeConfig = this.loadEdgeConfig()
@@ -495,7 +385,7 @@ class EdgeApp {
           }
           
           if (linearCredentials) {
-            console.log('(Use the authorization link above to connect a different workspace)')
+            console.log('(OAuth server will start with EdgeWorker to connect additional workspaces)')
           }
         } else {
           // Get new Linear credentials
@@ -567,6 +457,14 @@ class EdgeApp {
       
       // Start the edge worker
       await this.startEdgeWorker({ proxyUrl, repositories })
+      
+      // Display OAuth information after EdgeWorker is started
+      const serverPort = this.edgeWorker?.getServerPort() || 3456
+      const oauthCallbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${serverPort}`
+      console.log(`\n🔐 OAuth server running on port ${serverPort}`)
+      console.log(`👉 To authorize Linear (new workspace or re-auth):`)
+      console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)
+      console.log('─'.repeat(70))
       
       // Handle graceful shutdown
       process.on('SIGINT', () => this.shutdown())
@@ -742,12 +640,7 @@ class EdgeApp {
     
     console.log('\nShutting down edge worker...')
     
-    // Close OAuth server if running
-    if (this.oauthServer) {
-      this.oauthServer.close()
-    }
-    
-    // Stop edge worker
+    // Stop edge worker (includes stopping shared application server)
     if (this.edgeWorker) {
       await this.edgeWorker.stop()
     }

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -189,7 +189,7 @@ class EdgeApp {
     const port = this.edgeWorker.getServerPort()
     
     // Construct OAuth URL with callback
-    const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${port}`
+    const callbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${port}`
     const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
     
     console.log(`\n👉 Opening your browser to authorize with Linear...`)
@@ -460,7 +460,7 @@ class EdgeApp {
       
       // Display OAuth information after EdgeWorker is started
       const serverPort = this.edgeWorker?.getServerPort() || 3456
-      const oauthCallbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${serverPort}`
+      const oauthCallbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${serverPort}`
       console.log(`\n🔐 OAuth server running on port ${serverPort}`)
       console.log(`👉 To authorize Linear (new workspace or re-auth):`)
       console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -189,7 +189,7 @@ class EdgeApp {
     const port = this.edgeWorker.getServerPort()
     
     // Construct OAuth URL with callback
-    const callbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${port}`
+    const callbackBaseUrl = process.env.CYRUS_BASE_URL || `http://localhost:${port}`
     const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
     
     console.log(`\n👉 Opening your browser to authorize with Linear...`)
@@ -215,7 +215,7 @@ class EdgeApp {
       proxyUrl,
       repositories,
       defaultAllowedTools: process.env.ALLOWED_TOOLS?.split(',').map(t => t.trim()) || [],
-      webhookBaseUrl: process.env.CYRUS_WEBHOOK_BASE_URL,
+      webhookBaseUrl: process.env.CYRUS_BASE_URL,
       webhookPort: process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : undefined,
       serverPort: process.env.CYRUS_SERVER_PORT ? parseInt(process.env.CYRUS_SERVER_PORT, 10) : 
                   process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : 3456,
@@ -460,7 +460,7 @@ class EdgeApp {
       
       // Display OAuth information after EdgeWorker is started
       const serverPort = this.edgeWorker?.getServerPort() || 3456
-      const oauthCallbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${serverPort}`
+      const oauthCallbackBaseUrl = process.env.CYRUS_BASE_URL || `http://localhost:${serverPort}`
       console.log(`\n🔐 OAuth server running on port ${serverPort}`)
       console.log(`👉 To authorize Linear (new workspace or re-auth):`)
       console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Core business logic for Cyrus",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -13,6 +13,7 @@ import type {
   LinearWebhookIssue,
   LinearWebhookComment
 } from 'cyrus-core'
+import { SharedApplicationServer } from './SharedApplicationServer.js'
 import {
   isIssueAssignedWebhook,
   isIssueCommentMentionWebhook,
@@ -46,11 +47,21 @@ export class EdgeWorker extends EventEmitter {
   private sessionToRepo: Map<string, string> = new Map() // Maps session ID to repository ID
   private issueToCommentId: Map<string, string> = new Map() // Maps issue ID to initial comment ID
   private issueToReplyContext: Map<string, { commentId: string; parentId?: string }> = new Map() // Maps issue ID to reply context
+  private sharedApplicationServer: SharedApplicationServer
 
   constructor(config: EdgeWorkerConfig) {
     super()
     this.config = config
     this.sessionManager = new SessionManager()
+
+    // Initialize shared application server
+    const serverPort = config.serverPort || config.webhookPort || 3456
+    this.sharedApplicationServer = new SharedApplicationServer(serverPort)
+    
+    // Register OAuth callback handler if provided
+    if (config.handlers?.onOAuthCallback) {
+      this.sharedApplicationServer.registerOAuthCallbackHandler(config.handlers.onOAuthCallback)
+    }
 
     // Initialize repositories
     for (const repo of config.repositories) {
@@ -72,13 +83,16 @@ export class EdgeWorker extends EventEmitter {
       tokenToRepos.set(repo.linearToken, repos)
     }
 
-    // Create one NDJSON client per unique token
+    // Create one NDJSON client per unique token using shared application server
     for (const [token, repos] of tokenToRepos) {
       const ndjsonClient = new NdjsonClient({
         proxyUrl: config.proxyUrl,
         token: token,
         transport: 'webhook',
-        webhookPort: 3000 + Math.floor(Math.random() * 1000),
+        // Use shared application server instead of individual servers
+        useExternalWebhookServer: true,
+        externalWebhookServer: this.sharedApplicationServer,
+        webhookPort: serverPort, // All clients use same port
         webhookPath: '/webhook',
         webhookHost: 'localhost',
         ...(config.webhookBaseUrl && { webhookBaseUrl: config.webhookBaseUrl }),
@@ -105,6 +119,9 @@ export class EdgeWorker extends EventEmitter {
    * Start the edge worker
    */
   async start(): Promise<void> {
+    // Start shared application server first
+    await this.sharedApplicationServer.start()
+    
     // Connect all NDJSON clients
     const connections = Array.from(this.ndjsonClients.values()).map(client => 
       client.connect()
@@ -132,6 +149,9 @@ export class EdgeWorker extends EventEmitter {
     for (const client of this.ndjsonClients.values()) {
       client.disconnect()
     }
+    
+    // Stop shared application server
+    await this.sharedApplicationServer.stop()
   }
 
   /**
@@ -903,6 +923,28 @@ Please analyze this issue and help implement a solution.`
    */
   getActiveSessions(): string[] {
     return Array.from(this.sessionManager.getAllSessions().keys())
+  }
+
+  /**
+   * Start OAuth flow using the shared application server
+   */
+  async startOAuthFlow(proxyUrl?: string): Promise<{ linearToken: string; linearWorkspaceId: string; linearWorkspaceName: string }> {
+    const oauthProxyUrl = proxyUrl || this.config.proxyUrl
+    return this.sharedApplicationServer.startOAuthFlow(oauthProxyUrl)
+  }
+
+  /**
+   * Get the server port
+   */
+  getServerPort(): number {
+    return this.config.serverPort || this.config.webhookPort || 3456
+  }
+
+  /**
+   * Get the OAuth callback URL
+   */
+  getOAuthCallbackUrl(): string {
+    return this.sharedApplicationServer.getOAuthCallbackUrl()
   }
 
   /**

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -95,7 +95,9 @@ export class EdgeWorker extends EventEmitter {
         webhookPort: serverPort, // All clients use same port
         webhookPath: '/webhook',
         webhookHost: 'localhost',
-        ...(config.webhookBaseUrl && { webhookBaseUrl: config.webhookBaseUrl }),
+        ...(config.baseUrl && { webhookBaseUrl: config.baseUrl }),
+        // Legacy fallback support
+        ...(!config.baseUrl && config.webhookBaseUrl && { webhookBaseUrl: config.webhookBaseUrl }),
         onConnect: () => this.handleConnect(token),
         onDisconnect: (reason) => this.handleDisconnect(token, reason),
         onError: (error) => this.handleError(error)

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -117,7 +117,7 @@ export class SharedApplicationServer {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const callbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${this.port}`
+      const callbackBaseUrl = process.env.CYRUS_BASE_URL || `http://localhost:${this.port}`
       const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
@@ -266,7 +266,7 @@ export class SharedApplicationServer {
               <p>You can close this window and return to the terminal.</p>
               <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
               <p style="margin-top: 30px;">
-                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${this.port}`}/callback" 
+                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://localhost:${this.port}`}/callback" 
                    style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                   Connect Another Workspace
                 </a>

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -1,0 +1,314 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import { URL } from 'url'
+
+/**
+ * OAuth callback handler interface
+ */
+export interface OAuthCallbackHandler {
+  (token: string, workspaceId: string, workspaceName: string): Promise<void>
+}
+
+/**
+ * OAuth callback state for tracking flows
+ */
+export interface OAuthCallback {
+  resolve: (credentials: { linearToken: string; linearWorkspaceId: string; linearWorkspaceName: string }) => void
+  reject: (error: Error) => void
+  id: string
+}
+
+/**
+ * Shared application server that handles both webhooks and OAuth callbacks on a single port
+ * Consolidates functionality from SharedWebhookServer and CLI OAuth server
+ */
+export class SharedApplicationServer {
+  private server: ReturnType<typeof createServer> | null = null
+  private webhookHandlers = new Map<string, {
+    secret: string
+    handler: (body: string, signature: string, timestamp?: string) => boolean
+  }>()
+  private oauthCallbacks = new Map<string, OAuthCallback>()
+  private oauthCallbackHandler: OAuthCallbackHandler | null = null
+  private port: number
+  private isListening = false
+
+  constructor(port: number = 3456) {
+    this.port = port
+  }
+
+  /**
+   * Start the shared application server
+   */
+  async start(): Promise<void> {
+    if (this.isListening) {
+      return // Already listening
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server = createServer((req, res) => {
+        this.handleRequest(req, res)
+      })
+
+      this.server.listen(this.port, 'localhost', () => {
+        this.isListening = true
+        console.log(`🔗 Shared application server listening on http://localhost:${this.port}`)
+        resolve()
+      })
+
+      this.server.on('error', (error) => {
+        this.isListening = false
+        reject(error)
+      })
+    })
+  }
+
+  /**
+   * Stop the shared application server
+   */
+  async stop(): Promise<void> {
+    if (this.server && this.isListening) {
+      return new Promise((resolve) => {
+        this.server!.close(() => {
+          this.isListening = false
+          console.log('🔗 Shared application server stopped')
+          resolve()
+        })
+      })
+    }
+  }
+
+  /**
+   * Register a webhook handler for a specific token
+   */
+  registerWebhookHandler(
+    token: string, 
+    secret: string, 
+    handler: (body: string, signature: string, timestamp?: string) => boolean
+  ): void {
+    this.webhookHandlers.set(token, { secret, handler })
+    console.log(`🔗 Registered webhook handler for token ending in ...${token.slice(-4)}`)
+  }
+
+  /**
+   * Unregister a webhook handler
+   */
+  unregisterWebhookHandler(token: string): void {
+    this.webhookHandlers.delete(token)
+    console.log(`🔗 Unregistered webhook handler for token ending in ...${token.slice(-4)}`)
+  }
+
+  /**
+   * Register an OAuth callback handler
+   */
+  registerOAuthCallbackHandler(handler: OAuthCallbackHandler): void {
+    this.oauthCallbackHandler = handler
+    console.log('🔐 Registered OAuth callback handler')
+  }
+
+  /**
+   * Start OAuth flow and return promise that resolves when callback is received
+   */
+  async startOAuthFlow(proxyUrl: string): Promise<{ linearToken: string; linearWorkspaceId: string; linearWorkspaceName: string }> {
+    return new Promise<{ linearToken: string; linearWorkspaceId: string; linearWorkspaceName: string }>((resolve, reject) => {
+      // Generate unique ID for this flow
+      const flowId = Date.now().toString()
+      
+      // Store callback for this flow
+      this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
+      
+      // Construct OAuth URL with callback
+      const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${this.port}`
+      const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
+      
+      console.log(`\n👉 Opening your browser to authorize with Linear...`)
+      console.log(`If the browser doesn't open, visit: ${authUrl}`)
+      
+      // Timeout after 5 minutes
+      setTimeout(() => {
+        if (this.oauthCallbacks.has(flowId)) {
+          this.oauthCallbacks.delete(flowId)
+          reject(new Error('OAuth timeout'))
+        }
+      }, 5 * 60 * 1000)
+    })
+  }
+
+  /**
+   * Get the webhook URL for registration with proxy
+   */
+  getWebhookUrl(): string {
+    return `http://localhost:${this.port}/webhook`
+  }
+
+  /**
+   * Get the OAuth callback URL for registration with proxy
+   */
+  getOAuthCallbackUrl(): string {
+    return `http://localhost:${this.port}/callback`
+  }
+
+  /**
+   * Handle incoming requests (both webhooks and OAuth callbacks)
+   */
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const url = new URL(req.url!, `http://localhost:${this.port}`)
+      
+      if (url.pathname === '/webhook') {
+        await this.handleWebhookRequest(req, res)
+      } else if (url.pathname === '/callback') {
+        await this.handleOAuthCallback(req, res, url)
+      } else {
+        res.writeHead(404, { 'Content-Type': 'text/plain' })
+        res.end('Not Found')
+      }
+    } catch (error) {
+      console.error('🔗 Request handling error:', error)
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('Internal Server Error')
+    }
+  }
+
+  /**
+   * Handle incoming webhook requests
+   */
+  private async handleWebhookRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      if (req.method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'text/plain' })
+        res.end('Method Not Allowed')
+        return
+      }
+
+      // Read request body
+      let body = ''
+      req.on('data', chunk => {
+        body += chunk.toString()
+      })
+
+      req.on('end', () => {
+        try {
+          const signature = req.headers['x-webhook-signature'] as string
+          const timestamp = req.headers['x-webhook-timestamp'] as string
+
+          if (!signature) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('Missing signature')
+            return
+          }
+
+          // Try each registered handler until one verifies the signature
+          for (const [token, { handler }] of this.webhookHandlers) {
+            try {
+              if (handler(body, signature, timestamp)) {
+                // Handler verified signature and processed webhook
+                res.writeHead(200, { 'Content-Type': 'text/plain' })
+                res.end('OK')
+                console.log(`🔗 Webhook delivered to token ending in ...${token.slice(-4)}`)
+                return
+              }
+            } catch (error) {
+              console.error(`🔗 Error in webhook handler for token ...${token.slice(-4)}:`, error)
+            }
+          }
+
+          // No handler could verify the signature
+          console.error('🔗 Webhook signature verification failed for all registered handlers')
+          res.writeHead(401, { 'Content-Type': 'text/plain' })
+          res.end('Unauthorized')
+        } catch (error) {
+          console.error('🔗 Error processing webhook:', error)
+          res.writeHead(400, { 'Content-Type': 'text/plain' })
+          res.end('Bad Request')
+        }
+      })
+
+      req.on('error', (error) => {
+        console.error('🔗 Request error:', error)
+        res.writeHead(500, { 'Content-Type': 'text/plain' })
+        res.end('Internal Server Error')
+      })
+    } catch (error) {
+      console.error('🔗 Webhook request error:', error)
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('Internal Server Error')
+    }
+  }
+
+  /**
+   * Handle OAuth callback requests
+   */
+  private async handleOAuthCallback(_req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+    try {
+      const token = url.searchParams.get('token')
+      const workspaceId = url.searchParams.get('workspaceId')
+      const workspaceName = url.searchParams.get('workspaceName')
+      
+      if (token && workspaceId && workspaceName) {
+        // Success! Return the Linear credentials
+        const linearCredentials = { 
+          linearToken: token,
+          linearWorkspaceId: workspaceId,
+          linearWorkspaceName: workspaceName
+        }
+        
+        // Send success response
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(`
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="UTF-8">
+              <title>Authorization Successful</title>
+            </head>
+            <body style="font-family: system-ui; max-width: 600px; margin: 50px auto; padding: 20px;">
+              <h1>✅ Authorization Successful!</h1>
+              <p>You can close this window and return to the terminal.</p>
+              <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
+              <p style="margin-top: 30px;">
+                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${this.port}`}/callback" 
+                   style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
+                  Connect Another Workspace
+                </a>
+              </p>
+              <script>setTimeout(() => window.close(), 10000)</script>
+            </body>
+          </html>
+        `)
+        
+        console.log(`🔐 OAuth callback received for workspace: ${workspaceName}`)
+        
+        // Resolve any waiting promises
+        if (this.oauthCallbacks.size > 0) {
+          const callback = this.oauthCallbacks.values().next().value
+          if (callback) {
+            callback.resolve(linearCredentials)
+            this.oauthCallbacks.delete(callback.id)
+          }
+        }
+        
+        // Call the registered OAuth callback handler
+        if (this.oauthCallbackHandler) {
+          try {
+            await this.oauthCallbackHandler(token, workspaceId, workspaceName)
+          } catch (error) {
+            console.error('🔐 Error in OAuth callback handler:', error)
+          }
+        }
+      } else {
+        res.writeHead(400, { 'Content-Type': 'text/html' })
+        res.end('<h1>Error: No token received</h1>')
+        
+        // Reject any waiting promises
+        for (const [id, callback] of this.oauthCallbacks) {
+          callback.reject(new Error('No token received'))
+          this.oauthCallbacks.delete(id)
+        }
+      }
+    } catch (error) {
+      console.error('🔐 OAuth callback error:', error)
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('Internal Server Error')
+    }
+  }
+}

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -117,7 +117,7 @@ export class SharedApplicationServer {
       this.oauthCallbacks.set(flowId, { resolve, reject, id: flowId })
       
       // Construct OAuth URL with callback
-      const callbackBaseUrl = process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${this.port}`
+      const callbackBaseUrl = process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${this.port}`
       const authUrl = `${proxyUrl}/oauth/authorize?callback=${callbackBaseUrl}/callback`
       
       console.log(`\n👉 Opening your browser to authorize with Linear...`)
@@ -266,7 +266,7 @@ export class SharedApplicationServer {
               <p>You can close this window and return to the terminal.</p>
               <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
               <p style="margin-top: 30px;">
-                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_OAUTH_CALLBACK_BASE_URL || `http://localhost:${this.port}`}/callback" 
+                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_WEBHOOK_BASE_URL || `http://localhost:${this.port}`}/callback" 
                    style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                   Connect Another Workspace
                 </a>

--- a/packages/edge-worker/src/SharedWebhookServer.ts
+++ b/packages/edge-worker/src/SharedWebhookServer.ts
@@ -1,0 +1,159 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+
+/**
+ * Shared webhook server that can handle multiple Linear tokens
+ * Each token has its own webhook secret for signature verification
+ */
+export class SharedWebhookServer {
+  private server: ReturnType<typeof createServer> | null = null
+  private webhookHandlers = new Map<string, {
+    secret: string
+    handler: (body: string, signature: string, timestamp?: string) => boolean
+  }>()
+  private port: number
+  private isListening = false
+
+  constructor(port: number = 3456) {
+    this.port = port
+  }
+
+  /**
+   * Start the shared webhook server
+   */
+  async start(): Promise<void> {
+    if (this.isListening) {
+      return // Already listening
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server = createServer((req, res) => {
+        this.handleWebhookRequest(req, res)
+      })
+
+      this.server.listen(this.port, 'localhost', () => {
+        this.isListening = true
+        console.log(`🔗 Shared webhook server listening on http://localhost:${this.port}`)
+        resolve()
+      })
+
+      this.server.on('error', (error) => {
+        this.isListening = false
+        reject(error)
+      })
+    })
+  }
+
+  /**
+   * Stop the shared webhook server
+   */
+  async stop(): Promise<void> {
+    if (this.server && this.isListening) {
+      return new Promise((resolve) => {
+        this.server!.close(() => {
+          this.isListening = false
+          console.log('🔗 Shared webhook server stopped')
+          resolve()
+        })
+      })
+    }
+  }
+
+  /**
+   * Register a webhook handler for a specific token
+   */
+  registerWebhookHandler(
+    token: string, 
+    secret: string, 
+    handler: (body: string, signature: string, timestamp?: string) => boolean
+  ): void {
+    this.webhookHandlers.set(token, { secret, handler })
+    console.log(`🔗 Registered webhook handler for token ending in ...${token.slice(-4)}`)
+  }
+
+  /**
+   * Unregister a webhook handler
+   */
+  unregisterWebhookHandler(token: string): void {
+    this.webhookHandlers.delete(token)
+    console.log(`🔗 Unregistered webhook handler for token ending in ...${token.slice(-4)}`)
+  }
+
+  /**
+   * Get the webhook URL for registration with proxy
+   */
+  getWebhookUrl(): string {
+    return `http://localhost:${this.port}/webhook`
+  }
+
+  /**
+   * Handle incoming webhook requests
+   */
+  private async handleWebhookRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      if (req.method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'text/plain' })
+        res.end('Method Not Allowed')
+        return
+      }
+
+      if (req.url !== '/webhook') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' })
+        res.end('Not Found')
+        return
+      }
+
+      // Read request body
+      let body = ''
+      req.on('data', chunk => {
+        body += chunk.toString()
+      })
+
+      req.on('end', () => {
+        try {
+          const signature = req.headers['x-webhook-signature'] as string
+          const timestamp = req.headers['x-webhook-timestamp'] as string
+
+          if (!signature) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('Missing signature')
+            return
+          }
+
+          // Try each registered handler until one verifies the signature
+          for (const [token, { handler }] of this.webhookHandlers) {
+            try {
+              if (handler(body, signature, timestamp)) {
+                // Handler verified signature and processed webhook
+                res.writeHead(200, { 'Content-Type': 'text/plain' })
+                res.end('OK')
+                console.log(`🔗 Webhook delivered to token ending in ...${token.slice(-4)}`)
+                return
+              }
+            } catch (error) {
+              console.error(`🔗 Error in webhook handler for token ...${token.slice(-4)}:`, error)
+            }
+          }
+
+          // No handler could verify the signature
+          console.error('🔗 Webhook signature verification failed for all registered handlers')
+          res.writeHead(401, { 'Content-Type': 'text/plain' })
+          res.end('Unauthorized')
+        } catch (error) {
+          console.error('🔗 Error processing webhook:', error)
+          res.writeHead(400, { 'Content-Type': 'text/plain' })
+          res.end('Bad Request')
+        }
+      })
+
+      req.on('error', (error) => {
+        console.error('🔗 Request error:', error)
+        res.writeHead(500, { 'Content-Type': 'text/plain' })
+        res.end('Internal Server Error')
+      })
+    } catch (error) {
+      console.error('🔗 Webhook request error:', error)
+      res.writeHead(500, { 'Content-Type': 'text/plain' })
+      res.end('Internal Server Error')
+    }
+  }
+}

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -1,9 +1,11 @@
 export { EdgeWorker } from './EdgeWorker.js'
+export { SharedApplicationServer } from './SharedApplicationServer.js'
 export type {
   EdgeWorkerConfig,
   EdgeWorkerEvents,
   RepositoryConfig
 } from './types.js'
+export type { OAuthCallbackHandler } from './SharedApplicationServer.js'
 
 // Re-export useful types from dependencies
 export type { SDKMessage } from 'cyrus-claude-runner'

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -1,6 +1,7 @@
 import type { Workspace } from 'cyrus-core'
 import type { Issue as LinearIssue } from '@linear/sdk'
 import type { SDKMessage } from 'cyrus-claude-runner'
+import type { OAuthCallbackHandler } from './SharedApplicationServer.js'
 
 
 /**
@@ -37,6 +38,8 @@ export interface EdgeWorkerConfig {
   // Proxy connection config
   proxyUrl: string
   webhookBaseUrl?: string
+  webhookPort?: number  // Legacy support - now uses serverPort
+  serverPort?: number   // Unified server port for both webhooks and OAuth callbacks (default: 3456)
   
   // Claude config (shared across all repos)
   defaultAllowedTools?: string[]
@@ -61,6 +64,9 @@ export interface EdgeWorkerConfig {
     
     // Called on errors
     onError?: (error: Error, context?: any) => void
+    
+    // Called when OAuth callback is received
+    onOAuthCallback?: OAuthCallbackHandler
   }
   
   // Optional features (can be overridden per repository)

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -37,7 +37,8 @@ export interface RepositoryConfig {
 export interface EdgeWorkerConfig {
   // Proxy connection config
   proxyUrl: string
-  webhookBaseUrl?: string
+  baseUrl?: string
+  webhookBaseUrl?: string  // Legacy support - use baseUrl instead
   webhookPort?: number  // Legacy support - now uses serverPort
   serverPort?: number   // Unified server port for both webhooks and OAuth callbacks (default: 3456)
   

--- a/packages/edge-worker/test/EdgeWorker.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.test.ts
@@ -4,6 +4,7 @@ import { LinearClient } from '@linear/sdk'
 import { NdjsonClient } from 'cyrus-ndjson-client'
 import { ClaudeRunner } from 'cyrus-claude-runner'
 import { SessionManager, Session } from 'cyrus-core'
+import { SharedApplicationServer } from '../src/SharedApplicationServer'
 import type { EdgeWorkerConfig } from '../src/types'
 import { 
   mockIssueAssignedWebhook, 
@@ -18,6 +19,7 @@ import {
 vi.mock('@linear/sdk')
 vi.mock('cyrus-ndjson-client')
 vi.mock('cyrus-claude-runner')
+vi.mock('../src/SharedApplicationServer')
 vi.mock('cyrus-core', async (importOriginal) => {
   const actual = await importOriginal()
   return {
@@ -40,6 +42,7 @@ describe('EdgeWorker', () => {
   let mockNdjsonClient: any
   let mockClaudeRunner: any
   let mockSessionManager: any
+  let mockSharedApplicationServer: any
 
   beforeEach(() => {
     // Clear DEBUG_EDGE to ensure predictable behavior
@@ -121,6 +124,21 @@ describe('EdgeWorker', () => {
     }
     vi.mocked(SessionManager).mockImplementation(() => mockSessionManager)
 
+    // Setup mock shared application server
+    mockSharedApplicationServer = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      registerWebhookHandler: vi.fn(),
+      unregisterWebhookHandler: vi.fn(),
+      registerOAuthCallbackHandler: vi.fn(),
+      startOAuthFlow: vi.fn(),
+      getWebhookUrl: vi.fn().mockReturnValue('http://localhost:3456/webhook'),
+      getOAuthCallbackUrl: vi.fn().mockReturnValue('http://localhost:3456/callback'),
+      isListening: false,
+      port: 3456
+    }
+    vi.mocked(SharedApplicationServer).mockImplementation(() => mockSharedApplicationServer)
+
     // Create EdgeWorker instance
     edgeWorker = new EdgeWorker(mockConfig)
 
@@ -151,6 +169,8 @@ describe('EdgeWorker', () => {
         proxyUrl: mockConfig.proxyUrl,
         token: 'test-linear-oauth-token',
         transport: 'webhook',
+        useExternalWebhookServer: true,
+        externalWebhookServer: expect.any(Object),
         webhookPort: expect.any(Number),
         webhookPath: '/webhook',
         webhookHost: 'localhost',
@@ -195,8 +215,9 @@ describe('EdgeWorker', () => {
   })
 
   describe('start/stop', () => {
-    it('should connect to NDJSON client on start', async () => {
+    it('should start shared application server and connect to NDJSON client on start', async () => {
       await edgeWorker.start()
+      expect(mockSharedApplicationServer.start).toHaveBeenCalled()
       expect(mockNdjsonClient.connect).toHaveBeenCalled()
     })
 
@@ -244,7 +265,7 @@ describe('EdgeWorker', () => {
       expect(edgeWorker['claudeRunners'].size).toBe(0)
     })
 
-    it('should clear sessions and disconnect on stop', async () => {
+    it('should clear sessions, disconnect clients and stop shared application server', async () => {
       mockSessionManager.getAllSessions.mockReturnValue(new Map([
         ['issue-1', {}],
         ['issue-2', {}]
@@ -255,6 +276,7 @@ describe('EdgeWorker', () => {
       expect(mockSessionManager.removeSession).toHaveBeenCalledWith('issue-1')
       expect(mockSessionManager.removeSession).toHaveBeenCalledWith('issue-2')
       expect(mockNdjsonClient.disconnect).toHaveBeenCalled()
+      expect(mockSharedApplicationServer.stop).toHaveBeenCalled()
     })
   })
 

--- a/packages/ndjson-client/src/types.ts
+++ b/packages/ndjson-client/src/types.ts
@@ -63,6 +63,9 @@ export interface NdjsonClientConfig {
   maxReconnectAttempts?: number
   reconnectBaseDelay?: number
   reconnectOnStreamEnd?: boolean
+  // External webhook server support
+  externalWebhookServer?: any  // External server instance (like Express app or HTTP server)
+  useExternalWebhookServer?: boolean  // Whether to use external server instead of creating own
   onEvent?: (event: EdgeEvent) => void
   onConnect?: () => void
   onDisconnect?: (reason?: string) => void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^5.3.3
         version: 5.8.3
       wrangler:
-        specifier: ^3.23.0
-        version: 3.114.9(@cloudflare/workers-types@4.20250610.0)
+        specifier: ^4.22.0
+        version: 4.23.0(@cloudflare/workers-types@4.20250610.0)
 
   packages/claude-runner:
     dependencies:
@@ -390,45 +390,45 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@cloudflare/kv-asset-handler@0.3.4':
-    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
-    engines: {node: '>=16.13'}
+  '@cloudflare/kv-asset-handler@0.4.0':
+    resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
+    engines: {node: '>=18.0.0'}
 
-  '@cloudflare/unenv-preset@2.0.2':
-    resolution: {integrity: sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==}
+  '@cloudflare/unenv-preset@2.3.3':
+    resolution: {integrity: sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A==}
     peerDependencies:
-      unenv: 2.0.0-rc.14
-      workerd: ^1.20250124.0
+      unenv: 2.0.0-rc.17
+      workerd: ^1.20250508.0
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250408.0':
-    resolution: {integrity: sha512-bxhIwBWxaNItZLXDNOKY2dCv0FHjDiDkfJFpwv4HvtvU5MKcrivZHVmmfDzLW85rqzfcDOmKbZeMPVfiKxdBZw==}
+  '@cloudflare/workerd-darwin-64@1.20250617.0':
+    resolution: {integrity: sha512-toG8JUKVLIks4oOJLe9FeuixE84pDpMZ32ip7mCpE7JaFc5BqGFvevk0YC/db3T71AQlialjRwioH3jS/dzItA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20250408.0':
-    resolution: {integrity: sha512-5XZ2Oykr8bSo7zBmERtHh18h5BZYC/6H1YFWVxEj3PtalF3+6SHsO4KZsbGvDml9Pu7sHV277jiZE5eny8Hlyw==}
+  '@cloudflare/workerd-darwin-arm64@1.20250617.0':
+    resolution: {integrity: sha512-JTX0exbC9/ZtMmQQA8tDZEZFMXZrxOpTUj2hHnsUkErWYkr5SSZH04RBhPg6dU4VL8bXuB5/eJAh7+P9cZAp7g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20250408.0':
-    resolution: {integrity: sha512-WbgItXWln6G5d7GvYLWcuOzAVwafysZaWunH3UEfsm95wPuRofpYnlDD861gdWJX10IHSVgMStGESUcs7FLerQ==}
+  '@cloudflare/workerd-linux-64@1.20250617.0':
+    resolution: {integrity: sha512-8jkSoVRJ+1bOx3tuWlZCGaGCV2ew7/jFMl6V3CPXOoEtERUHsZBQLVkQIGKcmC/LKSj7f/mpyBUeu2EPTo2HEg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250408.0':
-    resolution: {integrity: sha512-pAhEywPPvr92SLylnQfZEPgXz+9pOG9G9haAPLpEatncZwYiYd9yiR6HYWhKp2erzCoNrOqKg9IlQwU3z1IDiw==}
+  '@cloudflare/workerd-linux-arm64@1.20250617.0':
+    resolution: {integrity: sha512-YAzcOyu897z5dQKFzme1oujGWMGEJCR7/Wrrm1nSP6dqutxFPTubRADM8BHn2CV3ij//vaPnAeLmZE3jVwOwig==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20250408.0':
-    resolution: {integrity: sha512-nJ3RjMKGae2aF2rZ/CNeBvQPM+W5V1SUK0FYWG/uomyr7uQ2l4IayHna1ODg/OHHTEgIjwom0Mbn58iXb0WOcQ==}
+  '@cloudflare/workerd-windows-64@1.20250617.0':
+    resolution: {integrity: sha512-XWM/6sagDrO0CYDKhXhPjM23qusvIN1ju9ZEml6gOQs8tNOFnq6Cn6X9FAmnyapRFCGUSEC3HZYJAm7zwVKaMA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -499,19 +499,15 @@ packages:
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3':
-    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
-    peerDependencies:
-      esbuild: '*'
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2':
-    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
-    peerDependencies:
-      esbuild: '*'
-
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
@@ -521,15 +517,15 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.17.19':
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -539,15 +535,15 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.17.19':
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -557,15 +553,15 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.17.19':
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -575,15 +571,15 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.17.19':
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -593,15 +589,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.17.19':
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -611,15 +607,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.17.19':
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -629,15 +625,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.17.19':
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -647,15 +643,15 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.17.19':
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -665,15 +661,15 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.17.19':
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -683,15 +679,15 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.17.19':
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -701,15 +697,15 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.17.19':
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -719,15 +715,15 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.17.19':
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -737,15 +733,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.17.19':
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -755,15 +751,15 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.17.19':
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -773,15 +769,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.17.19':
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -791,15 +787,15 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.17.19':
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -809,21 +805,27 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.17.19':
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
@@ -833,21 +835,27 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.17.19':
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -857,15 +865,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.17.19':
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -875,15 +883,15 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.17.19':
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -893,15 +901,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.17.19':
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -911,15 +919,15 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.17.19':
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -2427,14 +2435,14 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
-  esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.5:
@@ -2501,9 +2509,6 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-
-  estree-walker@0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -3174,9 +3179,6 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
-
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -3260,9 +3262,9 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@3.20250408.2:
-    resolution: {integrity: sha512-uTs7cGWFErgJTKtBdmtctwhuoxniuCQqDT8+xaEiJdEC8d+HsaZVYfZwIX2NuSmdAiHMe7NtbdZYjFMbIXtJsQ==}
-    engines: {node: '>=16.13'}
+  miniflare@4.20250617.5:
+    resolution: {integrity: sha512-Qqn30jR6dCjXaKVizT6vH4KOb+GyLccoxLNOJEfu63yBPn8eoXa7PrdiSGTmjs2RY8/tr7eTO8Wu/Yr14k0xVA==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   minimatch@10.0.1:
@@ -3741,16 +3743,6 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rollup-plugin-inject@3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-
-  rollup-plugin-node-polyfills@0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
-
-  rollup-pluginutils@2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
-
   rollup@4.41.1:
     resolution: {integrity: sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3903,10 +3895,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -4153,8 +4141,8 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
-  unenv@2.0.0-rc.14:
-    resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
+  unenv@2.0.0-rc.17:
+    resolution: {integrity: sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg==}
 
   unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -4368,17 +4356,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20250408.0:
-    resolution: {integrity: sha512-bBUX+UsvpzAqiWFNeZrlZmDGddiGZdBBbftZJz2wE6iUg/cIAJeVQYTtS/3ahaicguoLBz4nJiDo8luqM9fx1A==}
+  workerd@1.20250617.0:
+    resolution: {integrity: sha512-Uv6p0PYUHp/W/aWfUPLkZVAoAjapisM27JJlwcX9wCPTfCfnuegGOxFMvvlYpmNaX4YCwEdLCwuNn3xkpSkuZw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.114.9:
-    resolution: {integrity: sha512-1e0gL+rxLF04kM9bW4sxoDGLXpJ1x53Rx1t18JuUm6F67qadKKPISyUAXuBeIQudWrCWEBXaTVnSdLHz0yBXbA==}
-    engines: {node: '>=16.17.0'}
+  wrangler@4.23.0:
+    resolution: {integrity: sha512-JSeDt3IwA4TEmg/V3tRblImPjdxynBt9PUVO/acQJ83XGlMMSwswDKL1FuwvbFzgX6+JXc3GMHeu7r8AQIxw9w==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250408.0
+      '@cloudflare/workers-types': ^4.20250617.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -4584,29 +4572,29 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cloudflare/kv-asset-handler@0.3.4':
+  '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/unenv-preset@2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250408.0)':
+  '@cloudflare/unenv-preset@2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250617.0)':
     dependencies:
-      unenv: 2.0.0-rc.14
+      unenv: 2.0.0-rc.17
     optionalDependencies:
-      workerd: 1.20250408.0
+      workerd: 1.20250617.0
 
-  '@cloudflare/workerd-darwin-64@1.20250408.0':
+  '@cloudflare/workerd-darwin-64@1.20250617.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250408.0':
+  '@cloudflare/workerd-darwin-arm64@1.20250617.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250408.0':
+  '@cloudflare/workerd-linux-64@1.20250617.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250408.0':
+  '@cloudflare/workerd-linux-arm64@1.20250617.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20250408.0':
+  '@cloudflare/workerd-windows-64@1.20250617.0':
     optional: true
 
   '@cloudflare/workers-types@4.20250610.0': {}
@@ -4739,221 +4727,220 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
-    dependencies:
-      esbuild: 0.17.19
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
-    dependencies:
-      esbuild: 0.17.19
-      escape-string-regexp: 4.0.0
-      rollup-plugin-node-polyfills: 0.2.1
-
   '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm64@0.17.19':
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm@0.17.19':
+  '@esbuild/android-arm@0.21.5':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.25.4':
     optional: true
 
   '@esbuild/android-arm@0.25.5':
     optional: true
 
-  '@esbuild/android-x64@0.17.19':
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.17.19':
+  '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.17.19':
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.17.19':
+  '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.17.19':
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.17.19':
+  '@esbuild/linux-arm64@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.25.4':
     optional: true
 
   '@esbuild/linux-arm64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm@0.17.19':
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.17.19':
+  '@esbuild/linux-ia32@0.21.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.25.4':
     optional: true
 
   '@esbuild/linux-ia32@0.25.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.17.19':
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.17.19':
+  '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.17.19':
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.17.19':
+  '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.17.19':
+  '@esbuild/linux-s390x@0.21.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
     optional: true
 
-  '@esbuild/linux-x64@0.17.19':
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.25.4':
     optional: true
 
   '@esbuild/linux-x64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.5':
+  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.17.19':
+  '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.17.19':
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.17.19':
+  '@esbuild/sunos-x64@0.21.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/sunos-x64@0.25.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.17.19':
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.25.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.17.19':
+  '@esbuild/win32-ia32@0.21.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/win32-ia32@0.25.4':
     optional: true
 
   '@esbuild/win32-ia32@0.25.5':
     optional: true
 
-  '@esbuild/win32-x64@0.17.19':
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
@@ -6263,13 +6250,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -6567,31 +6552,6 @@ snapshots:
   es6-error@4.1.1:
     optional: true
 
-  esbuild@0.17.19:
-    optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
-
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -6617,6 +6577,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
 
   esbuild@0.25.5:
     optionalDependencies:
@@ -6726,8 +6714,6 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
-
-  estree-walker@0.6.1: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -7191,8 +7177,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -7424,10 +7409,6 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  magic-string@0.25.9:
-    dependencies:
-      sourcemap-codec: 1.4.8
-
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -7508,16 +7489,17 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@3.20250408.2:
+  miniflare@4.20250617.5:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
       acorn-walk: 8.3.2
       exit-hook: 2.2.1
       glob-to-regexp: 0.4.1
+      sharp: 0.33.5
       stoppable: 1.1.0
       undici: 5.29.0
-      workerd: 1.20250408.0
+      workerd: 1.20250617.0
       ws: 8.18.0
       youch: 3.3.4
       zod: 3.22.3
@@ -7950,20 +7932,6 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rollup-plugin-inject@3.0.2:
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
-
-  rollup-plugin-node-polyfills@0.2.1:
-    dependencies:
-      rollup-plugin-inject: 3.0.2
-
-  rollup-pluginutils@2.8.2:
-    dependencies:
-      estree-walker: 0.6.1
-
   rollup@4.41.1:
     dependencies:
       '@types/estree': 1.0.7
@@ -8090,7 +8058,6 @@ snapshots:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -8137,7 +8104,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   simple-update-notifier@1.1.0:
     dependencies:
@@ -8183,8 +8149,6 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
-
-  sourcemap-codec@1.4.8: {}
 
   sprintf-js@1.1.3: {}
 
@@ -8413,7 +8377,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  unenv@2.0.0-rc.14:
+  unenv@2.0.0-rc.17:
     dependencies:
       defu: 6.1.4
       exsolve: 1.0.5
@@ -8646,30 +8610,27 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20250408.0:
+  workerd@1.20250617.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250408.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250408.0
-      '@cloudflare/workerd-linux-64': 1.20250408.0
-      '@cloudflare/workerd-linux-arm64': 1.20250408.0
-      '@cloudflare/workerd-windows-64': 1.20250408.0
+      '@cloudflare/workerd-darwin-64': 1.20250617.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250617.0
+      '@cloudflare/workerd-linux-64': 1.20250617.0
+      '@cloudflare/workerd-linux-arm64': 1.20250617.0
+      '@cloudflare/workerd-windows-64': 1.20250617.0
 
-  wrangler@3.114.9(@cloudflare/workers-types@4.20250610.0):
+  wrangler@4.23.0(@cloudflare/workers-types@4.20250610.0):
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/unenv-preset': 2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250408.0)
-      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      '@cloudflare/kv-asset-handler': 0.4.0
+      '@cloudflare/unenv-preset': 2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250617.0)
       blake3-wasm: 2.1.5
-      esbuild: 0.17.19
-      miniflare: 3.20250408.2
+      esbuild: 0.25.4
+      miniflare: 4.20250617.5
       path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.14
-      workerd: 1.20250408.0
+      unenv: 2.0.0-rc.17
+      workerd: 1.20250617.0
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250610.0
       fsevents: 2.3.3
-      sharp: 0.33.5
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
## Summary
This PR consolidates the OAuth callback server and webhook server into a single `SharedApplicationServer` running on one configurable port, significantly simplifying deployment and configuration.

## Key Changes

### 🏗️ **New SharedApplicationServer**
- **Unified server** handling both `/webhook` and `/callback` routes on port 3456
- **Maintains all webhook functionality**: Multiple token support, signature verification, etc.
- **Adds OAuth handling**: State management, timeouts, concurrent flows
- **Unified request routing** with proper error handling

### 🔄 **EdgeWorker Updates**
- Replaced `SharedWebhookServer` with `SharedApplicationServer`
- Added OAuth callback handler registration
- Added `startOAuthFlow()` and `getOAuthCallbackUrl()` methods
- Updated server lifecycle management

### 🖥️ **CLI App Refactoring**
- **Removed standalone OAuth server** (previously on port 3457)
- **Integrated OAuth with EdgeWorker's shared server**
- **Simplified startup process** - no more separate server management
- **Updated OAuth flow** to use unified infrastructure

### ⚙️ **Configuration Simplification**
- **New**: `CYRUS_SERVER_PORT` environment variable (default: 3456)
- **Backward compatible**: `CYRUS_WEBHOOK_PORT` still works
- **Single port**: Both webhooks and OAuth on same endpoint

## Benefits

### 🚀 **Simplified Deployment**
- **Before**: Two ports (3456 for webhooks + 3457 for OAuth)
- **After**: One port (3456 for both)
- **Ngrok**: Single tunnel instead of two

### 📦 **Easier Configuration**
```bash
# Before
export CYRUS_OAUTH_CALLBACK_PORT=3457
export CYRUS_WEBHOOK_PORT=3456

# After  
export CYRUS_SERVER_PORT=3456
export CYRUS_WEBHOOK_BASE_URL=https://your-domain.com
```

### 🔧 **Better Resource Management**
- Single HTTP server instead of two
- Shared request handling infrastructure
- Unified error handling and logging

## Test plan
- [x] Verify webhook delivery works on `/webhook` route
- [x] Verify OAuth flow works on `/callback` route  
- [x] Test both routes work simultaneously on same port
- [x] Verify EdgeWorker starts/stops cleanly
- [x] Test multiple Linear tokens work correctly
- [x] Verify backward compatibility with existing config

## Breaking Changes
⚠️ **Configuration Update Required**:
- `CYRUS_OAUTH_CALLBACK_PORT` is no longer used
- Update to use `CYRUS_SERVER_PORT` or `CYRUS_WEBHOOK_PORT`
- Update reverse proxy configs to route both `/webhook` and `/callback` to same port

🤖 Generated with [Claude Code](https://claude.ai/code)