### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.5 and @anthropic-ai/sdk to v0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
   - Fallback model changed from `sonnet` to `haiku`
   - Label-based model selection still available - users can add `opus`, `sonnet`, or `haiku` labels to issues to override the default
   - Affects all new sessions that don't explicitly specify a model in config
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.0 to v0.1.5 for latest Claude Agent SDK improvements
+- Updated @anthropic-ai/sdk from v0.64.0 to v0.65.0 for latest Anthropic SDK improvements
+  - Added support for Claude Sonnet 4.5 and context management features
+  - See [@anthropic-ai/sdk v0.65.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.64.0...sdk-v0.65.0)
 
 ## [0.1.50] - 2025-09-30
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.0",
-		"@anthropic-ai/sdk": "^0.64.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.5",
+		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^58.1.0",
 		"fs-extra": "^11.3.0",
 		"zod": "^3.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.5
+        version: 0.1.5
       '@anthropic-ai/sdk':
-        specifier: ^0.64.0
-        version: 0.64.0(zod@3.25.75)
+        specifier: ^0.65.0
+        version: 0.65.0(zod@3.25.75)
       '@linear/sdk':
         specifier: ^58.1.0
         version: 58.1.0(encoding@0.1.13)
@@ -229,12 +229,12 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.0':
-    resolution: {integrity: sha512-D2Oko7WCMQHH9TOexBVbW/31LqyAaOpVgHIjbzcTjOTmWO5Stms1SwEuWpB3SAEIrHbOtqWEqZSZz3ZZ/JmMhg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.5':
+    resolution: {integrity: sha512-w6S3FTYmb72sU0RBcf7Sly22sBVXY0BpsF7PWzdamE8cuJiiA4agjhP6WLCJvybeInqP2k1VOWIfBsVsTXOHlQ==}
     engines: {node: '>=18.0.0'}
 
-  '@anthropic-ai/sdk@0.64.0':
-    resolution: {integrity: sha512-K2JaWzPiIA4/ghD7bMlyM/4JvM3k7sKdHFmXWAKqqpVL9ee1H7pguRqygxTgK+SrzK86ZMf1x3L+RK4IrDtxjA==}
+  '@anthropic-ai/sdk@0.65.0':
+    resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2554,7 +2554,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.0':
+  '@anthropic-ai/claude-agent-sdk@0.1.5':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -2563,7 +2563,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.64.0(zod@3.25.75)':
+  '@anthropic-ai/sdk@0.65.0(zod@3.25.75)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.0 to v0.1.5
- Updated `@anthropic-ai/sdk` from v0.64.0 to v0.65.0
- Updated CHANGELOG.md with SDK version updates

## Changes
- `packages/claude-runner/package.json`: Bumped both Anthropic dependencies to latest versions
- `CHANGELOG.md`: Added changelog entries for the SDK updates

## SDK Updates
The `@anthropic-ai/sdk` v0.65.0 includes:
- Support for Claude Sonnet 4.5
- Context management features

See the [full changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.64.0...sdk-v0.65.0) for details.

## Related Issue
Closes CYPACK-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)