### PR TITLE
feat: Update @anthropic-ai/claude-code to v1.0.90

### DIFF
--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.89",
+		"@anthropic-ai/claude-code": "1.0.90",
 		"@anthropic-ai/sdk": "^0.60.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.89
-        version: 1.0.89
+        specifier: 1.0.90
+        version: 1.0.90
       '@anthropic-ai/sdk':
         specifier: ^0.60.0
         version: 0.60.0
@@ -191,8 +191,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.89':
-    resolution: {integrity: sha512-FKzFA0whQ1oVqdq3HG7gE3aojcZfGxrhza9z7OMDUFm4YMADHQxn6TWxWss5dhzXze7vd+QOn8CuH+uHnhAr4w==}
+  '@anthropic-ai/claude-code@1.0.90':
+    resolution: {integrity: sha512-waC7GC4fnfyiFVFTS7Eo4MAS/iEYpyM67JZFXr+B07bOkjBYtBqXh77+Z/btcyI8NxvUtpnFS0R5FXkU/tKCwg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2365,7 +2365,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.89':
+  '@anthropic-ai/claude-code@1.0.90':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.89 to v1.0.90
- @anthropic-ai/sdk is already on the latest version (v0.60.0)

## Changelog
See [Claude Code v1.0.90 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1090) for details on the improvements.

Key improvement in v1.0.90: Settings file changes now take effect immediately without requiring a restart.

## Test Plan
- [x] Successfully ran `pnpm install` and `pnpm build`
- [x] All claude-runner package tests pass
- [x] All ndjson-client package tests pass
- [x] Verified package.json and pnpm-lock.yaml are properly updated

## Linear Issue
Closes PACK-318

🤖 Generated with [Claude Code](https://claude.ai/code)