### PR TITLE
Add instant response thoughts for agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Instant acknowledgment responses when Cyrus receives a request, providing immediate feedback to users
-- System prompt selection notifications that inform users which mode Cyrus is using based on issue labels (debugger, builder, or scoper)
+- Role mode notifications when issue labels trigger specific workflows (e.g., "Entering 'debugger' mode because of the 'Bug' label")
 
 ### Changed
 - TodoWrite tool messages are now displayed as "thoughts" instead of "actions" in Linear for better visual organization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Instant acknowledgment responses when Cyrus receives a request, providing immediate feedback to users
+- System prompt selection notifications that inform users which mode Cyrus is using based on issue labels (debugger, builder, or scoper)
+
 ### Changed
 - TodoWrite tool messages are now displayed as "thoughts" instead of "actions" in Linear for better visual organization
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -395,10 +395,6 @@ export class EdgeWorker extends EventEmitter {
       return
     }
 
-    // Post initial comment immediately
-    // TODO! replace this with agent activity, or comment out
-    // const initialComment = await this.postInitialComment(issue.id, repository.id)
-
     // Post instant acknowledgment thought
     await this.postInstantAcknowledgment(linearAgentActivitySessionId, repository.id)
 


### PR DESCRIPTION
## Summary
- Implemented instant acknowledgment response when agent session is created
- Added system prompt selection thought that indicates which mode (debugger/builder/scoper) is being used
- Both responses are posted as "thought" type agent activities

## Test plan
- [ ] When a new agent session is created, verify an instant acknowledgment thought appears
- [ ] When an issue has labels that trigger specific modes (Bug -> debugger, Feature/Improvement -> builder, PRD -> scoper), verify the appropriate thought appears
- [ ] Verify thoughts appear before Claude starts processing
- [ ] Test with issues without special labels to ensure standard flow still works

🤖 Generated with [Claude Code](https://claude.ai/code)