### PR TITLE
Implement dynamic allowed tools feature for MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- MCP tools are now dynamically discovered and allowed based on configured servers
+  - Previously only hardcoded Linear MCP tools were allowed
+  - Now automatically allows tools from all MCP servers configured in repository's mcpConfigPath
+  - Uses wildcard permission format (e.g., "mcp__linear" allows all Linear MCP tools)
+
 ## [0.1.39] - 2025-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ Each repository in the `repositories` array can have these optional properties:
 #### `allowedTools` (array of strings)
 Controls which tools Claude can use when processing issues. Default: all standard tools plus `Bash(git:*)` and `Bash(gh:*)`.
 
+**Note:** MCP tools are now automatically discovered! If you configure MCP servers via `mcpConfigPath`, all tools from those servers are automatically allowed. You don't need to manually add them to `allowedTools`.
+
 Examples:
 - `["Read(**)", "Edit(**)", "Bash(git:*)", "Task"]` - Allow reading, editing, git commands, and task management
 - `["Read(**)", "Edit(**)", "Bash(npm:*)", "WebSearch"]` - Allow reading, editing, npm commands, and web search
+
+MCP tool patterns (usually not needed due to automatic discovery):
 - `["Read(**)", "Edit(**)", "mcp__github"]` - Allow all tools from the GitHub MCP server
 - `["Read(**)", "Edit(**)", "mcp__github__search_repositories"]` - Allow only the search_repositories tool from GitHub MCP
 
@@ -64,6 +68,8 @@ For security configuration details, see: https://docs.anthropic.com/en/docs/clau
 
 #### `mcpConfigPath` (string or array of strings)
 Path(s) to MCP (Model Context Protocol) configuration files. MCP allows Claude to access external tools and data sources like databases or APIs.
+
+**Automatic Tool Discovery:** When you specify `mcpConfigPath`, Cyrus automatically discovers and allows all tools from the configured MCP servers. For example, if your config includes a "github" server, all GitHub tools become available without needing to add `"mcp__github"` to `allowedTools`.
 
 Can be specified as:
 - A single string: `"mcpConfigPath": "/home/user/myapp/mcp-config.json"`

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -27,7 +27,7 @@ export interface RepositoryConfig {
 	// Optional settings
 	isActive?: boolean; // Whether to process webhooks for this repo (default: true)
 	promptTemplatePath?: string; // Custom prompt template for this repo
-	allowedTools?: string[]; // Override Claude tools for this repository (overrides defaultAllowedTools)
+	allowedTools?: string[]; // Override Claude tools for this repository (overrides defaultAllowedTools). MCP tools from mcpConfigPath are automatically included.
 	mcpConfigPath?: string | string[]; // Path(s) to MCP configuration JSON file(s) (format: {"mcpServers": {...}})
 	appendInstruction?: string; // Additional instruction to append to the prompt in XML-style wrappers
 

--- a/packages/edge-worker/test/EdgeWorker.tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.tools.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import type { EdgeWorkerConfig, RepositoryConfig } from "../src/types.js";
+import { getSafeTools } from "cyrus-claude-runner";
+import * as fs from "node:fs";
+
+// Mock dependencies
+vi.mock("cyrus-core", () => ({
+	createWorkspaceId: () => "workspace-123",
+	PersistenceManager: vi.fn().mockImplementation(() => ({
+		loadSession: vi.fn(),
+		saveSession: vi.fn(),
+		deleteSession: vi.fn(),
+		listSessions: vi.fn(),
+	})),
+}));
+
+vi.mock("../src/services/LinearSdkService.js", () => ({
+	LinearSdkService: vi.fn().mockImplementation(() => ({
+		init: vi.fn(),
+		getIssue: vi.fn(),
+		getAssignedIssues: vi.fn(),
+		createComment: vi.fn(),
+		getIssueComments: vi.fn(),
+		getTeams: vi.fn(),
+		getWorkflowStates: vi.fn(),
+		updateIssue: vi.fn(),
+	})),
+}));
+
+vi.mock("cyrus-claude-runner", () => ({
+	ClaudeRunner: vi.fn(),
+	getSafeTools: vi.fn(() => [
+		"Read(**)",
+		"Edit(**)",
+		"Write(**)",
+		"Bash",
+		"LS",
+		"Grep(**)",
+		"Task",
+		"TodoWrite",
+		"NotebookRead(**)",
+		"NotebookEdit(**)",
+	]),
+}));
+
+vi.mock("node:fs");
+
+describe("EdgeWorker Tool Configuration", () => {
+	let edgeWorker: EdgeWorker;
+	let mockConfig: EdgeWorkerConfig;
+	let mockRepository: RepositoryConfig;
+
+	beforeEach(() => {
+		mockRepository = {
+			id: "test-repo",
+			name: "Test Repository",
+			repositoryPath: "/repos/test",
+			baseBranch: "main",
+			linearWorkspaceId: "test-workspace",
+			linearToken: "test-token",
+			workspaceBaseDir: "/workspaces",
+		};
+
+		mockConfig = {
+			proxyUrl: "http://proxy.test",
+			repositories: [mockRepository],
+		};
+
+		edgeWorker = new EdgeWorker(mockConfig);
+
+		// Setup console mocks
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.restoreAllMocks();
+	});
+
+	describe("getMcpServerNames", () => {
+		it("should always include linear server", () => {
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+			expect(serverNames).toContain("linear");
+		});
+
+		it("should parse single mcpConfigPath", () => {
+			mockRepository.mcpConfigPath = "/path/to/mcp.json";
+			vi.mocked(fs.readFileSync).mockReturnValue(
+				JSON.stringify({
+					mcpServers: {
+						github: {},
+						database: {},
+					},
+				}),
+			);
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toContain("linear");
+			expect(serverNames).toContain("github");
+			expect(serverNames).toContain("database");
+			expect(serverNames).toHaveLength(3);
+		});
+
+		it("should parse multiple mcpConfigPath array", () => {
+			mockRepository.mcpConfigPath = [
+				"/path/to/mcp1.json",
+				"/path/to/mcp2.json",
+			];
+			vi.mocked(fs.readFileSync)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							github: {},
+						},
+					}),
+				)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							database: {},
+							slack: {},
+						},
+					}),
+				);
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toContain("linear");
+			expect(serverNames).toContain("github");
+			expect(serverNames).toContain("database");
+			expect(serverNames).toContain("slack");
+			expect(serverNames).toHaveLength(4);
+		});
+
+		it("should handle missing mcpConfigPath gracefully", () => {
+			// No mcpConfigPath set
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toEqual(["linear"]);
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		it("should handle invalid JSON in mcpConfigPath", () => {
+			mockRepository.mcpConfigPath = "/path/to/invalid.json";
+			vi.mocked(fs.readFileSync).mockReturnValue("{ invalid json }");
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toEqual(["linear"]);
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining("Failed to load MCP config"),
+				expect.anything(),
+			);
+		});
+
+		it("should handle file read errors gracefully", () => {
+			mockRepository.mcpConfigPath = "/path/to/nonexistent.json";
+			vi.mocked(fs.readFileSync).mockImplementation(() => {
+				throw new Error("ENOENT: no such file or directory");
+			});
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toEqual(["linear"]);
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining("Failed to load MCP config"),
+				expect.anything(),
+			);
+		});
+
+		it("should deduplicate server names", () => {
+			mockRepository.mcpConfigPath = [
+				"/path/to/mcp1.json",
+				"/path/to/mcp2.json",
+			];
+			vi.mocked(fs.readFileSync)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							github: {},
+							database: {},
+						},
+					}),
+				)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							github: {}, // duplicate
+							slack: {},
+						},
+					}),
+				);
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			// Should deduplicate github
+			expect(serverNames).toEqual(["linear", "github", "database", "slack"]);
+		});
+
+		it("should handle configs without mcpServers key", () => {
+			mockRepository.mcpConfigPath = "/path/to/empty.json";
+			vi.mocked(fs.readFileSync).mockReturnValue(
+				JSON.stringify({
+					// No mcpServers key
+					someOtherConfig: {},
+				}),
+			);
+
+			const serverNames = (edgeWorker as any).getMcpServerNames.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(serverNames).toEqual(["linear"]);
+		});
+	});
+
+	describe("buildAllowedTools", () => {
+		it("should use repository allowedTools when specified", () => {
+			mockRepository.allowedTools = ["Read(**)", "Edit(**)", "Task"];
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(allowedTools).toContain("Read(**)");
+			expect(allowedTools).toContain("Edit(**)");
+			expect(allowedTools).toContain("Task");
+			expect(allowedTools).toContain("mcp__linear");
+		});
+
+		it("should use defaultAllowedTools when repository tools not specified", () => {
+			mockConfig.defaultAllowedTools = ["WebSearch", "WebFetch"];
+			edgeWorker = new EdgeWorker(mockConfig);
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(allowedTools).toContain("WebSearch");
+			expect(allowedTools).toContain("WebFetch");
+			expect(allowedTools).toContain("mcp__linear");
+		});
+
+		it("should fall back to getSafeTools when no tools configured", () => {
+			const safeTools = getSafeTools();
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			// Should contain all safe tools plus MCP tools
+			for (const tool of safeTools) {
+				expect(allowedTools).toContain(tool);
+			}
+			expect(allowedTools).toContain("mcp__linear");
+		});
+
+		it("should add MCP wildcard tools for all configured servers", () => {
+			mockRepository.allowedTools = ["Read(**)"];
+			mockRepository.mcpConfigPath = "/path/to/mcp.json";
+			vi.mocked(fs.readFileSync).mockReturnValue(
+				JSON.stringify({
+					mcpServers: {
+						github: {},
+						database: {},
+					},
+				}),
+			);
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			expect(allowedTools).toContain("Read(**)");
+			expect(allowedTools).toContain("mcp__linear");
+			expect(allowedTools).toContain("mcp__github");
+			expect(allowedTools).toContain("mcp__database");
+		});
+
+		it("should deduplicate tools if duplicates exist", () => {
+			mockRepository.allowedTools = ["Read(**)", "mcp__linear", "Task"];
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			// Should not have duplicate mcp__linear
+			const linearCount = allowedTools.filter(
+				(tool) => tool === "mcp__linear",
+			).length;
+			expect(linearCount).toBe(1);
+		});
+
+		it("should handle empty allowedTools array", () => {
+			mockRepository.allowedTools = [];
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			// Should only have MCP tools
+			expect(allowedTools).toEqual(["mcp__linear"]);
+		});
+
+		it("should log allowed tools configuration", () => {
+			mockRepository.allowedTools = ["Read(**)", "Edit(**)"];
+			mockRepository.mcpConfigPath = "/path/to/mcp.json";
+			vi.mocked(fs.readFileSync).mockReturnValue(
+				JSON.stringify({
+					mcpServers: {
+						github: {},
+					},
+				}),
+			);
+
+			(edgeWorker as any).buildAllowedTools.bind(edgeWorker)(mockRepository);
+
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining("Allowed tools for repository Test Repository"),
+				expect.objectContaining({
+					mcpWildcards: ["mcp__linear", "mcp__github"],
+					totalCount: 4,
+				}),
+			);
+		});
+	});
+
+	describe("Integration - buildAllowedTools with getMcpServerNames", () => {
+		it("should correctly combine tools from multiple sources", () => {
+			// Set up a realistic scenario
+			mockRepository.allowedTools = [
+				"Read(**)",
+				"Edit(**)",
+				"Bash",
+				"Task",
+				"WebSearch",
+			];
+			mockRepository.mcpConfigPath = [
+				"/path/to/github-mcp.json",
+				"/path/to/custom-mcp.json",
+			];
+
+			vi.mocked(fs.readFileSync)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							github: {
+								command: "npx",
+								args: ["@modelcontextprotocol/server-github"],
+							},
+						},
+					}),
+				)
+				.mockReturnValueOnce(
+					JSON.stringify({
+						mcpServers: {
+							ceedardb: {
+								command: "python",
+								args: ["-m", "mcp_ceedar"],
+							},
+							slack: {
+								command: "npx",
+								args: ["@modelcontextprotocol/server-slack"],
+							},
+						},
+					}),
+				);
+
+			const allowedTools = (edgeWorker as any).buildAllowedTools.bind(
+				edgeWorker,
+			)(mockRepository);
+
+			// Should have all base tools
+			expect(allowedTools).toContain("Read(**)");
+			expect(allowedTools).toContain("Edit(**)");
+			expect(allowedTools).toContain("Bash");
+			expect(allowedTools).toContain("Task");
+			expect(allowedTools).toContain("WebSearch");
+
+			// Should have MCP wildcards for all servers
+			expect(allowedTools).toContain("mcp__linear");
+			expect(allowedTools).toContain("mcp__github");
+			expect(allowedTools).toContain("mcp__ceedardb");
+			expect(allowedTools).toContain("mcp__slack");
+
+			// Total should be 9 unique tools
+			expect(allowedTools).toHaveLength(9);
+
+			// Check logging
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining("Found MCP servers in /path/to/github-mcp.json"),
+			);
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining("Found MCP servers in /path/to/custom-mcp.json"),
+			);
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining("Total MCP servers configured"),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Implements automatic discovery and inclusion of MCP tools from configured servers
- Replaces hardcoded `mcp__linear` with dynamic discovery of all MCP servers
- Adds comprehensive test coverage for the new functionality

## Changes
- **New `getMcpServerNames()` method**: Discovers all MCP servers from the repository's `mcpConfigPath` configuration
- **Updated `buildAllowedTools()` method**: Automatically generates wildcard permissions (`mcp__<server-name>`) for all discovered MCP servers  
- **Documentation updates**: README and type definitions now explain the automatic tool discovery feature
- **Test coverage**: Added 16 new tests covering all edge cases and integration scenarios

## Technical Details
The implementation reads MCP configuration files specified in `mcpConfigPath` and extracts server names from the `mcpServers` object. It then automatically allows all tools from these servers using the wildcard permission format documented at https://docs.anthropic.com/en/docs/claude-code/iam#tool-specific-permission-rules.

This means if a repository configures an MCP server like:
```json
{
  "mcpServers": {
    "github": { ... },
    "database": { ... }
  }
}
```

Cyrus will automatically allow:
- `mcp__linear` (always included)
- `mcp__github` (all GitHub tools)
- `mcp__database` (all database tools)

## Test plan
- [x] All existing tests pass
- [x] New tests cover getMcpServerNames functionality
- [x] New tests cover updated buildAllowedTools functionality  
- [x] Integration tests verify the features work together
- [x] TypeScript compilation succeeds
- [x] Documentation has been updated

Closes PACK-221

🤖 Generated with [Claude Code](https://claude.ai/code)