### PR TITLE
fix: Handle self-hosting CLI options correctly #236

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2034,6 +2034,13 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 	}
 
 	/**
+	 * Get the server base URL
+	 */
+	getServerBaseUrl(): string {
+		return this.sharedApplicationServer.getBaseUrl();
+	}
+
+	/**
 	 * Get the OAuth callback URL
 	 */
 	getOAuthCallbackUrl(): string {

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -146,7 +146,26 @@ export class SharedApplicationServer {
 		if (this.ngrokUrl) {
 			return this.ngrokUrl;
 		}
-		return process.env.CYRUS_BASE_URL || `http://${this.host}:${this.port}`;
+
+		// If CYRUS_BASE_URL is set, ensure it includes the port
+		if (process.env.CYRUS_BASE_URL) {
+			const baseUrl = process.env.CYRUS_BASE_URL;
+			// Check if the URL already contains a port
+			try {
+				const url = new URL(baseUrl);
+				if (!url.port && this.port !== 80 && this.port !== 443) {
+					// No port specified and not using default HTTP/HTTPS ports
+					url.port = this.port.toString();
+					return url.toString().replace(/\/$/, ""); // Remove trailing slash if present
+				}
+				return baseUrl;
+			} catch {
+				// If URL parsing fails, just return the base URL
+				return baseUrl;
+			}
+		}
+
+		return `http://${this.host}:${this.port}`;
 	}
 
 	/**
@@ -422,7 +441,7 @@ export class SharedApplicationServer {
               <p>You can close this window and return to the terminal.</p>
               <p>Your Linear workspace <strong>${workspaceName}</strong> has been connected.</p>
               <p style="margin-top: 30px;">
-                <a href="${this.proxyUrl}/oauth/authorize?callback=${process.env.CYRUS_BASE_URL || `http://${this.host}:${this.port}`}/callback" 
+                <a href="${this.proxyUrl}/oauth/authorize?callback=${this.getBaseUrl()}/callback" 
                    style="padding: 10px 20px; background: #5E6AD2; color: white; text-decoration: none; border-radius: 5px;">
                   Connect Another Workspace
                 </a>


### PR DESCRIPTION
## Summary
- Fixed auto-appending port to CYRUS_BASE_URL when not specified
- Fixed server binding to 0.0.0.0 when CYRUS_HOST_EXTERNAL=true (was binding to localhost during OAuth flow)

## Changes
1. **SharedApplicationServer**: Enhanced `getBaseUrl()` to automatically append port to CYRUS_BASE_URL when missing (except for standard HTTP/HTTPS ports)
2. **CLI App**: Pass correct `serverHost` (0.0.0.0 vs localhost) to SharedApplicationServer during OAuth flow based on CYRUS_HOST_EXTERNAL
3. **EdgeWorker**: Added `getServerBaseUrl()` method for consistent URL construction
4. **OAuth URLs**: Fixed all OAuth callback URL generation to use consistent logic

## Test Plan
- [x] Built all packages successfully
- [x] Passed linting and type checking
- [ ] Test with CYRUS_BASE_URL without port (should auto-append)
- [ ] Test with CYRUS_HOST_EXTERNAL=true (should bind to 0.0.0.0)
- [ ] Test OAuth flow with various configurations

Fixes #236

🤖 Generated with [Claude Code](https://claude.ai/code)