### PR TITLE
Add appendInstruction field to RepositoryConfig for custom prompt extensions

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1276,6 +1276,12 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
         prompt = prompt + '\n\n' + attachmentManifest
       }
       
+      // Append repository-specific instruction if provided
+      if (repository.appendInstruction) {
+        console.log(`[EdgeWorker] Adding repository-specific instruction`)
+        prompt = prompt + '\n\n<repository-specific-instruction>\n' + repository.appendInstruction + '\n</repository-specific-instruction>'
+      }
+      
       console.log(`[EdgeWorker] Final prompt length: ${prompt.length} characters`)
       return prompt
       

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -30,6 +30,7 @@ export interface RepositoryConfig {
   promptTemplatePath?: string  // Custom prompt template for this repo
   allowedTools?: string[]      // Override Claude tools for this repository (overrides defaultAllowedTools)
   mcpConfigPath?: string | string[]  // Path(s) to MCP configuration JSON file(s) (format: {"mcpServers": {...}})
+  appendInstruction?: string   // Additional instruction to append to the prompt in XML-style wrappers
 }
 
 /**


### PR DESCRIPTION
## Summary
• Added `appendInstruction?: string` field to `RepositoryConfig` interface
• Implemented prompt extension functionality in `buildPromptV2()` method
• Instructions are appended at the end of prompts within XML-style wrappers

## Implementation Details
The new `appendInstruction` field allows repository-specific customizations to be automatically appended to all prompts generated for that repository. When set, the instruction is wrapped in `<repository-specific-instruction>` XML tags and added at the very end of the prompt, after attachment manifests.

## Test Plan
- [x] Added field to RepositoryConfig interface in types.ts
- [x] Implemented appending logic in EdgeWorker.ts buildPromptV2 method
- [x] Verified TypeScript compilation passes
- [x] Verified build process completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)