### PR TITLE
feat: Emit model notification at thread initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Instant response is now sent when receiving follow-up messages in an existing conversation, providing immediate feedback that Cyrus is working on the request
   - Shows "I've queued up your message as guidance" when Cyrus is still processing a previous request
   - Shows "Getting started on that..." when Cyrus is ready to process the new request immediately
+- Model notification at thread initialization - Cyrus now announces which Claude model is being used (e.g., "Using model: claude-3-opus-20240229") when starting work on an issue
 
 ## [0.1.35-alpha.0] - 2025-01-26
 

--- a/packages/edge-worker/test/AgentSessionManager.model-notification.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.model-notification.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { LinearClient, LinearDocument } from '@linear/sdk'
+import { AgentSessionManager } from '../src/AgentSessionManager'
+import type { SDKSystemMessage } from 'cyrus-claude-runner'
+
+// Mock LinearClient
+vi.mock('@linear/sdk', () => ({
+  LinearClient: vi.fn().mockImplementation(() => ({
+    createAgentActivity: vi.fn()
+  })),
+  LinearDocument: {
+    AgentSessionType: {
+      CommentThread: 'comment_thread'
+    },
+    AgentSessionStatus: {
+      Active: 'active',
+      Complete: 'complete',
+      Error: 'error'
+    }
+  }
+}))
+
+describe('AgentSessionManager - Model Notification', () => {
+  let manager: AgentSessionManager
+  let mockLinearClient: any
+  let createAgentActivitySpy: any
+  const sessionId = 'test-session-123'
+  const issueId = 'issue-123'
+
+  beforeEach(() => {
+    mockLinearClient = new LinearClient({ apiKey: 'test' })
+    createAgentActivitySpy = vi.spyOn(mockLinearClient, 'createAgentActivity')
+    createAgentActivitySpy.mockResolvedValue({ 
+      success: true, 
+      agentActivity: Promise.resolve({ id: 'activity-123' }) 
+    })
+    
+    manager = new AgentSessionManager(mockLinearClient)
+    
+    // Create a test session
+    manager.createLinearAgentSession(sessionId, issueId, {
+      id: issueId,
+      identifier: 'TEST-123',
+      title: 'Test Issue',
+      description: 'Test description',
+      branchName: 'test-branch'
+    }, {
+      path: '/test/workspace',
+      isGitWorktree: false
+    })
+  })
+
+  it('should post model notification when system init message is received', async () => {
+    // Create a system init message with model information
+    const systemMessage: SDKSystemMessage = {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-123',
+      model: 'claude-3-opus-20240229',
+      tools: ['bash', 'grep', 'edit'],
+      permissionMode: 'allowed_tools',
+      apiKeySource: 'claude_desktop'
+    }
+
+    // Handle the system message
+    await manager.handleClaudeMessage(sessionId, systemMessage)
+
+    // Verify that createAgentActivity was called twice:
+    // 1. First for any other activities
+    // 2. Second for the model notification
+    const modelNotificationCall = createAgentActivitySpy.mock.calls.find((call: any) => 
+      call[0].content.type === 'thought' && 
+      call[0].content.body.includes('Using model:')
+    )
+
+    expect(modelNotificationCall).toBeTruthy()
+    expect(modelNotificationCall[0]).toEqual({
+      agentSessionId: sessionId,
+      content: {
+        type: 'thought',
+        body: 'Using model: claude-3-opus-20240229'
+      }
+    })
+  })
+
+  it('should not post model notification if model is not provided', async () => {
+    // Create a system init message without model information
+    const systemMessage: SDKSystemMessage = {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-123',
+      model: '',
+      tools: ['bash', 'grep', 'edit'],
+      permissionMode: 'allowed_tools',
+      apiKeySource: 'claude_desktop'
+    }
+
+    // Handle the system message
+    await manager.handleClaudeMessage(sessionId, systemMessage)
+
+    // Verify that no model notification was posted
+    const modelNotificationCall = createAgentActivitySpy.mock.calls.find((call: any) => 
+      call[0].content.type === 'thought' && 
+      call[0].content.body.includes('Using model:')
+    )
+
+    expect(modelNotificationCall).toBeFalsy()
+  })
+
+  it('should update session metadata with model information', async () => {
+    // Create a system init message with model information
+    const systemMessage: SDKSystemMessage = {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-123',
+      model: 'claude-3-sonnet-20240229',
+      tools: ['bash', 'grep', 'edit'],
+      permissionMode: 'allowed_tools',
+      apiKeySource: 'claude_desktop'
+    }
+
+    // Handle the system message
+    await manager.handleClaudeMessage(sessionId, systemMessage)
+
+    // Verify session metadata was updated
+    const session = manager.getSession(sessionId)
+    expect(session?.metadata?.model).toBe('claude-3-sonnet-20240229')
+    expect(session?.claudeSessionId).toBe('claude-session-123')
+  })
+
+  it('should handle error when posting model notification fails', async () => {
+    // Mock createAgentActivity to fail
+    createAgentActivitySpy.mockResolvedValueOnce({ 
+      success: false, 
+      error: 'Failed to create activity' 
+    })
+
+    // Spy on console.error
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Create a system init message with model information
+    const systemMessage: SDKSystemMessage = {
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-123',
+      model: 'claude-3-opus-20240229',
+      tools: ['bash', 'grep', 'edit'],
+      permissionMode: 'allowed_tools',
+      apiKeySource: 'claude_desktop'
+    }
+
+    // Handle the system message
+    await manager.handleClaudeMessage(sessionId, systemMessage)
+
+    // Verify error was logged
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[AgentSessionManager] Failed to post model notification:',
+      expect.objectContaining({ success: false })
+    )
+
+    // Clean up
+    consoleErrorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds model notification when Cyrus starts working on an issue
- Announces which Claude model is being used (e.g., "Using model: claude-3-opus-20240229")
- Provides transparency to users about which AI model is handling their request

## Test plan
- [x] Unit tests added for model notification feature
- [x] Tests verify that model notification is posted when system init message is received
- [x] Tests verify that model notification is not posted if model info is missing
- [x] Tests verify proper error handling

To manually test:
1. Assign an issue to Cyrus
2. Check that the model notification appears in Linear after the initial acknowledgment

🤖 Generated with [Claude Code](https://claude.ai/code)