### PR TITLE
feat: Add dynamic package instantiation for webhook client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Dynamic webhook client selection**: Support for choosing between proxy-based and direct webhook forwarding
+  - New environment variable `LINEAR_DIRECT_WEBHOOKS` to control webhook client selection
+  - When `LINEAR_DIRECT_WEBHOOKS=true`, uses `linear-webhook-client` for direct webhook forwarding
+  - When unset or `false`, uses existing `ndjson-client` for proxy-based webhook handling
+  - Maintains full backward compatibility with existing deployments
+
 ### Changed
 - Updated @anthropic-ai/claude-code from v1.0.90 to v1.0.95 for latest Claude Code improvements. See [Claude Code v1.0.95 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1095)
 - Replaced external cyrus-mcp-tools MCP server with inline tools using SDK callbacks for better performance

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -26,6 +26,7 @@
 		"@ngrok/ngrok": "^1.5.1",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*",
+		"cyrus-linear-webhook-client": "workspace:*",
 		"cyrus-ndjson-client": "workspace:*",
 		"file-type": "^18.7.0"
 	},

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -50,6 +50,7 @@ import {
 	PersistenceManager,
 } from "cyrus-core";
 import { NdjsonClient } from "cyrus-ndjson-client";
+import { LinearWebhookClient } from "cyrus-linear-webhook-client";
 import { fileTypeFromBuffer } from "file-type";
 import { AgentSessionManager } from "./AgentSessionManager.js";
 import { SharedApplicationServer } from "./SharedApplicationServer.js";
@@ -85,7 +86,7 @@ export class EdgeWorker extends EventEmitter {
 	private repositories: Map<string, RepositoryConfig> = new Map(); // repository 'id' (internal, stored in config.json) mapped to the full repo config
 	private agentSessionManagers: Map<string, AgentSessionManager> = new Map(); // Maps repository ID to AgentSessionManager, which manages ClaudeRunners for a repo
 	private linearClients: Map<string, LinearClient> = new Map(); // one linear client per 'repository'
-	private ndjsonClients: Map<string, NdjsonClient> = new Map(); // listeners for webhook events, one per linear token
+	private ndjsonClients: Map<string, NdjsonClient | LinearWebhookClient> = new Map(); // listeners for webhook events, one per linear token
 	private persistenceManager: PersistenceManager;
 	private sharedApplicationServer: SharedApplicationServer;
 	private cyrusHome: string;
@@ -246,11 +247,15 @@ export class EdgeWorker extends EventEmitter {
 			const firstRepo = repos[0];
 			if (!firstRepo) continue;
 			const primaryRepoId = firstRepo.id;
-			const ndjsonClient = new NdjsonClient({
+			
+			// Determine which client to use based on environment variable
+			const useLinearDirectWebhooks = process.env.LINEAR_DIRECT_WEBHOOKS === "true";
+			
+			const clientConfig = {
 				proxyUrl: config.proxyUrl,
 				token: token,
 				name: repos.map((r) => r.name).join(", "), // Pass repository names
-				transport: "webhook",
+				transport: "webhook" as const,
 				// Use shared application server instead of individual servers
 				useExternalWebhookServer: true,
 				externalWebhookServer: this.sharedApplicationServer,
@@ -262,19 +267,29 @@ export class EdgeWorker extends EventEmitter {
 				...(!config.baseUrl &&
 					config.webhookBaseUrl && { webhookBaseUrl: config.webhookBaseUrl }),
 				onConnect: () => this.handleConnect(primaryRepoId, repos),
-				onDisconnect: (reason) =>
+				onDisconnect: (reason?: string) =>
 					this.handleDisconnect(primaryRepoId, repos, reason),
-				onError: (error) => this.handleError(error),
-			});
+				onError: (error: Error) => this.handleError(error),
+			};
+			
+			// Create the appropriate client based on configuration
+			const ndjsonClient = useLinearDirectWebhooks 
+				? new LinearWebhookClient({
+					...clientConfig,
+					onWebhook: (payload) => this.handleWebhook(payload as unknown as LinearWebhook, repos),
+				})
+				: new NdjsonClient(clientConfig);
 
-			// Set up webhook handler - data should be the native webhook payload
-			ndjsonClient.on("webhook", (data) =>
-				this.handleWebhook(data as LinearWebhook, repos),
-			);
+			// Set up webhook handler for NdjsonClient (LinearWebhookClient uses onWebhook in constructor)
+			if (!useLinearDirectWebhooks) {
+				(ndjsonClient as NdjsonClient).on("webhook", (data) =>
+					this.handleWebhook(data as LinearWebhook, repos),
+				);
+			}
 
-			// Optional heartbeat logging
-			if (process.env.DEBUG_EDGE === "true") {
-				ndjsonClient.on("heartbeat", () => {
+			// Optional heartbeat logging (only for NdjsonClient)
+			if (process.env.DEBUG_EDGE === "true" && !useLinearDirectWebhooks) {
+				(ndjsonClient as NdjsonClient).on("heartbeat", () => {
 					console.log(
 						`❤️ Heartbeat received for token ending in ...${token.slice(-4)}`,
 					);

--- a/packages/linear-webhook-client/package.json
+++ b/packages/linear-webhook-client/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "cyrus-linear-webhook-client",
+	"version": "0.0.1",
+	"description": "Linear webhook client for direct webhook forwarding",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "echo 'Using pre-built dist files'",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@linear/sdk": "^58.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       cyrus-core:
         specifier: workspace:*
         version: link:../core
+      cyrus-linear-webhook-client:
+        specifier: workspace:*
+        version: link:../linear-webhook-client
       cyrus-ndjson-client:
         specifier: workspace:*
         version: link:../ndjson-client
@@ -188,6 +191,19 @@ importers:
       vitest-mock-extended:
         specifier: ^3.1.0
         version: 3.1.0(typescript@5.8.3)(vitest@1.6.1(@types/node@20.19.4)(lightningcss@1.30.1))
+
+  packages/linear-webhook-client:
+    dependencies:
+      '@linear/sdk':
+        specifier: ^58.0.0
+        version: 58.1.0(encoding@0.1.13)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.4
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
 
   packages/ndjson-client:
     devDependencies:
@@ -2914,7 +2930,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 20.19.4
 
   '@types/ms@2.1.0':
     optional: true


### PR DESCRIPTION
## Summary
- Added conditional logic to dynamically choose between `NdjsonClient` and `LinearWebhookClient` based on the `LINEAR_DIRECT_WEBHOOKS` environment variable
- When `LINEAR_DIRECT_WEBHOOKS=true`, the system uses `LinearWebhookClient` for direct webhook forwarding
- When unset or false, it continues using the existing `NdjsonClient` for proxy-based handling
- Maintains full backward compatibility with existing deployments

## Changes
- Modified `EdgeWorker.ts` to check `LINEAR_DIRECT_WEBHOOKS` environment variable
- Added import for `LinearWebhookClient` package
- Updated client instantiation logic to conditionally create the appropriate client
- Added `linear-webhook-client` dependency to `edge-worker` package
- Created minimal `package.json` for `linear-webhook-client` to support the pre-built dist files
- Updated CHANGELOG with feature description

## Test plan
- [x] Built all packages successfully
- [x] Ran all package tests - passing
- [x] Type checking passes
- [x] Backward compatibility maintained (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)