### PR TITLE
feat: handle orphaned Linear agent sessions when Cyrus restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Orphaned Linear agent session recovery - Cyrus now automatically recovers sessions after restarts
+  - Detects orphaned sessions when users continue conversations after Cyrus restarts
+  - Recovers session state from Linear API and recreates infrastructure
+  - Provides user-friendly notifications during recovery process
+  - Automatically recreates ClaudeRunner instances for all active sessions on startup
+  - Ensures seamless conversation continuation across deployments, crashes, and maintenance
+
 ### Changed
 - Updated Linear SDK from v54 to v55.1.0 to support Agent Activity Signals
   - Stop button in Linear UI now sends a deterministic `stop` signal that Cyrus responds to immediately


### PR DESCRIPTION
## Summary
- Implements recovery mechanism for orphaned Linear agent sessions
- Detects and recovers lost sessions after Cyrus restarts
- Provides user-friendly notifications during recovery process

## Problem
When Cyrus restarts, it loses track of in-memory agent sessions but Linear still has the sessions active. This causes "Unexpected: could not find Cyrus Agent Session" errors when users try to continue conversations. The issue occurs because:
1. Cyrus ignores `issueAssignedToYou` webhooks to avoid traditional notifications
2. Sessions created while Cyrus was offline are unknown when it comes back online
3. There's no mechanism to recover these orphaned sessions

## Solution
This PR adds comprehensive session recovery that:
1. **Detects orphaned sessions** - When receiving an `agentSession.prompted` webhook, checks if the session exists locally
2. **Recovers from Linear API** - Queries Linear to determine if this is a legitimate orphaned session
3. **Recreates infrastructure** - Rebuilds ClaudeRunner instances in resume mode using saved session data
4. **Provides user feedback** - Posts recovery notifications to keep users informed
5. **Handles startup recovery** - Automatically recreates ClaudeRunners for all active sessions on restart

## Implementation Details
- Modified `handleUserPostedAgentActivity` to attempt recovery when session not found
- Added `recoverOrphanedSession` method to handle the recovery logic
- Added helper methods for posting recovery status to Linear
- Enhanced `restoreMappings` to recreate ClaudeRunners for active sessions on startup
- Added `recreateClaudeRunnersForActiveSessions` for batch session recovery

## Testing
- Tested recovery after Cyrus restart with active sessions
- Verified user notifications appear correctly in Linear
- Confirmed no regression for normal online operation
- Validated workspace and attachments directory recreation

## Linear Issue
Fixes [PACK-231](https://linear.app/cyrus/issue/PACK-231/handle-orphaned-linear-agent-sessions-when-cyrus-restarts)

🤖 Generated with [Claude Code](https://claude.ai/code)