### PR TITLE
Add endpoint for GitHub token and update gh auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **GitHub token endpoint for automated auth management**: New endpoint for updating GitHub CLI credentials programmatically
+  - New `/github-token` endpoint that accepts POST requests with a GitHub token
+  - Only enabled when `MANAGE_GH_AUTH` environment variable is set to `true`
+  - Automatically updates `gh` CLI authentication credentials
+  - Useful for CI/CD pipelines and automated deployments
+
 ## [0.1.47] - 2025-01-09
 
 ### Fixed

--- a/docs/github-token-endpoint.md
+++ b/docs/github-token-endpoint.md
@@ -1,0 +1,115 @@
+# GitHub Token Endpoint
+
+## Overview
+
+The GitHub token endpoint provides a programmatic way to update the `gh` CLI authentication credentials used by Cyrus. This is particularly useful in CI/CD environments or automated deployment scenarios where you need to dynamically configure GitHub access.
+
+## Enabling the Endpoint
+
+The endpoint is **disabled by default** for security reasons. To enable it, set the `MANAGE_GH_AUTH` environment variable:
+
+```bash
+MANAGE_GH_AUTH=true cyrus start
+```
+
+When enabled, the endpoint will be available at:
+```
+http://localhost:3456/github-token
+```
+
+(The port may vary based on your `CYRUS_SERVER_PORT` configuration)
+
+## Usage
+
+### Making a Request
+
+Send a POST request with a JSON body containing the GitHub token:
+
+```bash
+curl -X POST http://localhost:3456/github-token \
+  -H "Content-Type: application/json" \
+  -d '{"token": "ghp_YOUR_GITHUB_TOKEN"}'
+```
+
+### Request Format
+
+**Method:** POST  
+**Content-Type:** application/json  
+**Body:**
+```json
+{
+  "token": "ghp_YOUR_GITHUB_TOKEN"
+}
+```
+
+### Response
+
+**Success (200 OK):**
+```json
+{
+  "success": true,
+  "message": "GitHub auth credentials updated successfully"
+}
+```
+
+**Error (400 Bad Request):**
+```json
+{
+  "error": "Missing token in request body"
+}
+```
+
+**Error (500 Internal Server Error):**
+```json
+{
+  "error": "Failed to update GitHub auth credentials",
+  "details": "Error message details"
+}
+```
+
+## Security Considerations
+
+1. **Disabled by Default:** The endpoint is only active when explicitly enabled via `MANAGE_GH_AUTH=true`
+2. **Local Only:** By default, the server listens on localhost, reducing exposure
+3. **Token Security:** Ensure GitHub tokens are transmitted securely (use HTTPS in production)
+4. **Limited Scope:** Use GitHub tokens with minimal required permissions
+
+## Example Test Script
+
+A test script is provided at `test-github-token-endpoint.js`:
+
+```javascript
+node test-github-token-endpoint.js ghp_YOUR_GITHUB_TOKEN
+```
+
+## Integration Examples
+
+### CI/CD Pipeline
+
+```yaml
+# GitHub Actions example
+- name: Configure Cyrus GitHub Auth
+  run: |
+    curl -X POST http://cyrus-server:3456/github-token \
+      -H "Content-Type: application/json" \
+      -d "{\"token\": \"${{ secrets.GITHUB_TOKEN }}\"}"
+```
+
+### Docker Compose
+
+```yaml
+services:
+  cyrus:
+    image: cyrus-ai
+    environment:
+      - MANAGE_GH_AUTH=true
+      - CYRUS_SERVER_PORT=3456
+    ports:
+      - "3456:3456"
+```
+
+## Troubleshooting
+
+1. **Endpoint returns 404:** Ensure `MANAGE_GH_AUTH=true` is set when starting Cyrus
+2. **Authentication fails:** Verify the GitHub token has appropriate permissions
+3. **Connection refused:** Check that the server is running and the port is correct

--- a/test-github-token-endpoint.js
+++ b/test-github-token-endpoint.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for GitHub token endpoint
+ * 
+ * Usage:
+ * 1. Start the CLI with MANAGE_GH_AUTH=true:
+ *    MANAGE_GH_AUTH=true pnpm start
+ * 
+ * 2. In another terminal, run this test:
+ *    node test-github-token-endpoint.js <github-token>
+ */
+
+const http = require('http');
+
+const token = process.argv[2];
+const port = process.env.CYRUS_SERVER_PORT || 3456;
+
+if (!token) {
+  console.error('Usage: node test-github-token-endpoint.js <github-token>');
+  process.exit(1);
+}
+
+const data = JSON.stringify({ token });
+
+const options = {
+  hostname: 'localhost',
+  port: port,
+  path: '/github-token',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': data.length
+  }
+};
+
+console.log(`Sending GitHub token to http://localhost:${port}/github-token...`);
+
+const req = http.request(options, res => {
+  let responseData = '';
+
+  res.on('data', chunk => {
+    responseData += chunk;
+  });
+
+  res.on('end', () => {
+    console.log(`Response status: ${res.statusCode}`);
+    console.log('Response:', responseData);
+    
+    if (res.statusCode === 200) {
+      console.log('✅ GitHub token endpoint test successful!');
+    } else {
+      console.log('❌ GitHub token endpoint test failed');
+    }
+  });
+});
+
+req.on('error', error => {
+  console.error('Error:', error);
+});
+
+req.write(data);
+req.end();


### PR DESCRIPTION
## Summary
This PR implements a new endpoint for programmatically updating GitHub CLI authentication credentials in the Cyrus CLI process.

## Changes
- Added  endpoint to SharedApplicationServer that accepts POST requests with GitHub tokens
- Endpoint is only enabled when `MANAGE_GH_AUTH` environment variable is set to `true`
- Automatically updates `gh` CLI authentication credentials using the provided token
- Added comprehensive error handling, logging, and JSON response formatting

## Testing
- Built all packages successfully
- All existing tests pass
- Included test script: `test-github-token-endpoint.js`

## Documentation
- Updated CHANGELOG.md with feature details
- Created comprehensive documentation at `docs/github-token-endpoint.md`

## Usage
1. Start the CLI with the environment variable:
   ```bash
   MANAGE_GH_AUTH=true cyrus start
   ```

2. Send a POST request to update GitHub credentials:
   ```bash
   curl -X POST http://localhost:3456/github-token \
     -H "Content-Type: application/json" \
     -d '{"token": "ghp_YOUR_GITHUB_TOKEN"}'
   ```

## Security Considerations
- Endpoint is **disabled by default** for security
- Only activates with explicit environment variable
- Server listens on localhost by default
- Includes proper error handling and validation

Closes CYPACK-63