### PR TITLE
feat: Add continueConversation option to ClaudeRunner for message replay

### DIFF
--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -335,6 +335,9 @@ export class ClaudeRunner extends EventEmitter {
 					...(this.config.resumeSessionId && {
 						resume: this.config.resumeSessionId,
 					}),
+					...(this.config.continueConversation !== undefined && {
+						continue: this.config.continueConversation,
+					}),
 					...(Object.keys(mcpServers).length > 0 && { mcpServers }),
 				},
 			};

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -12,6 +12,7 @@ export interface ClaudeRunnerConfig {
 	allowedTools?: string[];
 	allowedDirectories?: string[];
 	resumeSessionId?: string; // Session ID to resume from previous Claude session
+	continueConversation?: boolean; // Always pass --continue flag to replay user messages
 	workspaceName?: string;
 	systemPrompt?: string;
 	appendSystemPrompt?: string; // Additional prompt to append to the default system prompt

--- a/packages/claude-runner/test-scripts/test-continue-flag.js
+++ b/packages/claude-runner/test-scripts/test-continue-flag.js
@@ -44,16 +44,17 @@ async function main() {
 	const baseConfig = {
 		workingDirectory: "/tmp/test-continue",
 		allowedTools: ["Read", "Edit"],
+		cyrusHome: "/tmp/test-cyrus-home",
 		onMessage: (msg) => console.log(`  📧 ${msg.type}`),
 	};
 
-	// Test 1: Without continueSession
-	await testConfig("Without continueSession", baseConfig);
+	// Test 1: Without continueConversation
+	await testConfig("Without continueConversation", baseConfig);
 
-	// Test 2: With continueSession
-	await testConfig("With continueSession = true", {
+	// Test 2: With continueConversation
+	await testConfig("With continueConversation = true", {
 		...baseConfig,
-		continueSession: true,
+		continueConversation: true,
 	});
 
 	// Test 3: With MCP servers
@@ -63,9 +64,9 @@ async function main() {
 	});
 
 	// Test 4: With both
-	await testConfig("With MCP + continueSession", {
+	await testConfig("With MCP + continueConversation", {
 		...baseConfig,
-		continueSession: true,
+		continueConversation: true,
 		mcpConfigPath: ["/Users/agentops/code/ceedarmcpconfig.json"],
 	});
 }

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2599,6 +2599,8 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			model: repository.model || this.config.defaultModel,
 			fallbackModel:
 				repository.fallbackModel || this.config.defaultFallbackModel,
+			// Always enable continue conversation to replay user messages
+			continueConversation: true,
 			onMessage: (message: SDKMessage) => {
 				this.handleClaudeMessage(
 					linearAgentActivitySessionId,


### PR DESCRIPTION
## Summary
- Added `continueConversation` option to ClaudeRunner package that maps to the claude-code SDK's `continue` flag
- This option is now always enabled in EdgeWorker to ensure user messages are properly replayed

## Implementation Details
The `@anthropic-ai/claude-code` SDK has a `continue` option that enables message replay functionality. This PR:
1. Adds `continueConversation` property to the `ClaudeRunnerConfig` interface
2. Passes this option through to the SDK's query function
3. Sets `continueConversation: true` by default in EdgeWorker's `buildClaudeRunnerConfig` method

## Test Plan
- [x] Build successful (`pnpm build`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] All package tests pass (`pnpm test:run` in claude-runner package)
- [x] Updated test scripts to use new property name

## Related Issue
Fixes PACK-314

🤖 Generated with [Claude Code](https://claude.ai/code)