### PR TITLE
feat: Add Linear agent session creation on comments tool

### DIFF
--- a/packages/claude-runner/src/tools/cyrus-tools/index.ts
+++ b/packages/claude-runner/src/tools/cyrus-tools/index.ts
@@ -349,6 +349,104 @@ export function createCyrusToolsServer(
 		},
 	);
 
+	const agentSessionOnCommentTool = tool(
+		"linear_agent_session_create_on_comment",
+		"Create an agent session on a Linear comment to trigger a sub-agent for processing child issues or tasks.",
+		{
+			commentId: z
+				.string()
+				.describe("The ID of the Linear comment to create the session on"),
+			externalLink: z
+				.string()
+				.optional()
+				.describe(
+					"Optional URL of an external agent-hosted page associated with this session",
+				),
+		},
+		async ({ commentId, externalLink }) => {
+			try {
+				// Use raw GraphQL through the Linear client
+				// Access the underlying GraphQL client
+				const graphQLClient = (linearClient as any).client;
+
+				const mutation = `
+					mutation AgentSessionCreateOnComment($input: AgentSessionCreateOnComment!) {
+						agentSessionCreateOnComment(input: $input) {
+							success
+							lastSyncId
+							agentSession {
+								id
+							}
+						}
+					}
+				`;
+
+				const variables = {
+					input: {
+						commentId,
+						...(externalLink && { externalLink }),
+					},
+				};
+
+				console.log(`Creating agent session for comment ${commentId}`);
+
+				const response = await graphQLClient.rawRequest(mutation, variables);
+
+				const result = response.data.agentSessionCreateOnComment;
+
+				if (!result.success) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									success: false,
+									error: "Failed to create agent session on comment",
+								}),
+							},
+						],
+					};
+				}
+
+				const agentSessionId = result.agentSession.id;
+				console.log(`Agent session created successfully on comment: ${agentSessionId}`);
+
+				// Register the child-to-parent mapping if we have a parent session
+				if (options.parentSessionId && options.onSessionCreated) {
+					console.log(
+						`[CyrusTools] Mapping child session ${agentSessionId} to parent ${options.parentSessionId}`,
+					);
+					options.onSessionCreated(agentSessionId, options.parentSessionId);
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: result.success,
+								agentSessionId,
+								lastSyncId: result.lastSyncId,
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+				};
+			}
+		},
+	);
+
 	const giveFeedbackTool = tool(
 		"linear_agent_give_feedback",
 		"Provide feedback to a child agent session to continue its processing.",
@@ -431,6 +529,6 @@ export function createCyrusToolsServer(
 	return createSdkMcpServer({
 		name: "cyrus-tools",
 		version: "1.0.0",
-		tools: [uploadTool, agentSessionTool, giveFeedbackTool],
+		tools: [uploadTool, agentSessionTool, agentSessionOnCommentTool, giveFeedbackTool],
 	});
 }

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -17,6 +17,7 @@ You are an expert software architect responsible for decomposing complex issues 
 
 ### Cyrus MCP Tools
 - `mcp__cyrus-tools__linear_agent_session_create` - Create agent sessions for issue tracking
+- `mcp__cyrus-tools__linear_agent_session_create_on_comment` - Create agent sessions on comments to trigger sub-agents for child issues
 - `mcp__cyrus-tools__linear_agent_give_feedback` - Provide feedback to child agent sessions
 
 
@@ -53,7 +54,10 @@ Create sub-issues with:
 
 ### 3. Execute
 ```
-1. Start first sub-issue by assigning it to the agent [mcp__cyrus-tools__linear_agent_session_create]
+1. Start first sub-issue by triggering a new working session:
+   - For issues: Use mcp__cyrus-tools__linear_agent_session_create with issueId
+   - For comment threads on child issues: Use mcp__cyrus-tools__linear_agent_session_create_on_comment with commentId
+   This creates a sub-agent session that will process the work independently
 2. HALT and await completion notification
 3. Upon completion, evaluate results
 ```
@@ -107,6 +111,7 @@ Include in every sub-issue:
 4. **MAINTAIN** remote branch synchronization after each merge
 5. **DOCUMENT** decisions and plan adjustments in parent issue
 6. **PRIORITIZE** unblocking work when dependencies arise
+7. **USE** `linear_agent_session_create_on_comment` when you need to trigger a sub-agent on an existing issue comment thread - this creates a new working session without reassigning the issue
 
 
 ## Sub-Issue Creation Checklist


### PR DESCRIPTION
## Summary

- Added new MCP tool for creating agent sessions on Linear comments
- Enables orchestrator agents to trigger sub-agents on comment threads
- Updated orchestrator prompt with usage instructions

## Changes

### New Tool: `linear_agent_session_create_on_comment`
- Implements GraphQL mutation `AgentSessionCreateOnComment`
- Takes `commentId` and optional `externalLink` parameters
- Creates agent sessions on Linear comments to trigger sub-agents for processing child issues
- Maintains parent-child session mapping for proper feedback routing

### Orchestrator Prompt Updates
- Added the new tool to the Cyrus MCP Tools section
- Documented when to use it in the Execute workflow
- Added critical rule about using the tool for existing issue comment threads

## Test Plan

- [x] Build completes successfully (`pnpm build`)
- [x] All package tests pass (`pnpm test:packages:run`)
- [ ] Manual testing with Linear integration

## Context

This addresses the need to trigger sub-agents on existing issue comment threads without reassigning the issue, improving the workflow for complex multi-step tasks managed by orchestrator agents.

Resolves: CYPACK-26

🤖 Generated with [Claude Code](https://claude.ai/code)