### PR TITLE
feat: Add PostToolUse hook for playwright screenshot Read tool hints

### DIFF
--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -1,3 +1,11 @@
+// Re-export hook types from Claude SDK for use in edge-worker
+export type {
+	HookCallbackMatcher,
+	HookEvent,
+	HookInput,
+	HookJSONOutput,
+	PostToolUseHookInput,
+} from "@anthropic-ai/claude-code";
 export { AbortError, ClaudeRunner, StreamingPrompt } from "./ClaudeRunner.js";
 export {
 	availableTools,
@@ -26,12 +34,3 @@ export type {
 	SDKSystemMessage,
 	SDKUserMessage,
 } from "./types.js";
-
-// Re-export hook types from Claude SDK for use in edge-worker
-export type {
-	HookCallbackMatcher,
-	HookEvent,
-	HookInput,
-	PostToolUseHookInput,
-	HookJSONOutput,
-} from "@anthropic-ai/claude-code";

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -26,3 +26,12 @@ export type {
 	SDKSystemMessage,
 	SDKUserMessage,
 } from "./types.js";
+
+// Re-export hook types from Claude SDK for use in edge-worker
+export type {
+	HookCallbackMatcher,
+	HookEvent,
+	HookInput,
+	PostToolUseHookInput,
+	HookJSONOutput,
+} from "@anthropic-ai/claude-code";

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -9,7 +9,12 @@ import {
 } from "@linear/sdk";
 import type {
 	ClaudeRunnerConfig,
+	HookCallbackMatcher,
+	HookEvent,
+	HookInput,
+	HookJSONOutput,
 	McpServerConfig,
+	PostToolUseHookInput,
 	SDKMessage,
 } from "cyrus-claude-runner";
 import {
@@ -2738,8 +2743,60 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		resumeSessionId?: string,
 		labels?: string[],
 	): ClaudeRunnerConfig {
-		// No hooks needed - logic is now in the tools themselves
-		const hooks = {};
+		// Configure PostToolUse hook for playwright screenshots
+		const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {
+			PostToolUse: [
+				{
+					matcher: "mcp__playwright__playwright_screenshot",
+					hooks: [
+						async (input: HookInput, _toolUseID: string | undefined, _options: { signal: AbortSignal }) => {
+							const postToolUseInput = input as PostToolUseHookInput;
+							
+							try {
+								console.log(`[EdgeWorker] Screenshot tool completed: ${postToolUseInput.tool_name}`);
+								
+								// Extract file path from tool response
+								const toolResponse = postToolUseInput.tool_response as any;
+								let filePath: string | null = null;
+								
+								if (toolResponse) {
+									// Try to extract file path from various possible response formats
+									filePath = toolResponse.filePath || 
+											 toolResponse.file_path ||
+											 (toolResponse.fileName ? `/tmp/${toolResponse.fileName}` : null);
+								}
+								
+								// Create hint to use Read tool on screenshot file
+								let additionalContext = "Screenshot taken successfully.";
+								if (filePath) {
+									additionalContext += ` IMPORTANT: You should now use the Read tool to view the screenshot at: ${filePath}. This will help you analyze the visual content and verify what was captured in the screenshot.`;
+								} else {
+									additionalContext += " Consider using the Read tool to view the screenshot file if it was saved to disk.";
+								}
+								
+								return {
+									continue: true,
+									hookSpecificOutput: {
+										hookEventName: 'PostToolUse' as const,
+										additionalContext: additionalContext
+									}
+								} as HookJSONOutput;
+								
+							} catch (error) {
+								console.error(`[EdgeWorker] Error in screenshot PostToolUse hook:`, error);
+								return {
+									continue: true,
+									hookSpecificOutput: {
+										hookEventName: 'PostToolUse' as const,
+										additionalContext: "Screenshot completed. Consider using the Read tool to view the screenshot file."
+									}
+								} as HookJSONOutput;
+							}
+						}
+					]
+				}
+			]
+		};
 
 		// Check for model override labels (case-insensitive)
 		let modelOverride: string | undefined;

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2743,19 +2743,25 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 	): ClaudeRunnerConfig {
 		// Configure PostToolUse hook for playwright screenshots
 		const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {
-			PostToolUse: [{
-				matcher: "playwright_screenshot",
-				hooks: [
-					async (input, _toolUseID, { signal: _signal }) => {
-						const postToolUseInput = input as PostToolUseHookInput;
-						console.log(`Tool ${postToolUseInput.tool_name} completed with response:`, postToolUseInput.tool_response);
-						return {
-							continue: true,
-							additionalContext: "Screenshot taken successfully. You should use the Read tool to view the screenshot file to analyze the visual content."
-						};
-					}
-				]
-			}]
+			PostToolUse: [
+				{
+					matcher: "playwright_screenshot",
+					hooks: [
+						async (input, _toolUseID, { signal: _signal }) => {
+							const postToolUseInput = input as PostToolUseHookInput;
+							console.log(
+								`Tool ${postToolUseInput.tool_name} completed with response:`,
+								postToolUseInput.tool_response,
+							);
+							return {
+								continue: true,
+								additionalContext:
+									"Screenshot taken successfully. You should use the Read tool to view the screenshot file to analyze the visual content.",
+							};
+						},
+					],
+				},
+			],
 		};
 
 		// Check for model override labels (case-insensitive)

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2744,7 +2744,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		// Configure PostToolUse hook for playwright screenshots
 		const hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> = {
 			PostToolUse: [{
-				matcher: "mcp__playwright__playwright_screenshot",
+				matcher: "playwright_screenshot",
 				hooks: [
 					async (input, _toolUseID, { signal: _signal }) => {
 						const postToolUseInput = input as PostToolUseHookInput;


### PR DESCRIPTION
## Summary

Implements a PostToolUse hook using the Claude Code SDK that automatically suggests using the Read tool after taking screenshots with `mcp__playwright__playwright_screenshot`.

## Changes Made

- **Added PostToolUse hook** in `EdgeWorker.ts` with matcher for `mcp__playwright__playwright_screenshot`
- **Re-exported hook types** from `claude-runner` package to ensure proper TypeScript imports across packages
- **Smart file path extraction** from tool response with fallback handling for various response formats
- **Read tool hint generation** via `additionalContext` with `continue: true` to maintain normal execution flow
- **Error handling** to ensure hook failures don't break screenshot functionality

## Technical Details

- Hook fires after `mcp__playwright__playwright_screenshot` completes
- Extracts file path from `toolResponse.filePath`, `toolResponse.file_path`, or constructs from `toolResponse.fileName`
- Provides clear Read tool suggestion: "IMPORTANT: You should now use the Read tool to view the screenshot at: {filePath}"
- Uses Claude Code SDK's `hookSpecificOutput.additionalContext` to deliver the hint
- Maintains execution flow with `continue: true`

## Testing

- ✅ All existing tests pass
- ✅ TypeScript compilation successful across all packages
- ✅ Build completes without errors
- ✅ Hook implementation follows Claude Code SDK patterns

## Addresses

Closes CYPACK-31 - Add PostToolUse hook for playwright screenshot Read tool hints

🤖 Generated with [Claude Code](https://claude.ai/code)