### PR TITLE
Update @anthropic-ai/claude-code and @anthropic-ai/sdk to latest versions

### DIFF
--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,11 +16,11 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.112",
-		"@anthropic-ai/sdk": "^0.62.0",
+		"@anthropic-ai/claude-code": "1.0.118",
+		"@anthropic-ai/sdk": "^0.63.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",
-		"zod": "^3.23.0"
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-code from v1.0.112 to v1.0.118 
- Updated @anthropic-ai/sdk from v0.62.0 to v0.63.0
- Updated zod from v3.23.0 to v3.23.8 (stayed on v3 for claude-code compatibility)

## Details
The packages were already mostly up-to-date, with claude-code being 6 versions behind and SDK being 1 version behind. Both packages have been successfully updated to their latest versions.

**Zod Compatibility Note**: The new SDK v0.63.0 requires zod v4 as a peer dependency, but claude-code v1.0.118 is only compatible with zod v3. Using zod v3.23.8 results in a peer dependency warning but maintains full functionality.

## Test Results
✅ All 66 tests pass  
✅ Build completes successfully  
✅ TypeScript compilation successful  

## Changelog References
- [Claude Code v1.0.118 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#10118)

🤖 Generated with [Claude Code](https://claude.ai/code)