### PR TITLE
feat: Add ephemeral flag to standard tool call activities

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,7 +40,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"@linear/sdk": "^58.0.0",
+		"@linear/sdk": "^58.1.0",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*",
 		"cyrus-edge-worker": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
 		"typescript": "^5.3.3"
 	},
 	"dependencies": {
-		"@linear/sdk": "58.0.0"
+		"@linear/sdk": "58.1.0"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@linear/sdk": "^58.0.0",
+		"@linear/sdk": "^58.1.0",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/core/src/CyrusAgentSession.ts
+++ b/packages/core/src/CyrusAgentSession.ts
@@ -53,6 +53,7 @@ export interface CyrusAgentSessionEntry {
 		toolName?: string;
 		toolInput?: any;
 		parentToolUseId?: string;
+		toolResultError?: boolean; // Error status from tool_result blocks
 		timestamp: number; // e.g. Date.now()
 		durationMs?: number;
 		isError?: boolean;

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -22,7 +22,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@linear/sdk": "^58.0.0",
+		"@linear/sdk": "^58.1.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*",

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -118,9 +118,11 @@ export class AgentSessionManager {
 		// Extract tool info if this is an assistant message
 		const toolInfo =
 			sdkMessage.type === "assistant" ? this.extractToolInfo(sdkMessage) : null;
-		// Extract tool_use_id if this is a user message with tool_result
-		const toolResultId =
-			sdkMessage.type === "user" ? this.extractToolResultId(sdkMessage) : null;
+		// Extract tool_use_id and error status if this is a user message with tool_result
+		const toolResultInfo =
+			sdkMessage.type === "user"
+				? this.extractToolResultInfo(sdkMessage)
+				: null;
 
 		const sessionEntry: CyrusAgentSessionEntry = {
 			claudeSessionId: sdkMessage.session_id,
@@ -134,8 +136,9 @@ export class AgentSessionManager {
 					toolName: toolInfo.name,
 					toolInput: toolInfo.input,
 				}),
-				...(toolResultId && {
-					toolUseId: toolResultId,
+				...(toolResultInfo && {
+					toolUseId: toolResultInfo.toolUseId,
+					toolResultError: toolResultInfo.isError,
 				}),
 			},
 		};
@@ -398,6 +401,13 @@ export class AgentSessionManager {
 						return JSON.stringify(block.input, null, 2);
 					} else if (block.type === "tool_result") {
 						// For tool_result blocks, extract just the text content
+						// Also store the error status in metadata if needed
+						if ("is_error" in block && block.is_error) {
+							// Mark this as an error result - we'll handle this elsewhere
+						}
+						if (typeof block.content === "string") {
+							return block.content;
+						}
 						if (Array.isArray(block.content)) {
 							return block.content
 								.filter((contentBlock: any) => contentBlock.type === "text")
@@ -444,9 +454,11 @@ export class AgentSessionManager {
 	}
 
 	/**
-	 * Extract tool_use_id from Claude user message containing tool_result
+	 * Extract tool_use_id and error status from Claude user message containing tool_result
 	 */
-	private extractToolResultId(sdkMessage: SDKUserMessage): string | null {
+	private extractToolResultInfo(
+		sdkMessage: SDKUserMessage,
+	): { toolUseId: string; isError: boolean } | null {
 		const message = sdkMessage.message as APIUserMessage;
 
 		if (Array.isArray(message.content)) {
@@ -454,10 +466,28 @@ export class AgentSessionManager {
 				(block) => block.type === "tool_result",
 			);
 			if (toolResult && "tool_use_id" in toolResult) {
-				return toolResult.tool_use_id;
+				return {
+					toolUseId: toolResult.tool_use_id,
+					isError: "is_error" in toolResult && toolResult.is_error === true,
+				};
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Extract tool result content and error status from session entry
+	 */
+	private extractToolResult(
+		entry: CyrusAgentSessionEntry,
+	): { content: string; isError: boolean } | null {
+		// Check if we have the error status in metadata
+		const isError = entry.metadata?.toolResultError || false;
+
+		return {
+			content: entry.content,
+			isError: isError,
+		};
 	}
 
 	/**
@@ -483,6 +513,7 @@ export class AgentSessionManager {
 
 			// Build activity content based on entry type
 			let content: any;
+			let ephemeral = false;
 			switch (entry.type) {
 				case "user": {
 					const activeTaskId = this.activeTasksBySession.get(
@@ -494,6 +525,23 @@ export class AgentSessionManager {
 							body: `✅ Task Completed\n\n\n\n${entry.content}\n\n---\n\n`,
 						};
 						this.activeTasksBySession.delete(linearAgentActivitySessionId);
+					} else if (entry.metadata?.toolUseId) {
+						// This is a tool result - create an action activity with the result
+						const toolResult = this.extractToolResult(entry);
+						if (toolResult) {
+							content = {
+								type: "action",
+								action: "Tool Response",
+								parameter: "", // No parameter for tool response
+								result: toolResult.content,
+							};
+							// Mark as error if the tool result had an error
+							if (toolResult.isError) {
+								content.action = "Tool Error";
+							}
+						} else {
+							return;
+						}
 					} else {
 						return;
 					}
@@ -513,6 +561,8 @@ export class AgentSessionManager {
 								type: "thought",
 								body: formattedTodos,
 							};
+							// TodoWrite is not ephemeral
+							ephemeral = false;
 						} else if (toolName === "Task") {
 							// Special handling for Task tool - add start marker and track active task
 							const parameter = entry.content;
@@ -532,6 +582,8 @@ export class AgentSessionManager {
 								parameter: parameter,
 								// result will be added later when we get tool result
 							};
+							// Task is not ephemeral
+							ephemeral = false;
 						} else {
 							// Other tools - check if they're within an active Task
 							const parameter = entry.content;
@@ -552,6 +604,8 @@ export class AgentSessionManager {
 								parameter: parameter,
 								// result will be added later when we get tool result
 							};
+							// Standard tool calls are ephemeral
+							ephemeral = true;
 						}
 					} else {
 						// Regular assistant message - create a thought
@@ -604,10 +658,15 @@ export class AgentSessionManager {
 					};
 			}
 
-			const activityInput = {
+			const activityInput: any = {
 				agentSessionId: session.linearAgentActivitySessionId, // Use the Linear session ID
 				content,
 			};
+
+			// Add ephemeral flag if needed
+			if (ephemeral) {
+				activityInput.ephemeral = true;
+			}
 
 			const result = await this.linearClient.createAgentActivity(activityInput);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     dependencies:
       '@linear/sdk':
-        specifier: 58.0.0
-        version: 58.0.0(encoding@0.1.13)
+        specifier: 58.1.0
+        version: 58.1.0(encoding@0.1.13)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.1.3
@@ -28,8 +28,8 @@ importers:
   apps/cli:
     dependencies:
       '@linear/sdk':
-        specifier: ^58.0.0
-        version: 58.0.0(encoding@0.1.13)
+        specifier: ^58.1.0
+        version: 58.1.0(encoding@0.1.13)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../../packages/claude-runner
@@ -133,8 +133,8 @@ importers:
   packages/core:
     dependencies:
       '@linear/sdk':
-        specifier: ^58.0.0
-        version: 58.0.0(encoding@0.1.13)
+        specifier: ^58.1.0
+        version: 58.1.0(encoding@0.1.13)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -152,8 +152,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@linear/sdk':
-        specifier: ^58.0.0
-        version: 58.0.0(encoding@0.1.13)
+        specifier: ^58.1.0
+        version: 58.1.0(encoding@0.1.13)
       '@ngrok/ngrok':
         specifier: ^1.5.1
         version: 1.5.1
@@ -784,10 +784,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
-  '@linear/sdk@58.0.0':
-    resolution: {integrity: sha512-xdmlOZxfsh4Gae/sxy3vzNE1010EhDVMA7SrgfII5PmbrHZlIbgHM9cslKuN0z8M4HbvVKADPXRuhM+VSBLNrQ==}
-    engines: {node: '>=12.x', yarn: 1.x}
 
   '@linear/sdk@58.1.0':
     resolution: {integrity: sha512-sqzo1j+uZsxeJlMTV2mrBH3yukB/liev7IySmkZil0ka7ic6b4RE9Jk3x+ohw8YgYB52IRR3SPWzhWu96E6W9g==}
@@ -2748,14 +2744,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@linear/sdk@58.0.0(encoding@0.1.13)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
-      graphql: 15.10.1
-      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
 
   '@linear/sdk@58.1.0(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
## Summary

This PR implements ephemeral agent activities for standard tool calls in Linear, as requested in CYPACK-44.

## Changes

- **Updated Linear SDK** to version 58.1.0 across all packages to include the ephemeral property support
- **Added ephemeral behavior** for standard tool calls (Read, Write, Edit, etc.) - these activities will now disappear when replaced
- **Preserved non-ephemeral behavior** for special tools like Task and TodoWrite which should remain visible
- **Implemented tool response activities** that replace ephemeral tool calls with their results
- **Added error handling** to properly display "Tool Error" instead of "Tool Response" when tool results have errors

## Technical Details

The implementation tracks tool results using the is_error field from Claude Code SDK messages. When a tool call is made:
1. An ephemeral action activity is posted to Linear
2. When the tool result comes in, a new non-ephemeral action activity replaces it
3. Error results are clearly marked as "Tool Error" for visibility

## Testing

- All existing tests pass ✅
- Build succeeds without TypeScript errors ✅
- Code formatted with Biome ✅

🤖 Generated with [Claude Code](https://claude.ai/code)