### PR TITLE
feat: Add linear_get_child_issues tool to cyrus-tools

### DIFF
--- a/packages/claude-runner/src/tools/cyrus-tools/index.ts
+++ b/packages/claude-runner/src/tools/cyrus-tools/index.ts
@@ -530,6 +530,148 @@ export function createCyrusToolsServer(
 		},
 	);
 
+	const getChildIssuesTool = tool(
+		"linear_get_child_issues",
+		"Get all child issues (sub-issues) for a given Linear issue. Takes an issue identifier like 'CYHOST-91' and returns a list of child issue ids and their titles.",
+		{
+			issueId: z
+				.string()
+				.describe(
+					"The ID or identifier of the parent issue (e.g., 'CYHOST-91' or UUID)",
+				),
+			limit: z
+				.number()
+				.optional()
+				.describe(
+					"Maximum number of child issues to return (default: 50, max: 250)",
+				),
+			includeCompleted: z
+				.boolean()
+				.optional()
+				.describe("Whether to include completed child issues (default: true)"),
+			includeArchived: z
+				.boolean()
+				.optional()
+				.describe("Whether to include archived child issues (default: false)"),
+		},
+		async ({
+			issueId,
+			limit = 50,
+			includeCompleted = true,
+			includeArchived = false,
+		}) => {
+			try {
+				// Validate and clamp limit
+				const finalLimit = Math.min(Math.max(1, limit), 250);
+
+				console.log(
+					`Getting child issues for ${issueId} (limit: ${finalLimit})`,
+				);
+
+				// Fetch the parent issue first
+				const issue = await linearClient.issue(issueId);
+
+				if (!issue) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									success: false,
+									error: `Issue ${issueId} not found`,
+								}),
+							},
+						],
+					};
+				}
+
+				// Build the filter for child issues
+				const filter: any = {};
+
+				if (!includeCompleted) {
+					filter.state = { type: { neq: "completed" } };
+				}
+
+				if (!includeArchived) {
+					filter.archivedAt = { null: true };
+				}
+
+				// Get child issues using the children() method
+				const childrenConnection = await issue.children({
+					first: finalLimit,
+					...(Object.keys(filter).length > 0 && { filter }),
+				});
+
+				// Extract the child issues from the connection
+				const children = await childrenConnection.nodes;
+
+				// Process each child to get detailed information
+				const childrenData = await Promise.all(
+					children.map(async (child) => {
+						const [state, assignee] = await Promise.all([
+							child.state,
+							child.assignee,
+						]);
+
+						return {
+							id: child.id,
+							identifier: child.identifier,
+							title: child.title,
+							state: state?.name || "Unknown",
+							stateType: state?.type || null,
+							assignee: assignee?.name || null,
+							assigneeId: assignee?.id || null,
+							priority: child.priority,
+							priorityLabel: child.priorityLabel,
+							createdAt: child.createdAt.toISOString(),
+							updatedAt: child.updatedAt.toISOString(),
+							url: child.url,
+							archivedAt: child.archivedAt?.toISOString() || null,
+						};
+					}),
+				);
+
+				console.log(`Found ${childrenData.length} child issues for ${issueId}`);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									parentIssue: {
+										id: issue.id,
+										identifier: issue.identifier,
+										title: issue.title,
+										url: issue.url,
+									},
+									childCount: childrenData.length,
+									children: childrenData,
+								},
+								null,
+								2,
+							),
+						},
+					],
+				};
+			} catch (error) {
+				console.error(`Error getting child issues for ${issueId}:`, error);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+				};
+			}
+		},
+	);
+
 	return createSdkMcpServer({
 		name: "cyrus-tools",
 		version: "1.0.0",
@@ -538,6 +680,7 @@ export function createCyrusToolsServer(
 			agentSessionTool,
 			agentSessionOnCommentTool,
 			giveFeedbackTool,
+			getChildIssuesTool,
 		],
 	});
 }

--- a/packages/claude-runner/test-scripts/test-get-child-issues.js
+++ b/packages/claude-runner/test-scripts/test-get-child-issues.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { ClaudeRunner } from "../dist/ClaudeRunner.js";
+import dotenv from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load .env file from parent directory
+dotenv.config({ path: path.join(__dirname, "..", ".env") });
+
+async function testGetChildIssues() {
+	const linearToken = process.env.LINEAR_API_TOKEN;
+
+	if (!linearToken) {
+		console.error("LINEAR_API_TOKEN is required but not set in .env file");
+		process.exit(1);
+	}
+
+	console.log("Starting test for linear_get_child_issues tool...\n");
+
+	const runner = new ClaudeRunner({
+		includeSystemRole: true,
+		apiKey: "test-key", // Not needed for MCP operations
+		mcpConfig: {
+			"cyrus-tools": {
+				type: "inline-sdk",
+				module: path.join(__dirname, "..", "dist", "tools", "cyrus-tools", "index.js"),
+				initParams: [linearToken],
+				// For testing, don't set up session management callbacks
+			},
+		},
+	});
+
+	try {
+		await runner.start();
+		console.log("✅ ClaudeRunner started successfully\n");
+
+		// List available tools
+		const toolList = await runner.listTools();
+		console.log("Available Cyrus tools:");
+		const cyrusTools = toolList.tools.filter((tool) =>
+			tool.name.startsWith("linear_"),
+		);
+		for (const tool of cyrusTools) {
+			console.log(`  - ${tool.name}: ${tool.description}`);
+		}
+		console.log("");
+
+		// Check if our new tool is available
+		const hasGetChildIssues = cyrusTools.some(
+			(tool) => tool.name === "linear_get_child_issues",
+		);
+		if (hasGetChildIssues) {
+			console.log("✅ linear_get_child_issues tool is available\n");
+		} else {
+			console.error("❌ linear_get_child_issues tool not found!");
+			process.exit(1);
+		}
+
+		// Test the tool with a sample issue identifier
+		// Replace with an actual issue that has child issues in your Linear workspace
+		const testIssueId = process.argv[2] || "CYHOST-91";
+		
+		console.log(`Testing linear_get_child_issues with issue: ${testIssueId}`);
+		console.log("Options: includeCompleted=true, includeArchived=false, limit=10\n");
+
+		const result = await runner.callTool("linear_get_child_issues", {
+			issueId: testIssueId,
+			limit: 10,
+			includeCompleted: true,
+			includeArchived: false,
+		});
+
+		if (result.content && result.content.length > 0) {
+			const response = JSON.parse(result.content[0].text);
+			
+			if (response.success) {
+				console.log("✅ Tool executed successfully!\n");
+				console.log(`Parent Issue: ${response.parentIssue.identifier} - ${response.parentIssue.title}`);
+				console.log(`Parent URL: ${response.parentIssue.url}`);
+				console.log(`Number of child issues: ${response.childCount}\n`);
+				
+				if (response.children.length > 0) {
+					console.log("Child Issues:");
+					for (const child of response.children) {
+						console.log(`  - ${child.identifier}: ${child.title}`);
+						console.log(`    State: ${child.state} | Assignee: ${child.assignee || 'Unassigned'}`);
+						console.log(`    Priority: ${child.priorityLabel || 'No priority'}`);
+						console.log(`    URL: ${child.url}`);
+						console.log("");
+					}
+				} else {
+					console.log("No child issues found for this parent issue.");
+				}
+			} else {
+				console.error("❌ Tool execution failed:");
+				console.error(response.error);
+			}
+		} else {
+			console.error("❌ No response from tool");
+		}
+
+		// Test with different options
+		console.log("\n--- Testing with includeCompleted=false ---\n");
+		
+		const activeOnlyResult = await runner.callTool("linear_get_child_issues", {
+			issueId: testIssueId,
+			limit: 10,
+			includeCompleted: false,
+			includeArchived: false,
+		});
+
+		if (activeOnlyResult.content && activeOnlyResult.content.length > 0) {
+			const response = JSON.parse(activeOnlyResult.content[0].text);
+			
+			if (response.success) {
+				console.log(`Active child issues only: ${response.childCount} found`);
+				if (response.children.length > 0) {
+					for (const child of response.children) {
+						console.log(`  - ${child.identifier}: ${child.title} (${child.state})`);
+					}
+				}
+			}
+		}
+
+	} catch (error) {
+		console.error("Test failed:", error);
+		process.exit(1);
+	} finally {
+		await runner.stop();
+		console.log("\n✅ Test completed");
+	}
+}
+
+testGetChildIssues().catch((error) => {
+	console.error("Unhandled error:", error);
+	process.exit(1);
+});

--- a/packages/claude-runner/test/tools/cyrus-tools/get-child-issues-integration.test.ts
+++ b/packages/claude-runner/test/tools/cyrus-tools/get-child-issues-integration.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { createCyrusToolsServer } from "../../../src/tools/cyrus-tools/index.js";
+
+describe("linear_get_child_issues tool integration", () => {
+	it("should create cyrus tools server with expected structure", () => {
+		const server = createCyrusToolsServer("test-token");
+		
+		// Verify the server has the expected MCP structure
+		expect(server).toBeDefined();
+		expect(server.type).toBe("sdk");
+		expect(server.name).toBe("cyrus-tools");
+		expect(server.instance).toBeDefined();
+		
+		// The actual McpServer instance should exist
+		expect(server.instance).toBeDefined();
+	});
+
+	it("should have created server with proper configuration", () => {
+		const server = createCyrusToolsServer("test-token", {
+			parentSessionId: "parent-123",
+			onSessionCreated: (child, parent) => {
+				console.log(`Session created: ${child} -> ${parent}`);
+			},
+			onFeedbackDelivery: async (child, message) => {
+				console.log(`Feedback: ${child} -> ${message}`);
+				return true;
+			},
+		});
+		
+		// Basic server structure check
+		expect(server).toBeDefined();
+		expect(server.type).toBe("sdk");
+		expect(server.name).toBe("cyrus-tools");
+	});
+	
+	it("should verify tool exists through successful server creation", () => {
+		// Since we can't easily access the tools array from the MCP server,
+		// we verify the tool exists by checking that server creation succeeds
+		// The actual testing of the tool functionality happens through
+		// the test script that uses the ClaudeRunner to call the tool
+		
+		// Create a server to ensure it doesn't throw
+		expect(() => createCyrusToolsServer("test-token")).not.toThrow();
+		
+		// Create another server with options to ensure configuration works
+		expect(() => createCyrusToolsServer("test-token", {
+			parentSessionId: "test-parent",
+		})).not.toThrow();
+	});
+
+	it("should handle different configuration options", () => {
+		// Test with minimal config
+		const server1 = createCyrusToolsServer("token1");
+		expect(server1).toBeDefined();
+		
+		// Test with full config
+		const server2 = createCyrusToolsServer("token2", {
+			parentSessionId: "parent-456",
+		});
+		expect(server2).toBeDefined();
+		
+		// Test with empty options
+		const server3 = createCyrusToolsServer("token3", {});
+		expect(server3).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

This PR implements a new native Cyrus tool `linear_get_child_issues` that fetches all child issues (sub-issues) for a given Linear parent issue.

## Changes

- **New Tool**: `linear_get_child_issues` in cyrus-tools package
  - Takes issue identifier like 'CYHOST-91' or UUID
  - Returns list of child issue IDs, titles, and comprehensive metadata
  - Supports filtering options: `includeCompleted`, `includeArchived`, and `limit`

## Features

The tool provides:
- Parent issue information (id, identifier, title, url)
- Child count
- Detailed child issue data:
  - ID and identifier
  - Title and state (name + type)
  - Assignee information
  - Priority and priority label
  - Timestamps (created, updated, archived)
  - Linear URLs

## Usage Example

```javascript
const result = await runner.callTool("linear_get_child_issues", {
  issueId: "CYHOST-91",
  limit: 10,
  includeCompleted: true,
  includeArchived: false
});
```

## Testing

- Added integration tests to verify server creation and configuration
- Created manual test script for testing with real Linear API
- All existing tests pass

## Related Issue

Closes CYPACK-42

🤖 Generated with Claude Code (https://claude.ai/code)