### PR TITLE
Add functionality to specify cyrus home directory

### DIFF
--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -24,9 +24,24 @@ import open from "open";
 // Parse command line arguments
 const args = process.argv.slice(2);
 const envFileArg = args.find((arg) => arg.startsWith("--env-file="));
+const cyrusHomeArg = args.find((arg) => arg.startsWith("--cyrus-home="));
 
 // Constants
 const DEFAULT_PROXY_URL = "https://cyrus-proxy.ceedar.workers.dev";
+
+// Determine the Cyrus home directory once at startup
+let CYRUS_HOME: string;
+if (cyrusHomeArg) {
+	const customPath = cyrusHomeArg.split("=")[1];
+	if (customPath) {
+		CYRUS_HOME = resolve(customPath);
+	} else {
+		console.error("Error: --cyrus-home flag requires a directory path");
+		process.exit(1);
+	}
+} else {
+	CYRUS_HOME = resolve(homedir(), ".cyrus");
+}
 
 // Note: __dirname removed since version is now hardcoded
 
@@ -55,12 +70,14 @@ Options:
   --version          Show version number
   --help, -h         Show help
   --env-file=<path>  Load environment variables from file
+  --cyrus-home=<dir> Specify custom Cyrus config directory (default: ~/.cyrus)
 
 Examples:
   cyrus                          Start the edge worker
   cyrus check-tokens             Check all Linear token statuses
   cyrus refresh-token            Interactive token refresh
   cyrus add-repository           Add a new repository interactively
+  cyrus --cyrus-home=/tmp/cyrus  Use custom config directory
 `);
 	process.exit(0);
 }
@@ -98,12 +115,17 @@ interface Workspace {
 class EdgeApp {
 	private edgeWorker: EdgeWorker | null = null;
 	private isShuttingDown = false;
+	private cyrusHome: string;
+
+	constructor(cyrusHome: string = resolve(homedir(), ".cyrus")) {
+		this.cyrusHome = cyrusHome;
+	}
 
 	/**
 	 * Get the edge configuration file path
 	 */
 	getEdgeConfigPath(): string {
-		return resolve(homedir(), ".cyrus", "config.json");
+		return resolve(this.cyrusHome, "config.json");
 	}
 
 	/**
@@ -246,8 +268,7 @@ class EdgeApp {
 				.replace(/[^a-zA-Z0-9-_]/g, "-")
 				.toLowerCase();
 			const workspaceBaseDir = resolve(
-				homedir(),
-				".cyrus",
+				this.cyrusHome,
 				"workspaces",
 				repoNameSafe,
 			);
@@ -455,6 +476,7 @@ class EdgeApp {
 		const config: EdgeWorkerConfig = {
 			proxyUrl,
 			repositories,
+			cyrusHome: this.cyrusHome,
 			defaultAllowedTools:
 				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) || [],
 			// Model configuration: environment variables take precedence over config file
@@ -1480,7 +1502,7 @@ async function checkLinearToken(
 
 // Command: check-tokens
 async function checkTokensCommand() {
-	const app = new EdgeApp();
+	const app = new EdgeApp(CYRUS_HOME);
 	const configPath = app.getEdgeConfigPath();
 
 	if (!existsSync(configPath)) {
@@ -1506,7 +1528,7 @@ async function checkTokensCommand() {
 
 // Command: refresh-token
 async function refreshTokenCommand() {
-	const app = new EdgeApp();
+	const app = new EdgeApp(CYRUS_HOME);
 	const configPath = app.getEdgeConfigPath();
 
 	if (!existsSync(configPath)) {
@@ -1661,7 +1683,7 @@ async function refreshTokenCommand() {
 
 // Command: add-repository
 async function addRepositoryCommand() {
-	const app = new EdgeApp();
+	const app = new EdgeApp(CYRUS_HOME);
 
 	console.log("📋 Add New Repository");
 	console.log("─".repeat(50));
@@ -1729,7 +1751,7 @@ async function addRepositoryCommand() {
 
 // Command: set-customer-id
 async function setCustomerIdCommand() {
-	const app = new EdgeApp();
+	const app = new EdgeApp(CYRUS_HOME);
 	const configPath = app.getEdgeConfigPath();
 
 	// Get customer ID from command line args
@@ -1781,7 +1803,7 @@ async function setCustomerIdCommand() {
 
 // Command: billing
 async function billingCommand() {
-	const app = new EdgeApp();
+	const app = new EdgeApp(CYRUS_HOME);
 	const configPath = app.getEdgeConfigPath();
 
 	if (!existsSync(configPath)) {
@@ -1875,7 +1897,7 @@ switch (command) {
 
 	default: {
 		// Create and start the app
-		const app = new EdgeApp();
+		const app = new EdgeApp(CYRUS_HOME);
 		app.start().catch((error) => {
 			console.error("Fatal error:", error);
 			process.exit(1);

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -117,7 +117,7 @@ class EdgeApp {
 	private isShuttingDown = false;
 	private cyrusHome: string;
 
-	constructor(cyrusHome: string = resolve(homedir(), ".cyrus")) {
+	constructor(cyrusHome: string) {
 		this.cyrusHome = cyrusHome;
 	}
 

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -6,7 +6,6 @@ import {
 	type WriteStream,
 	writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import {
 	AbortError,
@@ -143,7 +142,7 @@ export class ClaudeRunner extends EventEmitter {
 	constructor(config: ClaudeRunnerConfig) {
 		super();
 		this.config = config;
-		this.cyrusHome = config.cyrusHome || join(homedir(), ".cyrus");
+		this.cyrusHome = config.cyrusHome;
 
 		// Forward config callbacks to events
 		if (config.onMessage) this.on("message", config.onMessage);

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -138,10 +138,12 @@ export class ClaudeRunner extends EventEmitter {
 	private readableLogStream: WriteStream | null = null;
 	private messages: SDKMessage[] = [];
 	private streamingPrompt: StreamingPrompt | null = null;
+	private cyrusHome: string;
 
 	constructor(config: ClaudeRunnerConfig) {
 		super();
 		this.config = config;
+		this.cyrusHome = config.cyrusHome || join(homedir(), ".cyrus");
 
 		// Forward config callbacks to events
 		if (config.onMessage) this.on("message", config.onMessage);
@@ -459,8 +461,7 @@ export class ClaudeRunner extends EventEmitter {
 		// If logging has already been set up and we now have versions, write the version file
 		if (this.logStream && versions) {
 			try {
-				const cyrusDir = join(homedir(), ".cyrus");
-				const logsDir = join(cyrusDir, "logs");
+				const logsDir = join(this.cyrusHome, "logs");
 				const workspaceName =
 					this.config.workspaceName ||
 					(this.config.workingDirectory
@@ -600,9 +601,8 @@ export class ClaudeRunner extends EventEmitter {
 				this.readableLogStream = null;
 			}
 
-			// Create logs directory structure: ~/.cyrus/logs/<workspace-name>/
-			const cyrusDir = join(homedir(), ".cyrus");
-			const logsDir = join(cyrusDir, "logs");
+			// Create logs directory structure: <cyrusHome>/logs/<workspace-name>/
+			const logsDir = join(this.cyrusHome, "logs");
 
 			// Get workspace name from config or extract from working directory
 			const workspaceName =

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -19,7 +19,7 @@ export interface ClaudeRunnerConfig {
 	mcpConfig?: Record<string, McpServerConfig>; // Additional/override MCP servers
 	model?: string; // Claude model to use (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
-	cyrusHome?: string; // Cyrus home directory (defaults to ~/.cyrus)
+	cyrusHome: string; // Cyrus home directory
 	promptVersions?: {
 		// Optional prompt template version information
 		userPromptVersion?: string;

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -19,6 +19,7 @@ export interface ClaudeRunnerConfig {
 	mcpConfig?: Record<string, McpServerConfig>; // Additional/override MCP servers
 	model?: string; // Claude model to use (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
+	cyrusHome?: string; // Cyrus home directory (defaults to ~/.cyrus)
 	promptVersions?: {
 		// Optional prompt template version information
 		userPromptVersion?: string;

--- a/packages/claude-runner/test-scripts/simple-claude-runner-test.js
+++ b/packages/claude-runner/test-scripts/simple-claude-runner-test.js
@@ -34,7 +34,7 @@ async function main() {
 	const config = {
 		// Working directory for Claude to operate in
 		workingDirectory: "/Users/agentops/code/hello-world-project",
-		
+
 		// Cyrus home directory for logs and state
 		cyrusHome: "/tmp/simple-test-cyrus-home",
 

--- a/packages/claude-runner/test-scripts/simple-claude-runner-test.js
+++ b/packages/claude-runner/test-scripts/simple-claude-runner-test.js
@@ -34,6 +34,9 @@ async function main() {
 	const config = {
 		// Working directory for Claude to operate in
 		workingDirectory: "/Users/agentops/code/hello-world-project",
+		
+		// Cyrus home directory for logs and state
+		cyrusHome: "/tmp/simple-test-cyrus-home",
 
 		// Use tools matching hello-world config
 		allowedTools: [

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -34,6 +34,7 @@ describe("ClaudeRunner", () => {
 
 	const defaultConfig: ClaudeRunnerConfig = {
 		workingDirectory: "/tmp/test",
+		cyrusHome: "/tmp/test-cyrus-home",
 	};
 
 	beforeEach(() => {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from "node:events";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -85,7 +84,7 @@ export class EdgeWorker extends EventEmitter {
 	constructor(config: EdgeWorkerConfig) {
 		super();
 		this.config = config;
-		this.cyrusHome = config.cyrusHome || join(homedir(), ".cyrus");
+		this.cyrusHome = config.cyrusHome;
 		this.persistenceManager = new PersistenceManager(
 			join(this.cyrusHome, "state"),
 		);

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -80,11 +80,13 @@ export class EdgeWorker extends EventEmitter {
 	private ndjsonClients: Map<string, NdjsonClient> = new Map(); // listeners for webhook events, one per linear token
 	private persistenceManager: PersistenceManager;
 	private sharedApplicationServer: SharedApplicationServer;
+	private cyrusHome: string;
 
 	constructor(config: EdgeWorkerConfig) {
 		super();
 		this.config = config;
-		this.persistenceManager = new PersistenceManager();
+		this.cyrusHome = config.cyrusHome || join(homedir(), ".cyrus");
+		this.persistenceManager = new PersistenceManager(join(this.cyrusHome, "state"));
 
 		// Initialize shared application server
 		const serverPort = config.serverPort || config.webhookPort || 3456;
@@ -667,8 +669,7 @@ export class EdgeWorker extends EventEmitter {
 		// Pre-create attachments directory even if no attachments exist yet
 		const workspaceFolderName = basename(workspace.path);
 		const attachmentsDir = join(
-			homedir(),
-			".cyrus",
+			this.cyrusHome,
 			workspaceFolderName,
 			"attachments",
 		);
@@ -972,8 +973,7 @@ export class EdgeWorker extends EventEmitter {
 		// Always set up attachments directory, even if no attachments in current comment
 		const workspaceFolderName = basename(session.workspace.path);
 		const attachmentsDir = join(
-			homedir(),
-			".cyrus",
+			this.cyrusHome,
 			workspaceFolderName,
 			"attachments",
 		);
@@ -2055,8 +2055,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		// Create attachments directory in home directory
 		const workspaceFolderName = basename(workspacePath);
 		const attachmentsDir = join(
-			homedir(),
-			".cyrus",
+			this.cyrusHome,
 			workspaceFolderName,
 			"attachments",
 		);
@@ -2591,6 +2590,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			allowedTools,
 			allowedDirectories,
 			workspaceName: session.issue?.identifier || session.issueId,
+			cyrusHome: this.cyrusHome,
 			mcpConfigPath: repository.mcpConfigPath,
 			mcpConfig: this.buildMcpConfig(repository),
 			appendSystemPrompt: (systemPrompt || "") + LAST_MESSAGE_MARKER,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -86,7 +86,9 @@ export class EdgeWorker extends EventEmitter {
 		super();
 		this.config = config;
 		this.cyrusHome = config.cyrusHome || join(homedir(), ".cyrus");
-		this.persistenceManager = new PersistenceManager(join(this.cyrusHome, "state"));
+		this.persistenceManager = new PersistenceManager(
+			join(this.cyrusHome, "state"),
+		);
 
 		// Initialize shared application server
 		const serverPort = config.serverPort || config.webhookPort || 3456;

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -86,8 +86,8 @@ export interface EdgeWorkerConfig {
 	// Repository configurations
 	repositories: RepositoryConfig[];
 
-	// Cyrus home directory (defaults to ~/.cyrus)
-	cyrusHome?: string;
+	// Cyrus home directory
+	cyrusHome: string;
 
 	// Optional handlers that apps can implement
 	handlers?: {

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -86,6 +86,9 @@ export interface EdgeWorkerConfig {
 	// Repository configurations
 	repositories: RepositoryConfig[];
 
+	// Cyrus home directory (defaults to ~/.cyrus)
+	cyrusHome?: string;
+
 	// Optional handlers that apps can implement
 	handlers?: {
 		// Called when workspace needs to be created

--- a/packages/edge-worker/test/EdgeWorker.attachments.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.attachments.test.ts
@@ -31,20 +31,19 @@ describe("EdgeWorker - Native Attachments", () => {
 
 	beforeEach(() => {
 		mockConfig = {
-			id: "test-worker",
-			sessionDirectory: "/tmp/test-sessions",
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: "/tmp/test-cyrus-home",
 			repositories: [
 				{
 					id: "test-repo",
 					name: "test-repo",
 					repositoryPath: "/test/repo",
+					workspaceBaseDir: "/test/workspaces",
 					linearToken: "test-token",
+					linearWorkspaceId: "test-workspace",
 					baseBranch: "main",
 				},
 			],
-			features: {
-				enableAttachmentDownload: true,
-			},
 		};
 
 		edgeWorker = new EdgeWorker(mockConfig);

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -77,6 +77,7 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 		// Create mock configuration
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",
+			cyrusHome: "/tmp/test-cyrus-home",
 			defaultAllowedTools: ["Read", "Write", "Edit"],
 			repositories: [
 				{

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -171,6 +171,7 @@ Base Branch: {{base_branch}}`;
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",
+			cyrusHome: "/tmp/test-cyrus-home",
 			repositories: [mockRepository],
 			handlers: {
 				createWorkspace: vi.fn().mockResolvedValue({

--- a/packages/edge-worker/test/EdgeWorker.repository-routing.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.repository-routing.test.ts
@@ -17,6 +17,7 @@ describe("EdgeWorker - Repository Routing", () => {
 		// Mock configuration with multiple repositories including project-based routing
 		mockConfig = {
 			proxyUrl: "https://test-proxy.com",
+			cyrusHome: "/tmp/test-cyrus-home",
 			repositories: [
 				{
 					id: "ceedar",

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -179,6 +179,7 @@ Issue: {{issue_identifier}}`;
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",
+			cyrusHome: "/tmp/test-cyrus-home",
 			repositories: [mockRepository],
 			handlers: {
 				createWorkspace: vi.fn().mockResolvedValue({

--- a/packages/edge-worker/test/EdgeWorker.versioning.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.versioning.test.ts
@@ -36,6 +36,7 @@ describe("EdgeWorker - Version Tag Extraction", () => {
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",
 			webhookPort: 3456,
+			cyrusHome: "/tmp/test-cyrus-home",
 			repositories: [
 				{
 					id: "test-repo",


### PR DESCRIPTION
## Summary
- Added `--cyrus-home` CLI flag to specify custom Cyrus configuration directory
- All subsystems now respect the custom directory setting
- Maintains backward compatibility with default `~/.cyrus` directory

## Changes
- **CLI**: Added `--cyrus-home=<dir>` flag parsing and validation
- **EdgeApp**: Updated to accept and propagate cyrusHome parameter 
- **EdgeWorker**: Added cyrusHome configuration support
- **ClaudeRunner**: Updated to use custom cyrusHome for logs directory
- **PersistenceManager**: Updated to use custom state directory path

## Test Plan
- [x] Build passes with `pnpm build`
- [x] CLI help shows new flag: `node dist/app.js --help`
- [x] Custom directory works: `cyrus --cyrus-home=/tmp/test-cyrus check-tokens`
- [x] Default behavior unchanged when flag not provided
- [x] All subsystems (logs, state, attachments, config) use the custom directory

## Acceptance Criteria
✅ Optional CLI flag specifying the cyrus "home" config/working directory
✅ The Cyrus home directory variable is determined once, then passed via arguments
✅ No singleton pattern, no new dependencies between packages
✅ Defaults to ".cyrus" when the CLI flag is not specified

Fixes PACK-287

🤖 Generated with [Claude Code](https://claude.ai/code)