### PR TITLE
Fix OAuth flow initialization issue on fresh startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fresh startup no longer crashes with "EdgeWorker not initialized" error when trying to connect to Linear
+- OAuth flow now works properly on first run (turns out asking for credentials before having a way to receive them was... problematic)
+
+### Added
+- Automatic ngrok tunnel setup for external access
+  - No more manual port forwarding or reverse proxy setup required
+  - Cyrus will ask for your ngrok auth token on first run and handle the rest
+  - Free ngrok account required (sorry, we can't make the internet work by magic alone)
+  - Skip ngrok setup if you prefer to handle networking yourself
+
 ## [0.1.30] - 2025-01-07
 
 ### CLI

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -19,10 +19,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@linear/sdk": "^39.0.0",
+    "@ngrok/ngrok": "^1.5.1",
     "cyrus-claude-runner": "workspace:*",
     "cyrus-core": "workspace:*",
     "cyrus-ndjson-client": "workspace:*",
-    "@linear/sdk": "^39.0.0",
     "file-type": "^18.7.0"
   },
   "devDependencies": {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -59,7 +59,7 @@ export class EdgeWorker extends EventEmitter {
     // Initialize shared application server
     const serverPort = config.serverPort || config.webhookPort || 3456
     const serverHost = config.serverHost || 'localhost'
-    this.sharedApplicationServer = new SharedApplicationServer(serverPort, serverHost)
+    this.sharedApplicationServer = new SharedApplicationServer(serverPort, serverHost, config.ngrokAuthToken)
     
     // Register OAuth callback handler if provided
     if (config.handlers?.onOAuthCallback) {

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -80,6 +80,13 @@ export class SharedApplicationServer {
   }
 
   /**
+   * Get the port number the server is listening on
+   */
+  getPort(): number {
+    return this.port
+  }
+
+  /**
    * Register a webhook handler for a specific token
    */
   registerWebhookHandler(

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -43,6 +43,7 @@ export interface EdgeWorkerConfig {
   webhookPort?: number  // Legacy support - now uses serverPort
   serverPort?: number   // Unified server port for both webhooks and OAuth callbacks (default: 3456)
   serverHost?: string   // Server host address ('localhost' or '0.0.0.0', default: 'localhost')
+  ngrokAuthToken?: string  // Ngrok auth token for tunnel creation
   
   // Claude config (shared across all repos)
   defaultAllowedTools?: string[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@linear/sdk':
         specifier: ^39.0.0
         version: 39.2.1(encoding@0.1.13)
+      '@ngrok/ngrok':
+        specifier: ^1.5.1
+        version: 1.5.1
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -1037,6 +1040,87 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@ngrok/ngrok-android-arm64@1.5.1':
+    resolution: {integrity: sha512-2Tokwi5GVWNLw3JEoM0Ieb/ypALniZu6fciUTgpuByutbKxOjvahD4fYOKwW3KMdV9bCb3XGGtWJCZXfRPPq1g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@ngrok/ngrok-darwin-arm64@1.5.1':
+    resolution: {integrity: sha512-HNOhrPDP+nJJY7Bh45DOeh6jmcGASWINGbUuseZM0C8psQMp7crPywjRh0inkRegUrb4K8y06sfmgt2fmsF6jQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ngrok/ngrok-darwin-universal@1.5.1':
+    resolution: {integrity: sha512-EsMxYC/tY+ZqhjbeZtVq5MFIuD8SEPgAlHINEszsHd8ZRICc2U9Xl15CbDrew3pcfEg/ZVFrOH9CyC4aZ/V/cA==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@ngrok/ngrok-darwin-x64@1.5.1':
+    resolution: {integrity: sha512-H/x1BsYpAoTMhOtv4oYvwY6WHqbY0MsJ1XFcJQgrpAIjgmYqlwsnsUMHvEdBB/KY9kXF9DPgKUdRMfJwUIpwGA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ngrok/ngrok-freebsd-x64@1.5.1':
+    resolution: {integrity: sha512-dY2W6HUv7e2xkpdfVj7fIk+5qmvrC7kVu6PJWJ8/rshW1FrU7qMcpnU53JvoQJRZzUf5k8xMNdx30zai/8mqYA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@ngrok/ngrok-linux-arm-gnueabihf@1.5.1':
+    resolution: {integrity: sha512-JvbI/IIycw4Qq02ysyOBsSK5E0bZDgRqXSslHLTwuDAfw14lmrq2U0QkBeEOL8qwJ7wCwCH1PEOJacUyrqa9bg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-arm64-gnu@1.5.1':
+    resolution: {integrity: sha512-yLFAlqTYYvH7QRg589HJarQGw1QrKQZcHiw0gm175eCqc+jpUG/Zcf8wohCTIJVLylMIzjDzVFSUsXC7UtMJdQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-arm64-musl@1.5.1':
+    resolution: {integrity: sha512-momB/ZjjrxaGYOZ3YPAw1kT4DAfWT1x3dAHL0YoSVfNCpc8Fw0189ZAcxGn0hUFqkGDmSARS9o8b7hYd1b41oA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-fmMaz0b1Ry2CDLLn0mV8b9nLxqm0taQ2jYyn+C9OrazYNMT4XYYDKRQSm4UEaNoakdnoH+f2FsrWi/712GFxAQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-x64-musl@1.5.1':
+    resolution: {integrity: sha512-6Ajl9wpJSlvukl4WrkIw+WxVwAr7WTGnE35Voec6CERWtKMsO/F+BOSu3pfAa6iwxGK//JBpsTT1IwLLw7b2xQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ngrok/ngrok-win32-arm64-msvc@1.5.1':
+    resolution: {integrity: sha512-JUH2yZxDPQGmQNT1d2KIu64u2k/R6uG1kEIXjcbsoff37v9aI6nUlzldRWB/wFSYkpZ4W/EuovM4Epar+fQOxQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ngrok/ngrok-win32-ia32-msvc@1.5.1':
+    resolution: {integrity: sha512-zS1JsMTJHnY+lPJFUwKnB5fzPm4GZCKeeZLehHrXP0LpQaKN8Y/vywqDGhuC0WtymvWE88+oreMV/6hQdviLSA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ngrok/ngrok-win32-x64-msvc@1.5.1':
+    resolution: {integrity: sha512-HegRwV9Gchh4p7K7sC6SPpWmFRwDEgwPByrb8tkuWDyP+EWNgpt3GKp8OAIK2xdWWHnN5VIwMa9u3COE/e5S8w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ngrok/ngrok@1.5.1':
+    resolution: {integrity: sha512-sfcgdpiAJHqmuO3e6QjQGbavIrR3E72do/NAsnGhm+7SGstLj1aM3Sd8mkfTORb2Hj7ATMuoBYuED5ylKuRQCg==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4968,6 +5052,61 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@ngrok/ngrok-android-arm64@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-darwin-arm64@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-darwin-universal@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-darwin-x64@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-freebsd-x64@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm-gnueabihf@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm64-gnu@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm64-musl@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-linux-x64-musl@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-win32-arm64-msvc@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-win32-ia32-msvc@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok-win32-x64-msvc@1.5.1':
+    optional: true
+
+  '@ngrok/ngrok@1.5.1':
+    optionalDependencies:
+      '@ngrok/ngrok-android-arm64': 1.5.1
+      '@ngrok/ngrok-darwin-arm64': 1.5.1
+      '@ngrok/ngrok-darwin-universal': 1.5.1
+      '@ngrok/ngrok-darwin-x64': 1.5.1
+      '@ngrok/ngrok-freebsd-x64': 1.5.1
+      '@ngrok/ngrok-linux-arm-gnueabihf': 1.5.1
+      '@ngrok/ngrok-linux-arm64-gnu': 1.5.1
+      '@ngrok/ngrok-linux-arm64-musl': 1.5.1
+      '@ngrok/ngrok-linux-x64-gnu': 1.5.1
+      '@ngrok/ngrok-linux-x64-musl': 1.5.1
+      '@ngrok/ngrok-win32-arm64-msvc': 1.5.1
+      '@ngrok/ngrok-win32-ia32-msvc': 1.5.1
+      '@ngrok/ngrok-win32-x64-msvc': 1.5.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the OAuth flow initialization issue that occurs on fresh `cyrus` startup when no repositories or Linear credentials exist. The problem was a chicken-and-egg initialization where OAuth flow required an EdgeWorker to be initialized, but EdgeWorker couldn't be created without Linear credentials.

• **Root Cause**: OAuth flow was called before EdgeWorker initialization during fresh startup sequence
• **Solution**: Use temporary SharedApplicationServer for OAuth flow when EdgeWorker is not available
• **Impact**: Fresh startups now properly display OAuth authorization URL instead of failing with "EdgeWorker not initialized"

## Changes Made

- Modified `startOAuthFlow` in `apps/cli/app.ts` to handle both initialized and uninitialized EdgeWorker cases  
- Added `getPort()` method to `SharedApplicationServer` to support temporary server usage
- Maintains backward compatibility - existing OAuth flow unchanged when EdgeWorker is already initialized

## Test Plan

- [x] Build succeeds (`pnpm build`)
- [x] Package tests pass (`pnpm test:packages:run`)
- [x] Fresh startup scenario: OAuth flow should now show proper authorization URL
- [x] Existing workflow: OAuth flow continues to work when EdgeWorker is already initialized
- [x] Temporary server cleanup: SharedApplicationServer is properly stopped after OAuth completion

Closes CEA-151

🤖 Generated with [Claude Code](https://claude.ai/code)