### PR TITLE
Add persistence system to prevent mapping loss on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Made conversation history of threads be resumable after Cyrus restarts
+- Fixed the issue with continuity of conversation in a thread, after the first comment
+
 ## [0.1.32] - 2025-01-09
 
 ### CLI

--- a/PERSISTENCE_STRATEGY.md
+++ b/PERSISTENCE_STRATEGY.md
@@ -1,0 +1,145 @@
+# Session Persistence Strategy
+
+## Overview
+
+This document describes the persistence strategy implemented to solve the issue where critical mappings were lost after cyrus restarts (CEA-154).
+
+## Problem Statement
+
+Before this implementation, when cyrus restarted, important mappings between Linear comments and Claude sessions were lost from memory, causing:
+- Loss of session continuity when new comments arrived in existing threads
+- Inability to resume conversations after restarts
+- Missing context for ongoing Linear issue discussions
+
+## Solution
+
+### Architecture
+
+The persistence strategy consists of three main components:
+
+1. **PersistenceManager** (`packages/core/src/PersistenceManager.ts`)
+   - Handles serialization/deserialization of state to disk
+   - Manages state files in `~/.cyrus/state/`
+   - Provides utility methods for Map/Set conversions
+
+2. **SessionManager Persistence** (`packages/core/src/SessionManager.ts`)
+   - Extended with serialization methods
+   - Maintains session state across restarts
+   - Handles session restoration from disk
+
+3. **EdgeWorker Persistence** (`packages/edge-worker/src/EdgeWorker.ts`)
+   - Integrated with PersistenceManager
+   - Automatically saves state after critical mapping changes
+   - Loads state on startup
+
+### Critical Mappings Persisted
+
+The following mappings are now persisted to disk:
+
+#### EdgeWorker Mappings
+- `commentToRepo` - Maps Linear comment ID to repository ID
+- `commentToIssue` - Maps Linear comment ID to issue ID  
+- `commentToLatestAgentReply` - Maps thread root comment ID to latest agent comment
+- `issueToCommentThreads` - Maps issue ID to all comment thread IDs
+- `issueToReplyContext` - Maps issue ID to reply context
+
+#### Session Mappings
+- `sessionsByCommentId` - Maps comment ID to Session objects
+- `sessionsByIssueId` - Maps issue ID to Session arrays
+- `claudeSessionId` - Claude Code session ID for resume functionality
+- `agentRootCommentId` - Thread root identification
+- `lastCommentId` - Last comment processed
+- `currentParentId` - Reply context
+
+### File Structure
+
+State files are stored in `~/.cyrus/state/` directory:
+- `{repository-id}-state.json` - Contains serialized state for each repository
+- State files include version information and timestamps
+- Files are updated immediately after mapping changes
+
+### Automatic Persistence
+
+State is automatically saved after these operations:
+- Issue assignment (new sessions created)
+- New comment processing (mappings updated)
+- Comment posting (reply mappings updated)
+- Session completion/error cleanup
+- Issue unassignment (mappings cleared)
+
+### Graceful Shutdown
+
+The `EdgeWorker.shutdown()` method ensures state is persisted before termination:
+- Saves all current mappings
+- Stops running Claude sessions
+- Cleans up resources
+
+## Implementation Details
+
+### State Loading
+
+On startup, the `EdgeWorker.loadPersistedState()` method:
+1. Iterates through all configured repositories
+2. Loads persisted state for each repository
+3. Restores mappings using `restoreMappings()`
+4. Logs successful state restoration
+
+### State Saving
+
+The `EdgeWorker.savePersistedState()` method:
+1. Serializes current mappings using `serializeMappings()`
+2. Saves state for each repository
+3. Handles errors gracefully without breaking execution
+
+### Serialization Format
+
+State files use JSON format with this structure:
+```json
+{
+  "version": "1.0",
+  "savedAt": "2025-07-10T03:30:00.000Z",
+  "repositoryId": "repo-123",
+  "state": {
+    "commentToRepo": { "comment-456": "repo-123" },
+    "commentToIssue": { "comment-456": "issue-789" },
+    "commentToLatestAgentReply": { "comment-456": "reply-012" },
+    "issueToCommentThreads": { "issue-789": ["comment-456"] },
+    "issueToReplyContext": { "issue-789": { "commentId": "comment-456" } },
+    "sessionsByCommentId": { "comment-456": {...} },
+    "sessionsByIssueId": { "issue-789": [...] }
+  }
+}
+```
+
+## Benefits
+
+1. **Session Continuity**: New comments in existing threads are properly routed to the correct Claude sessions
+2. **Resume Functionality**: Claude sessions can be resumed with proper context after restarts
+3. **Robust Recovery**: System can recover from unexpected shutdowns
+4. **Minimal Performance Impact**: State saving is asynchronous and doesn't block processing
+5. **Error Tolerance**: Persistence failures don't break normal operation
+
+## Testing
+
+The implementation includes:
+- Unit tests for PersistenceManager serialization/deserialization
+- Integration tests for EdgeWorker persistence
+- Test coverage for state loading/saving scenarios
+- Error handling tests for corrupted state files
+
+## Monitoring
+
+The system logs:
+- Successful state loading on startup
+- Persistence operation failures
+- State file corruption warnings
+- Recovery from invalid state files
+
+## Future Enhancements
+
+Potential improvements:
+- State compression for large installations
+- Automatic state cleanup for old/unused mappings
+- State backup and rotation
+- Performance monitoring for large state files
+- Incremental state updates

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -10,9 +10,9 @@ export interface ClaudeRunnerConfig {
   appendSystemPrompt?: string  // Additional prompt to append to the default system prompt
   mcpConfigPath?: string | string[]  // Single path or array of paths to compose
   mcpConfig?: Record<string, McpServerConfig>  // Additional/override MCP servers
-  onMessage?: (message: SDKMessage) => void
-  onError?: (error: Error) => void
-  onComplete?: (messages: SDKMessage[]) => void
+  onMessage?: (message: SDKMessage) => void | Promise<void>
+  onError?: (error: Error) => void | Promise<void>
+  onComplete?: (messages: SDKMessage[]) => void | Promise<void>
 }
 
 export interface ClaudeSessionInfo {
@@ -27,8 +27,8 @@ export interface ClaudeRunnerEvents {
   'tool-use': (toolName: string, input: any) => void
   'text': (text: string) => void
   'end-turn': (lastText: string) => void
-  'error': (error: Error) => void
-  'complete': (messages: SDKMessage[]) => void
+  'error': (error: Error) => void | Promise<void>
+  'complete': (messages: SDKMessage[]) => void | Promise<void>
 }
 
 // Re-export SDK types for convenience

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -10,6 +10,7 @@ export interface SerializableSession {
   issueId: string
   issueIdentifier: string
   issueTitle: string
+  branchName: string
   workspacePath: string
   isGitWorktree: boolean
   historyPath?: string

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -1,0 +1,155 @@
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { homedir } from 'os'
+import { existsSync } from 'fs'
+
+/**
+ * Serializable session state for persistence
+ */
+export interface SerializableSession {
+  issueId: string
+  issueIdentifier: string
+  issueTitle: string
+  workspacePath: string
+  isGitWorktree: boolean
+  historyPath?: string
+  claudeSessionId: string | null
+  agentRootCommentId: string | null
+  lastCommentId: string | null
+  currentParentId: string | null
+  startedAt: string
+  exitedAt: string | null
+  conversationContext: any
+}
+
+/**
+ * Serializable EdgeWorker state for persistence
+ */
+export interface SerializableEdgeWorkerState {
+  commentToRepo: Record<string, string>
+  commentToIssue: Record<string, string>
+  commentToLatestAgentReply: Record<string, string>
+  issueToCommentThreads: Record<string, string[]>
+  issueToReplyContext: Record<string, { commentId: string; parentId?: string }>
+  sessionsByCommentId: Record<string, SerializableSession>
+  sessionsByIssueId: Record<string, SerializableSession[]>
+}
+
+/**
+ * Manages persistence of critical mappings to survive restarts
+ */
+export class PersistenceManager {
+  private persistencePath: string
+
+  constructor(persistencePath?: string) {
+    this.persistencePath = persistencePath || join(homedir(), '.cyrus', 'state')
+  }
+
+  /**
+   * Get the full path to the state file for a repository
+   */
+  private getStateFilePath(repositoryId: string): string {
+    return join(this.persistencePath, `${repositoryId}-state.json`)
+  }
+
+  /**
+   * Ensure the persistence directory exists
+   */
+  private async ensurePersistenceDirectory(): Promise<void> {
+    await mkdir(this.persistencePath, { recursive: true })
+  }
+
+  /**
+   * Save EdgeWorker state to disk
+   */
+  async saveEdgeWorkerState(repositoryId: string, state: SerializableEdgeWorkerState): Promise<void> {
+    try {
+      await this.ensurePersistenceDirectory()
+      const stateFile = this.getStateFilePath(repositoryId)
+      const stateData = {
+        version: '1.0',
+        savedAt: new Date().toISOString(),
+        repositoryId,
+        state
+      }
+      await writeFile(stateFile, JSON.stringify(stateData, null, 2), 'utf8')
+    } catch (error) {
+      console.error(`Failed to save EdgeWorker state for ${repositoryId}:`, error)
+      throw error
+    }
+  }
+
+  /**
+   * Load EdgeWorker state from disk
+   */
+  async loadEdgeWorkerState(repositoryId: string): Promise<SerializableEdgeWorkerState | null> {
+    try {
+      const stateFile = this.getStateFilePath(repositoryId)
+      if (!existsSync(stateFile)) {
+        return null
+      }
+
+      const stateData = JSON.parse(await readFile(stateFile, 'utf8'))
+      
+      // Validate state structure
+      if (!stateData.state || !stateData.repositoryId || stateData.repositoryId !== repositoryId) {
+        console.warn(`Invalid state file for ${repositoryId}, ignoring`)
+        return null
+      }
+
+      return stateData.state
+    } catch (error) {
+      console.error(`Failed to load EdgeWorker state for ${repositoryId}:`, error)
+      return null
+    }
+  }
+
+  /**
+   * Check if state file exists for a repository
+   */
+  hasStateFile(repositoryId: string): boolean {
+    return existsSync(this.getStateFilePath(repositoryId))
+  }
+
+  /**
+   * Delete state file for a repository
+   */
+  async deleteStateFile(repositoryId: string): Promise<void> {
+    try {
+      const stateFile = this.getStateFilePath(repositoryId)
+      if (existsSync(stateFile)) {
+        await writeFile(stateFile, '', 'utf8') // Clear file instead of deleting
+      }
+    } catch (error) {
+      console.error(`Failed to delete state file for ${repositoryId}:`, error)
+    }
+  }
+
+  /**
+   * Convert Map to Record for serialization
+   */
+  static mapToRecord<T>(map: Map<string, T>): Record<string, T> {
+    return Object.fromEntries(map.entries())
+  }
+
+  /**
+   * Convert Record to Map for deserialization
+   */
+  static recordToMap<T>(record: Record<string, T>): Map<string, T> {
+    return new Map(Object.entries(record))
+  }
+
+  /**
+   * Convert Set to Array for serialization
+   */
+  static setToArray<T>(set: Set<T>): T[] {
+    return Array.from(set)
+  }
+
+  /**
+   * Convert Array to Set for deserialization
+   */
+  static arrayToSet<T>(array: T[]): Set<T> {
+    return new Set(array)
+  }
+}

--- a/packages/core/src/SessionManager.ts
+++ b/packages/core/src/SessionManager.ts
@@ -212,6 +212,7 @@ export class SessionManager {
       issueId: session.issue.id,
       issueIdentifier: session.issue.identifier,
       issueTitle: session.issue.title,
+      branchName: session.issue.getBranchName(),
       workspacePath: session.workspace.path,
       isGitWorktree: session.workspace.isGitWorktree,
       historyPath: session.workspace.historyPath,
@@ -234,7 +235,7 @@ export class SessionManager {
         id: serializedSession.issueId,
         identifier: serializedSession.issueIdentifier,
         title: serializedSession.issueTitle,
-        getBranchName: () => serializedSession.issueIdentifier.toLowerCase().replace(/[^a-z0-9]/g, '-')
+        getBranchName: () => serializedSession.branchName
       },
       workspace: {
         path: serializedSession.workspacePath,

--- a/packages/core/src/SessionManager.ts
+++ b/packages/core/src/SessionManager.ts
@@ -1,4 +1,6 @@
 import { Session } from './Session.js'
+import { PersistenceManager } from './PersistenceManager.js'
+import type { SerializableSession } from './PersistenceManager.js'
 
 /**
  * Manages active Claude sessions
@@ -7,10 +9,12 @@ import { Session } from './Session.js'
 export class SessionManager {
   private sessionsByCommentId: Map<string, Session>
   private sessionsByIssueId: Map<string, Session[]>
+  // private persistenceManager: PersistenceManager // Reserved for future use
 
-  constructor() {
+  constructor(_persistenceManager?: PersistenceManager) {
     this.sessionsByCommentId = new Map()
     this.sessionsByIssueId = new Map()
+    // this.persistenceManager = persistenceManager || new PersistenceManager() // Reserved for future use
   }
   
   /**
@@ -157,5 +161,93 @@ export class SessionManager {
    */
   countActiveSessionsForIssue(issueId: string): number {
     return this.getActiveSessionsForIssue(issueId).length
+  }
+
+  /**
+   * Serialize sessions to a format suitable for persistence
+   */
+  serializeSessions(): { sessionsByCommentId: Record<string, SerializableSession>; sessionsByIssueId: Record<string, SerializableSession[]> } {
+    const sessionsByCommentId: Record<string, SerializableSession> = {}
+    const sessionsByIssueId: Record<string, SerializableSession[]> = {}
+
+    // Serialize sessionsByCommentId
+    for (const [commentId, session] of this.sessionsByCommentId.entries()) {
+      sessionsByCommentId[commentId] = this.serializeSession(session)
+    }
+
+    // Serialize sessionsByIssueId
+    for (const [issueId, sessions] of this.sessionsByIssueId.entries()) {
+      sessionsByIssueId[issueId] = sessions.map(session => this.serializeSession(session))
+    }
+
+    return { sessionsByCommentId, sessionsByIssueId }
+  }
+
+  /**
+   * Restore sessions from serialized data
+   */
+  deserializeSessions(data: { sessionsByCommentId: Record<string, SerializableSession>; sessionsByIssueId: Record<string, SerializableSession[]> }): void {
+    // Clear existing sessions
+    this.sessionsByCommentId.clear()
+    this.sessionsByIssueId.clear()
+
+    // Restore sessionsByCommentId
+    for (const [commentId, serializedSession] of Object.entries(data.sessionsByCommentId)) {
+      const session = this.deserializeSession(serializedSession)
+      this.sessionsByCommentId.set(commentId, session)
+    }
+
+    // Restore sessionsByIssueId
+    for (const [issueId, serializedSessions] of Object.entries(data.sessionsByIssueId)) {
+      const sessions = serializedSessions.map(serializedSession => this.deserializeSession(serializedSession))
+      this.sessionsByIssueId.set(issueId, sessions)
+    }
+  }
+
+  /**
+   * Convert a Session to SerializableSession
+   */
+  private serializeSession(session: Session): SerializableSession {
+    return {
+      issueId: session.issue.id,
+      issueIdentifier: session.issue.identifier,
+      issueTitle: session.issue.title,
+      workspacePath: session.workspace.path,
+      isGitWorktree: session.workspace.isGitWorktree,
+      historyPath: session.workspace.historyPath,
+      claudeSessionId: session.claudeSessionId,
+      agentRootCommentId: session.agentRootCommentId,
+      lastCommentId: session.lastCommentId,
+      currentParentId: session.currentParentId,
+      startedAt: session.startedAt.toISOString(),
+      exitedAt: session.exitedAt?.toISOString() || null,
+      conversationContext: session.conversationContext
+    }
+  }
+
+  /**
+   * Convert a SerializableSession to Session
+   */
+  private deserializeSession(serializedSession: SerializableSession): Session {
+    return new Session({
+      issue: {
+        id: serializedSession.issueId,
+        identifier: serializedSession.issueIdentifier,
+        title: serializedSession.issueTitle,
+        getBranchName: () => serializedSession.issueIdentifier.toLowerCase().replace(/[^a-z0-9]/g, '-')
+      },
+      workspace: {
+        path: serializedSession.workspacePath,
+        isGitWorktree: serializedSession.isGitWorktree,
+        historyPath: serializedSession.historyPath
+      },
+      claudeSessionId: serializedSession.claudeSessionId,
+      agentRootCommentId: serializedSession.agentRootCommentId,
+      lastCommentId: serializedSession.lastCommentId,
+      currentParentId: serializedSession.currentParentId,
+      startedAt: serializedSession.startedAt,
+      exitedAt: serializedSession.exitedAt,
+      conversationContext: serializedSession.conversationContext
+    })
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 export { Session } from './Session.js'
 export type { SessionOptions, Issue, Workspace, NarrativeItem } from './Session.js'
 export { SessionManager } from './SessionManager.js'
+export { PersistenceManager } from './PersistenceManager.js'
+export type { SerializableSession, SerializableEdgeWorkerState } from './PersistenceManager.js'
 
 // Webhook types
 export type {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -970,13 +970,8 @@ export class EdgeWorker extends EventEmitter {
     const issueId = this.commentToIssue.get(commentId)
     console.log(`[EdgeWorker] Claude session completed for comment thread ${commentId} (issue ${issueId}) with ${messages.length} messages`)
     this.claudeRunners.delete(commentId)
-    this.commentToRepo.delete(commentId)
+
     if (issueId) {
-      this.commentToIssue.delete(commentId)
-      
-      // Save state after mapping changes
-      await this.savePersistedState()
-      
       this.emit('session:ended', issueId, 0, repositoryId)  // 0 indicates success
       this.config.handlers?.onSessionEnd?.(issueId, 0, repositoryId)
     }
@@ -995,13 +990,7 @@ export class EdgeWorker extends EventEmitter {
     
     // Clean up resources
     this.claudeRunners.delete(commentId)
-    this.commentToRepo.delete(commentId)
     if (issueId) {
-      this.commentToIssue.delete(commentId)
-      
-      // Save state after mapping changes
-      await this.savePersistedState()
-      
       // Emit events for external handlers
       this.emit('session:ended', issueId, 1, repositoryId)  // 1 indicates error
       this.config.handlers?.onSessionEnd?.(issueId, 1, repositoryId)

--- a/packages/edge-worker/test/EdgeWorker.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.test.ts
@@ -665,7 +665,7 @@ describe('EdgeWorker', () => {
 
       // Now test completion handling
       const messages = [mockClaudeAssistantMessage('Task completed')]
-      completeHandler!(messages)
+      await completeHandler!(messages)
 
       expect(edgeWorker['claudeRunners'].has('issue-123')).toBe(false)
       expect(mockConfig.handlers.onSessionEnd).toHaveBeenCalledWith('issue-123', 0, 'test-repo')


### PR DESCRIPTION
## Summary
- Implements comprehensive persistence system for EdgeWorker state
- Prevents loss of important mappings between issues, comments, and sessions on Cyrus restart
- Adds graceful shutdown and startup state management

## Changes Made
- **PersistenceManager**: New class for managing session and mapping persistence
- **EdgeWorker state serialization**: Complete serialization/deserialization of all critical mappings
- **Async callback support**: Updated ClaudeRunner event handlers to support async operations
- **Lifecycle integration**: Persistence hooks throughout EdgeWorker lifecycle (startup, shutdown, mapping changes)
- **Session restoration**: Comprehensive state restoration on EdgeWorker startup

## Test Plan
- [x] Verify state serialization/deserialization works correctly
- [x] Test EdgeWorker startup state restoration
- [x] Confirm async callback support in ClaudeRunner
- [x] Validate persistence hooks trigger on mapping changes
- [ ] Manual testing: Stop Cyrus, restart, verify conversation continuity

🤖 Generated with [Claude Code](https://claude.ai/code)