### PR TITLE
feat: Add label-based Claude model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to this project will be documented in this file.
   - Configured with read-only tools (cannot directly edit files)
   - Specializes in coordination and oversight of complex development tasks
   - Automatically triggered by "Orchestrator" label on Linear issues
+- **Label-based Claude model selection**: You can now override the Claude model used for specific issues by adding labels
+  - Add "opus", "sonnet", or "haiku" label to any Linear issue to force that model
+  - Model labels take highest priority (overrides both repository and global settings)
+  - Case-insensitive label matching for flexibility
+  - Automatically sets appropriate fallback models (opus→sonnet, sonnet→haiku, haiku→haiku)
 
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.88 to v1.0.89 for latest Claude Code improvements. See [Claude Code v1.0.89 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1089)

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -823,7 +823,10 @@ export class EdgeWorker extends EventEmitter {
 			allowedDirectories,
 		} = sessionData;
 
-		// Only fetch labels and determine system prompt for delegation (not mentions)
+		// Fetch labels (needed for both model selection and system prompt determination)
+		const labels = await this.fetchIssueLabels(fullIssue);
+		
+		// Only determine system prompt for delegation (not mentions)
 		let systemPrompt: string | undefined;
 		let systemPromptVersion: string | undefined;
 		let promptType:
@@ -834,8 +837,7 @@ export class EdgeWorker extends EventEmitter {
 			| undefined;
 
 		if (!isMentionTriggered) {
-			// Fetch issue labels and determine system prompt (delegation case)
-			const labels = await this.fetchIssueLabels(fullIssue);
+			// Determine system prompt based on labels (delegation case)
 			const systemPromptResult = await this.determineSystemPromptFromLabels(
 				labels,
 				repository,
@@ -877,6 +879,7 @@ export class EdgeWorker extends EventEmitter {
 			allowedDirectories,
 			undefined, // resumeSessionId
 			linearAgentActivitySessionId, // Pass current session ID as parent context
+			labels, // Pass labels for model override
 		);
 		const runner = new ClaudeRunner(runnerConfig);
 
@@ -2634,6 +2637,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		allowedDirectories: string[],
 		resumeSessionId?: string,
 		parentAgentSessionId?: string,
+		labels?: string[],
 	): any {
 		// Build hooks configuration
 		const hooks = {
@@ -2778,6 +2782,44 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			],
 		};
 
+		// Check for model override labels (case-insensitive)
+		let modelOverride: string | undefined;
+		let fallbackModelOverride: string | undefined;
+		
+		if (labels && labels.length > 0) {
+			const lowercaseLabels = labels.map((label) => label.toLowerCase());
+			
+			// Check for model override labels: opus, sonnet, haiku
+			if (lowercaseLabels.includes('opus')) {
+				modelOverride = 'opus';
+				console.log(
+					`[EdgeWorker] Model override via label: opus (for session ${linearAgentActivitySessionId})`,
+				);
+			} else if (lowercaseLabels.includes('sonnet')) {
+				modelOverride = 'sonnet';
+				console.log(
+					`[EdgeWorker] Model override via label: sonnet (for session ${linearAgentActivitySessionId})`,
+				);
+			} else if (lowercaseLabels.includes('haiku')) {
+				modelOverride = 'haiku';
+				console.log(
+					`[EdgeWorker] Model override via label: haiku (for session ${linearAgentActivitySessionId})`,
+				);
+			}
+			
+			// If a model override is found, also set a reasonable fallback
+			if (modelOverride) {
+				// Set fallback to the next lower tier: opus->sonnet, sonnet->haiku, haiku->haiku
+				if (modelOverride === 'opus') {
+					fallbackModelOverride = 'sonnet';
+				} else if (modelOverride === 'sonnet') {
+					fallbackModelOverride = 'haiku';
+				} else {
+					fallbackModelOverride = 'haiku';
+				}
+			}
+		}
+
 		const config = {
 			workingDirectory: session.workspace.path,
 			allowedTools,
@@ -2787,10 +2829,10 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			mcpConfigPath: repository.mcpConfigPath,
 			mcpConfig: this.buildMcpConfig(repository),
 			appendSystemPrompt: (systemPrompt || "") + LAST_MESSAGE_MARKER,
-			// Use repository-specific model or fall back to global default
-			model: repository.model || this.config.defaultModel,
+			// Priority order: label override > repository config > global default
+			model: modelOverride || repository.model || this.config.defaultModel,
 			fallbackModel:
-				repository.fallbackModel || this.config.defaultFallbackModel,
+				fallbackModelOverride || repository.fallbackModel || this.config.defaultFallbackModel,
 			hooks,
 			onMessage: (message: SDKMessage) => {
 				this.handleClaudeMessage(
@@ -3274,6 +3316,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			allowedDirectories,
 			needsNewClaudeSession ? undefined : session.claudeSessionId,
 			linearAgentActivitySessionId,
+			labels, // Pass labels for model override
 		);
 
 		const runner = new ClaudeRunner(runnerConfig);

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -825,7 +825,7 @@ export class EdgeWorker extends EventEmitter {
 
 		// Fetch labels (needed for both model selection and system prompt determination)
 		const labels = await this.fetchIssueLabels(fullIssue);
-		
+
 		// Only determine system prompt for delegation (not mentions)
 		let systemPrompt: string | undefined;
 		let systemPromptVersion: string | undefined;
@@ -2785,37 +2785,37 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		// Check for model override labels (case-insensitive)
 		let modelOverride: string | undefined;
 		let fallbackModelOverride: string | undefined;
-		
+
 		if (labels && labels.length > 0) {
 			const lowercaseLabels = labels.map((label) => label.toLowerCase());
-			
+
 			// Check for model override labels: opus, sonnet, haiku
-			if (lowercaseLabels.includes('opus')) {
-				modelOverride = 'opus';
+			if (lowercaseLabels.includes("opus")) {
+				modelOverride = "opus";
 				console.log(
 					`[EdgeWorker] Model override via label: opus (for session ${linearAgentActivitySessionId})`,
 				);
-			} else if (lowercaseLabels.includes('sonnet')) {
-				modelOverride = 'sonnet';
+			} else if (lowercaseLabels.includes("sonnet")) {
+				modelOverride = "sonnet";
 				console.log(
 					`[EdgeWorker] Model override via label: sonnet (for session ${linearAgentActivitySessionId})`,
 				);
-			} else if (lowercaseLabels.includes('haiku')) {
-				modelOverride = 'haiku';
+			} else if (lowercaseLabels.includes("haiku")) {
+				modelOverride = "haiku";
 				console.log(
 					`[EdgeWorker] Model override via label: haiku (for session ${linearAgentActivitySessionId})`,
 				);
 			}
-			
+
 			// If a model override is found, also set a reasonable fallback
 			if (modelOverride) {
 				// Set fallback to the next lower tier: opus->sonnet, sonnet->haiku, haiku->haiku
-				if (modelOverride === 'opus') {
-					fallbackModelOverride = 'sonnet';
-				} else if (modelOverride === 'sonnet') {
-					fallbackModelOverride = 'haiku';
+				if (modelOverride === "opus") {
+					fallbackModelOverride = "sonnet";
+				} else if (modelOverride === "sonnet") {
+					fallbackModelOverride = "haiku";
 				} else {
-					fallbackModelOverride = 'haiku';
+					fallbackModelOverride = "haiku";
 				}
 			}
 		}
@@ -2832,7 +2832,9 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			// Priority order: label override > repository config > global default
 			model: modelOverride || repository.model || this.config.defaultModel,
 			fallbackModel:
-				fallbackModelOverride || repository.fallbackModel || this.config.defaultFallbackModel,
+				fallbackModelOverride ||
+				repository.fallbackModel ||
+				this.config.defaultFallbackModel,
 			hooks,
 			onMessage: (message: SDKMessage) => {
 				this.handleClaudeMessage(


### PR DESCRIPTION
## Summary
- Implement model override via Linear issue labels (opus, sonnet, haiku)
- Labels take highest priority over repository and global model settings
- Case-insensitive label matching with automatic fallback model configuration

## Implementation Details

This PR adds the ability to specify which Claude model to use for a given Linear issue by adding a label to the issue:
- Add an "opus", "sonnet", or "haiku" label (case-insensitive) to any Linear issue
- The label-based model selection takes highest priority, overriding both repository and global model preferences
- Appropriate fallback models are automatically configured (opus→sonnet, sonnet→haiku, haiku→haiku)

### Changes Made
- Modified `buildClaudeRunnerConfig` method in EdgeWorker to accept and process issue labels
- Added model override logic that checks for model labels before falling back to repository/global settings
- Updated all call sites to pass labels to the configuration builder
- Fetched labels earlier in the agent session creation flow to ensure they're available for model selection

## Test Plan
- [x] TypeScript compilation passes
- [x] Existing tests continue to pass
- [ ] Manual testing with Linear issues containing model labels
- [ ] Verify model override works correctly in live environment

## Related Issue
Closes CYPACK-15

🤖 Generated with [Claude Code](https://claude.ai/code)