### PR TITLE
Migrate from Claude Code SDK to Claude Agent SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated @anthropic-ai/claude-code from v1.0.112 to v1.0.128 for latest Claude Code improvements. See [Claude Code v1.0.128 changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#10128)
+- **Migrated from Claude Code SDK to Claude Agent SDK**: Replaced `@anthropic-ai/claude-code` v1.0.128 with `@anthropic-ai/claude-agent-sdk` v0.1.0
+  - Updated all imports and type references to use the new package name
+  - Handled breaking change: SDK no longer uses Claude Code's system prompt by default - now explicitly requests Claude Code preset to maintain backward compatibility
+  - No changes needed for settings sources as the codebase doesn't rely on automatic settings file loading
 - Updated @anthropic-ai/sdk from v0.62.0 to v0.64.0 for latest Anthropic SDK improvements
 
 ## [0.1.48] - 2025-01-11

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-code": "1.0.128",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.0",
 		"@anthropic-ai/sdk": "^0.64.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -11,7 +11,7 @@ import {
 	query,
 	type SDKMessage,
 	type SDKUserMessage,
-} from "@anthropic-ai/claude-code";
+} from "@anthropic-ai/claude-agent-sdk";
 
 // AbortError is no longer exported in v1.0.95, so we define it locally
 export class AbortError extends Error {
@@ -342,14 +342,17 @@ export class ClaudeRunner extends EventEmitter {
 					model: this.config.model || "opus",
 					fallbackModel: this.config.fallbackModel || "sonnet",
 					abortController: this.abortController,
+					// Use Claude Code preset by default to maintain backward compatibility
+					// This can be overridden if systemPrompt is explicitly provided
+					systemPrompt: this.config.systemPrompt || {
+						type: "preset",
+						preset: "claude_code",
+					},
 					...(this.config.workingDirectory && {
 						cwd: this.config.workingDirectory,
 					}),
 					...(this.config.allowedDirectories && {
 						allowedDirectories: this.config.allowedDirectories,
-					}),
-					...(this.config.systemPrompt && {
-						customSystemPrompt: this.config.systemPrompt,
 					}),
 					...(this.config.appendSystemPrompt && {
 						appendSystemPrompt: this.config.appendSystemPrompt,

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -5,7 +5,7 @@ export type {
 	HookInput,
 	HookJSONOutput,
 	PostToolUseHookInput,
-} from "@anthropic-ai/claude-code";
+} from "@anthropic-ai/claude-agent-sdk";
 export { AbortError, ClaudeRunner, StreamingPrompt } from "./ClaudeRunner.js";
 export {
 	availableTools,

--- a/packages/claude-runner/src/tools/cyrus-tools/index.ts
+++ b/packages/claude-runner/src/tools/cyrus-tools/index.ts
@@ -1,5 +1,5 @@
 import { basename, extname } from "node:path";
-import { createSdkMcpServer, tool } from "@anthropic-ai/claude-code";
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { LinearClient } from "@linear/sdk";
 import fs from "fs-extra";
 import { z } from "zod";

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -7,7 +7,7 @@ import type {
 	SDKResultMessage,
 	SDKSystemMessage,
 	SDKUserMessage,
-} from "@anthropic-ai/claude-code";
+} from "@anthropic-ai/claude-agent-sdk";
 
 export interface ClaudeRunnerConfig {
 	workingDirectory?: string;
@@ -58,7 +58,7 @@ export type {
 	SDKResultMessage,
 	SDKSystemMessage,
 	SDKUserMessage,
-} from "@anthropic-ai/claude-code";
+} from "@anthropic-ai/claude-agent-sdk";
 // Re-export Anthropic API message types
 export type {
 	Message as APIAssistantMessage,

--- a/packages/claude-runner/test-scripts/minimal-async-test.js
+++ b/packages/claude-runner/test-scripts/minimal-async-test.js
@@ -4,7 +4,7 @@
  * Minimal test to check if AsyncIterable implementation is correct
  */
 
-import { query } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 
 // Test 1: Simple async generator (this should work)
 async function* simpleAsyncGenerator() {

--- a/packages/claude-runner/test-scripts/test-direct-sdk.js
+++ b/packages/claude-runner/test-scripts/test-direct-sdk.js
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { query } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 
 async function main() {
 	try {

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the Claude SDK
-vi.mock("@anthropic-ai/claude-code", () => ({
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 	query: vi.fn(),
 }));
 
@@ -21,7 +21,7 @@ vi.mock("os", () => ({
 	homedir: vi.fn(() => "/mock/home"),
 }));
 
-import { query } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import { AbortError, ClaudeRunner } from "../src/ClaudeRunner";
 import type { ClaudeRunnerConfig, SDKMessage } from "../src/types";
 
@@ -125,6 +125,7 @@ describe("ClaudeRunner", () => {
 					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
+					systemPrompt: { type: "preset", preset: "claude_code" },
 				},
 			});
 		});
@@ -153,6 +154,7 @@ describe("ClaudeRunner", () => {
 					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
+					systemPrompt: { type: "preset", preset: "claude_code" },
 				},
 			});
 		});
@@ -181,7 +183,7 @@ describe("ClaudeRunner", () => {
 					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
-					customSystemPrompt: "You are a helpful assistant",
+					systemPrompt: "You are a helpful assistant",
 				},
 			});
 		});

--- a/packages/claude-runner/test/disallowed-tools.test.ts
+++ b/packages/claude-runner/test/disallowed-tools.test.ts
@@ -1,10 +1,10 @@
-import * as claudeCode from "@anthropic-ai/claude-code";
+import * as claudeCode from "@anthropic-ai/claude-agent-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ClaudeRunner } from "../src/ClaudeRunner";
 import type { ClaudeRunnerConfig } from "../src/types";
 
-// Mock the query function from @anthropic-ai/claude-code
-vi.mock("@anthropic-ai/claude-code", () => ({
+// Mock the query function from @anthropic-ai/claude-agent-sdk
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 	query: vi.fn(),
 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,9 @@ importers:
 
   packages/claude-runner:
     dependencies:
-      '@anthropic-ai/claude-code':
-        specifier: 1.0.128
-        version: 1.0.128
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@anthropic-ai/sdk':
         specifier: ^0.64.0
         version: 0.64.0(zod@3.25.75)
@@ -229,10 +229,9 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-code@1.0.128':
-    resolution: {integrity: sha512-uUg5cFMJfeQetQzFw76Vpbro6DAXst2Lpu8aoZWRFSoQVYu5ZSAnbBoxaWmW/IgnHSqIIvtMwzCoqmcA9j9rNQ==}
+  '@anthropic-ai/claude-agent-sdk@0.1.0':
+    resolution: {integrity: sha512-D2Oko7WCMQHH9TOexBVbW/31LqyAaOpVgHIjbzcTjOTmWO5Stms1SwEuWpB3SAEIrHbOtqWEqZSZz3ZZ/JmMhg==}
     engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@anthropic-ai/sdk@0.64.0':
     resolution: {integrity: sha512-K2JaWzPiIA4/ghD7bMlyM/4JvM3k7sKdHFmXWAKqqpVL9ee1H7pguRqygxTgK+SrzK86ZMf1x3L+RK4IrDtxjA==}
@@ -2559,7 +2558,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-code@1.0.128':
+  '@anthropic-ai/claude-agent-sdk@0.1.0':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Migrated from `@anthropic-ai/claude-code` v1.0.128 to `@anthropic-ai/claude-agent-sdk` v0.1.0
- Updated all imports and type references across the claude-runner package
- Handled breaking changes to maintain backward compatibility

## Changes Made

### Package Updates
- Replaced `@anthropic-ai/claude-code` dependency with `@anthropic-ai/claude-agent-sdk` in `packages/claude-runner/package.json`
- Updated all TypeScript imports from the old package to the new one

### Breaking Changes Handled

#### 1. System Prompt Configuration
- **Issue**: The new SDK no longer uses Claude Code's system prompt by default
- **Solution**: Now explicitly request the Claude Code preset when no custom systemPrompt is provided
- **Implementation**: Uses `{ type: 'preset', preset: 'claude_code' }` to maintain backward compatibility

#### 2. Settings Sources
- **Issue**: The new SDK doesn't automatically load filesystem settings
- **Solution**: No changes needed - the codebase already doesn't rely on automatic settings file loading

### Test Updates
- Updated test expectations to use `systemPrompt` instead of `customSystemPrompt`
- Added default Claude Code preset expectations in tests where no system prompt is provided
- All tests passing successfully

## Verification Completed
✅ Installed and verified the new SDK package structure in node_modules
✅ Confirmed all types and exports are compatible with our usage
✅ `tool` and `createSdkMcpServer` signatures remain unchanged from our perspective
✅ All package tests passing (66 tests across 5 test files)
✅ Build successful
✅ Linting passing
✅ Type checking passing

## Migration Guide Reference
This migration follows the official guide: https://docs.claude.com/en/docs/claude-code/sdk/migration-guide

## Impact
This is a required migration as the Claude Code SDK has been renamed to better reflect its broader capabilities beyond just coding tasks. The migration maintains full backward compatibility with existing functionality.

Closes #102

🤖 Generated with [Claude Code](https://claude.ai/code)