### PR TITLE
Fix webhook signature verification failures after cyrus restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed webhook signature verification failures after restarting cyrus by extending edge worker registration TTL from 1 hour to 90 days
+  - Resolves "Webhook signature verification failed for all registered handlers" error that occurred when cyrus was stopped and restarted
+  - Edge worker registrations in the proxy now persist for 90 days instead of expiring after 1 hour
+
 ### Improved
 - New comments on Linear issues queue up when Cyrus is already busy working, so that you can send multiple in a row ([#77](https://github.com/ceedaragents/cyrus/pull/77)) (now feed into existing Claude sessions instead of killing and restarting the session
 

--- a/apps/proxy-worker/src/services/EdgeWorkerRegistry.ts
+++ b/apps/proxy-worker/src/services/EdgeWorkerRegistry.ts
@@ -53,7 +53,7 @@ export class EdgeWorkerRegistry {
     await this.env.EDGE_TOKENS.put(
       `edge:worker:${edgeWorkerId}`,
       JSON.stringify(edgeWorker),
-      { expirationTtl: 3600 } // 1 hour TTL, refreshed on activity
+      { expirationTtl: 7776000 } // 90 days TTL, refreshed on activity
     )
 
     // Update workspace-to-edge mapping
@@ -100,7 +100,7 @@ export class EdgeWorkerRegistry {
       await this.env.EDGE_TOKENS.put(
         `edge:worker:${edgeWorkerId}`,
         JSON.stringify(edgeWorker),
-        { expirationTtl: 3600 }
+        { expirationTtl: 7776000 }
       )
     }
   }
@@ -210,7 +210,7 @@ export class EdgeWorkerRegistry {
     
     if (!edges.includes(edgeWorkerId)) {
       edges.push(edgeWorkerId)
-      await this.env.EDGE_TOKENS.put(key, JSON.stringify(edges), { expirationTtl: 3600 })
+      await this.env.EDGE_TOKENS.put(key, JSON.stringify(edges), { expirationTtl: 7776000 })
     }
   }
 
@@ -226,7 +226,7 @@ export class EdgeWorkerRegistry {
       const filteredEdges = edges.filter(id => id !== edgeWorkerId)
       
       if (filteredEdges.length > 0) {
-        await this.env.EDGE_TOKENS.put(key, JSON.stringify(filteredEdges), { expirationTtl: 3600 })
+        await this.env.EDGE_TOKENS.put(key, JSON.stringify(filteredEdges), { expirationTtl: 7776000 })
       } else {
         await this.env.EDGE_TOKENS.delete(key)
       }


### PR DESCRIPTION
## Summary
- Fixed webhook signature verification failures that occurred when cyrus was stopped and restarted
- Extended edge worker registration TTL from 1 hour to 90 days in the proxy worker
- Resolves the "Webhook signature verification failed for all registered handlers" error

## Problem
When cyrus was stopped and restarted, webhook delivery would fail with signature verification errors. This happened because:

1. Edge worker registrations in the proxy worker expired after 1 hour (3600 seconds)
2. When cyrus restarted, it would attempt to receive webhooks but the proxy no longer had the registration or webhook secret
3. The proxy couldn't verify webhook signatures, causing delivery failures

## Solution
Extended the TTL (Time To Live) for edge worker registrations from 1 hour to 90 days (7,776,000 seconds) in four locations within `EdgeWorkerRegistry.ts`:

- `registerEdgeWorker()` - Initial registration storage
- `updateLastSeen()` - Registration refresh
- `addEdgeWorkerToWorkspace()` - Workspace mapping storage  
- `removeEdgeWorkerFromWorkspace()` - Workspace mapping updates

## Test plan
- [x] All existing package tests pass (47 tests in core, 15 tests in ndjson-client, 42 tests in claude-runner)
- [x] TTL values consistently updated across all relevant code paths
- [x] CHANGELOG.md updated with user-facing description
- [ ] Manual testing: Stop cyrus, wait, restart, and verify webhook delivery works
- [ ] Verify edge worker registrations persist for extended period in production

🤖 Generated with [Claude Code](https://claude.ai/code)