### PR TITLE
Change default model from opus to sonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Default model changed from opus to sonnet**: The default Claude model is now `sonnet` instead of `opus`
+  - Fallback model changed from `sonnet` to `haiku` for better cost efficiency
+  - Label-based model selection still available - users can add `opus`, `sonnet`, or `haiku` labels to issues to override the default
+  - Affects all new sessions that don't explicitly specify a model in config
+
 ## [0.1.50] - 2025-09-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **Default model changed from opus to sonnet**: The default Claude model is now `sonnet` instead of `opus`
-  - Fallback model changed from `sonnet` to `haiku` for better cost efficiency
+- **Default model changed from opus to sonnet 4.5**: The default Claude model is now `sonnet` instead of `opus`
+  - Fallback model changed from `sonnet` to `haiku`
   - Label-based model selection still available - users can add `opus`, `sonnet`, or `haiku` labels to issues to override the default
   - Affects all new sessions that don't explicitly specify a model in config
 

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -339,8 +339,8 @@ export class ClaudeRunner extends EventEmitter {
 			const queryOptions: Parameters<typeof query>[0] = {
 				prompt: promptForQuery,
 				options: {
-					model: this.config.model || "opus",
-					fallbackModel: this.config.fallbackModel || "sonnet",
+					model: this.config.model || "sonnet",
+					fallbackModel: this.config.fallbackModel || "haiku",
 					abortController: this.abortController,
 					// Use Claude Code preset by default to maintain backward compatibility
 					// This can be overridden if systemPrompt is explicitly provided

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -121,8 +121,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "Hello Claude",
 				options: {
-					model: "opus",
-					fallbackModel: "sonnet",
+					model: "sonnet",
+					fallbackModel: "haiku",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: { type: "preset", preset: "claude_code" },
@@ -150,8 +150,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "test",
 				options: {
-					model: "opus",
-					fallbackModel: "sonnet",
+					model: "sonnet",
+					fallbackModel: "haiku",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: { type: "preset", preset: "claude_code" },
@@ -179,8 +179,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "test",
 				options: {
-					model: "opus",
-					fallbackModel: "sonnet",
+					model: "sonnet",
+					fallbackModel: "haiku",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: "You are a helpful assistant",


### PR DESCRIPTION
## Summary
- Changed default model from `opus` to `sonnet` 
- Changed fallback model from `sonnet` to `haiku`
- Updated tests to reflect new defaults
- Label-based model selection still works - users can add `opus`, `sonnet`, or `haiku` labels to override the default

## Test plan
- [x] Updated unit tests pass
- [x] TypeScript compilation succeeds
- [x] Verified label-based model selection logic is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)