### PR TITLE
feat: Enable using 0.0.0.0 as the address to listen on in apps/cli

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -13,3 +13,12 @@ npm install -g cyrus-ai
 ```bash
 cyrus
 ```
+
+## Configuration
+
+### Environment Variables
+
+- `CYRUS_HOST_EXTERNAL` - Set to `true` to allow external connections (listens on `0.0.0.0` instead of `localhost`). Default: `false`
+  - Use this when running in Docker containers or when you need external access to the webhook server
+  - When `true`: Server listens on `0.0.0.0` (all interfaces)
+  - When `false` or unset: Server listens on `localhost` (local access only)

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -219,6 +219,7 @@ class EdgeApp {
       webhookPort: process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : undefined,
       serverPort: process.env.CYRUS_SERVER_PORT ? parseInt(process.env.CYRUS_SERVER_PORT, 10) : 
                   process.env.CYRUS_WEBHOOK_PORT ? parseInt(process.env.CYRUS_WEBHOOK_PORT, 10) : 3456,
+      serverHost: process.env.CYRUS_HOST_EXTERNAL === 'true' ? '0.0.0.0' : 'localhost',
       features: {
         enableContinuation: true
       },

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -56,7 +56,8 @@ export class EdgeWorker extends EventEmitter {
 
     // Initialize shared application server
     const serverPort = config.serverPort || config.webhookPort || 3456
-    this.sharedApplicationServer = new SharedApplicationServer(serverPort)
+    const serverHost = config.serverHost || 'localhost'
+    this.sharedApplicationServer = new SharedApplicationServer(serverPort, serverHost)
     
     // Register OAuth callback handler if provided
     if (config.handlers?.onOAuthCallback) {
@@ -94,7 +95,7 @@ export class EdgeWorker extends EventEmitter {
         externalWebhookServer: this.sharedApplicationServer,
         webhookPort: serverPort, // All clients use same port
         webhookPath: '/webhook',
-        webhookHost: 'localhost',
+        webhookHost: serverHost,
         ...(config.baseUrl && { webhookBaseUrl: config.baseUrl }),
         // Legacy fallback support
         ...(!config.baseUrl && config.webhookBaseUrl && { webhookBaseUrl: config.webhookBaseUrl }),

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -30,10 +30,12 @@ export class SharedApplicationServer {
   private oauthCallbacks = new Map<string, OAuthCallback>()
   private oauthCallbackHandler: OAuthCallbackHandler | null = null
   private port: number
+  private host: string
   private isListening = false
 
-  constructor(port: number = 3456) {
+  constructor(port: number = 3456, host: string = 'localhost') {
     this.port = port
+    this.host = host
   }
 
   /**
@@ -49,9 +51,9 @@ export class SharedApplicationServer {
         this.handleRequest(req, res)
       })
 
-      this.server.listen(this.port, 'localhost', () => {
+      this.server.listen(this.port, this.host, () => {
         this.isListening = true
-        console.log(`🔗 Shared application server listening on http://localhost:${this.port}`)
+        console.log(`🔗 Shared application server listening on http://${this.host}:${this.port}`)
         resolve()
       })
 
@@ -137,14 +139,14 @@ export class SharedApplicationServer {
    * Get the webhook URL for registration with proxy
    */
   getWebhookUrl(): string {
-    return `http://localhost:${this.port}/webhook`
+    return `http://${this.host}:${this.port}/webhook`
   }
 
   /**
    * Get the OAuth callback URL for registration with proxy
    */
   getOAuthCallbackUrl(): string {
-    return `http://localhost:${this.port}/callback`
+    return `http://${this.host}:${this.port}/callback`
   }
 
   /**
@@ -152,7 +154,7 @@ export class SharedApplicationServer {
    */
   private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
-      const url = new URL(req.url!, `http://localhost:${this.port}`)
+      const url = new URL(req.url!, `http://${this.host}:${this.port}`)
       
       if (url.pathname === '/webhook') {
         await this.handleWebhookRequest(req, res)
@@ -266,7 +268,7 @@ export class SharedApplicationServer {
               <p>You can close this window and return to the terminal.</p>
               <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
               <p style="margin-top: 30px;">
-                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://localhost:${this.port}`}/callback" 
+                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://${this.host}:${this.port}`}/callback" 
                    style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                   Connect Another Workspace
                 </a>

--- a/packages/edge-worker/src/SharedWebhookServer.ts
+++ b/packages/edge-worker/src/SharedWebhookServer.ts
@@ -11,10 +11,12 @@ export class SharedWebhookServer {
     handler: (body: string, signature: string, timestamp?: string) => boolean
   }>()
   private port: number
+  private host: string
   private isListening = false
 
-  constructor(port: number = 3456) {
+  constructor(port: number = 3456, host: string = 'localhost') {
     this.port = port
+    this.host = host
   }
 
   /**
@@ -30,9 +32,9 @@ export class SharedWebhookServer {
         this.handleWebhookRequest(req, res)
       })
 
-      this.server.listen(this.port, 'localhost', () => {
+      this.server.listen(this.port, this.host, () => {
         this.isListening = true
-        console.log(`🔗 Shared webhook server listening on http://localhost:${this.port}`)
+        console.log(`🔗 Shared webhook server listening on http://${this.host}:${this.port}`)
         resolve()
       })
 
@@ -82,7 +84,7 @@ export class SharedWebhookServer {
    * Get the webhook URL for registration with proxy
    */
   getWebhookUrl(): string {
-    return `http://localhost:${this.port}/webhook`
+    return `http://${this.host}:${this.port}/webhook`
   }
 
   /**

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -41,6 +41,7 @@ export interface EdgeWorkerConfig {
   webhookBaseUrl?: string  // Legacy support - use baseUrl instead
   webhookPort?: number  // Legacy support - now uses serverPort
   serverPort?: number   // Unified server port for both webhooks and OAuth callbacks (default: 3456)
+  serverHost?: string   // Server host address ('localhost' or '0.0.0.0', default: 'localhost')
   
   // Claude config (shared across all repos)
   defaultAllowedTools?: string[]


### PR DESCRIPTION
## Summary

- Implements CYRUS_HOST_EXTERNAL environment variable to enable external server access
- Adds configurable server host throughout the EdgeWorker architecture  
- Maintains backward compatibility with localhost as default
- Enables Docker and container deployment scenarios

## Changes Made

### Core Changes
- **EdgeWorkerConfig**: Added `serverHost` configuration option  
- **SharedApplicationServer**: Updated to accept configurable host parameter
- **SharedWebhookServer**: Updated to accept configurable host parameter
- **EdgeWorker**: Updated to pass host configuration through all components
- **CLI App**: Added CYRUS_HOST_EXTERNAL environment variable support

### Configuration
- `CYRUS_HOST_EXTERNAL=true` → listens on `0.0.0.0` (external access)
- `CYRUS_HOST_EXTERNAL=false` or unset → listens on `localhost` (default)

### Documentation
- Added CYRUS_HOST_EXTERNAL documentation to apps/cli/README.md
- Explains use cases for Docker containers and external access scenarios

## Test Plan

- [x] Verify TypeScript compilation passes for all affected packages
- [x] Confirm backward compatibility (default localhost behavior unchanged)
- [x] Validate configuration propagates through entire server chain
- [x] Test that environment variable correctly sets host binding
- [x] Ensure documentation is clear and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)