### PR TITLE
fix: resolve feedback delivery timeout issue in EdgeWorker

### DIFF
--- a/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
@@ -344,11 +344,16 @@ describe("EdgeWorker - Feedback Delivery", () => {
 				feedbackMessage,
 			);
 
-			// Assert
-			expect(result).toBe(false);
+			// Assert - Now returns true immediately (fire-and-forget)
+			expect(result).toBe(true);
 			expect(resumeClaudeSessionSpy).toHaveBeenCalledOnce();
+
+			// Wait a bit for the async error handling to occur
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// The error is logged asynchronously
 			expect(console.error).toHaveBeenCalledWith(
-				`[EdgeWorker] Failed to resume child session with feedback:`,
+				`[EdgeWorker] Failed to complete child session with feedback:`,
 				expect.any(Error),
 			);
 		});


### PR DESCRIPTION
## Summary
This PR fixes the issue where the `linear_agent_give_feedback` tool times out even though feedback is successfully delivered to the child session.

## Problem
The `give_feedback` tool was reporting timeouts because it was waiting for the entire child Claude session to complete before returning. This caused the tool to timeout even though the feedback was actually delivered and the child session started processing it successfully.

## Root Cause
The `onFeedbackDelivery` callback in EdgeWorker was awaiting `resumeClaudeSession()`, which doesn't return until the entire Claude session completes. This meant the feedback tool would wait for potentially minutes or hours for the child session to finish.

## Solution  
Changed the feedback delivery to use a fire-and-forget pattern:
- The child session is now started asynchronously without blocking
- The tool returns success immediately after initiating the feedback
- The child session continues processing in the background
- Errors during session execution are still logged asynchronously

## Changes
- Modified `EdgeWorker.ts` to not await `resumeClaudeSession()` in the feedback callback
- Updated existing test to reflect the new behavior (errors are now logged asynchronously)
- Added comprehensive test suite to verify the timeout fix

## Testing
- ✅ All existing tests pass
- ✅ New tests verify immediate return behavior
- ✅ TypeScript compilation successful
- ✅ Linting passes

## Test Evidence
The new test suite demonstrates:
1. Feedback delivery returns in <100ms instead of waiting for session completion
2. Child sessions continue processing in the background after feedback is delivered
3. Errors are still properly logged asynchronously

Fixes CYPACK-49

🤖 Generated with [Claude Code](https://claude.ai/code)