### PR TITLE
chore: update @anthropic-ai/claude-code to v1.0.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-code from v1.0.72 to v1.0.73 for latest Claude Code improvements
+
 ### Fixed
 - Resolved issue where Cyrus would fail to respond when it was initially delegated when the receiver was down
   - Now properly creates new sessions when prompted if none existed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.72",
+		"@anthropic-ai/claude-code": "^1.0.73",
 		"@anthropic-ai/sdk": "^0.59.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.72
-        version: 1.0.72
+        specifier: ^1.0.73
+        version: 1.0.73
       '@anthropic-ai/sdk':
         specifier: ^0.59.0
         version: 0.59.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.72':
-    resolution: {integrity: sha512-nA/l/xKX4sgOE0Y6P3o6czNGQqlyqJPjs9CHFxantsmyKvOot9VlRW4AiEAn42hQrZReCXeSnt8LOMx9ev7Erg==}
+  '@anthropic-ai/claude-code@1.0.73':
+    resolution: {integrity: sha512-UVBkta/BWy49xR9fgi/Oy2tl7p/k+lOCinv21zSK/E9KB4JObAAZ1BAOWteu4fhv7gs3Ipfev5r6yo3OplmwNg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.72':
+  '@anthropic-ai/claude-code@1.0.73':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.72 to v1.0.73
- @anthropic-ai/sdk was already on the latest version (v0.59.0)

## Test plan
- [x] Ran all package tests (`pnpm test:packages:run`) - All 106 tests passing
- [x] Verified TypeScript compilation (`pnpm typecheck`) - No errors
- [x] Confirmed build succeeds (`pnpm build`) - All packages built successfully

🤖 Generated with [Claude Code](https://claude.ai/code)