### PR TITLE
feat: Add PostToolUse hook for parent-child agent session tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ All notable changes to this project will be documented in this file.
   - File upload capability: Upload files to Linear and get asset URLs for use in issues and comments
   - Agent session creation: Create AI/bot tracking sessions on Linear issues
   - Automatically available in all Cyrus sessions without additional configuration
+- PostToolUse hook integration for tracking parent-child agent session relationships
+  - Automatically captures child agent session IDs when linear_agent_session_create tool is used
+  - Maintains mapping of child sessions to parent sessions for hierarchical tracking
+  - Child session results are automatically forwarded to parent sessions upon completion
 
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89 for latest Claude Code improvements. See [Claude Code v1.0.89 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1089)
 - Upgraded @linear/sdk from v38/v55 to v58.0.0 across all packages for latest Linear API features
+- Enhanced ClaudeRunner and EdgeWorker to support Claude Code SDK hooks for tool interception
 
 ### Packages
 

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -336,6 +336,7 @@ export class ClaudeRunner extends EventEmitter {
 						resume: this.config.resumeSessionId,
 					}),
 					...(Object.keys(mcpServers).length > 0 && { mcpServers }),
+					...(this.config.hooks && { hooks: this.config.hooks }),
 				},
 			};
 

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -1,4 +1,6 @@
 import type {
+	HookCallbackMatcher,
+	HookEvent,
 	McpServerConfig,
 	SDKAssistantMessage,
 	SDKMessage,
@@ -25,6 +27,7 @@ export interface ClaudeRunnerConfig {
 		userPromptVersion?: string;
 		systemPromptVersion?: string;
 	};
+	hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>; // Claude SDK hooks
 	onMessage?: (message: SDKMessage) => void | Promise<void>;
 	onError?: (error: Error) => void | Promise<void>;
 	onComplete?: (messages: SDKMessage[]) => void | Promise<void>;

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -228,7 +228,7 @@ export class AgentSessionManager {
 					// Resume parent session with child result
 					try {
 						const childResult = resultMessage.result;
-						const promptToParent = `Child agent session completed with result:\n\n${childResult}`;
+						const promptToParent = `Child agent session, with ID ${linearAgentActivitySessionId} completed with result:\n\n${childResult}`;
 						
 						// Use the resumeParentSession callback to handle the parent session
 						await this.resumeParentSession(parentAgentSessionId, promptToParent);

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -31,12 +31,18 @@ export class AgentSessionManager {
 	private entries: Map<string, CyrusAgentSessionEntry[]> = new Map(); // Stores a list of session entries per each session by its linearAgentActivitySessionId
 	private activeTasksBySession: Map<string, string> = new Map(); // Maps session ID to active Task tool use ID
 	private getParentSessionId?: (childSessionId: string) => string | undefined;
-	private resumeParentSession?: (parentSessionId: string, prompt: string) => Promise<void>;
+	private resumeParentSession?: (
+		parentSessionId: string,
+		prompt: string,
+	) => Promise<void>;
 
 	constructor(
 		linearClient: LinearClient,
 		getParentSessionId?: (childSessionId: string) => string | undefined,
-		resumeParentSession?: (parentSessionId: string, prompt: string) => Promise<void>,
+		resumeParentSession?: (
+			parentSessionId: string,
+			prompt: string,
+		) => Promise<void>,
 	) {
 		this.linearClient = linearClient;
 		this.getParentSessionId = getParentSessionId;
@@ -229,10 +235,13 @@ export class AgentSessionManager {
 					try {
 						const childResult = resultMessage.result;
 						const promptToParent = `Child agent session, with ID ${linearAgentActivitySessionId} completed with result:\n\n${childResult}`;
-						
+
 						// Use the resumeParentSession callback to handle the parent session
-						await this.resumeParentSession(parentAgentSessionId, promptToParent);
-						
+						await this.resumeParentSession(
+							parentAgentSessionId,
+							promptToParent,
+						);
+
 						console.log(
 							`[AgentSessionManager] Successfully sent child result to parent session ${parentAgentSessionId}`,
 						);

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -796,11 +796,6 @@ export class EdgeWorker extends EventEmitter {
 			allowedTools,
 		);
 
-		// Check if this session has a parent
-		const parentAgentSessionId = this.childToParentAgentSession.get(
-			linearAgentActivitySessionId,
-		);
-
 		// Create Claude runner with attachment directory access and optional system prompt
 		const runnerConfig = this.buildClaudeRunnerConfig(
 			session,
@@ -810,7 +805,7 @@ export class EdgeWorker extends EventEmitter {
 			allowedTools,
 			allowedDirectories,
 			undefined, // resumeSessionId
-			parentAgentSessionId,
+			linearAgentActivitySessionId, // Pass current session ID as parent context
 		);
 		const runner = new ClaudeRunner(runnerConfig);
 
@@ -1114,11 +1109,6 @@ export class EdgeWorker extends EventEmitter {
 
 			const allowedDirectories = [attachmentsDir];
 
-			// Check if this session has a parent
-			const parentAgentSessionId = this.childToParentAgentSession.get(
-				linearAgentActivitySessionId,
-			);
-
 			// Create runner - resume existing session or start new one
 			const runnerConfig = this.buildClaudeRunnerConfig(
 				session,
@@ -1128,7 +1118,7 @@ export class EdgeWorker extends EventEmitter {
 				allowedTools,
 				allowedDirectories,
 				needsNewClaudeSession ? undefined : session.claudeSessionId,
-				parentAgentSessionId,
+				linearAgentActivitySessionId, // Pass current session ID as parent context
 			);
 
 			const runner = new ClaudeRunner(runnerConfig);


### PR DESCRIPTION
## Summary

This PR implements PostToolUse hook integration to enable hierarchical tracking of parent-child agent session relationships in Linear.

## Changes

### 1. Enhanced ClaudeRunner (`packages/claude-runner/src/types.ts`)
- Added `hooks` field to `ClaudeRunnerConfig` interface to support Claude SDK hooks
- Updated ClaudeRunner to pass hooks configuration to Claude SDK query options

### 2. Updated EdgeWorker (`packages/edge-worker/src/EdgeWorker.ts`)
- Added `childToParentAgentSession` Map to track parent-child session relationships
- Implemented PostToolUse hook that:
  - Intercepts `linear_agent_session_create` tool responses
  - Extracts the new `agentSessionId` from tool responses
  - Creates child → parent session mappings
- Updated `buildClaudeRunnerConfig` to include hooks and accept optional `parentAgentSessionId`
- Modified call sites to check for and pass parent session IDs when available

### 3. Enhanced AgentSessionManager (`packages/edge-worker/src/AgentSessionManager.ts`)
- Added callback function parameter to lookup parent sessions
- Modified `completeSession` to automatically forward results to parent sessions
- Parent sessions receive child results as "prompted" activities in Linear

## How It Works

1. When the `linear_agent_session_create` MCP tool is called, the PostToolUse hook intercepts the response
2. The hook extracts the new `agentSessionId` from the tool response
3. If there's a parent session context, it creates a mapping: child → parent
4. When a child session completes, the system checks for a parent mapping
5. If a parent exists, the child's result is automatically sent to the parent as a prompted activity

## Benefits

- Enables complex multi-agent workflows with automatic result propagation
- Maintains clear parent-child relationships between agent sessions
- Seamlessly integrates with existing Linear agent session infrastructure
- No breaking changes to existing functionality

## Testing

- ✅ All existing tests pass
- ✅ Build successful
- ✅ Code formatted per project standards (Biome)
- ✅ TypeScript compilation successful
- ✅ Package tests passing

## Related Issue

Closes CYPACK-10

🤖 Generated with [Claude Code](https://claude.ai/code)