### PR TITLE
Update Anthropic AI SDK and Claude Code to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
   - Stop button in Linear UI now sends a deterministic `stop` signal that Cyrus responds to immediately
   - When you click the stop button while Cyrus is working, it will cleanly halt all operations and confirm the stop action
   - The stop signal implementation ensures no work continues after the stop is requested
-- Updated Anthropic AI SDK from v0.57.0 to v0.59.0 for improved Claude integration
+- Updated Anthropic AI SDK from v0.57.0 to v0.59.0 and Claude Code from v1.0.61 to v1.0.72 for improved Claude integration
 
 ## [0.1.39] - 2025-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
   - Stop button in Linear UI now sends a deterministic `stop` signal that Cyrus responds to immediately
   - When you click the stop button while Cyrus is working, it will cleanly halt all operations and confirm the stop action
   - The stop signal implementation ensures no work continues after the stop is requested
+- Updated Anthropic AI SDK from v0.57.0 to v0.59.0 for improved Claude integration
 
 ## [0.1.39] - 2025-08-08
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.61",
-		"@anthropic-ai/sdk": "^0.57.0"
+		"@anthropic-ai/claude-code": "^1.0.72",
+		"@anthropic-ai/sdk": "^0.59.0"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,11 +95,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.61
-        version: 1.0.61
+        specifier: ^1.0.72
+        version: 1.0.72
       '@anthropic-ai/sdk':
-        specifier: ^0.57.0
-        version: 0.57.0
+        specifier: ^0.59.0
+        version: 0.59.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -188,13 +188,13 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.61':
-    resolution: {integrity: sha512-+gjKzY1hsWfHoH52SgKR6E0ujCDPyyRsjyRShtZfS0urKd8VQq3D/DF3hvT3P4JJeW0YuWp5Dep0aSRON+/FFA==}
+  '@anthropic-ai/claude-code@1.0.72':
+    resolution: {integrity: sha512-nA/l/xKX4sgOE0Y6P3o6czNGQqlyqJPjs9CHFxantsmyKvOot9VlRW4AiEAn42hQrZReCXeSnt8LOMx9ev7Erg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@anthropic-ai/sdk@0.57.0':
-    resolution: {integrity: sha512-z5LMy0MWu0+w2hflUgj4RlJr1R+0BxKXL7ldXTO8FasU8fu599STghO+QKwId2dAD0d464aHtU+ChWuRHw4FNw==}
+  '@anthropic-ai/sdk@0.59.0':
+    resolution: {integrity: sha512-m9w9tC+N+GUNprwEOhU3VKKSYwXA1fIevRCe7kOFonV4xu5vxqmqyoLy+dkdVvc5W1F4WUTVE/7I4criaF9gnw==}
     hasBin: true
 
   '@babel/helper-string-parser@7.27.1':
@@ -2347,7 +2347,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.61':
+  '@anthropic-ai/claude-code@1.0.72':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -2356,7 +2356,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.57.0': {}
+  '@anthropic-ai/sdk@0.59.0': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 


### PR DESCRIPTION
## Summary
- Updated `@anthropic-ai/sdk` from v0.57.0 to v0.59.0
- Updated `@anthropic-ai/claude-code` from v1.0.61 to v1.0.72
- Updated CHANGELOG.md to document the SDK version update

## Test plan
- [ ] Build all packages successfully with `pnpm build`
- [ ] Run all tests with `pnpm test:packages`
- [ ] Verify claude-runner functionality works correctly with the new SDK version
- [ ] Test a sample Claude session to ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)