### PR TITLE
Release v0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.42] - 2025-08-15
+
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.77 to v1.0.80 for latest Claude Code improvements. See [Claude Code v1.0.80 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1080)
 - Updated @anthropic-ai/sdk from v0.59.0 to v0.60.0 for latest Anthropic SDK improvements
@@ -12,6 +14,23 @@ All notable changes to this project will be documented in this file.
 - Fixed issue where duplicate messages appeared in Linear when Claude provided final responses
   - Added consistent LAST_MESSAGE_MARKER to all prompt types to ensure Claude includes the special marker in final responses
   - Marker is automatically removed before posting to Linear, preventing duplicate content
+
+### Packages
+
+#### cyrus-core
+- cyrus-core@0.0.10
+
+#### cyrus-claude-runner  
+- cyrus-claude-runner@0.0.20
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.25
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.16
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.42
 
 ## [0.1.41] - 2025-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-code from v1.0.77 to v1.0.80 for latest Claude Code improvements. See [Claude Code v1.0.80 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1080)
+- Updated @anthropic-ai/sdk from v0.59.0 to v0.60.0 for latest Anthropic SDK improvements
+
+### Fixed
+- Fixed issue where duplicate messages appeared in Linear when Claude provided final responses
+  - Added consistent LAST_MESSAGE_MARKER to all prompt types to ensure Claude includes the special marker in final responses
+  - Marker is automatically removed before posting to Linear, preventing duplicate content
+
 ## [0.1.41] - 2025-08-13
 
 ### Added
@@ -15,13 +24,9 @@ All notable changes to this project will be documented in this file.
   - See [Configuration docs](https://github.com/ceedaragents/cyrus#configuration) for setup details
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.77 to v1.0.80 for latest Claude Code improvements. See [Claude Code v1.0.80 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1080)
-- Updated @anthropic-ai/sdk from v0.59.0 to v0.60.0 for latest Anthropic SDK improvements
+- Updated @anthropic-ai/claude-code from v1.0.72 to v1.0.73 for latest Claude Code improvements
 
 ### Fixed
-- Fixed issue where duplicate messages appeared in Linear when Claude provided final responses
-  - Added consistent LAST_MESSAGE_MARKER to all prompt types to ensure Claude includes the special marker in final responses
-  - Marker is automatically removed before posting to Linear, preventing duplicate content
 - Fixed Windows compatibility issues that caused agent failures on Windows systems
   - Replaced Unix-specific `mkdir -p` commands with cross-platform Node.js `mkdirSync` 
   - Implemented intelligent shell script detection supporting Windows (.ps1, .bat, .cmd) and Unix (.sh) scripts

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.41",
+	"version": "0.1.42",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.19",
+	"version": "0.0.20",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
Release v0.1.42 with Claude Code SDK updates and duplicate message fix

## Changes
### Changed
- Updated @anthropic-ai/claude-code from v1.0.77 to v1.0.80 for latest Claude Code improvements
- Updated @anthropic-ai/sdk from v0.59.0 to v0.60.0 for latest Anthropic SDK improvements

### Fixed
- Fixed issue where duplicate messages appeared in Linear when Claude provided final responses
  - Added consistent LAST_MESSAGE_MARKER to all prompt types
  - Marker is automatically removed before posting to Linear

## Package versions to publish
- cyrus-core@0.0.10 (no changes)
- cyrus-claude-runner@0.0.20 (SDK updates)
- cyrus-edge-worker@0.0.25 (LAST_MESSAGE_MARKER fix)
- cyrus-ndjson-client@0.0.16 (no changes)
- cyrus-ai@0.1.42

## Checklist
- [x] CHANGELOG.md updated with new version
- [x] Package versions bumped appropriately
- [x] All packages build successfully
- [ ] Ready to publish after PR is merged

🤖 Generated with [Claude Code](https://claude.ai/code)