### PR TITLE
Improve Linear token error handling and centralize config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed streaming input sessions not properly cleaning up after completion
+  - Resolves issue where "I've queued up your message..." appeared even after sessions had resolved
+  - Properly closes input streams when Claude sessions complete naturally
+
 ### Changed
 - Configuration file location moved from `.edge-config.json` in current directory to `~/.cyrus/config.json`
   - Automatically migrates existing `.edge-config.json` files to the new location

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Configuration file location moved from `.edge-config.json` in current directory to `~/.cyrus/config.json`
+  - Automatically migrates existing `.edge-config.json` files to the new location
+  - Uses standard user configuration directory for better cross-platform compatibility
+  - Reports migration status when detected
+- Default workspace directory changed from `{repository}/workspaces` to `~/.cyrus/workspaces/{repo-name}`
+  - Centralizes all cyrus-related files in the user's home directory
+  - Uses sanitized repository names as namespace folders
+  - Existing configurations remain unchanged
+
 ## [0.1.22] - 2025-01-06
 
 ### CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ pnpm build
 # Run tests across all packages
 pnpm test
 
-# Run tests only in packages directory
-pnpm test:packages
+# Run tests only in packages directory (recommended)
+pnpm test:packages:run
 
 # Run TypeScript type checking
 pnpm typecheck

--- a/apps/proxy-worker/src/services/EdgeWorkerRegistry.ts
+++ b/apps/proxy-worker/src/services/EdgeWorkerRegistry.ts
@@ -32,7 +32,7 @@ export class EdgeWorkerRegistry {
     const workspaceIds = await this.validateLinearToken(registration.linearToken)
     
     if (!workspaceIds || workspaceIds.length === 0) {
-      throw new Error('Invalid token or no workspace access')
+      throw new Error('Authentication required, not authenticated')
     }
 
     // Generate webhook secret for this edge worker

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -303,6 +303,12 @@ export class ClaudeRunner extends EventEmitter {
       // Clean up
       this.abortController = null
       
+      // Complete and clean up streaming prompt if it exists
+      if (this.streamingPrompt) {
+        this.streamingPrompt.complete()
+        this.streamingPrompt = null
+      }
+      
       // Close log stream
       if (this.logStream) {
         this.logStream.end()

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -995,12 +995,12 @@ Please analyze this issue and help implement a solution.`
   }
 
   /**
-   * Get connection status
+   * Get connection status by repository ID
    */
   getConnectionStatus(): Map<string, boolean> {
     const status = new Map<string, boolean>()
-    for (const [token, client] of this.ndjsonClients) {
-      status.set(token, client.isConnected())
+    for (const [repoId, client] of this.ndjsonClients) {
+      status.set(repoId, client.isConnected())
     }
     return status
   }
@@ -1010,6 +1010,20 @@ Please analyze this issue and help implement a solution.`
    */
   getActiveSessions(): string[] {
     return Array.from(this.sessionManager.getAllSessions().keys())
+  }
+
+  /**
+   * Get NDJSON client by token (for testing purposes)
+   * @internal
+   */
+  _getClientByToken(token: string): any {
+    for (const [repoId, client] of this.ndjsonClients) {
+      const repo = this.repositories.get(repoId)
+      if (repo?.linearToken === token) {
+        return client
+      }
+    }
+    return undefined
   }
 
   /**

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -18,6 +18,7 @@ export interface RepositoryConfig {
   
   // Linear configuration
   linearWorkspaceId: string    // Linear workspace/team ID
+  linearWorkspaceName?: string // Linear workspace display name (optional, for UI)
   linearToken: string          // OAuth token for this Linear workspace
   teamKeys?: string[]          // Linear team keys for routing (e.g., ["CEE", "BOOK"])
   

--- a/packages/edge-worker/test/EdgeWorker.multi-repo.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.multi-repo.test.ts
@@ -194,13 +194,7 @@ describe('EdgeWorker - Multi-Repository Support', () => {
     expect(ndjsonClients.size).toBe(2)
 
     // Find the client for token-B (mobile repo)
-    let mobilClient: MockNdjsonClient | undefined
-    for (const [token, client] of ndjsonClients) {
-      if (token === 'token-B') {
-        mobilClient = client as unknown as MockNdjsonClient
-        break
-      }
-    }
+    const mobilClient = (edgeWorker as any)._getClientByToken('token-B') as MockNdjsonClient
     expect(mobilClient).toBeDefined()
 
     // Simulate webhook for workspace-2 (mobile repo)
@@ -283,14 +277,7 @@ describe('EdgeWorker - Multi-Repository Support', () => {
     edgeWorker.on('session:started', sessionStartedHandler)
 
     // Get backend repository's client (token-A)
-    const ndjsonClients = (edgeWorker as any).ndjsonClients
-    let backendClient: MockNdjsonClient | undefined
-    for (const [token, client] of ndjsonClients) {
-      if (token === 'token-A') {
-        backendClient = client as unknown as MockNdjsonClient
-        break
-      }
-    }
+    const backendClient = (edgeWorker as any)._getClientByToken('token-A') as MockNdjsonClient
 
     // Simulate issue assignment for backend repo
     const webhookData = {
@@ -492,16 +479,8 @@ describe('EdgeWorker - Multi-Repository Support', () => {
       const onSessionStartMock = vi.fn()
       edgeWorker.on('session:started', onSessionStartMock)
 
-      // Get the shared client (token-shared) - EdgeWorker should have created it
-      const ndjsonClients = (edgeWorker as any).ndjsonClients
-      let sharedClient: MockNdjsonClient | undefined
-      for (const [token, client] of ndjsonClients) {
-        if (token === 'token-shared') {
-          sharedClient = client as unknown as MockNdjsonClient
-          break
-        }
-      }
-
+      // Get the shared client (token-shared)
+      const sharedClient = (edgeWorker as any)._getClientByToken('token-shared') as MockNdjsonClient
       if (!sharedClient) {
         throw new Error('Expected to find NDJSON client for token-shared')
       }
@@ -629,8 +608,7 @@ describe('EdgeWorker - Multi-Repository Support', () => {
       edgeWorker.on('session:started', onSessionStartMock)
 
       // Get the shared client (token-shared)
-      const ndjsonClients = (edgeWorker as any).ndjsonClients
-      const sharedClient = ndjsonClients.get('token-shared') as MockNdjsonClient
+      const sharedClient = (edgeWorker as any)._getClientByToken('token-shared') as MockNdjsonClient
 
       // Webhook without team key but with matching identifier
       const webhookNoTeam = {
@@ -708,8 +686,7 @@ describe('EdgeWorker - Multi-Repository Support', () => {
       edgeWorker.on('session:started', onSessionStartMock)
 
       // Get the shared client (token-shared)
-      const ndjsonClients = (edgeWorker as any).ndjsonClients
-      const sharedClient = ndjsonClients.get('token-shared') as MockNdjsonClient
+      const sharedClient = (edgeWorker as any)._getClientByToken('token-shared') as MockNdjsonClient
 
       // Webhook with team key that doesn't match any repository
       const unmatchedWebhook = {

--- a/packages/edge-worker/test/EdgeWorker.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.test.ts
@@ -176,6 +176,7 @@ describe('EdgeWorker', () => {
       expect(vi.mocked(NdjsonClient)).toHaveBeenCalledWith({
         proxyUrl: mockConfig.proxyUrl,
         token: 'test-linear-oauth-token',
+        name: 'Test Repository',
         transport: 'webhook',
         useExternalWebhookServer: true,
         externalWebhookServer: expect.any(Object),
@@ -796,7 +797,7 @@ describe('EdgeWorker', () => {
     it('should return connection status', () => {
       const statusBefore = edgeWorker.getConnectionStatus()
       expect(statusBefore.size).toBe(1)
-      expect(statusBefore.get('test-linear-oauth-token')).toBe(true) // Mock returns true by default
+      expect(statusBefore.get('test-repo')).toBe(true) // Mock returns true by default
 
       // Test that we can check connection status
       const onConnect = vi.mocked(NdjsonClient).mock.calls[0][0].onConnect
@@ -804,7 +805,7 @@ describe('EdgeWorker', () => {
 
       const statusAfter = edgeWorker.getConnectionStatus()
       expect(statusAfter.size).toBe(1)
-      expect(statusAfter.get('test-linear-oauth-token')).toBe(true)
+      expect(statusAfter.get('test-repo')).toBe(true)
     })
 
     it('should return active sessions', () => {


### PR DESCRIPTION
## Summary
- Adds graceful error handling for expired Linear tokens instead of failing completely
- Introduces `cyrus refresh-token` and `cyrus check-tokens` commands for easy token management
- Centralizes configuration and workspace files in `~/.cyrus/` directory
- **Fixes critical streaming input cleanup bug**

## Changes

### 🛡️ Enhanced Error Handling
- **Graceful degradation**: When Linear tokens expire, cyrus continues running with repositories that have valid tokens
- **Clear error messages**: Shows specific repository names and workspace information for failed authentications
- **Actionable guidance**: Provides specific commands to run for token refresh

### 🔧 New CLI Commands
- **`cyrus check-tokens`**: Validates all Linear tokens and shows their status
- **`cyrus refresh-token`**: Interactive token refresh that preserves all repository configuration
  - Uses proxy OAuth flow with valid client ID (fixes "Could not find OAuth client" error)
  - Automatically updates all repositories sharing the same expired token
  - No need to reconfigure repository settings

### 📁 Centralized Configuration
- **Config location**: Moved from `.edge-config.json` in current directory to `~/.cyrus/config.json`
  - Automatic migration with user notification
  - Uses standard user configuration directory
- **Workspace location**: Default changed from `{repository}/workspaces` to `~/.cyrus/workspaces/{repo-name}`
  - Centralizes all cyrus-related files
  - Uses sanitized repository names as namespace folders

### 🔄 Streaming Input Bug Fix
- **Fixed critical issue**: Sessions were not properly cleaning up their streaming input state after completion
- **Root cause**: `streamingPrompt` was not being cleared in the `finally` block, causing `isStreaming()` to return true even after sessions ended
- **Impact**: Resolves "I've queued up your message..." appearing when sessions had already resolved
- **Solution**: Proper cleanup in ClaudeRunner's finally block ensures streaming state is reset

### 🔧 Technical Improvements
- Enhanced webhook registration error detection
- Better repository identification in error messages
- UTF-8 encoding fixes for OAuth success page
- Cross-platform home directory handling

## Test plan
- [x] Test graceful handling when one repository has expired token
- [x] Test `cyrus check-tokens` command shows correct status
- [x] Test `cyrus refresh-token` successfully updates tokens via OAuth flow
- [x] Test automatic config migration from legacy location
- [x] Test new default workspace directory structure
- [x] Test streaming input cleanup fix - verify sessions don't appear "stuck" after completion
- [x] Verify existing configurations continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)