### PR TITLE
feat: update @anthropic-ai/claude-code from v1.0.73 to v1.0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
   - See [Configuration docs](https://github.com/ceedaragents/cyrus#configuration) for setup details
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.72 to v1.0.73 for latest Claude Code improvements
+- Updated @anthropic-ai/claude-code from v1.0.73 to v1.0.77 for latest Claude Code improvements. See [Claude Code v1.0.77 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1077)
 
 ### Fixed
 - Fixed Windows compatibility issues that caused agent failures on Windows systems

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.73",
+		"@anthropic-ai/claude-code": "^1.0.77",
 		"@anthropic-ai/sdk": "^0.59.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.73
-        version: 1.0.73
+        specifier: ^1.0.77
+        version: 1.0.77
       '@anthropic-ai/sdk':
         specifier: ^0.59.0
         version: 0.59.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.73':
-    resolution: {integrity: sha512-UVBkta/BWy49xR9fgi/Oy2tl7p/k+lOCinv21zSK/E9KB4JObAAZ1BAOWteu4fhv7gs3Ipfev5r6yo3OplmwNg==}
+  '@anthropic-ai/claude-code@1.0.77':
+    resolution: {integrity: sha512-P4jQ9bd9DEcgQUXb94gh8h7bnconmS2qE3eGUHyxNAi8fhSDqA038fmduCKZ/0wCVGPaldYoFIaO35M/ChRtGA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.73':
+  '@anthropic-ai/claude-code@1.0.77':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.73 to v1.0.77 in the claude-runner package
- @anthropic-ai/sdk is already at the latest version (v0.59.0)
- Updated CHANGELOG.md with changelog link as requested

## Changes Made
- Modified `packages/claude-runner/package.json` to update @anthropic-ai/claude-code dependency
- Updated CHANGELOG.md with proper version reference and link to upstream changelog
- All tests pass and build succeeds with updated package

## Test Plan
- [x] Package installs successfully
- [x] Claude-runner package builds without errors
- [x] All existing tests pass (50/50 tests)
- [x] TypeScript type checking passes
- [x] No breaking changes detected

Closes PACK-241

🤖 Generated with [Claude Code](https://claude.ai/code)