### PR TITLE
Add appendInstruction field to repository config for custom prompt extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- You can now append custom instructions to Claude's system prompt via `appendInstruction` in repository config - because sometimes Claude needs a gentle reminder that your variable names are art, not accidents
+
 ### Fixed
 - Made conversation history of threads be resumable after Cyrus restarts
 - Fixed the issue with continuity of conversation in a thread, after the first comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- You can now append custom instructions to Claude's system prompt via `appendInstruction` in repository config - because sometimes Claude needs a gentle reminder that your variable names are art, not accidents
+- You can now append custom instructions to Claude's system prompt via `appendInstruction` in repository config (~/.cyrus/config.json) - because sometimes Claude needs a gentle reminder that your variable names are art, not accidents
 
 ### Fixed
 - Made conversation history of threads be resumable after Cyrus restarts


### PR DESCRIPTION
## Summary
- Adds `appendInstruction` field to `RepositoryConfig` interface for extending Claude's system prompt
- Updates EdgeWorker's prompt generation to append custom instructions within XML-style wrappers
- Allows repository-specific customization of Claude's behavior via configuration

## Test plan
- [x] TypeScript compilation passes with new interface field
- [x] EdgeWorker properly appends instructions to prompts in XML format
- [x] Build succeeds for all packages

🤖 Generated with [Claude Code](https://claude.ai/code)