### PR TITLE
feat: Add instant response for 'prompted' webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Instant response is now sent when receiving follow-up messages in an existing conversation, providing immediate feedback that Cyrus is working on the request
+  - Shows "I've queued up your message as guidance" when Cyrus is still processing a previous request
+  - Shows "Getting started on that..." when Cyrus is ready to process the new request immediately
 
 ## [0.1.35-alpha.0] - 2025-01-26
 


### PR DESCRIPTION
## Summary
- Added instant acknowledgment when receiving follow-up messages in Linear conversations
- Sends "Getting started on that..." as a thought activity when the 'prompted' webhook is received
- Provides consistent user experience matching the 'created' webhook behavior

## Implementation Details
The solution adds a new `postInstantPromptedAcknowledgment` method that:
1. Sends an agent activity of type "thought" with the message "Getting started on that..."
2. Is called immediately when handling the `agentSession.prompted` webhook
3. Ensures users get immediate feedback that Cyrus has received their follow-up request

This matches the existing behavior for new agent sessions where "I've received your request and I'm starting to work on it" is sent.

## Test plan
- [x] TypeScript compilation passes
- [x] Implementation follows existing patterns
- [ ] Manual testing with Linear webhook integration

Resolves CEA-186

🤖 Generated with [Claude Code](https://claude.ai/code)