### PR TITLE
chore: Release v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.44] - 2025-08-19
+
+### Changed
+- Updated @anthropic-ai/claude-code dependency to use exact version (1.0.83) instead of caret range for improved consistency
+- Updated CLAUDE.md documentation with clearer MCP Linear integration testing instructions
+
+### Packages
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.22
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.27
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.44
+
 ## [0.1.43] - 2025-08-18
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.43",
+	"version": "0.1.44",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.21",
+	"version": "0.0.22",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Prepare release v0.1.44
- Update @anthropic-ai/claude-code dependency to use exact version (1.0.83) for improved consistency
- Update CLAUDE.md documentation with clearer instructions

## Changes in this release
- Updated CHANGELOG.md with v0.1.44 release notes
- Claude-runner package updated to use exact version of @anthropic-ai/claude-code dependency

## Test plan
- [x] All package tests pass (`pnpm test:packages:run`)
- [x] TypeScript compilation successful (`pnpm typecheck` for relevant packages)
- [x] Build successful (`pnpm build`)

## Publishing checklist (to be done after merge)
- [ ] Publish cyrus-claude-runner@0.0.22
- [ ] Publish cyrus-edge-worker@0.0.27
- [ ] Publish cyrus-ai@0.1.44

🤖 Generated with [Claude Code](https://claude.ai/code)