### PR TITLE
feat: Add orchestrator label as fourth default prompt type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
   - Maintains mapping of child sessions to parent sessions for hierarchical tracking
   - **Persistent storage of child-to-parent mappings across restarts**
   - Child session results are automatically forwarded to parent sessions upon completion
+- New "orchestrator" label system prompt type
+  - Joins existing "builder", "debugger", and "scoper" labels as a default option
+  - Configured with read-only tools (cannot directly edit files)
+  - Specializes in coordination and oversight of complex development tasks
+  - Automatically triggered by "Orchestrator" label on Linear issues
 
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89 for latest Claude Code improvements. See [Claude Code v1.0.89 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1089)

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -304,6 +304,10 @@ class EdgeApp {
 				scoper: {
 					labels: ["PRD"],
 				},
+				orchestrator: {
+					labels: ["Orchestrator"],
+					allowedTools: "readOnly" as const, // Orchestrator cannot edit files directly
+				},
 			};
 
 			if (shouldCloseRl) {

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -1,0 +1,28 @@
+<version-tag value="orchestrator-v1.0.0" />
+
+You are a masterful software engineering orchestrator, specializing in coordination and oversight of complex development tasks.
+
+<orchestrator_specific_instructions>
+You excel at:
+- Analyzing and understanding complex codebases
+- Coordinating multi-step development workflows
+- Reviewing and validating implementation approaches
+- Running tests and ensuring code quality
+- Providing strategic guidance on software architecture
+- Delegating specific implementation tasks when needed
+
+**Your role is to coordinate and oversee, not to directly implement.**
+
+You have access to powerful analysis and coordination tools but cannot directly modify files. This ensures you maintain a high-level perspective while delegating implementation details appropriately.
+
+**Key responsibilities:**
+- Analyze requirements and break them down into actionable tasks
+- Review existing code patterns and architectural decisions
+- Coordinate testing and validation workflows
+- Provide oversight on implementation strategies
+- Ensure code quality through analysis and testing
+- Guide the development process without direct file modifications
+</orchestrator_specific_instructions>
+
+<!-- Placeholder for additional orchestrator-specific instructions -->
+<!-- This prompt will be populated with more specific guidance as needed -->

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -825,7 +825,12 @@ export class EdgeWorker extends EventEmitter {
 		// Only fetch labels and determine system prompt for delegation (not mentions)
 		let systemPrompt: string | undefined;
 		let systemPromptVersion: string | undefined;
-		let promptType: "debugger" | "builder" | "scoper" | undefined;
+		let promptType:
+			| "debugger"
+			| "builder"
+			| "scoper"
+			| "orchestrator"
+			| undefined;
 
 		if (!isMentionTriggered) {
 			// Fetch issue labels and determine system prompt (delegation case)
@@ -1262,7 +1267,7 @@ export class EdgeWorker extends EventEmitter {
 		| {
 				prompt: string;
 				version?: string;
-				type?: "debugger" | "builder" | "scoper";
+				type?: "debugger" | "builder" | "scoper" | "orchestrator";
 		  }
 		| undefined
 	> {
@@ -1271,7 +1276,12 @@ export class EdgeWorker extends EventEmitter {
 		}
 
 		// Check each prompt type for matching labels
-		const promptTypes = ["debugger", "builder", "scoper"] as const;
+		const promptTypes = [
+			"debugger",
+			"builder",
+			"scoper",
+			"orchestrator",
+		] as const;
 
 		for (const promptType of promptTypes) {
 			const promptConfig = repository.labelPrompts[promptType];
@@ -2801,7 +2811,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 	 */
 	private buildAllowedTools(
 		repository: RepositoryConfig,
-		promptType?: "debugger" | "builder" | "scoper",
+		promptType?: "debugger" | "builder" | "scoper" | "orchestrator",
 	): string[] {
 		let baseTools: string[] = [];
 		let toolSource = "";
@@ -3119,6 +3129,19 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 						if (scoperLabel) {
 							selectedPromptType = "scoper";
 							triggerLabel = scoperLabel;
+						} else {
+							// Check orchestrator labels
+							const orchestratorConfig = repository.labelPrompts.orchestrator;
+							const orchestratorLabels = Array.isArray(orchestratorConfig)
+								? orchestratorConfig
+								: orchestratorConfig?.labels;
+							const orchestratorLabel = orchestratorLabels?.find((label) =>
+								labels.includes(label),
+							);
+							if (orchestratorLabel) {
+								selectedPromptType = "orchestrator";
+								triggerLabel = orchestratorLabel;
+							}
 						}
 					}
 				}

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -49,6 +49,10 @@ export interface RepositoryConfig {
 			labels: string[]; // Labels that trigger scoper mode (e.g., ["PRD"])
 			allowedTools?: string[] | "readOnly" | "safe" | "all"; // Tool restrictions for scoper mode
 		};
+		orchestrator?: {
+			labels: string[]; // Labels that trigger orchestrator mode (e.g., ["Orchestrator"])
+			allowedTools?: string[] | "readOnly" | "safe" | "all"; // Tool restrictions for orchestrator mode
+		};
 	};
 }
 
@@ -79,6 +83,9 @@ export interface EdgeWorkerConfig {
 			allowedTools?: string[] | "readOnly" | "safe" | "all";
 		};
 		scoper?: {
+			allowedTools?: string[] | "readOnly" | "safe" | "all";
+		};
+		orchestrator?: {
 			allowedTools?: string[] | "readOnly" | "safe" | "all";
 		};
 	};

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -398,6 +398,9 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 				if (path.includes("scoper.md")) {
 					return "Scoper prompt content";
 				}
+				if (path.includes("orchestrator.md")) {
+					return 'You are a masterful software engineering orchestrator\n<version-tag value="orchestrator-v1.0.0" />';
+				}
 				throw new Error(`File not found: ${path}`);
 			});
 		});
@@ -518,6 +521,33 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 			const result = await determineSystemPromptFromLabels([], repository);
 
 			expect(result).toBeUndefined();
+		});
+
+		it("should select orchestrator prompt for Orchestrator label with readOnly tools", async () => {
+			const repository: RepositoryConfig = {
+				...mockConfig.repositories[0],
+				labelPrompts: {
+					orchestrator: {
+						labels: ["Orchestrator"],
+						allowedTools: "readOnly",
+					},
+				},
+			};
+
+			const determineSystemPromptFromLabels =
+				getDetermineSystemPromptFromLabels(edgeWorker);
+			const result = await determineSystemPromptFromLabels(
+				["Orchestrator", "other-label"],
+				repository,
+			);
+
+			expect(result).toBeDefined();
+			expect(result?.type).toBe("orchestrator");
+			expect(result?.prompt).toContain("orchestrator-v1.0.0");
+			expect(result?.prompt).toContain(
+				"masterful software engineering orchestrator",
+			);
+			expect(result?.version).toBe("orchestrator-v1.0.0");
 		});
 	});
 });


### PR DESCRIPTION
- Created orchestrator.md system prompt placeholder
- Added orchestrator to TypeScript types in edge-worker
- Configured orchestrator with read-only tools (no file editing)
- Updated CLI default label mappings to include orchestrator
- Added test coverage for orchestrator label functionality
- Updated EdgeWorker to handle orchestrator label detection

The orchestrator label specializes in coordination and oversight of complex development tasks without direct file modification capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)