### PR TITLE
Add Linear agent guidance injection to prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Agent guidance injection**: Cyrus now automatically receives and includes workspace-level and team-specific agent guidance from Linear in all prompts. This allows you to configure agent behavior directly in Linear's settings, with team-specific guidance taking precedence over workspace-level guidance.
+
+### Changed
+- Updated @linear/sdk from v58.1.0 to v60.0.0 to support agent guidance feature
+
 ## [0.1.52] - 2025-10-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **Agent guidance injection**: Cyrus now automatically receives and includes workspace-level and team-specific agent guidance from Linear in all prompts. This allows you to configure agent behavior directly in Linear's settings, with team-specific guidance taking precedence over workspace-level guidance.
+- **Agent guidance injection**: Cyrus now automatically receives and includes both workspace-level and team-specific agent guidance from Linear in all prompts. When both types of guidance are configured, both are included in the prompt, with team-specific guidance taking precedence as specified by Linear's guidance system.
 
 ### Changed
 - Updated @linear/sdk from v58.1.0 to v60.0.0 to support agent guidance feature

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"typescript": "^5.3.3"
 	},
 	"dependencies": {
-		"@linear/sdk": "58.1.0"
+		"@linear/sdk": "60.0.0"
 	},
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx,json,md}": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,9 +36,13 @@ export type {
 	LinearWebhookAgentSession,
 	LinearWebhookComment,
 	LinearWebhookCreator,
+	LinearWebhookGuidanceRule,
 	LinearWebhookIssue,
 	LinearWebhookNotification,
+	LinearWebhookOrganizationOrigin,
 	LinearWebhookTeam,
+	LinearWebhookTeamOrigin,
+	LinearWebhookTeamWithParent,
 } from "./webhook-types.js";
 export {
 	isAgentSessionCreatedWebhook,

--- a/packages/core/src/webhook-types.ts
+++ b/packages/core/src/webhook-types.ts
@@ -185,6 +185,40 @@ export interface LinearWebhookCreator {
 }
 
 /**
+ * Team properties including parent information for guidance rules
+ */
+export interface LinearWebhookTeamWithParent {
+	displayName: string;
+	id: string;
+	key: string;
+	name: string;
+	parentId?: string;
+}
+
+/**
+ * Organization origin for guidance rules
+ */
+export interface LinearWebhookOrganizationOrigin {
+	type: "Organization";
+}
+
+/**
+ * Team origin for guidance rules
+ */
+export interface LinearWebhookTeamOrigin {
+	type: "Team";
+	team: LinearWebhookTeamWithParent;
+}
+
+/**
+ * Agent guidance rule metadata
+ */
+export interface LinearWebhookGuidanceRule {
+	body: string;
+	origin?: LinearWebhookOrganizationOrigin | LinearWebhookTeamOrigin;
+}
+
+/**
  * Agent Session data from webhooks
  */
 export interface LinearWebhookAgentSession {
@@ -248,6 +282,7 @@ export interface LinearAgentSessionCreatedWebhook {
 	oauthClientId: string;
 	appUserId: string;
 	agentSession: LinearWebhookAgentSession;
+	guidance?: LinearWebhookGuidanceRule[];
 	webhookTimestamp: string;
 	webhookId: string;
 }
@@ -264,6 +299,7 @@ export interface LinearAgentSessionPromptedWebhook {
 	appUserId: string;
 	agentSession: LinearWebhookAgentSession;
 	agentActivity: LinearWebhookAgentActivity;
+	guidance?: LinearWebhookGuidanceRule[];
 	webhookTimestamp: string;
 	webhookId: string;
 }

--- a/packages/core/src/webhook-types.ts
+++ b/packages/core/src/webhook-types.ts
@@ -3,6 +3,8 @@
  * These are the exact structures Linear sends in webhooks
  */
 
+import type { LinearDocument } from "@linear/sdk";
+
 /**
  * Linear team data from webhooks
  */
@@ -185,38 +187,15 @@ export interface LinearWebhookCreator {
 }
 
 /**
- * Team properties including parent information for guidance rules
+ * Agent guidance types - re-exported from @linear/sdk for convenience
  */
-export interface LinearWebhookTeamWithParent {
-	displayName: string;
-	id: string;
-	key: string;
-	name: string;
-	parentId?: string;
-}
-
-/**
- * Organization origin for guidance rules
- */
-export interface LinearWebhookOrganizationOrigin {
-	type: "Organization";
-}
-
-/**
- * Team origin for guidance rules
- */
-export interface LinearWebhookTeamOrigin {
-	type: "Team";
-	team: LinearWebhookTeamWithParent;
-}
-
-/**
- * Agent guidance rule metadata
- */
-export interface LinearWebhookGuidanceRule {
-	body: string;
-	origin?: LinearWebhookOrganizationOrigin | LinearWebhookTeamOrigin;
-}
+export type LinearWebhookGuidanceRule =
+	LinearDocument.GuidanceRuleWebhookPayload;
+export type LinearWebhookOrganizationOrigin =
+	LinearDocument.OrganizationOriginWebhookPayload;
+export type LinearWebhookTeamOrigin = LinearDocument.TeamOriginWebhookPayload;
+export type LinearWebhookTeamWithParent =
+	LinearDocument.TeamWithParentWebhookPayload;
 
 /**
  * Agent Session data from webhooks

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -837,11 +837,14 @@ export class EdgeWorker extends EventEmitter {
 				`[EdgeWorker] Agent guidance received: ${guidance.length} rule(s)`,
 			);
 			for (const rule of guidance) {
-				const origin = rule.origin
-					? rule.origin.type === "Team"
-						? `Team: ${rule.origin.team.displayName}`
-						: "Organization"
-					: "Unknown";
+				let origin = "Unknown";
+				if (rule.origin) {
+					if (rule.origin.__typename === "TeamOriginWebhookPayload") {
+						origin = `Team: ${rule.origin.team.displayName}`;
+					} else {
+						origin = "Organization";
+					}
+				}
 				console.log(
 					`[EdgeWorker]   - ${origin}: ${rule.body.substring(0, 100)}...`,
 				);
@@ -1573,11 +1576,14 @@ export class EdgeWorker extends EventEmitter {
 				prompt +=
 					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
-					const origin = rule.origin
-						? rule.origin.type === "Team"
-							? `Team (${rule.origin.team.displayName})`
-							: "Organization"
-						: "Global";
+					let origin = "Global";
+					if (rule.origin) {
+						if (rule.origin.__typename === "TeamOriginWebhookPayload") {
+							origin = `Team (${rule.origin.team.displayName})`;
+						} else {
+							origin = "Organization";
+						}
+					}
 					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
 				}
 				prompt += "\n</agent_guidance>";
@@ -1647,11 +1653,14 @@ IMPORTANT: You were specifically mentioned in the comment above. Focus on addres
 				prompt +=
 					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
-					const origin = rule.origin
-						? rule.origin.type === "Team"
-							? `Team (${rule.origin.team.displayName})`
-							: "Organization"
-						: "Global";
+					let origin = "Global";
+					if (rule.origin) {
+						if (rule.origin.__typename === "TeamOriginWebhookPayload") {
+							origin = `Team (${rule.origin.team.displayName})`;
+						} else {
+							origin = "Organization";
+						}
+					}
 					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
 				}
 				prompt += "\n</agent_guidance>";
@@ -2028,11 +2037,14 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
 				prompt +=
 					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
-					const origin = rule.origin
-						? rule.origin.type === "Team"
-							? `Team (${rule.origin.team.displayName})`
-							: "Organization"
-						: "Global";
+					let origin = "Global";
+					if (rule.origin) {
+						if (rule.origin.__typename === "TeamOriginWebhookPayload") {
+							origin = `Team (${rule.origin.team.displayName})`;
+						} else {
+							origin = "Organization";
+						}
+					}
 					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
 				}
 				prompt += "\n</agent_guidance>";

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -35,6 +35,7 @@ import type {
 	LinearWebhook,
 	LinearWebhookAgentSession,
 	LinearWebhookComment,
+	LinearWebhookGuidanceRule,
 	LinearWebhookIssue,
 	SerializableEdgeWorkerState,
 	SerializedCyrusAgentSession,
@@ -826,9 +827,26 @@ export class EdgeWorker extends EventEmitter {
 		console.log(
 			`[EdgeWorker] Handling agent session created: ${webhook.agentSession.issue.identifier}`,
 		);
-		const { agentSession } = webhook;
+		const { agentSession, guidance } = webhook;
 		const linearAgentActivitySessionId = agentSession.id;
 		const { issue } = agentSession;
+
+		// Log guidance if present
+		if (guidance && guidance.length > 0) {
+			console.log(
+				`[EdgeWorker] Agent guidance received: ${guidance.length} rule(s)`,
+			);
+			for (const rule of guidance) {
+				const origin = rule.origin
+					? rule.origin.type === "Team"
+						? `Team: ${rule.origin.team.displayName}`
+						: "Organization"
+					: "Unknown";
+				console.log(
+					`[EdgeWorker]   - ${origin}: ${rule.body.substring(0, 100)}...`,
+				);
+			}
+		}
 
 		const commentBody = agentSession.comment?.body;
 		// HACK: This is required since the comment body is always populated, thus there is no other way to differentiate between the two trigger events
@@ -966,24 +984,28 @@ export class EdgeWorker extends EventEmitter {
 							fullIssue,
 							repository,
 							attachmentResult.manifest,
+							guidance,
 						)
 					: isMentionTriggered
 						? await this.buildMentionPrompt(
 								fullIssue,
 								agentSession,
 								attachmentResult.manifest,
+								guidance,
 							)
 						: systemPrompt
 							? await this.buildLabelBasedPrompt(
 									fullIssue,
 									repository,
 									attachmentResult.manifest,
+									guidance,
 								)
 							: await this.buildPromptV2(
 									fullIssue,
 									repository,
 									undefined,
 									attachmentResult.manifest,
+									guidance,
 								);
 
 			const { prompt, version: userPromptVersion } = promptResult;
@@ -1408,12 +1430,15 @@ export class EdgeWorker extends EventEmitter {
 	 * Build simplified prompt for label-based workflows
 	 * @param issue Full Linear issue
 	 * @param repository Repository configuration
+	 * @param attachmentManifest Optional attachment manifest
+	 * @param guidance Optional agent guidance rules from Linear
 	 * @returns Formatted prompt string
 	 */
 	private async buildLabelBasedPrompt(
 		issue: LinearIssue,
 		repository: RepositoryConfig,
 		attachmentManifest: string = "",
+		guidance?: LinearWebhookGuidanceRule[],
 	): Promise<{ prompt: string; version?: string }> {
 		console.log(
 			`[EdgeWorker] buildLabelBasedPrompt called for issue ${issue.identifier}`,
@@ -1541,6 +1566,20 @@ export class EdgeWorker extends EventEmitter {
 				.replace(/{{workspace_teams}}/g, workspaceTeams)
 				.replace(/{{workspace_labels}}/g, workspaceLabels);
 
+			// Append agent guidance if present
+			if (guidance && guidance.length > 0) {
+				prompt += "\n\n<agent_guidance>\n";
+				for (const rule of guidance) {
+					const origin = rule.origin
+						? rule.origin.type === "Team"
+							? `Team (${rule.origin.team.displayName})`
+							: "Organization"
+						: "Global";
+					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
+				}
+				prompt += "\n</agent_guidance>";
+			}
+
 			if (attachmentManifest) {
 				console.log(
 					`[EdgeWorker] Adding attachment manifest to label-based prompt, length: ${attachmentManifest.length} characters`,
@@ -1565,12 +1604,14 @@ export class EdgeWorker extends EventEmitter {
 	 * @param repository Repository configuration
 	 * @param agentSession The agent session containing the mention
 	 * @param attachmentManifest Optional attachment manifest to append
+	 * @param guidance Optional agent guidance rules from Linear
 	 * @returns The constructed prompt and optional version tag
 	 */
 	private async buildMentionPrompt(
 		issue: LinearIssue,
 		agentSession: LinearWebhookAgentSession,
 		attachmentManifest: string = "",
+		guidance?: LinearWebhookGuidanceRule[],
 	): Promise<{ prompt: string; version?: string }> {
 		try {
 			console.log(
@@ -1595,6 +1636,20 @@ ${mentionContent}
 </mention_request>
 
 IMPORTANT: You were specifically mentioned in the comment above. Focus on addressing the specific question or request in the mention. You can use the Linear MCP tools to fetch additional context about the issue if needed.`;
+
+			// Append agent guidance if present
+			if (guidance && guidance.length > 0) {
+				prompt += "\n\n<agent_guidance>\n";
+				for (const rule of guidance) {
+					const origin = rule.origin
+						? rule.origin.type === "Team"
+							? `Team (${rule.origin.team.displayName})`
+							: "Organization"
+						: "Global";
+					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
+				}
+				prompt += "\n</agent_guidance>";
+			}
 
 			// Append attachment manifest if any
 			if (attachmentManifest) {
@@ -1822,6 +1877,7 @@ ${reply.body}
 	 * @param repository Repository configuration
 	 * @param newComment Optional new comment to focus on (for handleNewRootComment)
 	 * @param attachmentManifest Optional attachment manifest
+	 * @param guidance Optional agent guidance rules from Linear
 	 * @returns Formatted prompt string
 	 */
 	private async buildPromptV2(
@@ -1829,6 +1885,7 @@ ${reply.body}
 		repository: RepositoryConfig,
 		newComment?: LinearWebhookComment,
 		attachmentManifest: string = "",
+		guidance?: LinearWebhookGuidanceRule[],
 	): Promise<{ prompt: string; version?: string }> {
 		console.log(
 			`[EdgeWorker] buildPromptV2 called for issue ${issue.identifier}${newComment ? " with new comment" : ""}`,
@@ -1956,6 +2013,20 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
 			} else {
 				// Remove the new comment section entirely
 				prompt = prompt.replace(/{{#if new_comment}}[\s\S]*?{{\/if}}/g, "");
+			}
+
+			// Append agent guidance if present
+			if (guidance && guidance.length > 0) {
+				prompt += "\n\n<agent_guidance>\n";
+				for (const rule of guidance) {
+					const origin = rule.origin
+						? rule.origin.type === "Team"
+							? `Team (${rule.origin.team.displayName})`
+							: "Organization"
+						: "Global";
+					prompt += `\n## Guidance from ${origin}\n${rule.body}\n`;
+				}
+				prompt += "\n</agent_guidance>";
 			}
 
 			// Append attachment manifest if provided

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1567,8 +1567,11 @@ export class EdgeWorker extends EventEmitter {
 				.replace(/{{workspace_labels}}/g, workspaceLabels);
 
 			// Append agent guidance if present
+			// Note: Linear provides guidance in priority order - team-specific guidance appears
+			// before workspace-level guidance. All guidance rules are included.
 			if (guidance && guidance.length > 0) {
-				prompt += "\n\n<agent_guidance>\n";
+				prompt +=
+					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
 					const origin = rule.origin
 						? rule.origin.type === "Team"
@@ -1638,8 +1641,11 @@ ${mentionContent}
 IMPORTANT: You were specifically mentioned in the comment above. Focus on addressing the specific question or request in the mention. You can use the Linear MCP tools to fetch additional context about the issue if needed.`;
 
 			// Append agent guidance if present
+			// Note: Linear provides guidance in priority order - team-specific guidance appears
+			// before workspace-level guidance. All guidance rules are included.
 			if (guidance && guidance.length > 0) {
-				prompt += "\n\n<agent_guidance>\n";
+				prompt +=
+					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
 					const origin = rule.origin
 						? rule.origin.type === "Team"
@@ -2016,8 +2022,11 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
 			}
 
 			// Append agent guidance if present
+			// Note: Linear provides guidance in priority order - team-specific guidance appears
+			// before workspace-level guidance. All guidance rules are included.
 			if (guidance && guidance.length > 0) {
-				prompt += "\n\n<agent_guidance>\n";
+				prompt +=
+					"\n\n<agent_guidance>\nThe following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.\n";
 				for (const rule of guidance) {
 					const origin = rule.origin
 						? rule.origin.type === "Team"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     dependencies:
       '@linear/sdk':
-        specifier: 58.1.0
-        version: 58.1.0(encoding@0.1.13)
+        specifier: 60.0.0
+        version: 60.0.0(encoding@0.1.13)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.1.3
@@ -817,6 +817,10 @@ packages:
 
   '@linear/sdk@58.1.0':
     resolution: {integrity: sha512-sqzo1j+uZsxeJlMTV2mrBH3yukB/liev7IySmkZil0ka7ic6b4RE9Jk3x+ohw8YgYB52IRR3SPWzhWu96E6W9g==}
+    engines: {node: '>=12.x', yarn: 1.x}
+
+  '@linear/sdk@60.0.0':
+    resolution: {integrity: sha512-6mllj354yC4iJ3euXvijisCQdTIlr77gpUl9Oit8qJYGXegtHZv+RwySdiLfNS6bXQy/Z5e0IYXXNg2sv9UrUQ==}
     engines: {node: '>=12.x', yarn: 1.x}
 
   '@ngrok/ngrok-android-arm64@1.5.1':
@@ -2917,6 +2921,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@linear/sdk@58.1.0(encoding@0.1.13)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
+      graphql: 15.10.1
+      isomorphic-unfetch: 3.1.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  '@linear/sdk@60.0.0(encoding@0.1.13)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.1)
       graphql: 15.10.1


### PR DESCRIPTION
## Summary
Implements automatic injection of Linear's agent guidance (workspace-level and team-specific) into all Cyrus agent prompts. **When both types of guidance are configured, both are included in the prompt**, with team-specific guidance taking precedence as specified by Linear's guidance system.

## Changes
- **Updated @linear/sdk** from v58.1.0 to v60.0.0 to support agent guidance feature
- **Added new webhook types** for agent guidance rules, including:
  - `LinearWebhookGuidanceRule` - the guidance content and origin
  - `LinearWebhookTeamOrigin` - team-specific guidance source
  - `LinearWebhookOrganizationOrigin` - workspace-level guidance source
- **Updated webhook payloads** to include optional `guidance` field in `LinearAgentSessionCreatedWebhook` and `LinearAgentSessionPromptedWebhook`
- **Modified EdgeWorker** to extract guidance from webhooks and log them for visibility
- **Injected guidance into all prompt builders**:
  - `buildMentionPrompt` - for @mention triggers
  - `buildLabelBasedPrompt` - for label-based delegation
  - `buildPromptV2` - for fallback prompts
- **Added detailed logging** to show which guidance rules are being applied
- **Added explanatory comments and prompt headers** to clarify that both workspace and team guidance are included when present

## How It Works
1. When Linear sends an AgentSessionEvent webhook, it now includes an optional `guidance` array
2. Each guidance rule contains:
   - `body` - the markdown-formatted guidance text
   - `origin` - either Organization (workspace-level) or Team (team-specific with team info)
3. Cyrus extracts and logs all guidance rules
4. **All guidance is injected into the agent prompt** inside an `<agent_guidance>` section with a header explaining precedence
5. When both workspace and team guidance exist, both are included with team-specific guidance taking precedence per Linear's specification

## Example Prompt Output
When both workspace and team guidance are present, the prompt includes:

```
<agent_guidance>
The following guidance has been configured for this workspace/team in Linear. Team-specific guidance takes precedence over workspace-level guidance.

## Guidance from Team (Engineering)
Always write unit tests for new features.

## Guidance from Organization
Follow the company coding standards documented in CONTRIBUTING.md
</agent_guidance>
```

## Testing
- ✅ All existing tests pass
- ✅ TypeScript type checking passes
- ✅ Build succeeds

## Related
- Linear Changelog: [Agent Interaction Guidelines and SDK](https://linear.app/changelog/2025-07-30-agent-interaction-guidelines-and-sdk)
- Linear Docs: [Agent Interaction Guidelines](https://linear.app/developers/aig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)