### PR TITLE
Update @anthropic-ai/claude-code to v1.0.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.95 to v1.0.112 for latest Claude Code improvements. See [Claude Code v1.0.112 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#10112)
+- Updated @anthropic-ai/claude-code from v1.0.95 to v1.0.117 for latest Claude Code improvements. See [Claude Code v1.0.117 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#10117)
 - Updated @anthropic-ai/sdk from v0.60.0 to v0.62.0 for latest Anthropic SDK improvements
 
 ## [0.1.48] - 2025-01-11

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.112",
+		"@anthropic-ai/claude-code": "1.0.117",
 		"@anthropic-ai/sdk": "^0.62.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 1.0.112
-        version: 1.0.112
+        specifier: 1.0.117
+        version: 1.0.117
       '@anthropic-ai/sdk':
         specifier: ^0.62.0
         version: 0.62.0
@@ -223,8 +223,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.112':
-    resolution: {integrity: sha512-UMGxS1iLA8RlrDGpSzMfnJpVHXxcL7AdD8kQfqFy/hAFqwyKpoJPHGBwXt5KjuVDwcWwkpXc3tXDVt//4z6icg==}
+  '@anthropic-ai/claude-code@1.0.117':
+    resolution: {integrity: sha512-ZSBFpwPqMZJZq9//BYSW0MLGQY0svAtncPe2EVxohO87Gym6Dqi+IRSVZkWSwF07gmzZH3luqrepX3q33l7T+Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2409,7 +2409,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.112':
+  '@anthropic-ai/claude-code@1.0.117':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.112 to v1.0.117 (latest version)
- @anthropic-ai/sdk is already on the latest version (v0.62.0)  
- Updated changelog with version information and link to Claude Code changelog

## Test plan
- [x] All package tests pass (66/66 tests in claude-runner)
- [x] TypeScript compilation succeeds
- [x] Dependencies properly installed and resolved

🤖 Generated with [Claude Code](https://claude.ai/code)