### PR TITLE
Release v0.1.49 - Migrate to Claude Agent SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.49] - 2025-09-29
+
 ### Changed
 - **Migrated from Claude Code SDK to Claude Agent SDK**: Replaced `@anthropic-ai/claude-code` v1.0.128 with `@anthropic-ai/claude-agent-sdk` v0.1.0
   - Updated all imports and type references to use the new package name
   - Handled breaking change: SDK no longer uses Claude Code's system prompt by default - now explicitly requests Claude Code preset to maintain backward compatibility
   - No changes needed for settings sources as the codebase doesn't rely on automatic settings file loading
 - Updated @anthropic-ai/sdk from v0.62.0 to v0.64.0 for latest Anthropic SDK improvements
+
+### Packages
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.25
+
+#### cyrus-core
+- cyrus-core@0.0.13
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.32
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.49
 
 ## [0.1.48] - 2025-01-11
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.48",
+	"version": "0.1.49",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Released 4 packages to npm with SDK migration changes
- Updated CHANGELOG.md with release notes

## Packages Published
- cyrus-claude-runner@0.0.25
- cyrus-core@0.0.13
- cyrus-edge-worker@0.0.32
- cyrus-ai@0.1.49

## Changes
- Migrated from @anthropic-ai/claude-code v1.0.128 to @anthropic-ai/claude-agent-sdk v0.1.0
- Updated @anthropic-ai/sdk from v0.62.0 to v0.64.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)