### PR TITLE
Fix session continuation issue in EdgeWorker (CEA-156)

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -954,8 +954,9 @@ export class EdgeWorker extends EventEmitter {
     console.log(`[EdgeWorker] Claude session completed for comment thread ${commentId} (issue ${issueId}) with ${messages.length} messages`)
     this.claudeRunners.delete(commentId)
     this.commentToRepo.delete(commentId)
+    // NOTE: Do NOT delete commentToIssue mapping here - this allows for continuation
+    // The mapping should only be deleted when the issue is unassigned or there's an error
     if (issueId) {
-      this.commentToIssue.delete(commentId)
       this.emit('session:ended', issueId, 0, repositoryId)  // 0 indicates success
       this.config.handlers?.onSessionEnd?.(issueId, 0, repositoryId)
     }


### PR DESCRIPTION
## Summary
- Fixed the root cause of issues with Cyrus responses not continuing properly after initial assignment
- The problem was in the `handleClaudeComplete` function where the `commentToIssue` mapping was being deleted prematurely
- This caused subsequent comments to fail with "No issue mapping found for comment" error

## Root Cause Analysis
Based on the provided logs, the issue occurred in three stages:

1. **Initial assignment**: Session starts successfully but completes immediately without doing actual work
2. **Comment continuation**: When user adds a comment, the system can't find the issue mapping because it was deleted
3. **Third attempt**: Only works when user provides full context again as a new root comment

The core issue was that `handleClaudeComplete` was cleaning up the `commentToIssue` mapping on successful completion, but this mapping is needed for session continuation.

## Fix
- Modified `handleClaudeComplete` to preserve the `commentToIssue` mapping on successful completion
- The mapping is only deleted when there's an error or when the issue is unassigned
- This allows proper session continuation when users add new comments

## Test plan
- [x] Built and type-checked the edge-worker package successfully
- [x] Verified the fix doesn't break existing functionality
- [x] Confirmed error handling and unassignment cleanup still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)