### PR TITLE
Update @anthropic-ai packages to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.90 to v1.0.95 for latest Claude Code improvements. See [Claude Code v1.0.95 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1095)
+- Updated @anthropic-ai/claude-code from v1.0.95 to v1.0.103 for latest Claude Code improvements. See [Claude Code v1.0.103 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1103)
+- Updated @anthropic-ai/sdk from v0.60.0 to v0.61.0 for latest Anthropic SDK improvements
 - Replaced external cyrus-mcp-tools MCP server with inline tools using SDK callbacks for better performance
 - Cyrus tools (file upload, agent session creation, feedback) now run in-process instead of via separate MCP server
 - Enhanced orchestrator prompt to explicitly require reading/viewing all screenshots taken for visual verification

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.95",
-		"@anthropic-ai/sdk": "^0.60.0",
+		"@anthropic-ai/claude-code": "1.0.103",
+		"@anthropic-ai/sdk": "^0.61.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",
 		"zod": "^3.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,11 +99,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.95
-        version: 1.0.95
+        specifier: 1.0.103
+        version: 1.0.103
       '@anthropic-ai/sdk':
-        specifier: ^0.60.0
-        version: 0.60.0
+        specifier: ^0.61.0
+        version: 0.61.0
       '@linear/sdk':
         specifier: ^58.1.0
         version: 58.1.0(encoding@0.1.13)
@@ -207,13 +207,13 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.95':
-    resolution: {integrity: sha512-VLwfezJ8vnNpkdUdyMORQ1JXx/C7GFd8MLiJTXXThvMTxhNEr8IhAY/bExNrtdkWx2+aipGocRLgNZrUon9HMw==}
+  '@anthropic-ai/claude-code@1.0.103':
+    resolution: {integrity: sha512-hUj95G2ydlcIoKS5yALUNysRzuMCKZCxQ7CjjmSAkeNgf591rtNTJjQWjnTAfuljyk1a2trvXmYo/zNAChDsDA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@anthropic-ai/sdk@0.60.0':
-    resolution: {integrity: sha512-9zu/TXaUy8BZhXedDtt1wT3H4LOlpKDO1/ftiFpeR3N1PCr3KJFKkxxlQWWt1NNp08xSwUNJ3JNY8yhl8av6eQ==}
+  '@anthropic-ai/sdk@0.61.0':
+    resolution: {integrity: sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==}
     hasBin: true
 
   '@babel/helper-string-parser@7.27.1':
@@ -2393,7 +2393,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.95':
+  '@anthropic-ai/claude-code@1.0.103':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -2402,7 +2402,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.60.0': {}
+  '@anthropic-ai/sdk@0.61.0': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.95 to v1.0.103 ([v1.0.103 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1103))
- Updated @anthropic-ai/sdk from v0.60.0 to v0.61.0
- Updated changelog with version updates and links

## Test plan
- [x] Packages updated to latest versions
- [x] All package tests pass (`pnpm test:packages:run`)
- [x] TypeScript compilation succeeds (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.ai/code)