### PR TITLE
Fix OAuth redirect URL bug in 'Connect Another Workspace' button

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -61,7 +61,7 @@ export class EdgeWorker extends EventEmitter {
     // Initialize shared application server
     const serverPort = config.serverPort || config.webhookPort || 3456
     const serverHost = config.serverHost || 'localhost'
-    this.sharedApplicationServer = new SharedApplicationServer(serverPort, serverHost, config.ngrokAuthToken)
+    this.sharedApplicationServer = new SharedApplicationServer(serverPort, serverHost, config.ngrokAuthToken, config.proxyUrl)
     
     // Register OAuth callback handler if provided
     if (config.handlers?.onOAuthCallback) {

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -36,11 +36,13 @@ export class SharedApplicationServer {
   private ngrokListener: any = null
   private ngrokAuthToken: string | null = null
   private ngrokUrl: string | null = null
+  private proxyUrl: string
 
-  constructor(port: number = 3456, host: string = 'localhost', ngrokAuthToken?: string) {
+  constructor(port: number = 3456, host: string = 'localhost', ngrokAuthToken?: string, proxyUrl?: string) {
     this.port = port
     this.host = host
     this.ngrokAuthToken = ngrokAuthToken || null
+    this.proxyUrl = proxyUrl || process.env.PROXY_URL || 'https://cyrus-proxy.ceedar.workers.dev'
   }
 
   /**
@@ -363,7 +365,7 @@ export class SharedApplicationServer {
               <p>You can close this window and return to the terminal.</p>
               <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
               <p style="margin-top: 30px;">
-                <a href="${process.env.PROXY_URL}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://${this.host}:${this.port}`}/callback" 
+                <a href="${this.proxyUrl}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://${this.host}:${this.port}`}/callback" 
                    style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                   Connect Another Workspace
                 </a>


### PR DESCRIPTION
## Summary
• Fixed the 'Connect Another Workspace' button displaying malformed OAuth URLs with 'undefined' in the path
• Modified SharedApplicationServer to accept proxyUrl parameter instead of relying on undefined process.env.PROXY_URL  
• Updated EdgeWorker to pass config.proxyUrl to SharedApplicationServer constructor

## Test plan
- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] Changes follow existing code patterns and conventions

The fix ensures that the OAuth authorization URL is properly constructed using the actual proxy URL from the EdgeWorker configuration, eliminating the 'undefined' path segment that was causing the bug.

🤖 Generated with [Claude Code](https://claude.ai/code)