### PR TITLE
feat: Add label-based repository routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Label-based repository routing - Route Linear issues to different git repositories based on their labels
+  - New `routingLabels` configuration option allows specifying which labels should route to a specific repository
+  - Useful when multiple repositories handle issues from the same Linear team (e.g., backend vs frontend repos)
+  - Label routing takes precedence over team-based routing for more granular control
+
 ### Changed
 - Updated Linear SDK from v54 to v55.1.0 to support Agent Activity Signals
   - Stop button in Linear UI now sends a deterministic `stop` signal that Cyrus responds to immediately

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Routes Linear issues from specific teams to this repository. When specified, onl
 
 Example: `["CEE", "FRONT", "BACK"]` - Only process issues from teams CEE, FRONT, and BACK
 
+#### `routingLabels` (array of strings)
+Routes Linear issues with specific labels to this repository. This is useful when you have multiple repositories handling issues from the same Linear team but want to route based on labels (e.g., "backend" vs "frontend" labels).
+
+Example: `["backend", "api"]` - Only process issues that have the "backend" or "api" label
+
+Note: Label-based routing takes precedence over team-based routing. If an issue matches both a `routingLabels` and `teamKeys` configuration, the label match will be used.
+
 #### `labelPrompts` (object)
 Routes issues to different AI modes based on Linear labels. Default:
 ```json
@@ -116,6 +123,7 @@ Routes issues to different AI modes based on Linear labels. Default:
     "allowedTools": ["Read(**)", "Edit(**)", "Bash(git:*)", "Bash(gh:*)", "Task"],
     "mcpConfigPath": "./mcp-config.json",
     "teamKeys": ["BACKEND"],
+    "routingLabels": ["backend", "api", "infrastructure"],
     "labelPrompts": {
       "debugger": ["Bug", "Hotfix"],
       "builder": ["Feature"],

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -458,39 +458,36 @@ export class EdgeWorker extends EventEmitter {
 		);
 
 		// If we have repos with routing labels and an issue ID, check labels
-		if (reposWithRoutingLabels.length > 0 && issueId) {
+		if (reposWithRoutingLabels.length > 0 && issueId && workspaceRepos[0]) {
 			// We need a Linear client to fetch labels
 			// Use the first workspace repo's client temporarily
-			const tempRepo = workspaceRepos[0];
-			if (tempRepo) {
-				const linearClient = this.linearClients.get(tempRepo.id);
+			const linearClient = this.linearClients.get(workspaceRepos[0].id);
 
-				if (linearClient) {
-					try {
-						// Fetch the issue to get labels
-						const issue = await linearClient.issue(issueId);
-						const labels = await this.fetchIssueLabels(issue);
+			if (linearClient) {
+				try {
+					// Fetch the issue to get labels
+					const issue = await linearClient.issue(issueId);
+					const labels = await this.fetchIssueLabels(issue);
 
-						// Check each repo with routing labels
-						for (const repo of reposWithRoutingLabels) {
-							if (
-								repo.routingLabels?.some((routingLabel) =>
-									labels.includes(routingLabel),
-								)
-							) {
-								console.log(
-									`[EdgeWorker] Matched repository ${repo.name} by label routing`,
-								);
-								return repo;
-							}
+					// Check each repo with routing labels
+					for (const repo of reposWithRoutingLabels) {
+						if (
+							repo.routingLabels?.some((routingLabel) =>
+								labels.includes(routingLabel),
+							)
+						) {
+							console.log(
+								`[EdgeWorker] Matched repository ${repo.name} by label routing`,
+							);
+							return repo;
 						}
-					} catch (error) {
-						console.error(
-							`[EdgeWorker] Failed to fetch labels for routing:`,
-							error,
-						);
-						// Fall back to team-based routing
 					}
+				} catch (error) {
+					console.error(
+						`[EdgeWorker] Failed to fetch labels for routing:`,
+						error,
+					);
+					// Fall back to team-based routing
 				}
 			}
 		}

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -335,7 +335,7 @@ export class EdgeWorker extends EventEmitter {
 		}
 
 		// Find the appropriate repository for this webhook
-		const repository = this.findRepositoryForWebhook(webhook, repos);
+		const repository = await this.findRepositoryForWebhook(webhook, repos);
 		if (!repository) {
 			console.log(
 				"No repository configured for webhook from workspace",
@@ -348,6 +348,7 @@ export class EdgeWorker extends EventEmitter {
 						name: r.name,
 						workspaceId: r.linearWorkspaceId,
 						teamKeys: r.teamKeys,
+						routingLabels: r.routingLabels,
 					})),
 				);
 			}
@@ -417,61 +418,106 @@ export class EdgeWorker extends EventEmitter {
 
 	/**
 	 * Find the repository configuration for a webhook
+	 * Now supports async operations for label-based routing
 	 */
-	private findRepositoryForWebhook(
+	private async findRepositoryForWebhook(
 		webhook: LinearWebhook,
 		repos: RepositoryConfig[],
-	): RepositoryConfig | null {
+	): Promise<RepositoryConfig | null> {
 		const workspaceId = webhook.organizationId;
 		if (!workspaceId) return repos[0] || null; // Fallback to first repo if no workspace ID
+
+		// Get issue ID to fetch labels if needed
+		let issueId: string | undefined;
+		let teamKey: string | undefined;
+		let issueIdentifier: string | undefined;
 
 		// Handle agent session webhooks which have different structure
 		if (
 			isAgentSessionCreatedWebhook(webhook) ||
 			isAgentSessionPromptedWebhook(webhook)
 		) {
-			const teamKey = webhook.agentSession?.issue?.team?.key;
-			if (teamKey) {
-				const repo = repos.find((r) => r.teamKeys?.includes(teamKey));
-				if (repo) return repo;
-			}
-
-			// Try parsing issue identifier as fallback
-			const issueId = webhook.agentSession?.issue?.identifier;
-			if (issueId?.includes("-")) {
-				const prefix = issueId.split("-")[0];
-				if (prefix) {
-					const repo = repos.find((r) => r.teamKeys?.includes(prefix));
-					if (repo) return repo;
-				}
-			}
+			issueId = webhook.agentSession?.issue?.id;
+			teamKey = webhook.agentSession?.issue?.team?.key;
+			issueIdentifier = webhook.agentSession?.issue?.identifier;
 		} else {
-			// Original logic for other webhook types
-			const teamKey = webhook.notification?.issue?.team?.key;
-			if (teamKey) {
-				const repo = repos.find((r) => r.teamKeys?.includes(teamKey));
-				if (repo) return repo;
-			}
+			issueId = webhook.notification?.issue?.id;
+			teamKey = webhook.notification?.issue?.team?.key;
+			issueIdentifier = webhook.notification?.issue?.identifier;
+		}
 
-			// Try parsing issue identifier as fallback
-			const issueId = webhook.notification?.issue?.identifier;
-			if (issueId?.includes("-")) {
-				const prefix = issueId.split("-")[0];
-				if (prefix) {
-					const repo = repos.find((r) => r.teamKeys?.includes(prefix));
-					if (repo) return repo;
+		// Filter repos by workspace first
+		const workspaceRepos = repos.filter(
+			(repo) => repo.linearWorkspaceId === workspaceId,
+		);
+		if (workspaceRepos.length === 0) return null;
+
+		// Check if any repos have routingLabels configured
+		const reposWithRoutingLabels = workspaceRepos.filter(
+			(repo) => repo.routingLabels && repo.routingLabels.length > 0,
+		);
+
+		// If we have repos with routing labels and an issue ID, check labels
+		if (reposWithRoutingLabels.length > 0 && issueId) {
+			// We need a Linear client to fetch labels
+			// Use the first workspace repo's client temporarily
+			const tempRepo = workspaceRepos[0];
+			if (tempRepo) {
+				const linearClient = this.linearClients.get(tempRepo.id);
+
+				if (linearClient) {
+					try {
+						// Fetch the issue to get labels
+						const issue = await linearClient.issue(issueId);
+						const labels = await this.fetchIssueLabels(issue);
+
+						// Check each repo with routing labels
+						for (const repo of reposWithRoutingLabels) {
+							if (
+								repo.routingLabels?.some((routingLabel) =>
+									labels.includes(routingLabel),
+								)
+							) {
+								console.log(
+									`[EdgeWorker] Matched repository ${repo.name} by label routing`,
+								);
+								return repo;
+							}
+						}
+					} catch (error) {
+						console.error(
+							`[EdgeWorker] Failed to fetch labels for routing:`,
+							error,
+						);
+						// Fall back to team-based routing
+					}
 				}
 			}
 		}
 
-		// Original workspace fallback - find first repo without teamKeys or matching workspace
+		// Fall back to team-based routing
+		if (teamKey) {
+			const repo = workspaceRepos.find((r) => r.teamKeys?.includes(teamKey));
+			if (repo) return repo;
+		}
+
+		// Try parsing issue identifier as fallback
+		if (issueIdentifier?.includes("-")) {
+			const prefix = issueIdentifier.split("-")[0];
+			if (prefix) {
+				const repo = workspaceRepos.find((r) => r.teamKeys?.includes(prefix));
+				if (repo) return repo;
+			}
+		}
+
+		// Original workspace fallback - find first repo without teamKeys or routing labels
 		return (
-			repos.find(
+			workspaceRepos.find(
 				(repo) =>
-					repo.linearWorkspaceId === workspaceId &&
-					(!repo.teamKeys || repo.teamKeys.length === 0),
+					(!repo.teamKeys || repo.teamKeys.length === 0) &&
+					(!repo.routingLabels || repo.routingLabels.length === 0),
 			) ||
-			repos.find((repo) => repo.linearWorkspaceId === workspaceId) ||
+			workspaceRepos[0] ||
 			null
 		);
 	}

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -20,6 +20,7 @@ export interface RepositoryConfig {
 	linearWorkspaceName?: string; // Linear workspace display name (optional, for UI)
 	linearToken: string; // OAuth token for this Linear workspace
 	teamKeys?: string[]; // Linear team keys for routing (e.g., ["CEE", "BOOK"])
+	routingLabels?: string[]; // Linear labels for routing issues to this repository (e.g., ["backend", "api"])
 
 	// Workspace configuration
 	workspaceBaseDir: string; // Where to create issue workspaces for this repo


### PR DESCRIPTION
## Summary
- Adds `routingLabels` configuration option to route Linear issues to specific repositories based on their labels
- Label routing takes precedence over existing team-based routing for more granular control
- Useful when multiple repositories handle issues from the same Linear team (e.g., backend vs frontend repos)

## Implementation
- Added `routingLabels` field to RepositoryConfig interface
- Updated `findRepositoryForWebhook` method to check issue labels when determining repository routing
- When an issue has labels matching a repository's `routingLabels`, it routes to that repository
- Falls back to team-based routing if no label match is found

## Configuration Example
```json
{
  "repositories": [{
    "id": "backend-repo",
    "name": "backend",
    "routingLabels": ["backend", "api", "infrastructure"],
    // ... other config
  }, {
    "id": "frontend-repo", 
    "name": "frontend",
    "routingLabels": ["frontend", "ui", "design"],
    // ... other config
  }]
}
```

## Test Plan
- [ ] Configure two repositories with different `routingLabels` for the same Linear team
- [ ] Create Linear issues with different labels and verify they route to the correct repository
- [ ] Verify team-based routing still works when no labels match
- [ ] Test error handling when label fetching fails

Fixes #PACK-225

🤖 Generated with [Claude Code](https://claude.ai/code)