### PR TITLE
chore: Update @anthropic-ai/claude-code to v1.0.84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-code from v1.0.83 to v1.0.84 for latest Claude Code improvements. See [Claude Code v1.0.84 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1084)
+
 ## [0.1.43] - 2025-08-18
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.83",
+		"@anthropic-ai/claude-code": "^1.0.84",
 		"@anthropic-ai/sdk": "^0.60.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: ^1.0.83
-        version: 1.0.83
+        specifier: ^1.0.84
+        version: 1.0.84
       '@anthropic-ai/sdk':
         specifier: ^0.60.0
         version: 0.60.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.83':
-    resolution: {integrity: sha512-Mm+88khPbg9eAUbrWGirigWeC4xu2hH0ns3+lnfKWX3e8RJDOV9vnCHjzbEIVXvvvw1YmeIO7TxsFk5/MVuhGA==}
+  '@anthropic-ai/claude-code@1.0.84':
+    resolution: {integrity: sha512-+Qu+z1jTdZPu0UL4dalntkofDGL0BgWqs6XmRlq+RuxurHJy58zKae4PL8naevrkbgazauIPYDDGmHF3u+B0uQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.83':
+  '@anthropic-ai/claude-code@1.0.84':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.83 to v1.0.84
- @anthropic-ai/sdk remains at v0.60.0 (already on latest version)
- Updated CHANGELOG.md with link to Claude Code v1.0.84 changelog

## Claude Code v1.0.84 Changes
According to the [Claude Code v1.0.84 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1084):
- Fixed tool use/tool result ID mismatch error during unstable network conditions
- Corrected issue where Claude sometimes ignored real-time steering when completing a task
- Enhanced @-mention functionality by adding ~/.claude/* files to suggestions
- Now using built-in ripgrep by default (opt out with USE_BUILTIN_RIPGREP=0)

## Test Plan
- [x] Checked current versions of both packages
- [x] Verified latest versions on npm
- [x] Updated package.json with new version
- [x] Ran `pnpm install` to update lockfile
- [x] Updated CHANGELOG.md with version link

Closes PACK-284

🤖 Generated with [Claude Code](https://claude.ai/code)