### PR TITLE
feat: Enhanced orchestrator-to-child communication and nested orchestration support

### DIFF
--- a/orchestrator-execution-flow.md
+++ b/orchestrator-execution-flow.md
@@ -1,0 +1,107 @@
+# Orchestrator Execution and Feedback Flow Diagram
+
+This Mermaid diagram illustrates the execution and feedback flow sequence outlined in the orchestrator.md prompt.
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator Agent
+    participant L as Linear (Issues)
+    participant C as Child Agent
+    participant W as Child Worktree
+    participant R as Remote Repository
+
+    Note over O: 1. Initialize Phase
+    O->>R: Push local branch to remote
+    O->>L: Analyze parent issue requirements
+    O->>L: Check for existing sub-issues
+    O->>O: Identify work type and dependencies
+
+    Note over O: 2. Decompose Phase
+    O->>L: Create sub-issue with structured template
+    Note over O,L: Include: Clear title, Parent assignee inheritance,<br/>Structured description, Agent type labels,<br/>Mandatory verification requirements
+
+    Note over O: 3. Execute Phase
+    O->>L: Create agent session (mcp__cyrus-tools__linear_agent_session_create)
+    O->>C: Trigger child agent session
+    Note over O: HALT - Await completion notification
+    C->>W: Create child worktree
+    C->>W: Implement changes
+    C->>W: Run local tests/verification
+    C->>L: Post completion with verification instructions
+
+    Note over O: 4. Evaluate Results (MANDATORY VERIFICATION)
+    O->>C: Receive completion notification
+    O->>W: Navigate to child worktree directory
+    O->>W: Execute ALL verification commands
+    W-->>O: Return verification results
+    
+    alt Verification Success
+        Note over O: ALL verification steps passed
+        O->>W: Execute: git merge child-branch
+        O->>R: Push to remote: git push origin <branch>
+        O->>L: Document verification results in parent issue
+        Note over O: Check if more sub-issues needed
+        alt More sub-issues required
+            O->>O: Start next sub-issue (back to step 2)
+        else All sub-issues complete
+            O->>O: Move to Complete phase
+        end
+    else Verification Partial Success
+        Note over O: Some verification steps failed
+        O->>C: Provide feedback (mcp__cyrus-tools__linear_agent_give_feedback)
+        Note over O: DO NOT merge - await fixes
+        C->>W: Implement fixes
+        C->>L: Update with new verification instructions
+        Note over O: Loop back to verification
+    else Verification Failed
+        Note over O: Significant failures or missing verification
+        O->>O: Analyze root cause
+        alt Need Enhanced Instructions
+            O->>L: Create revised sub-issue with enhanced requirements
+        else Wrong Agent Type
+            O->>L: Create new sub-issue with different agent label
+        else Technical Blocker
+            O->>L: Create unblocking issue
+        end
+        Note over O: Re-attempt with corrections
+    end
+
+    Note over O: 5. Complete Phase
+    O->>L: Verify all sub-issues completed
+    O->>O: Validate parent objectives achieved
+    O->>L: Document final state and learnings
+    O->>R: Create PR using gh pr create
+
+    Note over O: Critical Feedback Loops
+    Note over O,C: Verification-Merge Loop:<br/>Child Completes → Navigate to Worktree →<br/>Execute Verification → Compare Results →<br/>[PASS: Merge & Push] OR [FAIL: Feedback & Retry]
+
+    Note over O,C: Error Recovery Loop:<br/>Agent Failure → Analyze Root Cause →<br/>Enhance/Add/Change/Unblock → Re-attempt
+
+    Note over O,W: Quality Assurance Loop:<br/>Visual Verification (Screenshots MUST be read) →<br/>Evidence Documentation →<br/>Independent Validation Required
+```
+
+## Key Flow Characteristics
+
+### Sequential Processing
+- Work is **not parallel** - only one sub-issue active at a time
+- Next session only triggered after successful merge of current issue
+
+### Mandatory Verification Gates
+1. **Pre-Merge Gate**: Verification commands must pass in child worktree
+2. **Visual Confirmation Gate**: All screenshots must be read/viewed for UI changes
+3. **Evidence Gate**: Documentation of verification results required
+4. **Integration Gate**: Confirm no regressions introduced
+
+### State Tracking
+- **Completed**: (with verification results)
+- **Active**: (currently executing)
+- **Pending**: (queued)
+- **Blocked**: (awaiting resolution)
+
+### Critical Quality Controls
+- **NO BLIND TRUST**: Never merge based solely on child agent completion claims
+- **VERIFICATION IS NON-NEGOTIABLE**: Every sub-issue must be independently validated
+- **EVIDENCE-BASED DECISIONS**: Merge only after documented verification success
+- **VISUAL CONFIRMATION REQUIRED**: Screenshots must be taken AND read/viewed
+
+The diagram emphasizes the orchestrator's role as a quality gate that ensures rigorous validation through independent execution rather than trusting agent completion claims.

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -64,6 +64,7 @@ Create sub-issues with:
     - `Bug` → Triggers debugger agent
     - `Feature`/`Improvement` → Triggers builder agent  
     - `PRD` → Triggers scoper agent
+    - `Orchestrator` → Triggers orchestrator agent (for complex tasks requiring nested orchestration)
 
 ### 3. Execute
 ```
@@ -135,6 +136,53 @@ Before merging any completed sub-issue, you MUST:
 - Document final state and learnings
 ```
 
+## Nested Orchestration & Reporting Strategy
+
+### When You Are a Sub-Orchestrator
+
+If you are an orchestrator agent that was created by another orchestrator (nested orchestration), you MUST follow a special reporting protocol:
+
+1. **DO NOT post results normally** - Regular agents complete and post results automatically, but nested orchestrators must use a different approach
+2. **USE the `report_results_to_manager` tool** - When all your sub-tasks are complete and verified, use this tool to report comprehensive results to your manager orchestrator
+3. **HALT after reporting** - After calling `report_results_to_manager`, you will receive a PostToolUse hint instructing you to halt and wait for potential feedback from your manager
+4. **Your manager will either**:
+   - Accept your results and continue with their orchestration
+   - Provide feedback using `linear_agent_give_feedback` for you to address
+
+### Reporting Format
+
+When using `report_results_to_manager`, structure your results as:
+
+```markdown
+## Orchestration Summary
+**Objective**: [What was requested]
+**Status**: COMPLETED
+
+## Sub-Issues Completed
+1. [Issue ID] - [Title] - [Brief outcome]
+2. [Issue ID] - [Title] - [Brief outcome]
+...
+
+## Key Achievements
+- [Major accomplishment 1]
+- [Major accomplishment 2]
+
+## Verification Results
+- All tests passing: ✓
+- Build successful: ✓
+- Integration verified: ✓
+
+## Final State
+[Description of the final state of the codebase/system]
+```
+
+### Determining If You Are a Nested Orchestrator
+
+You are a nested orchestrator if:
+- You have the `Orchestrator` label on your issue
+- You were created by another orchestrator as a sub-issue
+- You have access to the `report_results_to_manager` tool (only available to orchestrators)
+
 ## Sub-Issue Design Principles
 
 ### Atomic & Independent
@@ -177,11 +225,15 @@ Include in every sub-issue:
 
 10. **READ ALL SCREENSHOTS**: When taking screenshots for visual verification, you MUST read/view every screenshot to confirm visual changes match expectations. Never take a screenshot without reading it - the visual confirmation is the entire purpose of the screenshot.
 
+11. **HALT AFTER FEEDBACK**: When you call `linear_agent_give_feedback`, you will receive a PostToolUse hint instructing you to halt and wait. You MUST stop and wait for the sub-agent to process the feedback and return results.
+
+12. **NESTED ORCHESTRATOR REPORTING**: If you are a nested orchestrator (have the `Orchestrator` label and were created by another orchestrator), you MUST use `report_results_to_manager` instead of normal completion. After calling this tool, halt immediately and wait for potential feedback from your manager.
+
 
 ## Sub-Issue Creation Checklist
 
 When creating a sub-issue, verify:
-- [ ] Agent type label added (`Bug`, `Feature`, `Improvement`, or `PRD`)
+- [ ] Agent type label added (`Bug`, `Feature`, `Improvement`, `PRD`, or `Orchestrator`)
 - [ ] Model selection label evaluated (`sonnet` for simple tasks)
 - [ ] **Parent assignee inherited** (`assigneeId` parameter set to parent's `{{assignee_id}}`)
 - [ ] Clear objective defined


### PR DESCRIPTION
## Summary
- Enhanced bidirectional communication between orchestrator and child agents with thought posting
- Added support for nested orchestration with new `Orchestrator` label and reporting tools
- Improved visibility of agent interactions in Linear interface

## Changes

### Communication Enhancements
- **Child → Parent**: Child sessions now post thoughts when receiving feedback from orchestrator
- **Parent → Child**: Parent sessions post thoughts when receiving results from sub-agents
- Both directions now have clear visibility in Linear's activity feed

### Nested Orchestration Support
- Added `Orchestrator` label option for complex tasks requiring multi-level orchestration
- Created `report_results_to_manager` tool for nested orchestrators to report to their managers
- Implemented automatic detection of orchestrator sessions based on labels

### Tool & Hook Improvements
- Added PostToolUse hints for:
  - `linear_agent_give_feedback`: Instructs agent to halt and wait for sub-agent results
  - `report_results_to_manager`: Instructs orchestrator to halt and wait for manager feedback
- Enhanced EdgeWorker to support `isOrchestrator` flag and `onReportToManager` callback

### Documentation
- Updated orchestrator.md with comprehensive nested orchestration strategy
- Added reporting format guidelines for sub-orchestrators
- Created Mermaid sequence diagram documenting execution and feedback flow
- [📄 View Orchestrator Flow Diagram](https://uploads.linear.app/ee2a1136-fe42-47ac-897f-f4ee8e824eb8/4e55d0d2-1e01-4762-bec4-4a0612fb63d7/af30e067-c2c4-44b0-84d0-0ffb58686c83)

## Test Plan
- [x] Build successful (`pnpm build`)
- [x] TypeScript compilation verified (`pnpm typecheck`)
- [ ] Test orchestrator creating sub-orchestrator with `Orchestrator` label
- [ ] Verify thought posting when feedback is delivered
- [ ] Verify thought posting when results are received
- [ ] Test `report_results_to_manager` tool functionality
- [ ] Verify PostToolUse hints trigger proper halting behavior

## Related
- Linear Issue: [CYPACK-32](https://linear.app/ceedar/issue/CYPACK-32)

🤖 Generated with [Claude Code](https://claude.ai/code)