### PR TITLE
feat: Sub-issues inherit parent assignee automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 - Removed cyrus-mcp-tools package in favor of inline tool implementation
 
 ### Added
+- **Sub-issue assignee inheritance**: Sub-issues created by orchestrator agents now automatically inherit the same assignee as their parent issue
+  - Enhanced label-prompt-template to include assignee information (`{{assignee_id}}` and `{{assignee_name}}`)
+  - Updated orchestrator prompt instructions to require `assigneeId` parameter in sub-issue creation
+  - Modified EdgeWorker to extract and inject parent issue assignee data into orchestrator context
 - **Mandatory verification framework for orchestrator agents**: Enhanced parent-child delegation with executable verification requirements
   - Parent orchestrators can now access child agent worktrees for independent verification
   - **Orchestrator prompt v2.2.0** with mandatory verification requirements in sub-issue descriptions

--- a/packages/edge-worker/label-prompt-template.md
+++ b/packages/edge-worker/label-prompt-template.md
@@ -9,4 +9,8 @@
 <title>{{issue_title}}</title>
 <description>{{issue_description}}</description>
 <url>{{issue_url}}</url>
+<assignee>
+<id>{{assignee_id}}</id>
+<name>{{assignee_name}}</name>
+</assignee>
 </linear_issue>

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -12,7 +12,7 @@ You are an expert software architect and designer responsible for decomposing co
 ## Required Tools
 
 ### Linear MCP Tools
-- `mcp__linear__linear_createIssue` - Create sub-issues with proper context. **CRITICAL: ALWAYS INCLUDE THE `parentId` PARAMETER**
+- `mcp__linear__linear_createIssue` - Create sub-issues with proper context. **CRITICAL: ALWAYS INCLUDE THE `parentId` PARAMETER AND `assigneeId` PARAMETER TO INHERIT THE PARENT'S ASSIGNEE**
 - `mcp__linear__linear_getIssueById` - Retrieve issue details
 
 ### Cyrus MCP Tools
@@ -34,6 +34,7 @@ You are an expert software architect and designer responsible for decomposing co
 ### 2. Decompose
 Create sub-issues with:
 - **Clear title**: `[Type] Specific action and target`
+- **Parent assignee inheritance**: Use the `assigneeId` from the parent issue context (available as `{{assignee_id}}`) to ensure all sub-issues are assigned to the same person
 - **Structured description** (include the exact text template below in the sub-issue description):
   ```
   Objective: [What needs to be accomplished]
@@ -182,6 +183,7 @@ Include in every sub-issue:
 When creating a sub-issue, verify:
 - [ ] Agent type label added (`Bug`, `Feature`, `Improvement`, or `PRD`)
 - [ ] Model selection label evaluated (`sonnet` for simple tasks)
+- [ ] **Parent assignee inherited** (`assigneeId` parameter set to parent's `{{assignee_id}}`)
 - [ ] Clear objective defined
 - [ ] Acceptance criteria specified
 - [ ] All necessary context included


### PR DESCRIPTION
## Summary
- ✅ Sub-issues created by orchestrator agents now automatically inherit the same assignee as their parent issue
- ✅ Enhanced label-prompt-template to include assignee information (`{{assignee_id}}` and `{{assignee_name}}`)  
- ✅ Updated orchestrator prompt instructions to require `assigneeId` parameter in sub-issue creation
- ✅ Modified EdgeWorker to extract and inject parent issue assignee data into orchestrator context

## Changes Made

### 1. Template Enhancement (`packages/edge-worker/label-prompt-template.md`)
Added assignee information to the issue context:
```xml
<assignee>
<id>{{assignee_id}}</id>
<name>{{assignee_name}}</name>
</assignee>
```

### 2. Orchestrator Instructions (`packages/edge-worker/prompts/orchestrator.md`)
- Updated Linear MCP tools section to emphasize assignee inheritance
- Added parent assignee inheritance requirement to sub-issue creation checklist
- Enhanced decomposition workflow to include assignee inheritance step

### 3. EdgeWorker Implementation (`packages/edge-worker/src/EdgeWorker.ts`)
Modified `buildLabelBasedPrompt()` method to:
- Extract assignee ID from Linear issue object (`issue.assigneeId`)
- Fetch full assignee details to get display name
- Replace new template placeholders with assignee data
- Handle errors gracefully with fallback values

## Test Plan
- [x] Build passes (`pnpm build`)
- [x] Type checking passes (`pnpm typecheck`) 
- [x] Linting passes (`pnpm lint`)
- [x] CHANGELOG.md updated with feature description
- [ ] Manual verification with orchestrator agent creating sub-issues

## Resolves
Fixes CYPACK-29: Sub-issues created by orchestrators now automatically inherit the same assignee as their parent issue.

🤖 Generated with [Claude Code](https://claude.ai/code)