### PR TITLE
Release v0.1.41

### DIFF
--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.18",
+	"version": "0.0.19",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
Preparing release v0.1.41 with new features, dependency updates, and bug fixes.

## Changes

### Added
- Dynamic tool configuration based on system prompt labels
  - Restrict Claude's tools per task type (debugger mode gets read-only access, builder mode gets safe tools, etc.)
  - Supports presets (`"readOnly"`, `"safe"`, `"all"`) or custom tool lists in `labelPrompts` config
  - Improves security and keeps Claude focused on appropriate tools

### Changed  
- Updated @anthropic-ai/claude-code from v1.0.77 to v1.0.80
- Updated @anthropic-ai/sdk from v0.59.0 to v0.60.0
- Updated claude-runner package to v0.0.19

### Fixed
- Windows compatibility issues that prevented agent from running on Windows systems
- Issue where Cyrus would fail to respond when initially delegated while receiver was down
- Biome formatting issues in claude-runner

## Test Plan
- [x] All package tests pass (`pnpm test:packages:run`)
- [x] TypeScript compilation succeeds (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [ ] Ready to publish after merge

## Publishing Steps (after merge)
1. Update CHANGELOG.md to change [Unreleased] to [0.1.41]
2. Update apps/cli/package.json version to 0.1.41
3. Build and publish packages in order
4. Publish CLI

🤖 Generated with [Claude Code](https://claude.ai/code)