### PR TITLE
Update Linear SDK to v54 from v52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated Linear SDK from v52 to v54 for improved API compatibility and access to latest Linear features
+
 ## [0.1.36] - 2025-01-31
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,7 +40,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"@linear/sdk": "^52.0.0",
+		"@linear/sdk": "^54.0.0",
 		"cyrus-core": "workspace:*",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-edge-worker": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@linear/sdk": "^52.0.0",
+		"@linear/sdk": "^54.0.0",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -22,7 +22,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@linear/sdk": "^52.0.0",
+		"@linear/sdk": "^54.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   apps/cli:
     dependencies:
       '@linear/sdk':
-        specifier: ^52.0.0
-        version: 52.0.0(encoding@0.1.13)
+        specifier: ^54.0.0
+        version: 54.0.0(encoding@0.1.13)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../../packages/claude-runner
@@ -232,8 +232,8 @@ importers:
   packages/core:
     dependencies:
       '@linear/sdk':
-        specifier: ^52.0.0
-        version: 52.0.0(encoding@0.1.13)
+        specifier: ^54.0.0
+        version: 54.0.0(encoding@0.1.13)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -251,8 +251,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@linear/sdk':
-        specifier: ^52.0.0
-        version: 52.0.0(encoding@0.1.13)
+        specifier: ^54.0.0
+        version: 54.0.0(encoding@0.1.13)
       '@ngrok/ngrok':
         specifier: ^1.5.1
         version: 1.5.1
@@ -1023,8 +1023,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@linear/sdk@52.0.0':
-    resolution: {integrity: sha512-Dd8fPBcMa0E3Az8v2mICyAjCMF5169dx1TDhF6LrWZbQCeg3xXkL7uZUuvljC79XmK1cG/IRj+iHE0ekepMkUw==}
+  '@linear/sdk@54.0.0':
+    resolution: {integrity: sha512-K/le4oxUWbT/6t1x/c/NbhcofE3hGXIh/1+dQ5Bciy7gAf51NLdS/UDIBAzuiBWmzzKwJWyxMQShEZGqHG7AMQ==}
     engines: {node: '>=12.x', yarn: 1.x}
 
   '@malept/cross-spawn-promise@2.0.0':
@@ -4728,7 +4728,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@linear/sdk@52.0.0(encoding@0.1.13)':
+  '@linear/sdk@54.0.0(encoding@0.1.13)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
       graphql: 15.10.1


### PR DESCRIPTION
## Summary
- Updates Linear SDK dependency from v52 to v54 across all packages
- Ensures compatibility with latest Linear API features
- All tests pass without requiring code changes

## Test plan
- [x] Updated @linear/sdk version in all package.json files
- [x] Ran `pnpm install` to update dependencies
- [x] Built all packages successfully with `pnpm build`
- [x] All tests pass with `pnpm test:packages:run`
- [x] TypeScript compilation successful (no breaking changes detected)
- [x] Biome linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)