### PR TITLE
chore: Release patch versions for apps/cli and packages/edge-worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.21] - 2025-07-05
+
+### CLI
+- cyrus-ai@0.1.21
+
 ### Added
 - Added `CYRUS_HOST_EXTERNAL` environment variable to enable external server access ([#78](https://github.com/ceedaragents/cyrus/pull/78))
   - Set to `true` to listen on `0.0.0.0` (all interfaces) instead of `localhost`
@@ -15,6 +20,11 @@ All notable changes to this project will be documented in this file.
   - **Action Required**: Update environment configuration to use `CYRUS_BASE_URL` instead of `CYRUS_WEBHOOK_BASE_URL`
   - **Legacy Support**: `CYRUS_WEBHOOK_BASE_URL` is still supported for backward compatibility but deprecated
   - The variable serves both webhook and OAuth callback purposes since they run on the same server
+
+### Packages
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.9
 
 ## [0.1.19] - 2025-01-04
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-ai",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "description": "AI-powered Linear issue automation using Claude",
   "main": "dist/app.js",
   "types": "dist/app.d.ts",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-edge-worker",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "Unified edge worker for processing Linear issues with Claude",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump cyrus-ai from 0.1.19 to 0.1.21  
- Bump cyrus-edge-worker from 0.0.7 to 0.0.9
- Move unreleased changes to version 0.1.21 in CHANGELOG.md
- Successfully published both packages to npm

## Changes Included
### Added
- `CYRUS_HOST_EXTERNAL` environment variable to enable external server access
  - Set to `true` to listen on `0.0.0.0` (all interfaces) instead of `localhost`
  - Enables Docker container deployment and external webhook access scenarios
  - Maintains backward compatibility with `localhost` as default

### Changed
- **BREAKING**: Renamed `CYRUS_WEBHOOK_BASE_URL` to `CYRUS_BASE_URL` for clearer naming
  - **Action Required**: Update environment configuration to use `CYRUS_BASE_URL` instead of `CYRUS_WEBHOOK_BASE_URL`
  - **Legacy Support**: `CYRUS_WEBHOOK_BASE_URL` is still supported for backward compatibility but deprecated
  - The variable serves both webhook and OAuth callback purposes since they run on the same server

## Test plan
- [x] All packages build successfully
- [x] All tests pass (152 tests across all packages)
- [x] Both packages successfully published to npm
- [x] Version numbers verified as available on npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)