### PR TITLE
Release v0.1.51 & v0.1.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.52] - 2025-10-04
+
+### Changed
+- Version bump for all packages to ensure proper dependency resolution
+
+### Packages
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.27
+
+#### cyrus-core
+- cyrus-core@0.0.15
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.34
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.20
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.52
+
 ## [0.1.51] - 2025-10-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.51] - 2025-10-04
+
 ### Fixed
 - **Restored file-based settings loading**: Fixed regression from claude-agent-sdk update where CLAUDE.md files, settings files, and custom slash commands were not being loaded
   - Added explicit `settingSources: ["user", "project", "local"]` configuration to ClaudeRunner
@@ -19,6 +21,23 @@ All notable changes to this project will be documented in this file.
 - Updated @anthropic-ai/sdk from v0.64.0 to v0.65.0 for latest Anthropic SDK improvements
   - Added support for Claude Sonnet 4.5 and context management features
   - See [@anthropic-ai/sdk v0.65.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.64.0...sdk-v0.65.0)
+
+### Packages
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.26
+
+#### cyrus-core
+- cyrus-core@0.0.14
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.33
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.19
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.51
 
 ## [0.1.50] - 2025-09-30
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.50",
+	"version": "0.1.51",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.51",
+	"version": "0.1.52",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.0.14",
+	"version": "0.0.15",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.33",
+	"version": "0.0.34",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/ndjson-client/package.json
+++ b/packages/ndjson-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ndjson-client",
-	"version": "0.0.19",
+	"version": "0.0.20",
 	"description": "NDJSON streaming client for proxy communication",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- **v0.1.51**: Updated CHANGELOG.md and published CLI with dependency fixes
- **v0.1.52**: Bumped and published ALL packages to ensure proper dependency resolution

## v0.1.51 Changes
- Restored file-based settings loading (fixed regression from claude-agent-sdk update)
- Changed default model from opus to sonnet 4.5
- Updated dependencies

## v0.1.52 Published Packages
- cyrus-claude-runner@0.0.27
- cyrus-core@0.0.15
- cyrus-edge-worker@0.0.34
- cyrus-ndjson-client@0.0.20
- cyrus-ai@0.1.52

Both releases have been successfully published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)