### PR TITLE
feat: Add disallowedTools configuration option for tool restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Tool restriction configuration**: New `disallowedTools` configuration option to explicitly block specific tools
+  - Can be configured at global, repository, prompt type, and label-specific levels
+  - Follows same hierarchy as `allowedTools` (label > prompt defaults > repository > global)
+  - No default disallowed tools - only explicitly configured tools are blocked
+  - Environment variable support: `DISALLOWED_TOOLS` for global defaults
+  - Passed through to Claude Code via `disallowedTools` option
+
 ## [0.1.45] - 2025-08-28
 
 ### Added

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -484,6 +484,8 @@ class EdgeApp {
 			cyrusHome: this.cyrusHome,
 			defaultAllowedTools:
 				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) || [],
+			defaultDisallowedTools:
+				process.env.DISALLOWED_TOOLS?.split(",").map((t) => t.trim()) || undefined,
 			// Model configuration: environment variables take precedence over config file
 			defaultModel:
 				process.env.CYRUS_DEFAULT_MODEL || this.loadEdgeConfig().defaultModel,

--- a/apps/cli/app.ts
+++ b/apps/cli/app.ts
@@ -485,7 +485,8 @@ class EdgeApp {
 			defaultAllowedTools:
 				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) || [],
 			defaultDisallowedTools:
-				process.env.DISALLOWED_TOOLS?.split(",").map((t) => t.trim()) || undefined,
+				process.env.DISALLOWED_TOOLS?.split(",").map((t) => t.trim()) ||
+				undefined,
 			// Model configuration: environment variables take precedence over config file
 			defaultModel:
 				process.env.CYRUS_DEFAULT_MODEL || this.loadEdgeConfig().defaultModel,

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -272,11 +272,11 @@ export class ClaudeRunner extends EventEmitter {
 
 			// Process disallowed tools - no defaults, just pass through
 			// Only pass if array is non-empty
-			const processedDisallowedTools = 
+			const processedDisallowedTools =
 				this.config.disallowedTools && this.config.disallowedTools.length > 0
 					? this.config.disallowedTools
 					: undefined;
-			
+
 			// Log disallowed tools if configured
 			if (processedDisallowedTools) {
 				console.log(
@@ -347,7 +347,9 @@ export class ClaudeRunner extends EventEmitter {
 						appendSystemPrompt: this.config.appendSystemPrompt,
 					}),
 					...(processedAllowedTools && { allowedTools: processedAllowedTools }),
-					...(processedDisallowedTools && { disallowedTools: processedDisallowedTools }),
+					...(processedDisallowedTools && {
+						disallowedTools: processedDisallowedTools,
+					}),
 					...(this.config.resumeSessionId && {
 						resume: this.config.resumeSessionId,
 					}),

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -270,6 +270,21 @@ export class ClaudeRunner extends EventEmitter {
 					: directoryTools;
 			}
 
+			// Process disallowed tools - no defaults, just pass through
+			// Only pass if array is non-empty
+			const processedDisallowedTools = 
+				this.config.disallowedTools && this.config.disallowedTools.length > 0
+					? this.config.disallowedTools
+					: undefined;
+			
+			// Log disallowed tools if configured
+			if (processedDisallowedTools) {
+				console.log(
+					`[ClaudeRunner] Disallowed tools configured:`,
+					processedDisallowedTools,
+				);
+			}
+
 			// Parse MCP config - merge file(s) and inline configs
 			let mcpServers = {};
 
@@ -332,6 +347,7 @@ export class ClaudeRunner extends EventEmitter {
 						appendSystemPrompt: this.config.appendSystemPrompt,
 					}),
 					...(processedAllowedTools && { allowedTools: processedAllowedTools }),
+					...(processedDisallowedTools && { disallowedTools: processedDisallowedTools }),
 					...(this.config.resumeSessionId && {
 						resume: this.config.resumeSessionId,
 					}),

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -12,6 +12,7 @@ import type {
 export interface ClaudeRunnerConfig {
 	workingDirectory?: string;
 	allowedTools?: string[];
+	disallowedTools?: string[];
 	allowedDirectories?: string[];
 	resumeSessionId?: string; // Session ID to resume from previous Claude session
 	workspaceName?: string;

--- a/packages/claude-runner/test/disallowed-tools.test.ts
+++ b/packages/claude-runner/test/disallowed-tools.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ClaudeRunner } from "../src/ClaudeRunner";
+import type { ClaudeRunnerConfig } from "../src/types";
+import * as claudeCode from "@anthropic-ai/claude-code";
+
+// Mock the query function from @anthropic-ai/claude-code
+vi.mock("@anthropic-ai/claude-code", () => ({
+	query: vi.fn(),
+}));
+
+// Mock file system with all required methods
+vi.mock("fs", () => ({
+	readFileSync: vi.fn(),
+	existsSync: vi.fn(() => true),
+	mkdirSync: vi.fn(),
+	createWriteStream: vi.fn(() => ({
+		write: vi.fn(),
+		end: vi.fn(),
+		on: vi.fn(),
+	})),
+	statSync: vi.fn(() => ({
+		isDirectory: vi.fn(() => true),
+	})),
+}));
+
+describe("ClaudeRunner - disallowedTools", () => {
+	const queryMock = vi.mocked(claudeCode.query);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		
+		// Mock the query to return an async generator
+		queryMock.mockImplementation(async function* () {
+			// Empty generator for testing
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should pass disallowedTools to Claude Code when configured", async () => {
+		const config: ClaudeRunnerConfig = {
+			workingDirectory: "/test",
+			allowedTools: ["Read(**)", "Edit(**)"],
+			disallowedTools: ["Bash", "WebFetch"],
+			cyrusHome: "/test/cyrus",
+		};
+
+		// Mock the query to capture arguments and return a session ID message
+		queryMock.mockImplementation(async function* (args: any) {
+			// Yield a session ID message
+			yield {
+				type: "system",
+				role: "session_info",
+				content: {
+					session_id: "test-session",
+				},
+			};
+		});
+
+		const runner = new ClaudeRunner(config);
+		
+		// Run the query with a test prompt
+		const prompt = "Test prompt";
+		const messages = [];
+		
+		await runner.start(prompt);
+
+		// Check that query was called with disallowedTools
+		expect(queryMock).toHaveBeenCalledTimes(1);
+		const callArgs = queryMock.mock.calls[0][0];
+		
+		expect(callArgs.options).toBeDefined();
+		expect(callArgs.options.disallowedTools).toEqual(["Bash", "WebFetch"]);
+		expect(callArgs.options.allowedTools).toContain("Read(**)");
+		expect(callArgs.options.allowedTools).toContain("Edit(**)");
+	});
+
+	it("should not pass disallowedTools when not configured", async () => {
+		const config: ClaudeRunnerConfig = {
+			workingDirectory: "/test",
+			allowedTools: ["Read(**)", "Edit(**)"],
+			// No disallowedTools
+			cyrusHome: "/test/cyrus",
+		};
+
+		// Mock the query to capture arguments and return a session ID message
+		queryMock.mockImplementation(async function* (args: any) {
+			yield {
+				type: "system",
+				role: "session_info",
+				content: {
+					session_id: "test-session",
+				},
+			};
+		});
+
+		const runner = new ClaudeRunner(config);
+		await runner.start("Test prompt");
+
+		// Check that query was called without disallowedTools
+		expect(queryMock).toHaveBeenCalledTimes(1);
+		const callArgs = queryMock.mock.calls[0][0];
+		
+		expect(callArgs.options).toBeDefined();
+		expect(callArgs.options.disallowedTools).toBeUndefined();
+		expect(callArgs.options.allowedTools).toContain("Read(**)");
+		expect(callArgs.options.allowedTools).toContain("Edit(**)");
+	});
+
+	it("should handle empty disallowedTools array", async () => {
+		const config: ClaudeRunnerConfig = {
+			workingDirectory: "/test",
+			allowedTools: ["Read(**)", "Edit(**)"],
+			disallowedTools: [], // Empty array
+			cyrusHome: "/test/cyrus",
+		};
+
+		// Mock the query to capture arguments and return a session ID message
+		queryMock.mockImplementation(async function* (args: any) {
+			yield {
+				type: "system",
+				role: "session_info",
+				content: {
+					session_id: "test-session",
+				},
+			};
+		});
+
+		const runner = new ClaudeRunner(config);
+		await runner.start("Test prompt");
+
+		// Check that query was called without disallowedTools (empty array is falsy)
+		expect(queryMock).toHaveBeenCalledTimes(1);
+		const callArgs = queryMock.mock.calls[0][0];
+		
+		expect(callArgs.options).toBeDefined();
+		expect(callArgs.options.disallowedTools).toBeUndefined();
+	});
+
+	it("should log disallowedTools when configured", async () => {
+		const consoleSpy = vi.spyOn(console, "log");
+		
+		const config: ClaudeRunnerConfig = {
+			workingDirectory: "/test",
+			disallowedTools: ["Bash", "SystemAccess", "DangerousTool"],
+			cyrusHome: "/test/cyrus",
+		};
+
+		// Mock the query to capture arguments and return a session ID message
+		queryMock.mockImplementation(async function* (args: any) {
+			yield {
+				type: "system",
+				role: "session_info",
+				content: {
+					session_id: "test-session",
+				},
+			};
+		});
+
+		const runner = new ClaudeRunner(config);
+		await runner.start("Test");
+
+		// Check that disallowedTools were logged
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[ClaudeRunner] Disallowed tools configured:",
+			["Bash", "SystemAccess", "DangerousTool"]
+		);
+		
+		consoleSpy.mockRestore();
+	});
+});

--- a/packages/claude-runner/test/disallowed-tools.test.ts
+++ b/packages/claude-runner/test/disallowed-tools.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as claudeCode from "@anthropic-ai/claude-code";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ClaudeRunner } from "../src/ClaudeRunner";
 import type { ClaudeRunnerConfig } from "../src/types";
-import * as claudeCode from "@anthropic-ai/claude-code";
 
 // Mock the query function from @anthropic-ai/claude-code
 vi.mock("@anthropic-ai/claude-code", () => ({
@@ -28,7 +28,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		
+
 		// Mock the query to return an async generator
 		queryMock.mockImplementation(async function* () {
 			// Empty generator for testing
@@ -48,7 +48,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 		};
 
 		// Mock the query to capture arguments and return a session ID message
-		queryMock.mockImplementation(async function* (args: any) {
+		queryMock.mockImplementation(async function* (_args: any) {
 			// Yield a session ID message
 			yield {
 				type: "system",
@@ -60,17 +60,17 @@ describe("ClaudeRunner - disallowedTools", () => {
 		});
 
 		const runner = new ClaudeRunner(config);
-		
+
 		// Run the query with a test prompt
 		const prompt = "Test prompt";
-		const messages = [];
-		
+		const _messages = [];
+
 		await runner.start(prompt);
 
 		// Check that query was called with disallowedTools
 		expect(queryMock).toHaveBeenCalledTimes(1);
 		const callArgs = queryMock.mock.calls[0][0];
-		
+
 		expect(callArgs.options).toBeDefined();
 		expect(callArgs.options.disallowedTools).toEqual(["Bash", "WebFetch"]);
 		expect(callArgs.options.allowedTools).toContain("Read(**)");
@@ -86,7 +86,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 		};
 
 		// Mock the query to capture arguments and return a session ID message
-		queryMock.mockImplementation(async function* (args: any) {
+		queryMock.mockImplementation(async function* (_args: any) {
 			yield {
 				type: "system",
 				role: "session_info",
@@ -102,7 +102,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 		// Check that query was called without disallowedTools
 		expect(queryMock).toHaveBeenCalledTimes(1);
 		const callArgs = queryMock.mock.calls[0][0];
-		
+
 		expect(callArgs.options).toBeDefined();
 		expect(callArgs.options.disallowedTools).toBeUndefined();
 		expect(callArgs.options.allowedTools).toContain("Read(**)");
@@ -118,7 +118,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 		};
 
 		// Mock the query to capture arguments and return a session ID message
-		queryMock.mockImplementation(async function* (args: any) {
+		queryMock.mockImplementation(async function* (_args: any) {
 			yield {
 				type: "system",
 				role: "session_info",
@@ -134,14 +134,14 @@ describe("ClaudeRunner - disallowedTools", () => {
 		// Check that query was called without disallowedTools (empty array is falsy)
 		expect(queryMock).toHaveBeenCalledTimes(1);
 		const callArgs = queryMock.mock.calls[0][0];
-		
+
 		expect(callArgs.options).toBeDefined();
 		expect(callArgs.options.disallowedTools).toBeUndefined();
 	});
 
 	it("should log disallowedTools when configured", async () => {
 		const consoleSpy = vi.spyOn(console, "log");
-		
+
 		const config: ClaudeRunnerConfig = {
 			workingDirectory: "/test",
 			disallowedTools: ["Bash", "SystemAccess", "DangerousTool"],
@@ -149,7 +149,7 @@ describe("ClaudeRunner - disallowedTools", () => {
 		};
 
 		// Mock the query to capture arguments and return a session ID message
-		queryMock.mockImplementation(async function* (args: any) {
+		queryMock.mockImplementation(async function* (_args: any) {
 			yield {
 				type: "system",
 				role: "session_info",
@@ -165,9 +165,9 @@ describe("ClaudeRunner - disallowedTools", () => {
 		// Check that disallowedTools were logged
 		expect(consoleSpy).toHaveBeenCalledWith(
 			"[ClaudeRunner] Disallowed tools configured:",
-			["Bash", "SystemAccess", "DangerousTool"]
+			["Bash", "SystemAccess", "DangerousTool"],
 		);
-		
+
 		consoleSpy.mockRestore();
 	});
 });

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -30,6 +30,7 @@ export interface RepositoryConfig {
 	isActive?: boolean; // Whether to process webhooks for this repo (default: true)
 	promptTemplatePath?: string; // Custom prompt template for this repo
 	allowedTools?: string[]; // Override Claude tools for this repository (overrides defaultAllowedTools)
+	disallowedTools?: string[]; // Tools to explicitly disallow for this repository (no defaults)
 	mcpConfigPath?: string | string[]; // Path(s) to MCP configuration JSON file(s) (format: {"mcpServers": {...}})
 	appendInstruction?: string; // Additional instruction to append to the prompt in XML-style wrappers
 	model?: string; // Claude model to use for this repository (e.g., "opus", "sonnet", "haiku")
@@ -40,18 +41,22 @@ export interface RepositoryConfig {
 		debugger?: {
 			labels: string[]; // Labels that trigger debugger mode (e.g., ["Bug"])
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for debugger mode
+			disallowedTools?: string[]; // Tools to explicitly disallow in debugger mode
 		};
 		builder?: {
 			labels: string[]; // Labels that trigger builder mode (e.g., ["Feature", "Improvement"])
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for builder mode
+			disallowedTools?: string[]; // Tools to explicitly disallow in builder mode
 		};
 		scoper?: {
 			labels: string[]; // Labels that trigger scoper mode (e.g., ["PRD"])
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for scoper mode
+			disallowedTools?: string[]; // Tools to explicitly disallow in scoper mode
 		};
 		orchestrator?: {
 			labels: string[]; // Labels that trigger orchestrator mode (e.g., ["Orchestrator"])
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator"; // Tool restrictions for orchestrator mode
+			disallowedTools?: string[]; // Tools to explicitly disallow in orchestrator mode
 		};
 	};
 }
@@ -71,6 +76,7 @@ export interface EdgeWorkerConfig {
 
 	// Claude config (shared across all repos)
 	defaultAllowedTools?: string[];
+	defaultDisallowedTools?: string[]; // Tools to explicitly disallow across all repositories (no defaults)
 	defaultModel?: string; // Default Claude model to use across all repositories (e.g., "opus", "sonnet", "haiku")
 	defaultFallbackModel?: string; // Default fallback model if primary model is unavailable
 
@@ -78,15 +84,19 @@ export interface EdgeWorkerConfig {
 	promptDefaults?: {
 		debugger?: {
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
+			disallowedTools?: string[];
 		};
 		builder?: {
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
+			disallowedTools?: string[];
 		};
 		scoper?: {
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
+			disallowedTools?: string[];
 		};
 		orchestrator?: {
 			allowedTools?: string[] | "readOnly" | "safe" | "all" | "coordinator";
+			disallowedTools?: string[];
 		};
 	};
 
@@ -195,4 +205,5 @@ export interface LinearAgentSessionData {
 	attachmentsDir: string;
 	allowedDirectories: string[];
 	allowedTools: string[];
+	disallowedTools: string[];
 }


### PR DESCRIPTION
## Summary
- Adds new `disallowedTools` configuration option to explicitly block specific tools
- Follows the same hierarchical configuration pattern as `allowedTools`
- No default disallowed tools - only explicitly configured tools are blocked

## Changes
- **Type definitions**: Added `disallowedTools` to all configuration interfaces (EdgeWorkerConfig, RepositoryConfig, label prompts, etc.)
- **EdgeWorker**: Implemented `buildDisallowedTools` method following same hierarchy as `buildAllowedTools`
- **ClaudeRunner**: Added logic to pass `disallowedTools` through to Claude Code
- **CLI**: Added support for `DISALLOWED_TOOLS` environment variable
- **Tests**: Added comprehensive tests for disallowedTools functionality in both EdgeWorker and ClaudeRunner

## Configuration Hierarchy
Same as `allowedTools`:
1. Repository-specific prompt type configuration 
2. Global prompt defaults
3. Repository-level disallowed tools
4. Global default disallowed tools
5. No defaults (empty array)

## Test Plan
- [x] Run all package tests with `pnpm test`
- [x] Verify TypeScript compilation with `pnpm typecheck`
- [x] Build all packages with `pnpm build`
- [x] Test that empty arrays aren't passed (they're falsy)
- [x] Verify logging works for configured disallowedTools

🤖 Generated with [Claude Code](https://claude.ai/code)