### PR TITLE
feat: Update @anthropic-ai/claude-code to v1.0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-code from v1.0.83 to v1.0.88 for latest Claude Code improvements including OAuth fix, token limit visibility, Sonnet 4 as default model, and model aliases. See [Claude Code v1.0.88 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1088)
+
 ## [0.1.44] - 2025-08-19
 
 ### Changed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.83",
+		"@anthropic-ai/claude-code": "1.0.88",
 		"@anthropic-ai/sdk": "^0.60.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.83
-        version: 1.0.83
+        specifier: 1.0.88
+        version: 1.0.88
       '@anthropic-ai/sdk':
         specifier: ^0.60.0
         version: 0.60.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.83':
-    resolution: {integrity: sha512-Mm+88khPbg9eAUbrWGirigWeC4xu2hH0ns3+lnfKWX3e8RJDOV9vnCHjzbEIVXvvvw1YmeIO7TxsFk5/MVuhGA==}
+  '@anthropic-ai/claude-code@1.0.88':
+    resolution: {integrity: sha512-Np6H4EjkbmNolUpx98DvqLXV/iJrw2y7dz2rDJ7av9ajMz6HZfB8bdJV5D75+jO+Gk1pvA54HCIm0c65lDrzcw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.83':
+  '@anthropic-ai/claude-code@1.0.88':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.83 to v1.0.88
- @anthropic-ai/sdk remains at v0.60.0 (already on latest version)

## Key Improvements
The latest version brings several important improvements:
- **Fixed OAuth authentication issues** - Resolves authentication problems
- **Added status line input for token limit** - Better visibility of token usage
- **Updated default Sonnet model to Sonnet 4** - Uses the latest Sonnet model by default
- **Environment variables for model aliases** - More flexible model configuration

## Changes
- Updated package.json dependency version
- Updated pnpm-lock.yaml with new version
- Added CHANGELOG.md entry with reference to [Claude Code v1.0.88 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1088)

## Test Plan
✅ Built all packages successfully (`pnpm build`)
✅ All tests passing (`pnpm test:packages:run`)
✅ TypeScript compilation successful for core packages (`pnpm typecheck`)

Closes PACK-313

🤖 Generated with [Claude Code](https://claude.ai/code)