### PR TITLE
Release v0.1.46 - Run a release of the cyrus packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.46] - 2025-01-09
+
 ### Added
 - **Dynamic webhook client selection**: Support for choosing between proxy-based and direct webhook forwarding
   - New environment variable `LINEAR_DIRECT_WEBHOOKS` to control webhook client selection
-  - When `LINEAR_DIRECT_WEBHOOKS=true`, uses `linear-webhook-client` for direct webhook forwarding
+  - When `LINEAR_DIRECT_WEBHOOKS=true`, uses new `linear-webhook-client` package for direct webhook forwarding
   - When unset or `false`, uses existing `ndjson-client` for proxy-based webhook handling
   - Maintains full backward compatibility with existing deployments
-
-### Changed
-- Updated @anthropic-ai/claude-code from v1.0.90 to v1.0.95 for latest Claude Code improvements. See [Claude Code v1.0.95 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1095)
-- Replaced external cyrus-mcp-tools MCP server with inline tools using SDK callbacks for better performance
-- Cyrus tools (file upload, agent session creation, feedback) now run in-process instead of via separate MCP server
-- Enhanced orchestrator prompt to explicitly require reading/viewing all screenshots taken for visual verification
-
-### Removed
-- Removed cyrus-mcp-tools package in favor of inline tool implementation
-
-### Added
 - **Sub-issue assignee inheritance with workspace context**: Sub-issues created by orchestrator agents now automatically inherit the same assignee as their parent issue, with complete workspace awareness
   - Enhanced label-prompt-template to include assignee information (`{{assignee_id}}` and `{{assignee_name}}`)
   - Added workspace teams context (`{{workspace_teams}}`) with team names, keys, IDs, and descriptions
@@ -48,6 +39,15 @@ All notable changes to this project will be documented in this file.
   - Enables orchestrator agents to trigger sub-agents on existing issue comment threads
   - Must be used with root comments only (not replies) due to Linear API constraints
   - Maintains parent-child session mapping for proper feedback routing
+
+### Changed
+- Updated @anthropic-ai/claude-code from v1.0.90 to v1.0.95 for latest Claude Code improvements. See [Claude Code v1.0.95 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#1095)
+- Replaced external cyrus-mcp-tools MCP server with inline tools using SDK callbacks for better performance
+- Cyrus tools (file upload, agent session creation, feedback) now run in-process instead of via separate MCP server
+- Enhanced orchestrator prompt to explicitly require reading/viewing all screenshots taken for visual verification
+
+### Removed
+- Removed cyrus-mcp-tools package in favor of inline tool implementation
 
 ## [0.1.45] - 2025-08-28
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.45",
+	"version": "0.1.46",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.23",
+	"version": "0.0.24",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.28",
+	"version": "0.0.29",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/ndjson-client/package.json
+++ b/packages/ndjson-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ndjson-client",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"description": "NDJSON streaming client for proxy communication",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Released Cyrus v0.1.46 with all packages including the new linear-webhook-client
- Updated CHANGELOG.md with release notes
- Bumped versions for all modified packages

## Published Packages
- cyrus-ai@0.1.46 (CLI)
- cyrus-core@0.0.12
- cyrus-claude-runner@0.0.24
- cyrus-edge-worker@0.0.29
- cyrus-ndjson-client@0.0.18
- cyrus-linear-webhook-client@0.0.1 (NEW - first release)

## Key Features in this Release
- **Dynamic webhook client selection**: Support for choosing between proxy-based and direct webhook forwarding via LINEAR_DIRECT_WEBHOOKS environment variable
- **Sub-issue assignee inheritance with workspace context**
- **Mandatory verification framework for orchestrator agents**
- **@cyrus /label-based-prompt command**
- **Tool restriction configuration**
- **New Linear MCP tool for creating agent sessions on comments**

## Test Plan
- [x] All packages built successfully
- [x] All packages published to npm successfully
- [x] Verified packages are available on npm registry
- [x] CHANGELOG.md updated with release notes

🤖 Generated with [Claude Code](https://claude.ai/code)