### PR TITLE
Rename edge config to be namespaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ workspaces
 .env.secret-agents
 
 # Edge config
-.edge-config.json
+.cyrus-edge-config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Made conversation history of threads be resumable after Cyrus restarts
 - Fixed the issue with continuity of conversation in a thread, after the first comment
 
+### Changed
+- Renamed `.edge-config.json` to `.cyrus-edge-config.json`
+
 ## [0.1.32] - 2025-01-09
 
 ### CLI

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -93,7 +93,7 @@ class EdgeApp {
    * Get the legacy edge configuration file path (for migration)
    */
   getLegacyEdgeConfigPath(): string {
-    return resolve(process.cwd(), '.edge-config.json')
+    return resolve(process.cwd(), '.cyrus-edge-config.json')
   }
 
 

--- a/packages/claude-runner/test-scripts/README.md
+++ b/packages/claude-runner/test-scripts/README.md
@@ -7,7 +7,7 @@ This directory contains test scripts for validating MCP (Model Context Protocol)
 ### `test-mcp-config.js`
 Tests MCP configuration through the ClaudeRunner wrapper. This script:
 - Loads MCP config from `../../../ceedardbmcpconfig.json`
-- Extracts allowed tools from `../../../.edge-config.json` 
+- Extracts allowed tools from `../../../.cyrus-edge-config.json` 
 - Uses ClaudeRunner to start a Claude session with MCP support
 - Tests database queries using the `mcp__ceedardb__query` tool
 
@@ -32,7 +32,7 @@ node test-scripts/test-direct-sdk.js
 
 Both scripts expect these files to exist in the parent directory (relative to cyrus repo root):
 - `../ceedardbmcpconfig.json` - MCP server configuration
-- `../.edge-config.json` - Repository and allowed tools configuration
+- `../.cyrus-edge-config.json` - Repository and allowed tools configuration
 
 ## Example Output
 

--- a/packages/claude-runner/test-scripts/test-direct-sdk.js
+++ b/packages/claude-runner/test-scripts/test-direct-sdk.js
@@ -8,7 +8,7 @@ async function main() {
   try {
     // Read configs (going up three levels from packages/claude-runner)
     const mcpConfigPath = resolve('../../../ceedardbmcpconfig.json')
-    const edgeConfigPath = resolve('../../../.edge-config.json')
+    const edgeConfigPath = resolve('../../../.cyrus-edge-config.json')
     
     console.log('📁 MCP Config Path:', mcpConfigPath)
     console.log('📁 Edge Config Path:', edgeConfigPath)

--- a/packages/claude-runner/test-scripts/test-mcp-config.js
+++ b/packages/claude-runner/test-scripts/test-mcp-config.js
@@ -11,7 +11,7 @@ async function main() {
     console.log('Reading MCP config from:', mcpConfigPath)
     
     // Read edge config to get allowed tools for 'ceedar'
-    const edgeConfigPath = resolve('../.edge-config.json')
+    const edgeConfigPath = resolve('../.cyrus-edge-config.json')
     console.log('Reading edge config from:', edgeConfigPath)
     
     let allowedTools = []


### PR DESCRIPTION
It's best to make it obvious what this this. If it exists in the root of my repo, it will be best if namespaced