### PR TITLE
Prepare alpha release v0.1.35-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.33-alpha.0] - 2025-01-26
+
 ### Added
 - Instant acknowledgment responses when Cyrus receives a request, providing immediate feedback to users
 - Role mode notifications when issue labels trigger specific workflows (e.g., "Entering 'debugger' mode because of the 'Bug' label")
@@ -14,6 +16,23 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Made conversation history of threads be resumable after Cyrus restarts
 - Fixed the issue with continuity of conversation in a thread, after the first comment
+
+### Packages
+
+#### cyrus-core
+- cyrus-core@0.0.6-alpha.0
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.13-alpha.0
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.18-alpha.0
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.13-alpha.0
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.33-alpha.0
 
 ## [0.1.32] - 2025-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.33-alpha.0] - 2025-01-26
+## [0.1.35-alpha.0] - 2025-01-26
 
 ### Added
 - Instant acknowledgment responses when Cyrus receives a request, providing immediate feedback to users
 - Role mode notifications when issue labels trigger specific workflows (e.g., "Entering 'debugger' mode because of the 'Bug' label")
+- You can now append custom instructions to Claude's system prompt via `appendInstruction` in repository config (~/.cyrus/config.json) - because sometimes Claude needs a gentle reminder that your variable names are art, not accidents
 
 ### Changed
 - TodoWrite tool messages are now displayed as "thoughts" instead of "actions" in Linear for better visual organization
@@ -32,7 +33,7 @@ All notable changes to this project will be documented in this file.
 - cyrus-ndjson-client@0.0.13-alpha.0
 
 #### cyrus-ai (CLI)
-- cyrus-ai@0.1.33-alpha.0
+- cyrus-ai@0.1.35-alpha.0
 
 ## [0.1.32] - 2025-01-09
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-ai",
-  "version": "0.1.32",
+  "version": "0.1.33-alpha.0",
   "description": "AI-powered Linear issue automation using Claude",
   "main": "dist/app.js",
   "types": "dist/app.d.ts",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-ai",
-  "version": "0.1.33-alpha.0",
+  "version": "0.1.35-alpha.0",
   "description": "AI-powered Linear issue automation using Claude",
   "main": "dist/app.js",
   "types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-claude-runner",
-  "version": "0.0.12",
+  "version": "0.0.13-alpha.0",
   "description": "Claude process spawning and management for Cyrus",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-core",
-  "version": "0.0.5",
+  "version": "0.0.6-alpha.0",
   "description": "Core business logic for Cyrus",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-edge-worker",
-  "version": "0.0.17",
+  "version": "0.0.18-alpha.0",
   "description": "Unified edge worker for processing Linear issues with Claude",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -976,6 +976,12 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
         prompt = prompt + '\n\n' + attachmentManifest
       }
 
+      // Append repository-specific instruction if provided
+      if (repository.appendInstruction) {
+        console.log(`[EdgeWorker] Adding repository-specific instruction`)
+        prompt = prompt + '\n\n<repository-specific-instruction>\n' + repository.appendInstruction + '\n</repository-specific-instruction>'
+      }
+
       console.log(`[EdgeWorker] Final prompt length: ${prompt.length} characters`)
       return prompt
 

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -30,6 +30,7 @@ export interface RepositoryConfig {
   promptTemplatePath?: string  // Custom prompt template for this repo
   allowedTools?: string[]      // Override Claude tools for this repository (overrides defaultAllowedTools)
   mcpConfigPath?: string | string[]  // Path(s) to MCP configuration JSON file(s) (format: {"mcpServers": {...}})
+  appendInstruction?: string   // Additional instruction to append to the prompt in XML-style wrappers
   
   // Label-based system prompt configuration
   labelPrompts?: {

--- a/packages/ndjson-client/package.json
+++ b/packages/ndjson-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyrus-ndjson-client",
-  "version": "0.0.12",
+  "version": "0.0.13-alpha.0",
   "description": "NDJSON streaming client for proxy communication",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Updated all package versions to alpha versions
- Merged latest changes from main branch
- Updated CHANGELOG.md with recent unreleased changes
- Prepared for publishing alpha versions to npm

## Changes in this alpha release

### Added
- Instant acknowledgment responses when Cyrus receives a request, providing immediate feedback to users
- Role mode notifications when issue labels trigger specific workflows (e.g., "Entering 'debugger' mode because of the 'Bug' label")
- You can now append custom instructions to Claude's system prompt via `appendInstruction` in repository config (~/.cyrus/config.json) - because sometimes Claude needs a gentle reminder that your variable names are art, not accidents

### Changed
- TodoWrite tool messages are now displayed as "thoughts" instead of "actions" in Linear for better visual organization

### Fixed
- Made conversation history of threads be resumable after Cyrus restarts
- Fixed the issue with continuity of conversation in a thread, after the first comment

## Package Versions
- **cyrus-core**: `0.0.5` → `0.0.6-alpha.0`
- **cyrus-claude-runner**: `0.0.12` → `0.0.13-alpha.0`
- **cyrus-edge-worker**: `0.0.17` → `0.0.18-alpha.0`
- **cyrus-ndjson-client**: `0.0.12` → `0.0.13-alpha.0`
- **cyrus-ai** (CLI): `0.1.32` → `0.1.35-alpha.0` (skipping 0.1.33-0.1.34 which are already published)

## Test Plan
- [x] All package tests pass (except known issues in core and proxy-worker)
- [x] Packages build successfully
- [x] CHANGELOG updated with release notes
- [x] Merged latest changes from main branch
- [ ] Ready for alpha publishing to npm

## Notes
- This is an alpha release for testing the recent improvements
- Version bumped to 0.1.35-alpha.0 since npm already has 0.1.34 published
- Some test failures in core package and TypeScript errors in proxy-worker are tracked separately
- Core functionality packages (CLI, claude-runner, edge-worker, ndjson-client) are ready for alpha release

🤖 Generated with [Claude Code](https://claude.ai/code)