### PR TITLE
fix: Fix linear_upload_file MCP tool fs.stat error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Removed cyrus-mcp-tools package in favor of inline tool implementation
 
+### Fixed
+- Fixed `linear_upload_file` MCP tool error where `fs.stat` was not a function due to incorrect ES module import pattern for fs-extra package
+
 ### Added
 - **@cyrus /label-based-prompt command**: New special command for mention-triggered sessions
   - Use `@cyrus /label-based-prompt` in comments to trigger label-based prompts instead of mention prompts


### PR DESCRIPTION
## Summary
- Fixed `linear_upload_file` MCP tool failing with "fs.stat is not a function" error
- Changed fs-extra import from namespace to default import pattern
- Added test coverage for fs-extra import compatibility
- Updated CHANGELOG.md with fix entry

## Problem
The `mcp__cyrus-tools__linear_upload_file` MCP tool was failing with a JavaScript runtime error when attempting to upload files to Linear. The error was: `{"success":false,"error":"fs.stat is not a function"}`.

## Root Cause
The issue was caused by incorrect ES module import pattern for the `fs-extra` package:
- **Incorrect**: `import * as fs from "fs-extra"` (namespace import)
- **Correct**: `import fs from "fs-extra"` (default import)

With namespace import, the fs methods like `stat` and `readFile` were not directly accessible on the imported object. The fs-extra package exports all functionality through a default export, not as named exports.

## Solution
Changed the import statement in `/packages/claude-runner/src/tools/cyrus-tools/index.ts` from namespace import to default import. This properly exposes all fs methods including `stat` and `readFile`.

## Testing
- Added comprehensive test to verify fs-extra import compatibility
- All existing tests pass
- Linting and type checking pass
- Build completes successfully

## Fixes
Fixes CYPACK-25

🤖 Generated with [Claude Code](https://claude.ai/code)