### PR TITLE
Fix MaxListeners warning in CLI app

### DIFF
--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -653,7 +653,12 @@ class EdgeApp {
       console.log(`   ${proxyUrl}/oauth/authorize?callback=${oauthCallbackBaseUrl}/callback`)
       console.log('─'.repeat(70))
       
-      // Handle graceful shutdown
+      // Handle graceful shutdown - remove existing listeners first to prevent duplicates
+      process.removeAllListeners('SIGINT')
+      process.removeAllListeners('SIGTERM')
+      process.removeAllListeners('uncaughtException')
+      process.removeAllListeners('unhandledRejection')
+      
       process.on('SIGINT', () => this.shutdown())
       process.on('SIGTERM', () => this.shutdown())
       


### PR DESCRIPTION
## Summary
- Fixed MaxListeners warning by removing duplicate process event listeners
- Added `removeAllListeners()` calls before registering new process handlers 
- Prevents memory leak when `start()` method is called multiple times

## Test plan
- [x] TypeScript compilation passes
- [x] Build completes successfully
- [x] Process listeners are properly cleaned up before new registration

🤖 Generated with [Claude Code](https://claude.ai/code)