### PR TITLE
Add debug logging for AppUserNotification webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Added debug logging for `AppUserNotification` webhook payloads in EdgeWorker
+
 ## [0.1.53] - 2025-10-04
 
 ### Added

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -463,6 +463,13 @@ export class EdgeWorker extends EventEmitter {
 		webhook: LinearWebhook,
 		repos: RepositoryConfig[],
 	): Promise<void> {
+		// Log AppUserNotification webhook payload
+		if ((webhook as any).type === "AppUserNotification") {
+			console.log(
+				`[EdgeWorker] AppUserNotification webhook payload: ${JSON.stringify(webhook)}`,
+			);
+		}
+
 		// Log verbose webhook info if enabled
 		if (process.env.CYRUS_WEBHOOK_DEBUG === "true") {
 			console.log(


### PR DESCRIPTION
## Summary
- Added console.log statement to log AppUserNotification webhook payloads in EdgeWorker
- Logs JSON stringified payload when webhook type is "AppUserNotification"

## Test plan
- [x] Build successful
- [x] TypeScript type checking passed
- [ ] Test with a live webhook to verify logging output

🤖 Generated with [Claude Code](https://claude.com/claude-code)