### PR TITLE
Fix: Prevent duplication of last message as both thought and response

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -344,6 +344,11 @@ export class AgentSessionManager {
             }
           } else {
             // Regular assistant message - create a thought
+            // Check if this message contains the last message marker
+            if (entry.content.includes('___LAST_MESSAGE_MARKER___')) {
+              console.log(`[AgentSessionManager] Skipping assistant message with last message marker - will be posted as response later`)
+              return // Skip posting this as a thought
+            }
             content = {
               type: 'thought',
               body: entry.content
@@ -367,9 +372,11 @@ export class AgentSessionManager {
               body: entry.content
             }
           } else {
+            // Strip the last message marker from the response
+            const cleanedContent = entry.content.replace(/___LAST_MESSAGE_MARKER___/g, '').trim()
             content = {
               type: 'response',
-              body: entry.content
+              body: cleanedContent
             }
           }
           break

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -442,6 +442,8 @@ export class EdgeWorker extends EventEmitter {
     }
 
     // Create Claude runner with attachment directory access and optional system prompt
+    // Always append the last message marker to prevent duplication
+    const lastMessageMarker = '\n\n___LAST_MESSAGE_MARKER___\nIMPORTANT: When providing your final summary response, include the special marker ___LAST_MESSAGE_MARKER___ at the very beginning of your message. This marker will be automatically removed before posting.'
     const runner = new ClaudeRunner({
       workingDirectory: workspace.path,
       allowedTools,
@@ -449,7 +451,7 @@ export class EdgeWorker extends EventEmitter {
       workspaceName: fullIssue.identifier,
       mcpConfigPath: repository.mcpConfigPath,
       mcpConfig: this.buildMcpConfig(repository),
-      ...(systemPrompt && { appendSystemPrompt: systemPrompt }),
+      appendSystemPrompt: (systemPrompt || '') + lastMessageMarker,
       onMessage: (message) => this.handleClaudeMessage(linearAgentActivitySessionId, message, repository.id),
       // onComplete: (messages) => this.handleClaudeComplete(initialComment.id, messages, repository.id),
       onError: (error) => this.handleClaudeError(error)
@@ -547,6 +549,8 @@ export class EdgeWorker extends EventEmitter {
       const allowedTools = this.buildAllowedTools(repository)
 
       // Create new runner with resume mode if we have a Claude session ID
+      // Always append the last message marker to prevent duplication
+      const lastMessageMarker = '\n\n___LAST_MESSAGE_MARKER___\nIMPORTANT: When providing your final summary response, include the special marker ___LAST_MESSAGE_MARKER___ at the very beginning of your message. This marker will be automatically removed before posting.'
       const runner = new ClaudeRunner({
         workingDirectory: session.workspace.path,
         allowedTools,
@@ -554,6 +558,7 @@ export class EdgeWorker extends EventEmitter {
         workspaceName: issue.identifier,
         mcpConfigPath: repository.mcpConfigPath,
         mcpConfig: this.buildMcpConfig(repository),
+        appendSystemPrompt: lastMessageMarker,
         onMessage: (message) => {
           this.handleClaudeMessage(linearAgentActivitySessionId, message, repository.id)
         },

--- a/packages/edge-worker/test/AgentSessionManager.duplication.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.duplication.test.ts
@@ -50,7 +50,7 @@ describe('AgentSessionManager - Last Message Duplication', () => {
     })
   })
 
-  it('should duplicate the last assistant message as both thought and response', async () => {
+  it('should duplicate the last assistant message as both thought and response without the fix', async () => {
     const claudeSessionId = 'claude-session-123'
     
     // Simulate system message to set Claude session ID
@@ -120,5 +120,72 @@ describe('AgentSessionManager - Last Message Duplication', () => {
 
     // This demonstrates the bug: same content posted twice with different types
     console.log('BUG REPRODUCED: Last message posted as both thought and response')
+  })
+
+  it('should NOT duplicate the last message when using the special marker', async () => {
+    const claudeSessionId = 'claude-session-123'
+    
+    // Simulate system message to set Claude session ID
+    await manager.handleClaudeMessage(sessionId, {
+      type: 'system',
+      subtype: 'init',
+      session_id: claudeSessionId,
+      model: 'test-model',
+      tools: [],
+      permissionMode: 'test',
+      apiKeySource: 'test'
+    })
+
+    // Simulate assistant message with marker and "Summary for Linear:"
+    const summaryContent = `___LAST_MESSAGE_MARKER___Summary for Linear:
+- What bug/error was identified: Last message duplication
+- Root cause analysis: Messages posted as both thought and response
+- Fix implemented: Using special marker to prevent duplication
+- Tests added/passing: This test verifies the fix`
+
+    const assistantMessage: SDKAssistantMessage = {
+      type: 'assistant',
+      session_id: claudeSessionId,
+      parent_tool_use_id: null,
+      message: {
+        content: summaryContent,
+        role: 'assistant'
+      } as APIAssistantMessage
+    }
+
+    await manager.handleClaudeMessage(sessionId, assistantMessage)
+
+    // Simulate result message with same content (including marker)
+    const resultMessage: SDKResultMessage = {
+      type: 'result',
+      subtype: 'success',
+      result: summaryContent,
+      session_id: claudeSessionId,
+      duration_ms: 1000,
+      duration_api_ms: 800,
+      is_error: false,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_write_tokens: 0,
+        cache_read_tokens: 0,
+        total_tokens: 150
+      }
+    }
+
+    await manager.handleClaudeMessage(sessionId, resultMessage)
+
+    // Verify the fix works: only one activity created (the response)
+    expect(createAgentActivitySpy).toHaveBeenCalledTimes(1)
+
+    // The single call should be for the result message (response) with marker stripped
+    const call = createAgentActivitySpy.mock.calls[0][0]
+    expect(call.content.type).toBe('response')
+    expect(call.content.body).not.toContain('___LAST_MESSAGE_MARKER___')
+    expect(call.content.body).toContain('Summary for Linear:')
+    
+    console.log('FIX VERIFIED: Marker prevents duplication and is stripped from output')
   })
 })

--- a/packages/edge-worker/test/AgentSessionManager.duplication.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.duplication.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { LinearClient, LinearDocument } from '@linear/sdk'
+import { AgentSessionManager } from '../src/AgentSessionManager'
+import type { SDKAssistantMessage, SDKResultMessage, APIAssistantMessage } from 'cyrus-claude-runner'
+
+// Mock LinearClient
+vi.mock('@linear/sdk', () => ({
+  LinearClient: vi.fn().mockImplementation(() => ({
+    createAgentActivity: vi.fn()
+  })),
+  LinearDocument: {
+    AgentSessionType: {
+      CommentThread: 'comment_thread'
+    },
+    AgentSessionStatus: {
+      Active: 'active',
+      Complete: 'complete',
+      Error: 'error'
+    }
+  }
+}))
+
+describe('AgentSessionManager - Last Message Duplication', () => {
+  let manager: AgentSessionManager
+  let mockLinearClient: any
+  let createAgentActivitySpy: any
+  const sessionId = 'test-session-123'
+  const issueId = 'issue-123'
+
+  beforeEach(() => {
+    mockLinearClient = new LinearClient({ apiKey: 'test' })
+    createAgentActivitySpy = vi.spyOn(mockLinearClient, 'createAgentActivity')
+    createAgentActivitySpy.mockResolvedValue({ 
+      success: true, 
+      agentActivity: Promise.resolve({ id: 'activity-123' }) 
+    })
+    
+    manager = new AgentSessionManager(mockLinearClient)
+    
+    // Create a test session
+    manager.createLinearAgentSession(sessionId, issueId, {
+      id: issueId,
+      identifier: 'TEST-123',
+      title: 'Test Issue',
+      url: 'https://linear.app/test/issue/TEST-123'
+    }, {
+      id: 'workspace-123',
+      name: 'Test Workspace',
+      displayName: 'Test Workspace'
+    })
+  })
+
+  it('should duplicate the last assistant message as both thought and response', async () => {
+    const claudeSessionId = 'claude-session-123'
+    
+    // Simulate system message to set Claude session ID
+    await manager.handleClaudeMessage(sessionId, {
+      type: 'system',
+      subtype: 'init',
+      session_id: claudeSessionId,
+      model: 'test-model',
+      tools: [],
+      permissionMode: 'test',
+      apiKeySource: 'test'
+    })
+
+    // Simulate assistant message with "Summary for Linear:"
+    const summaryContent = `Summary for Linear:
+- What bug/error was identified: Last message duplication
+- Root cause analysis: Messages posted as both thought and response
+- Fix implemented: None yet
+- Tests added/passing: Creating test now`
+
+    const assistantMessage: SDKAssistantMessage = {
+      type: 'assistant',
+      session_id: claudeSessionId,
+      parent_tool_use_id: null,
+      message: {
+        content: summaryContent,
+        role: 'assistant'
+      } as APIAssistantMessage
+    }
+
+    await manager.handleClaudeMessage(sessionId, assistantMessage)
+
+    // Simulate result message with same content
+    const resultMessage: SDKResultMessage = {
+      type: 'result',
+      subtype: 'success',
+      result: summaryContent,
+      session_id: claudeSessionId,
+      duration_ms: 1000,
+      duration_api_ms: 800,
+      is_error: false,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_write_tokens: 0,
+        cache_read_tokens: 0,
+        total_tokens: 150
+      }
+    }
+
+    await manager.handleClaudeMessage(sessionId, resultMessage)
+
+    // Verify the duplication issue exists
+    expect(createAgentActivitySpy).toHaveBeenCalledTimes(2)
+
+    // First call should be for the assistant message (thought)
+    const firstCall = createAgentActivitySpy.mock.calls[0][0]
+    expect(firstCall.content.type).toBe('thought')
+    expect(firstCall.content.body).toBe(summaryContent)
+
+    // Second call should be for the result message (response)
+    const secondCall = createAgentActivitySpy.mock.calls[1][0]
+    expect(secondCall.content.type).toBe('response')
+    expect(secondCall.content.body).toBe(summaryContent)
+
+    // This demonstrates the bug: same content posted twice with different types
+    console.log('BUG REPRODUCED: Last message posted as both thought and response')
+  })
+})


### PR DESCRIPTION
## Summary
- Fixed duplicate posting of Claude's final summary message in Linear threads
- The last message was appearing as both a "thought" and "response" in Linear UI
- Messages were sometimes appearing out of order with the response posted before the thought

## Test plan
- [x] Added comprehensive test in `AgentSessionManager.duplication.test.ts` that reproduces the issue
- [x] Added test verifying the fix prevents duplication
- [x] Verified marker is properly stripped from final output
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)