### PR TITLE
Fix webhook signature verification for LinearWebhookClient

### DIFF
--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -188,7 +188,9 @@ export class SharedApplicationServer {
 	 */
 	registerWebhookHandler(
 		token: string,
-		secretOrHandler: string | ((req: IncomingMessage, res: ServerResponse) => Promise<void>),
+		secretOrHandler:
+			| string
+			| ((req: IncomingMessage, res: ServerResponse) => Promise<void>),
 		handler?: (body: string, signature: string, timestamp?: string) => boolean,
 	): void {
 		if (typeof secretOrHandler === "string" && handler) {
@@ -350,7 +352,7 @@ export class SharedApplicationServer {
 				console.log(
 					`🔗 Direct Linear webhook received, trying ${this.linearWebhookHandlers.size} direct handlers`,
 				);
-				
+
 				// Try each direct handler
 				for (const [token, handler] of this.linearWebhookHandlers) {
 					try {
@@ -367,7 +369,7 @@ export class SharedApplicationServer {
 						);
 					}
 				}
-				
+
 				// No direct handler could process it
 				console.error(
 					`🔗 Direct webhook processing failed for all ${this.linearWebhookHandlers.size} handlers`,

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -41,6 +41,11 @@ export class SharedApplicationServer {
 			handler: (body: string, signature: string, timestamp?: string) => boolean;
 		}
 	>();
+	// Separate handlers for LinearWebhookClient that handle raw req/res
+	private linearWebhookHandlers = new Map<
+		string,
+		(req: IncomingMessage, res: ServerResponse) => Promise<void>
+	>();
 	private oauthCallbacks = new Map<string, OAuthCallback>();
 	private oauthCallbackHandler: OAuthCallbackHandler | null = null;
 	private port: number;
@@ -177,26 +182,43 @@ export class SharedApplicationServer {
 
 	/**
 	 * Register a webhook handler for a specific token
+	 * Supports two signatures:
+	 * 1. For ndjson-client: (token, secret, handler)
+	 * 2. For linear-webhook-client: (token, handler) where handler takes (req, res)
 	 */
 	registerWebhookHandler(
 		token: string,
-		secret: string,
-		handler: (body: string, signature: string, timestamp?: string) => boolean,
+		secretOrHandler: string | ((req: IncomingMessage, res: ServerResponse) => Promise<void>),
+		handler?: (body: string, signature: string, timestamp?: string) => boolean,
 	): void {
-		this.webhookHandlers.set(token, { secret, handler });
-		console.log(
-			`🔗 Registered webhook handler for token ending in ...${token.slice(-4)}`,
-		);
+		if (typeof secretOrHandler === "string" && handler) {
+			// ndjson-client style registration
+			this.webhookHandlers.set(token, { secret: secretOrHandler, handler });
+			console.log(
+				`🔗 Registered webhook handler (proxy-style) for token ending in ...${token.slice(-4)}`,
+			);
+		} else if (typeof secretOrHandler === "function") {
+			// linear-webhook-client style registration
+			this.linearWebhookHandlers.set(token, secretOrHandler);
+			console.log(
+				`🔗 Registered webhook handler (direct-style) for token ending in ...${token.slice(-4)}`,
+			);
+		} else {
+			throw new Error("Invalid webhook handler registration parameters");
+		}
 	}
 
 	/**
 	 * Unregister a webhook handler
 	 */
 	unregisterWebhookHandler(token: string): void {
-		this.webhookHandlers.delete(token);
-		console.log(
-			`🔗 Unregistered webhook handler for token ending in ...${token.slice(-4)}`,
-		);
+		const hadProxyHandler = this.webhookHandlers.delete(token);
+		const hadDirectHandler = this.linearWebhookHandlers.delete(token);
+		if (hadProxyHandler || hadDirectHandler) {
+			console.log(
+				`🔗 Unregistered webhook handler for token ending in ...${token.slice(-4)}`,
+			);
+		}
 	}
 
 	/**
@@ -318,6 +340,44 @@ export class SharedApplicationServer {
 				return;
 			}
 
+			// Check if this is a direct Linear webhook (has linear-signature header)
+			const linearSignature = req.headers["linear-signature"] as string;
+			const isDirectWebhook = !!linearSignature;
+
+			if (isDirectWebhook && this.linearWebhookHandlers.size > 0) {
+				// For direct Linear webhooks, pass the raw request to the handler
+				// The LinearWebhookClient will handle its own signature verification
+				console.log(
+					`🔗 Direct Linear webhook received, trying ${this.linearWebhookHandlers.size} direct handlers`,
+				);
+				
+				// Try each direct handler
+				for (const [token, handler] of this.linearWebhookHandlers) {
+					try {
+						// The handler will manage the response
+						await handler(req, res);
+						console.log(
+							`🔗 Direct webhook delivered to token ending in ...${token.slice(-4)}`,
+						);
+						return;
+					} catch (error) {
+						console.error(
+							`🔗 Error in direct webhook handler for token ...${token.slice(-4)}:`,
+							error,
+						);
+					}
+				}
+				
+				// No direct handler could process it
+				console.error(
+					`🔗 Direct webhook processing failed for all ${this.linearWebhookHandlers.size} handlers`,
+				);
+				res.writeHead(401, { "Content-Type": "text/plain" });
+				res.end("Unauthorized");
+				return;
+			}
+
+			// Otherwise, handle as proxy-style webhook
 			// Read request body
 			let body = "";
 			req.on("data", (chunk) => {
@@ -326,11 +386,12 @@ export class SharedApplicationServer {
 
 			req.on("end", () => {
 				try {
+					// For proxy-style webhooks, we need the signature header
 					const signature = req.headers["x-webhook-signature"] as string;
 					const timestamp = req.headers["x-webhook-timestamp"] as string;
 
 					console.log(
-						`🔗 Webhook received with ${body.length} bytes, ${this.webhookHandlers.size} registered handlers`,
+						`🔗 Proxy webhook received with ${body.length} bytes, ${this.webhookHandlers.size} registered handlers`,
 					);
 
 					if (!signature) {

--- a/packages/linear-webhook-client/tsconfig.json
+++ b/packages/linear-webhook-client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./dist",
+    "outDir": "./dist",
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true
+  },
+  "include": ["dist/**/*"],
+  "exclude": ["node_modules", "**/*.test.*", "**/*.spec.*"]
+}

--- a/packages/linear-webhook-client/tsconfig.json
+++ b/packages/linear-webhook-client/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "./dist",
-    "outDir": "./dist",
-    "allowJs": true,
-    "checkJs": false,
-    "skipLibCheck": true
-  },
-  "include": ["dist/**/*"],
-  "exclude": ["node_modules", "**/*.test.*", "**/*.spec.*"]
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./dist",
+		"outDir": "./dist",
+		"allowJs": true,
+		"checkJs": false,
+		"skipLibCheck": true
+	},
+	"include": ["dist/**/*"],
+	"exclude": ["node_modules", "**/*.test.*", "**/*.spec.*"]
 }


### PR DESCRIPTION
## Summary
- Fixed webhook signature verification errors when using `LINEAR_DIRECT_WEBHOOKS=true`
- Edge-worker now properly handles both proxy-based and direct Linear webhooks
- Resolves "Missing signature header" errors reported in CYPACK-60

## Problem
When using the new `linear-webhook-client` package with direct webhook forwarding from Vercel router, webhooks were being rejected with "Missing signature header" because:
1. Direct webhooks use `linear-signature` header instead of `x-webhook-signature`
2. LinearWebhookClient expects to handle raw HTTP req/res for its own verification
3. SharedApplicationServer was only set up for proxy-style webhook handlers

## Solution
Modified SharedApplicationServer to support both webhook handler types:
- Added separate `linearWebhookHandlers` Map for direct webhook handlers
- Overloaded `registerWebhookHandler` to accept both registration styles
- Routes webhooks with `linear-signature` header directly to LinearWebhookClient handlers
- Maintains full backward compatibility with existing proxy webhook flow

## Test Plan
- [x] All existing tests pass (77 tests)
- [x] TypeScript compilation successful
- [x] No breaking changes to existing functionality

Fixes CYPACK-60

🤖 Generated with [Claude Code](https://claude.ai/code)