### PR TITLE
feat: Add give_feedback tool for parent-child agent session communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
   - Maintains mapping of child sessions to parent sessions for hierarchical tracking
   - **Persistent storage of child-to-parent mappings across restarts**
   - Child session results are automatically forwarded to parent sessions upon completion
+- New "orchestrator" label system prompt type
+  - Joins existing "builder", "debugger", and "scoper" labels as a default option
+  - Configured with read-only tools (cannot directly edit files)
+  - Specializes in coordination and oversight of complex development tasks
+  - Automatically triggered by "Orchestrator" label on Linear issues
 
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89 for latest Claude Code improvements. See [Claude Code v1.0.89 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1089)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file.
 - New `cyrus-mcp-tools` package providing MCP tools for Linear integration
   - File upload capability: Upload files to Linear and get asset URLs for use in issues and comments
   - Agent session creation: Create AI/bot tracking sessions on Linear issues
+  - **Give feedback tool: Allows parent sessions to send feedback to child sessions**
   - Automatically available in all Cyrus sessions without additional configuration
 - PostToolUse hook integration for tracking parent-child agent session relationships
   - Automatically captures child agent session IDs when linear_agent_session_create tool is used
+  - **Triggers child session resumption when linear_agent_give_feedback tool is used**
   - Maintains mapping of child sessions to parent sessions for hierarchical tracking
   - Child session results are automatically forwarded to parent sessions upon completion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
   - Automatically captures child agent session IDs when linear_agent_session_create tool is used
   - **Triggers child session resumption when linear_agent_give_feedback tool is used**
   - Maintains mapping of child sessions to parent sessions for hierarchical tracking
+  - **Persistent storage of child-to-parent mappings across restarts**
   - Child session results are automatically forwarded to parent sessions upon completion
 
 ### Changed

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -304,6 +304,10 @@ class EdgeApp {
 				scoper: {
 					labels: ["PRD"],
 				},
+				orchestrator: {
+					labels: ["Orchestrator"],
+					allowedTools: "coordinator" as const, // Uses coordinator tools (all except file editing)
+				},
 			};
 
 			if (shouldCloseRl) {

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -34,19 +34,22 @@ export type ToolName = (typeof availableTools)[number];
 
 /**
  * Default read-only tools that are safe to enable
+ * Note: TodoWrite is included as it only modifies task tracking, not actual code files
  */
 export const readOnlyTools: ToolName[] = [
 	"Read(**)",
 	"WebFetch",
 	"WebSearch",
 	"TodoRead",
+	"TodoWrite",
 	"NotebookRead",
 	"Task",
 	"Batch",
 ];
 
 /**
- * Tools that can modify the file system
+ * Tools that can modify the file system or state
+ * Note: TodoWrite modifies task state but not actual files
  */
 export const writeTools: ToolName[] = [
 	"Edit(**)",
@@ -83,6 +86,27 @@ export function getSafeTools(): string[] {
 		"TodoWrite",
 		"NotebookRead",
 		"NotebookEdit",
+		"Batch",
+	];
+}
+
+/**
+ * Get coordinator tools - all tools except those that can edit files
+ * Includes: Read, Bash (for running tests/builds), Task, WebFetch, WebSearch, TodoRead, TodoWrite, NotebookRead, Batch
+ * Excludes: Edit, NotebookEdit (no file/content modification)
+ * Used by orchestrator role for coordination without direct file modification
+ * Note: TodoWrite is included for task tracking during coordination
+ */
+export function getCoordinatorTools(): string[] {
+	return [
+		"Read(**)",
+		"Bash", // Included for running tests, builds, git commands
+		"Task",
+		"WebFetch",
+		"WebSearch",
+		"TodoRead",
+		"TodoWrite", // For task tracking during coordination
+		"NotebookRead",
 		"Batch",
 	];
 }

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -2,6 +2,7 @@ export { ClaudeRunner, StreamingPrompt } from "./ClaudeRunner.js";
 export {
 	availableTools,
 	getAllTools,
+	getCoordinatorTools,
 	getReadOnlyTools,
 	getSafeTools,
 	readOnlyTools,

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -31,6 +31,8 @@ export interface SerializableEdgeWorkerState {
 		string,
 		Record<string, SerializedCyrusAgentSessionEntry[]>
 	>;
+	// Child to parent agent session mapping
+	childToParentAgentSession?: Record<string, string>;
 }
 
 /**

--- a/packages/cyrus-mcp-tools/package.json
+++ b/packages/cyrus-mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "MCP tools for Cyrus - Linear file uploads, agent session creation, and other utilities.",
 	"main": "dist/index.js",
 	"type": "module",
@@ -28,7 +28,8 @@
 		"description": "MCP tools for Cyrus including Linear file uploads and agent session management",
 		"tools": [
 			"linear_upload_file",
-			"linear_agent_session_create"
+			"linear_agent_session_create",
+			"linear_agent_give_feedback"
 		]
 	},
 	"keywords": [

--- a/packages/cyrus-mcp-tools/src/tools/definitions/give-feedback-tool.ts
+++ b/packages/cyrus-mcp-tools/src/tools/definitions/give-feedback-tool.ts
@@ -1,0 +1,34 @@
+import type { MCPToolDefinition } from "../../types.js";
+
+/**
+ * Tool for providing feedback to a child agent session.
+ * This tool allows a parent agent session to send feedback messages to its child sessions.
+ */
+export const giveFeedbackToolDefinition: MCPToolDefinition = {
+	name: "linear_agent_give_feedback",
+	description:
+		"Provide feedback to a child agent session to continue its processing.",
+	input_schema: {
+		type: "object",
+		properties: {
+			agentSessionId: {
+				type: "string",
+				description: "The ID of the child agent session to provide feedback to",
+			},
+			message: {
+				type: "string",
+				description: "The feedback message to send to the child agent session",
+			},
+		},
+		required: ["agentSessionId", "message"],
+	},
+	output_schema: {
+		type: "object",
+		properties: {
+			success: {
+				type: "boolean",
+				description: "Whether the feedback was successfully queued",
+			},
+		},
+	},
+};

--- a/packages/cyrus-mcp-tools/src/tools/definitions/index.ts
+++ b/packages/cyrus-mcp-tools/src/tools/definitions/index.ts
@@ -1,12 +1,18 @@
 import type { MCPToolDefinition } from "../../types.js";
 import { createAgentSessionToolDefinition } from "./agent-session-tool.js";
+import { giveFeedbackToolDefinition } from "./give-feedback-tool.js";
 import { uploadFileToolDefinition } from "./upload-tool.js";
 
 // All tool definitions
 export const allToolDefinitions: MCPToolDefinition[] = [
 	uploadFileToolDefinition,
 	createAgentSessionToolDefinition,
+	giveFeedbackToolDefinition,
 ];
 
 // Export all tool definitions individually
-export { uploadFileToolDefinition, createAgentSessionToolDefinition };
+export {
+	uploadFileToolDefinition,
+	createAgentSessionToolDefinition,
+	giveFeedbackToolDefinition,
+};

--- a/packages/cyrus-mcp-tools/src/tools/handlers/give-feedback-handler.ts
+++ b/packages/cyrus-mcp-tools/src/tools/handlers/give-feedback-handler.ts
@@ -1,0 +1,35 @@
+import type { LinearService } from "../../services/linear-service.js";
+
+/**
+ * Handler for the give_feedback tool.
+ * Returns success immediately as the actual feedback logic is handled
+ * by the Claude Code SDK PostToolUse hook in EdgeWorker.
+ */
+export function handleGiveFeedback(
+	_linearService: LinearService,
+): (args: unknown) => Promise<unknown> {
+	return async (args: unknown): Promise<unknown> => {
+		// Simple validation - the actual work happens in the PostToolUse hook
+		const typedArgs = args as {
+			agentSessionId?: string;
+			message?: string;
+		};
+
+		if (!typedArgs.agentSessionId) {
+			return {
+				success: false,
+				error: "agentSessionId is required",
+			};
+		}
+
+		if (!typedArgs.message) {
+			return {
+				success: false,
+				error: "message is required",
+			};
+		}
+
+		// Return success - the PostToolUse hook will handle the actual feedback
+		return { success: true };
+	};
+}

--- a/packages/cyrus-mcp-tools/src/tools/handlers/index.ts
+++ b/packages/cyrus-mcp-tools/src/tools/handlers/index.ts
@@ -1,5 +1,6 @@
 import type { LinearService } from "../../services/linear-service.js";
 import { handleCreateAgentSession } from "./agent-session-handler.js";
+import { handleGiveFeedback } from "./give-feedback-handler.js";
 import { handleUploadFile } from "./upload-handler.js";
 
 // Define the handler function type
@@ -16,8 +17,9 @@ export function registerToolHandlers(
 	return {
 		linear_upload_file: handleUploadFile(linearService),
 		linear_agent_session_create: handleCreateAgentSession(linearService),
+		linear_agent_give_feedback: handleGiveFeedback(linearService),
 	};
 }
 
 // Export all handlers individually
-export { handleUploadFile, handleCreateAgentSession };
+export { handleUploadFile, handleCreateAgentSession, handleGiveFeedback };

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -1,28 +1,160 @@
-<version-tag value="orchestrator-v1.0.0" />
+<version-tag value="orchestrator-v2.0.0" />
 
-You are a masterful software engineering orchestrator, specializing in coordination and oversight of complex development tasks.
+You are an expert software architect responsible for decomposing complex issues into executable sub-tasks and orchestrating their completion through specialized agents.
 
-<orchestrator_specific_instructions>
-You excel at:
-- Analyzing and understanding complex codebases
-- Coordinating multi-step development workflows
-- Reviewing and validating implementation approaches
-- Running tests and ensuring code quality
-- Providing strategic guidance on software architecture
-- Delegating specific implementation tasks when needed
+## Core Responsibilities
 
-**Your role is to coordinate and oversee, not to directly implement.**
+1. **Analyze** parent issues and create atomic, well-scoped sub-issues
+2. **Delegate** work to specialized agents using appropriate labels
+3. **Evaluate** completed work against acceptance criteria
+4. **Iterate** based on results until objectives are met
 
-You have access to powerful analysis and coordination tools but cannot directly modify files. This ensures you maintain a high-level perspective while delegating implementation details appropriately.
+## Required Tools
 
-**Key responsibilities:**
-- Analyze requirements and break them down into actionable tasks
-- Review existing code patterns and architectural decisions
-- Coordinate testing and validation workflows
-- Provide oversight on implementation strategies
-- Ensure code quality through analysis and testing
-- Guide the development process without direct file modifications
-</orchestrator_specific_instructions>
+### Linear MCP Tools
+- `mcp__linear__linear_createIssue` - Create sub-issues with proper context. Add labels here as well
+- `mcp__linear__linear_getIssueById` - Retrieve issue details
 
-<!-- Placeholder for additional orchestrator-specific instructions -->
-<!-- This prompt will be populated with more specific guidance as needed -->
+### Cyrus MCP Tools  
+- `mcp__cyrus-mcp-tools__linear_agent_session_create` - Delegate sub-issue execution
+- `mcp__cyrus-mcp-tools__give_feedback` - Provide guidance to active agents
+
+## Execution Workflow
+
+### 1. Initialize
+```
+- Push local branch to remote
+- Analyze parent issue requirements
+- Check for existing sub-issues
+- Identify work type and dependencies
+```
+
+### 2. Decompose
+Create sub-issues with:
+- **Clear title**: `[Type] Specific action and target`
+- **Structured description**:
+  ```
+  Objective: [What needs to be accomplished]
+  Context: [Relevant background from parent]
+  Acceptance Criteria:
+  - [ ] Specific measurable outcome 1
+  - [ ] Specific measurable outcome 2
+  Dependencies: [Required prior work]
+  Technical Notes: [Code paths, constraints]
+  ```
+- **Appropriate label**:
+  - `Bug` → Triggers debugger agent
+  - `Feature`/`Improvement` → Triggers builder agent  
+  - `PRD` → Triggers scoper agent
+
+### 3. Execute
+```
+1. Start first sub-issue with linear_agent_session_create
+2. HALT and await completion notification
+3. Upon completion, evaluate results
+```
+
+### 4. Evaluate Results
+
+**Success Criteria Met:**
+- Merge child branch into local
+- Push to remote
+- Start next sub-issue
+
+**Criteria Partially Met:**
+- Use give_feedback with specific improvements needed
+
+**Criteria Not Met:**
+- Analyze root cause
+- Create revised sub-issue with enhanced detail
+- Consider different agent role if needed
+
+### 5. Complete
+```
+- Verify all sub-issues completed
+- Validate parent objectives achieved
+- Document final state and learnings
+```
+
+## Sub-Issue Design Principles
+
+### Atomic & Independent
+- Each sub-issue must be independently executable
+- Include ALL necessary context within description
+- Avoid circular dependencies
+
+### Right-Sized
+- Single clear objective
+- Testable outcome
+
+### Context-Rich
+Include in every sub-issue:
+- Link to parent issue
+- Relevant code paths
+- Related documentation
+- Prior attempts/learnings
+- Integration points
+
+## Critical Rules
+
+1. **ALWAYS** verify sub-issue results before proceeding
+2. **NEVER** skip evaluation - completed work may need refinement
+3. **MAINTAIN** remote branch synchronization after each merge
+4. **DOCUMENT** decisions and plan adjustments in parent issue
+5. **PRIORITIZE** unblocking work when dependencies arise
+
+## Evaluation Checklist
+
+When sub-issue completes, verify:
+- [ ] Acceptance criteria fully satisfied
+- [ ] Tests created and passing
+- [ ] Code meets project standards
+- [ ] Documentation updated
+- [ ] No regression introduced
+- [ ] Integration verified
+
+## State Management
+
+Track in parent issue:
+```markdown
+## Orchestration Status
+**Completed**: [List of merged sub-issues]
+**Active**: [Currently executing sub-issue]
+**Pending**: [Queued sub-issues]
+**Blocked**: [Issues awaiting resolution]
+
+## Key Decisions
+- [Decision]: [Rationale]
+
+## Risks & Mitigations
+- [Risk]: [Mitigation strategy]
+```
+
+## Error Recovery
+
+If agent fails:
+1. Analyze error output
+2. Determine if issue with:
+   - Instructions clarity → Enhance description
+   - Missing context → Add information
+   - Wrong agent type → Change label
+   - Technical blocker → Create unblocking issue
+3. Re-attempt with corrections
+
+## Remember
+
+- You orchestrate; specialized agents implement
+- Quality over speed - ensure each piece is solid
+- Adjust plans based on discoveries
+- Small, focused iterations beat large, complex ones
+- Communication clarity determines success
+
+<pr_instructions>
+**When all sub-issues are complete and all quality checks pass, you MUST create the pull request using the GitHub CLI:**
+   
+```bash
+gh pr create
+```
+**You MUST make sure that the PR is created for the correct base branch associated with the current working branch. Do NOT assume that the base branch is the default one.**
+Use this command unless a PR already exists. Make sure the PR is populated with an appropriate title and body. If required, edit the message before submitting.
+</pr_instructions>

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -1,0 +1,28 @@
+<version-tag value="orchestrator-v1.0.0" />
+
+You are a masterful software engineering orchestrator, specializing in coordination and oversight of complex development tasks.
+
+<orchestrator_specific_instructions>
+You excel at:
+- Analyzing and understanding complex codebases
+- Coordinating multi-step development workflows
+- Reviewing and validating implementation approaches
+- Running tests and ensuring code quality
+- Providing strategic guidance on software architecture
+- Delegating specific implementation tasks when needed
+
+**Your role is to coordinate and oversee, not to directly implement.**
+
+You have access to powerful analysis and coordination tools but cannot directly modify files. This ensures you maintain a high-level perspective while delegating implementation details appropriately.
+
+**Key responsibilities:**
+- Analyze requirements and break them down into actionable tasks
+- Review existing code patterns and architectural decisions
+- Coordinate testing and validation workflows
+- Provide oversight on implementation strategies
+- Ensure code quality through analysis and testing
+- Guide the development process without direct file modifications
+</orchestrator_specific_instructions>
+
+<!-- Placeholder for additional orchestrator-specific instructions -->
+<!-- This prompt will be populated with more specific guidance as needed -->

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2666,6 +2666,14 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 											console.log(
 												`[Parent-Child Mapping] Successfully created. Total mappings: ${this.childToParentAgentSession.size}`,
 											);
+											
+											// Save state after adding new mapping
+											this.savePersistedState().catch((error) => {
+												console.error(
+													`[Parent-Child Mapping] Failed to save state after creating mapping:`,
+													error,
+												);
+											});
 										}
 									} catch (error) {
 										console.error(
@@ -2914,9 +2922,15 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			agentSessions[repositoryId] = serializedState.sessions;
 			agentSessionEntries[repositoryId] = serializedState.entries;
 		}
+		// Serialize child to parent agent session mapping
+		const childToParentAgentSession = Object.fromEntries(
+			this.childToParentAgentSession.entries()
+		);
+		
 		return {
 			agentSessions,
 			agentSessionEntries,
+			childToParentAgentSession,
 		};
 	}
 
@@ -2946,6 +2960,16 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 					);
 				}
 			}
+		}
+		
+		// Restore child to parent agent session mapping
+		if (state.childToParentAgentSession) {
+			this.childToParentAgentSession = new Map(
+				Object.entries(state.childToParentAgentSession)
+			);
+			console.log(
+				`[EdgeWorker] Restored ${this.childToParentAgentSession.size} child-to-parent agent session mappings`,
+			);
 		}
 	}
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2666,7 +2666,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 											console.log(
 												`[Parent-Child Mapping] Successfully created. Total mappings: ${this.childToParentAgentSession.size}`,
 											);
-											
+
 											// Save state after adding new mapping
 											this.savePersistedState().catch((error) => {
 												console.error(
@@ -2924,9 +2924,9 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		}
 		// Serialize child to parent agent session mapping
 		const childToParentAgentSession = Object.fromEntries(
-			this.childToParentAgentSession.entries()
+			this.childToParentAgentSession.entries(),
 		);
-		
+
 		return {
 			agentSessions,
 			agentSessionEntries,
@@ -2961,11 +2961,11 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 				}
 			}
 		}
-		
+
 		// Restore child to parent agent session mapping
 		if (state.childToParentAgentSession) {
 			this.childToParentAgentSession = new Map(
-				Object.entries(state.childToParentAgentSession)
+				Object.entries(state.childToParentAgentSession),
 			);
 			console.log(
 				`[EdgeWorker] Restored ${this.childToParentAgentSession.size} child-to-parent agent session mappings`,

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -39,15 +39,19 @@ export interface RepositoryConfig {
 	labelPrompts?: {
 		debugger?: {
 			labels: string[]; // Labels that trigger debugger mode (e.g., ["Bug"])
-			allowedTools?: string[] | "readOnly" | "safe" | "all"; // Tool restrictions for debugger mode
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for debugger mode
 		};
 		builder?: {
 			labels: string[]; // Labels that trigger builder mode (e.g., ["Feature", "Improvement"])
-			allowedTools?: string[] | "readOnly" | "safe" | "all"; // Tool restrictions for builder mode
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for builder mode
 		};
 		scoper?: {
 			labels: string[]; // Labels that trigger scoper mode (e.g., ["PRD"])
-			allowedTools?: string[] | "readOnly" | "safe" | "all"; // Tool restrictions for scoper mode
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for scoper mode
+		};
+		orchestrator?: {
+			labels: string[]; // Labels that trigger orchestrator mode (e.g., ["Orchestrator"])
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for orchestrator mode
 		};
 	};
 }
@@ -73,13 +77,16 @@ export interface EdgeWorkerConfig {
 	// Global defaults for prompt types
 	promptDefaults?: {
 		debugger?: {
-			allowedTools?: string[] | "readOnly" | "safe" | "all";
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
 		};
 		builder?: {
-			allowedTools?: string[] | "readOnly" | "safe" | "all";
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
 		};
 		scoper?: {
-			allowedTools?: string[] | "readOnly" | "safe" | "all";
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
+		};
+		orchestrator?: {
+			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
 		};
 	};
 

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -398,6 +398,9 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 				if (path.includes("scoper.md")) {
 					return "Scoper prompt content";
 				}
+				if (path.includes("orchestrator.md")) {
+					return 'You are a masterful software engineering orchestrator\n<version-tag value="orchestrator-v1.0.0" />';
+				}
 				throw new Error(`File not found: ${path}`);
 			});
 		});
@@ -518,6 +521,33 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 			const result = await determineSystemPromptFromLabels([], repository);
 
 			expect(result).toBeUndefined();
+		});
+
+		it("should select orchestrator prompt for Orchestrator label with coordinator tools preset", async () => {
+			const repository: RepositoryConfig = {
+				...mockConfig.repositories[0],
+				labelPrompts: {
+					orchestrator: {
+						labels: ["Orchestrator"],
+						allowedTools: "coordinator",
+					},
+				},
+			};
+
+			const determineSystemPromptFromLabels =
+				getDetermineSystemPromptFromLabels(edgeWorker);
+			const result = await determineSystemPromptFromLabels(
+				["Orchestrator", "other-label"],
+				repository,
+			);
+
+			expect(result).toBeDefined();
+			expect(result?.type).toBe("orchestrator");
+			expect(result?.prompt).toContain("orchestrator-v1.0.0");
+			expect(result?.prompt).toContain(
+				"masterful software engineering orchestrator",
+			);
+			expect(result?.version).toBe("orchestrator-v1.0.0");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Added `linear_agent_give_feedback` tool to cyrus-mcp-tools package
- Implemented PostToolUse hook in EdgeWorker to handle the feedback tool
- Enables parent agent sessions to send feedback to their child sessions

## Implementation Details

### New Tool: `linear_agent_give_feedback`
- Takes `agentSessionId` and `message` as inputs
- Returns success status immediately
- Actual feedback handling is done through the Claude Code SDK PostToolUse hook

### EdgeWorker PostToolUse Hook
- Listens for the `linear_agent_give_feedback` tool execution
- Extracts the child session ID and feedback message from tool input
- Resumes the child session using the existing `resumeClaudeSession` method
- Provides the feedback message as a prompt to the child session

### Helper Method
- Added `getRepositoryForSession` method to EdgeWorker to find the repository configuration for a given session

## Test plan
- [x] Build all packages successfully
- [x] Run package tests (`pnpm test:packages:run`)
- [x] Lint checks pass (`pnpm format`)
- [ ] Manual testing with parent-child agent sessions

🤖 Generated with [Claude Code](https://claude.ai/code)