### PR TITLE
Prepare release v0.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.39] - 2025-08-06
+
 ### Added
 - Native Linear attachments (like Sentry error links) are now included in the issue context sent to Claude
   - Cyrus now fetches attachments using Linear's native attachment API
@@ -32,8 +34,6 @@ All notable changes to this project will be documented in this file.
   - Always include attachments directory in allowedDirectories configuration
 - Fixed issue where messages from @ Cyrus mention comments weren't being added to context
 - Fixed issue where sub-issue base branches weren't being added to the user-prompt template, causing Cyrus to create PRs against the default branch instead
-
-### Added
 
 
 ## [0.1.37] - 2025-08-03


### PR DESCRIPTION
## Summary
- Prepare CHANGELOG.md for v0.1.39 release
- Move unreleased changes to a versioned section with today's date
- Ready for final review before publishing

## Changes Included in v0.1.39
### Added
- Native Linear attachments support (Sentry links, etc.)
- New `cyrus add-repository` command
- Attachment support for comments
- @ mention vs delegation differentiation
- Subscription management CLI commands

### Fixed
- Attachment accessibility during streaming sessions
- @ mention context handling
- Sub-issue base branch configuration

## Test Plan
- [x] Updated CHANGELOG.md with new version section
- [x] Ran package tests (passing except edge-worker which has known issues)
- [x] TypeScript compilation verified for publishable packages
- [x] All packages built successfully

🤖 Generated with [Claude Code](https://claude.ai/code)