### PR TITLE
Update @anthropic-ai/claude-code to v1.0.89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.83 to v1.0.88 for latest Claude Code improvements including OAuth fix, token limit visibility, Sonnet 4 as default model, and model aliases. See [Claude Code v1.0.88 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1088)
+- Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89 for latest Claude Code improvements. See [Claude Code v1.0.89 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1089)
 
 ## [0.1.44] - 2025-08-19
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.88",
+		"@anthropic-ai/claude-code": "1.0.89",
 		"@anthropic-ai/sdk": "^0.60.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.88
-        version: 1.0.88
+        specifier: 1.0.89
+        version: 1.0.89
       '@anthropic-ai/sdk':
         specifier: ^0.60.0
         version: 0.60.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.88':
-    resolution: {integrity: sha512-Np6H4EjkbmNolUpx98DvqLXV/iJrw2y7dz2rDJ7av9ajMz6HZfB8bdJV5D75+jO+Gk1pvA54HCIm0c65lDrzcw==}
+  '@anthropic-ai/claude-code@1.0.89':
+    resolution: {integrity: sha512-FKzFA0whQ1oVqdq3HG7gE3aojcZfGxrhza9z7OMDUFm4YMADHQxn6TWxWss5dhzXze7vd+QOn8CuH+uHnhAr4w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.88':
+  '@anthropic-ai/claude-code@1.0.89':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89
- @anthropic-ai/sdk remains at v0.60.0 (already up-to-date)
- Updated CHANGELOG.md with version link

## Changes
This PR updates the `@anthropic-ai/claude-code` package to the latest version (v1.0.89) that was published on August 22, 2025.

The `@anthropic-ai/sdk` package is already at the latest version (0.60.0) and doesn't require updating.

## Test Plan
- [x] Ran `pnpm install` to update dependencies
- [x] Ran `pnpm test:run` in claude-runner package - all 50 tests pass
- [x] Ran `pnpm build` in claude-runner package - builds successfully
- [x] Updated CHANGELOG.md with version link

🤖 Generated with [Claude Code](https://claude.ai/code)