### PR TITLE
Replace unofficial Linear MCP with official HTTP-based server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **Automatic MCP config detection**: Cyrus now automatically detects and loads `.mcp.json` files in the repository root. The `.mcp.json` serves as a base configuration that can be extended by explicit `mcpConfigPath` settings, allowing for composable MCP server configurations.
 
+### Changed
+- **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
+
 ### Fixed
 - **Custom instructions now work correctly**: Fixed critical bug where `appendSystemPrompt` was being silently ignored, causing Cyrus to not follow custom instructions or agent guidance. The feature has been fixed to use the correct SDK API (`systemPrompt.append`), making custom prompts and Linear agent guidance work as intended.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
+
 ## [0.1.54] - 2025-10-04
 
 ### Added
 - **Automatic MCP config detection**: Cyrus now automatically detects and loads `.mcp.json` files in the repository root. The `.mcp.json` serves as a base configuration that can be extended by explicit `mcpConfigPath` settings, allowing for composable MCP server configurations.
-
-### Changed
-- **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
 
 ### Fixed
 - **Custom instructions now work correctly**: Fixed critical bug where `appendSystemPrompt` was being silently ignored, causing Cyrus to not follow custom instructions or agent guidance. The feature has been fixed to use the correct SDK API (`systemPrompt.append`), making custom prompts and Linear agent guidance work as intended.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ To test the Linear MCP (Model Context Protocol) integration in the claude-runner
 
 The test script demonstrates:
 - Loading Linear API token from environment variables
-- Configuring the `@tacticlaunch/mcp-linear` MCP server
+- Configuring the official Linear HTTP MCP server
 - Listing available MCP tools
 - Using Linear MCP tools to fetch user info and issues
 - Proper error handling and logging
@@ -218,7 +218,7 @@ The script will show:
 - Current user information
 - Issues in your Linear workspace
 
-This integration is automatically available in all Cyrus sessions - the EdgeWorker automatically configures the Linear MCP server for each repository using its Linear token.
+This integration is automatically available in all Cyrus sessions - the EdgeWorker automatically configures the official Linear MCP server for each repository using its Linear token.
 
 ## Publishing
 

--- a/packages/claude-runner/test-scripts/debug-streaming.js
+++ b/packages/claude-runner/test-scripts/debug-streaming.js
@@ -41,11 +41,10 @@ async function main() {
 		mcpConfigPath: ["/Users/agentops/code/ceedarmcpconfig.json"],
 		mcpConfig: {
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: {
-					LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN,
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
 				},
 			},
 		},

--- a/packages/claude-runner/test-scripts/edgeworker-like-test.js
+++ b/packages/claude-runner/test-scripts/edgeworker-like-test.js
@@ -45,11 +45,10 @@ async function main() {
 		// Add Linear MCP server exactly like EdgeWorker does
 		mcpConfig: {
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: {
-					LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN,
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
 				},
 			},
 		},

--- a/packages/claude-runner/test-scripts/mcp-isolation-test.js
+++ b/packages/claude-runner/test-scripts/mcp-isolation-test.js
@@ -85,10 +85,11 @@ async function main() {
 	// Test 2: Only Linear MCP server
 	await testMCPConfig("Only Linear MCP", {
 		linear: {
-			type: "stdio",
-			command: "npx",
-			args: ["-y", "@tacticlaunch/mcp-linear"],
-			env: { LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN },
+			type: "http",
+			url: "https://mcp.linear.app/mcp",
+			headers: {
+				Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
+			},
 		},
 	});
 
@@ -102,10 +103,11 @@ async function main() {
 		"All MCP servers (production config)",
 		{
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: { LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN },
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
+				},
 			},
 		},
 		["/Users/agentops/code/ceedarmcpconfig.json"],

--- a/packages/claude-runner/test-scripts/production-like-test.js
+++ b/packages/claude-runner/test-scripts/production-like-test.js
@@ -29,11 +29,10 @@ async function main() {
 		// Add Linear MCP server like production
 		mcpConfig: {
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: {
-					LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN,
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
 				},
 			},
 		},

--- a/packages/claude-runner/test-scripts/simple-claude-runner-test.js
+++ b/packages/claude-runner/test-scripts/simple-claude-runner-test.js
@@ -83,14 +83,13 @@ async function main() {
 		// Workspace name for logging
 		workspaceName: "claude-runner-test",
 
-		// MCP configuration - using stdio server with env variable
+		// MCP configuration - using official Linear HTTP MCP server
 		mcpConfig: {
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: {
-					LINEAR_API_TOKEN: process.env.LINEAR_API_TOKEN,
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${process.env.LINEAR_API_TOKEN}`,
 				},
 			},
 		},

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2754,11 +2754,10 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		// Always inject the Linear MCP servers with the repository's token
 		const mcpConfig: Record<string, McpServerConfig> = {
 			linear: {
-				type: "stdio",
-				command: "npx",
-				args: ["-y", "@tacticlaunch/mcp-linear"],
-				env: {
-					LINEAR_API_TOKEN: repository.linearToken,
+				type: "http",
+				url: "https://mcp.linear.app/mcp",
+				headers: {
+					Authorization: `Bearer ${repository.linearToken}`,
 				},
 			},
 			"cyrus-tools": createCyrusToolsServer(repository.linearToken, {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2752,6 +2752,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 		parentSessionId?: string,
 	): Record<string, McpServerConfig> {
 		// Always inject the Linear MCP servers with the repository's token
+		// https://linear.app/docs/mcp
 		const mcpConfig: Record<string, McpServerConfig> = {
 			linear: {
 				type: "http",


### PR DESCRIPTION
## Summary
- Replaced `@tacticlaunch/mcp-linear` (stdio-based) with Linear's official HTTP MCP server (`https://mcp.linear.app/mcp`)
- Updated EdgeWorker MCP configuration to use HTTP protocol with Bearer token authentication
- Updated all test scripts to use the new official server configuration
- Updated CLAUDE.md documentation to reference the official server

## Test plan
- [x] TypeScript compilation passes
- [x] All test scripts updated to use new MCP configuration
- [x] EdgeWorker builds successfully
- [x] Documentation updated to reflect changes

## Benefits
- Better stability using Linear's official MCP server
- Access to latest Linear API features
- More reliable HTTP-based communication vs stdio

🤖 Generated with [Claude Code](https://claude.com/claude-code)