### PR TITLE
cleanup: remove unnecessary "Skipping Task result" log

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -445,10 +445,6 @@ export class AgentSessionManager {
 						};
 						this.activeTasksBySession.delete(linearAgentActivitySessionId);
 					} else {
-						// Task was already completed, skip this duplicate result
-						console.log(
-							`[AgentSessionManager] Skipping duplicate Task result for already completed task ${entry.metadata?.parentToolUseId}`,
-						);
 						return;
 					}
 					break;


### PR DESCRIPTION
This was originally used for debugging, but is unnecessary in production. Resolves #166