### PR TITLE
feat: Add support for direct assignment of Sentry-created issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
   - Cyrus now fetches attachments using Linear's native attachment API
   - Attachments appear in a dedicated "Linear Issue Links" section in the prompt
   - Particularly useful for Sentry error tracking links and other external integrations
+- Support for direct assignment of Sentry-created issues without delegation
+  - Cyrus now detects when issues created by Sentry are directly assigned (not delegated)
+  - Automatically processes these issues by creating a synthetic agent session
+  - Identifies Sentry issues by checking for Sentry attachments, labels, or description patterns
 
 ## [0.1.38] - 2025-08-03
 


### PR DESCRIPTION
## Summary

This PR adds support for processing Linear issues that are directly assigned to Cyrus by Sentry, without requiring delegation through Linear's agent system.

## Problem

When Sentry creates an issue in Linear and automatically assigns Cyrus, it uses direct assignment rather than delegation. The current implementation explicitly ignores issueAssignedToYou webhooks in favor of agent session events, causing these Sentry-created issues to be ignored.

## Solution

- Added detection logic to identify Sentry-created issues based on:
  - Sentry attachments (URLs containing 'sentry.io')
  - Sentry-related labels
  - Sentry patterns in issue descriptions
- When a direct assignment webhook is received for a Sentry issue:
  - Creates a synthetic agent session
  - Processes the issue using the same flow as delegated issues
  - Posts updates back to Linear as comments

## Implementation Details

1. **New methods in EdgeWorker**:
   - checkIfSentryCreatedIssue(): Detects if an issue was created by Sentry
   - handleSentryIssueAssignment(): Processes Sentry issues with direct assignment

2. **Modified webhook handling**:
   - issueAssignedToYou webhooks are now checked for Sentry origin
   - Non-Sentry direct assignments continue to be ignored

## Testing

- All existing tests pass
- Build completes successfully
- Code follows project formatting standards

## Backwards Compatibility

- Existing delegation-based workflow remains unchanged
- Only affects handling of direct assignments from Sentry
- No breaking changes to public APIs

Fixes PACK-204