### PR TITLE
Update @anthropic-ai/claude-code to 1.0.111 and @anthropic-ai/sdk to 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-code from 1.0.95 to 1.0.111 ([changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#10111))
+- Updated @anthropic-ai/sdk from 0.60.0 to 0.62.0
+
 ## [0.1.47] - 2025-01-09
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.95",
-		"@anthropic-ai/sdk": "^0.60.0",
+		"@anthropic-ai/claude-code": "1.0.111",
+		"@anthropic-ai/sdk": "^0.62.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",
 		"zod": "^3.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,11 +99,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.95
-        version: 1.0.95
+        specifier: 1.0.111
+        version: 1.0.111
       '@anthropic-ai/sdk':
-        specifier: ^0.60.0
-        version: 0.60.0
+        specifier: ^0.62.0
+        version: 0.62.0
       '@linear/sdk':
         specifier: ^58.1.0
         version: 58.1.0(encoding@0.1.13)
@@ -223,13 +223,13 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.95':
-    resolution: {integrity: sha512-VLwfezJ8vnNpkdUdyMORQ1JXx/C7GFd8MLiJTXXThvMTxhNEr8IhAY/bExNrtdkWx2+aipGocRLgNZrUon9HMw==}
+  '@anthropic-ai/claude-code@1.0.111':
+    resolution: {integrity: sha512-1aALYgO8JyGtRdsFskB3uZiAUKbx8u2YcGoa55ZGwsczTBBVIy/+jsuOi3bAubqlBzi5/8gfFBwYK5QuA621MA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@anthropic-ai/sdk@0.60.0':
-    resolution: {integrity: sha512-9zu/TXaUy8BZhXedDtt1wT3H4LOlpKDO1/ftiFpeR3N1PCr3KJFKkxxlQWWt1NNp08xSwUNJ3JNY8yhl8av6eQ==}
+  '@anthropic-ai/sdk@0.62.0':
+    resolution: {integrity: sha512-gT2VFKX0gSp7KJNlav/vzRFjJOPYDZxCJRx7MYUc+fqURc5aS6OI/UJeD2KytJkjsIWv0OOwH1ePc1S5QE2GZw==}
     hasBin: true
 
   '@babel/helper-string-parser@7.27.1':
@@ -2409,7 +2409,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.95':
+  '@anthropic-ai/claude-code@1.0.111':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -2418,7 +2418,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.60.0': {}
+  '@anthropic-ai/sdk@0.62.0': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 


### PR DESCRIPTION
## Summary

- Updated @anthropic-ai/claude-code from 1.0.95 to 1.0.111
- Updated @anthropic-ai/sdk from 0.60.0 to 0.62.0

## Changes Made

- Updated package versions in packages/claude-runner/package.json
- Updated dependencies with pnpm install
- Added changelog entries with link to Claude Code changelog

## Test Plan

- [x] All tests pass (66/66)
- [x] TypeScript compilation clean
- [x] Build succeeds
- [x] Linting passes

This update brings the latest improvements and bug fixes from Anthropic's packages.

🤖 Generated with [Claude Code](https://claude.ai/code)