### PR TITLE
feat: increase attachment download limit from 10 to 20

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2221,7 +2221,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 			let imageCount = 0;
 			let skippedCount = 0;
 			let failedCount = 0;
-			const maxAttachments = 10;
+			const maxAttachments = 20;
 
 			// Ensure directory exists
 			await mkdir(attachmentsDir, { recursive: true });
@@ -2436,7 +2436,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		let newAttachmentCount = 0;
 		let newImageCount = 0;
 		let failedCount = 0;
-		const maxAttachments = 10;
+		const maxAttachments = 20;
 
 		// Extract URLs from the comment
 		const urls = this.extractAttachmentUrls(commentBody);

--- a/packages/edge-worker/test/EdgeWorker.attachments.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.attachments.test.ts
@@ -216,7 +216,7 @@ describe("EdgeWorker - Native Attachments", () => {
 				commentBody,
 				attachmentsDir,
 				"test-token",
-				9, // Already have 9 attachments, so only 1 more allowed
+				19, // Already have 19 attachments, so only 1 more allowed with limit of 20
 			);
 
 			expect(result.totalNewAttachments).toBe(1);


### PR DESCRIPTION
## Summary
- Increased the attachment download limit from 10 to 20 in EdgeWorker
- Updated test to reflect the new limit

## Context
The current limit of 10 attachments was too restrictive for issues with many attachments, causing some attachments to be skipped.

This change updates:
- `EdgeWorker.ts`: Changed `maxAttachments` from 10 to 20 in two locations
- Updated the corresponding test to validate the new limit behavior

## Test Plan
✅ All tests pass (`pnpm test:packages:run`)
✅ Build succeeds (`pnpm build`)

Fixes: CYPACK-50

🤖 Generated with [Claude Code](https://claude.ai/code)