### PR TITLE
fix: Handle malformed markdown links in Linear attachment URLs

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2187,7 +2187,8 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		if (!text) return [];
 
 		// Match URLs that start with https://uploads.linear.app
-		const regex = /https:\/\/uploads\.linear\.app\/[^\s<>"')]+/gi;
+		// Exclude brackets and parentheses to avoid capturing malformed markdown link syntax
+		const regex = /https:\/\/uploads\.linear\.app\/[a-zA-Z0-9\/_.-]+/gi;
 		const matches = text.match(regex) || [];
 
 		// Remove duplicates

--- a/packages/edge-worker/test/EdgeWorker.attachments.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.attachments.test.ts
@@ -258,6 +258,40 @@ describe("EdgeWorker - Native Attachments", () => {
 			expect(result.totalNewAttachments).toBe(0);
 			expect(result.failedCount).toBe(1);
 		});
+
+		it("should handle malformed markdown links correctly", async () => {
+			// Test malformed markdown that caused the original bug
+			const commentBody =
+				"Check this: [file.png](https://uploads.linear.app/ee2a1136-fe42-47ac-897f-f4ee8e824eb8/f43efb28-7db5-485b-aba1-bd5998bd46bc/a2e99ac8-337e-4b69-887e-e4cf0ddc42ab](https://uploads.linear.app/ee2a1136-fe42-47ac-897f-f4ee8e824eb8/f43efb28-7db5-485b-aba1-bd5998bd46bc/duplicate-url";
+			
+			// Mock successful download for the correctly extracted URLs
+			(edgeWorker as any).downloadAttachment = vi
+				.fn()
+				.mockResolvedValue({ success: true, fileType: ".png", isImage: true });
+
+			// Mock countExistingImages
+			(edgeWorker as any).countExistingImages = vi.fn().mockResolvedValue(0);
+
+			const result = await (edgeWorker as any).downloadCommentAttachments(
+				commentBody,
+				"/tmp/test-attachments", 
+				"test-token",
+				0,
+			);
+
+			// Should extract exactly 2 valid URLs (not the malformed concatenated one)
+			expect(result.totalNewAttachments).toBe(2);
+			expect((edgeWorker as any).downloadAttachment).toHaveBeenCalledTimes(2);
+			
+			// Verify the URLs passed to downloadAttachment don't contain brackets or malformed parts
+			const downloadCalls = (edgeWorker as any).downloadAttachment.mock.calls;
+			downloadCalls.forEach((call: any[]) => {
+				const url = call[0];
+				expect(url).toMatch(/^https:\/\/uploads\.linear\.app\/[a-zA-Z0-9\/_.-]+$/);
+				expect(url).not.toContain(']');
+				expect(url).not.toContain('(');
+			});
+		});
 	});
 
 	describe("generateNewAttachmentManifest", () => {


### PR DESCRIPTION
## Summary
- Fixed attachment download failures when Linear issues contain malformed markdown link syntax
- Changed URL extraction regex to use a positive character class that only allows valid URL characters
- Added comprehensive test coverage for malformed markdown link handling

## The Problem
When Linear issue descriptions contained malformed markdown formatted links like:
```
[file.png](https://uploads.linear.app/uuid](https://uploads.linear.app/uuid
```

The attachment downloader would fail with 404 errors because the regex was capturing invalid URLs that included markdown syntax characters:
```
https://uploads.linear.app/ee2a1136-fe42-47ac-897f-f4ee8e824eb8/f43efb28-7db5-485b-aba1-bd5998bd46bc/a2e99ac8-337e-4b69-887e-e4cf0ddc42ab](https://uploads.linear.app/ee2a1136-fe42-47ac-897f-f4ee8e824eb8/f43efb28-7db5-485b-aba1-bd5998bd46bc/a2e99ac8-337e-4b69-887e-e4cf0ddc42ab
```

## The Solution
Changed the URL extraction regex in `EdgeWorker.extractAttachmentUrls()` from:
```typescript
/https:\/\/uploads\.linear\.app\/[^\s<>"')]+/gi
```

To:
```typescript
/https:\/\/uploads\.linear\.app\/[a-zA-Z0-9\/_.-]+/gi
```

The new regex uses a positive character class that only allows:
- Letters (a-z, A-Z)
- Numbers (0-9)
- Forward slashes (/)
- Underscores (_)
- Periods (.)
- Hyphens (-)

This prevents markdown syntax characters like brackets `]` and parentheses `(` from being included in extracted URLs.

## Test Plan
✅ Added comprehensive test case for malformed markdown links
✅ All existing attachment tests pass
✅ Full test suite passes (75 tests in EdgeWorker package)
✅ Verified that valid Linear URLs are still extracted correctly
✅ Verified that malformed URLs with markdown syntax are properly filtered

Fixes CYPACK-38

🤖 Generated with [Claude Code](https://claude.ai/code)