### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.5 to v0.1.8 ([release notes](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#0108))
 
 ## [0.1.54] - 2025-10-04
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.5",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.8",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.5
-        version: 0.1.5
+        specifier: ^0.1.8
+        version: 0.1.8
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -229,8 +229,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.5':
-    resolution: {integrity: sha512-w6S3FTYmb72sU0RBcf7Sly22sBVXY0BpsF7PWzdamE8cuJiiA4agjhP6WLCJvybeInqP2k1VOWIfBsVsTXOHlQ==}
+  '@anthropic-ai/claude-agent-sdk@0.1.8':
+    resolution: {integrity: sha512-QaylzHEweHI4FOKAfFd8FNzbyFd+WSA8Hb5V8+O0gOi0X1iV5xa+f6lFjBI9AlGP3frfb1ONn6LYmn0d+szV3g==}
     engines: {node: '>=18.0.0'}
 
   '@anthropic-ai/sdk@0.65.0':
@@ -2558,7 +2558,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.5':
+  '@anthropic-ai/claude-agent-sdk@0.1.8':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.5 to v0.1.8
- Updated CHANGELOG.md with release notes link
- All tests pass successfully

## Changes
- Upgraded to latest Claude Agent SDK (v0.1.8)
- See [Claude Code v0.1.08 release notes](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#0108) for details on what's new

## Testing
- Ran full package test suite: all tests passing
- Verified TypeScript compilation
- Confirmed compatibility with existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)