### PR TITLE
fix: skip Tool Output wrapper blocks when tool result is empty

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -558,8 +558,10 @@ export class AgentSessionManager {
 									? toolInput
 									: JSON.stringify(toolInput, null, 2);
 
-							// Wrap the tool output in a collapsible block
-							const wrappedResult = `+++Tool Output\n${toolResult.content}\n+++`;
+							// Only wrap the tool output in a collapsible block if it has content
+							const wrappedResult = toolResult.content?.trim()
+								? `+++Tool Output\n${toolResult.content}\n+++`
+								: "";
 
 							content = {
 								type: "action",


### PR DESCRIPTION
## Summary
- Fixed issue where empty tool results were still being wrapped in `+++Tool Output` blocks
- Added check to only wrap tool output when content is non-empty

## Test plan
- [x] Verified the fix doesn't introduce TypeScript errors
- [x] Tested with commands that produce no output (e.g., `rm` command)
- [x] Empty tool results no longer show `+++Tool Output` wrapper blocks

Fixes CYPACK-107

🤖 Generated with [Claude Code](https://claude.com/claude-code)