### PR TITLE
Add changelog entry for settingSources fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Restored file-based settings loading**: Fixed regression from claude-agent-sdk update where CLAUDE.md files, settings files, and custom slash commands were not being loaded
+  - Added explicit `settingSources: ["user", "project", "local"]` configuration to ClaudeRunner
+  - This restores backwards compatibility with existing user configurations
+  - See [Claude Code SDK Migration Guide](https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default)
+
 ### Changed
 - **Default model changed from opus to sonnet 4.5**: The default Claude model is now `sonnet` instead of `opus`
   - Fallback model changed from `sonnet` to `haiku`


### PR DESCRIPTION
## Summary

Adds a changelog entry documenting the fix for the file-based settings loading regression.

## Background

After updating to claude-agent-sdk v0.1.5, CLAUDE.md files, settings files, and custom slash commands were not being loaded due to the SDK no longer loading file-based settings sources by default. This caused unexpected behavior for users who relied on these configuration files.

## Changes

- Added a "Fixed" section to the Unreleased changelog
- Documented the settingSources configuration fix
- Linked to the Claude Code SDK migration guide for reference

## Related

- Fixes the regression introduced by the claude-agent-sdk update
- Related to PR #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)