### PR TITLE
Add Sora 2 video generation MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Sora 2 video generation support**: Added custom MCP tools for Azure OpenAI Sora 2 video generation with three tools: `mcp__sora-tools__sora_generate_video` to start video generation, `mcp__sora-tools__sora_check_status` to poll job status, and `mcp__sora-tools__sora_get_video` to download completed videos. Configure via `soraApiKey`, `soraEndpoint`, and `soraOutputDirectory` in repository config.
+
 ### Changed
 - **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
 - Updated @anthropic-ai/claude-agent-sdk from v0.1.5 to v0.1.8 for latest Claude Agent SDK improvements
-
 ## [0.1.54] - 2025-10-04
 
 ### Added

--- a/apps/cli/repositories.example.json
+++ b/apps/cli/repositories.example.json
@@ -10,7 +10,10 @@
 			"workspaceBaseDir": "/path/to/workspaces/repo1",
 			"isActive": true,
 			"promptTemplatePath": "./agent-prompt-template.md",
-			"mcpConfigPath": "./mcp-config.json"
+			"mcpConfigPath": "./mcp-config.json",
+			"soraApiKey": "your-azure-openai-api-key",
+			"soraEndpoint": "https://your-resource.openai.azure.com",
+			"soraOutputDirectory": "/path/to/save/videos"
 		},
 		{
 			"id": "repo2",

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -21,6 +21,10 @@ export {
 	type CyrusToolsOptions,
 	createCyrusToolsServer,
 } from "./tools/cyrus-tools/index.js";
+export {
+	createSoraToolsServer,
+	type SoraToolsOptions,
+} from "./tools/sora-tools/index.js";
 export type {
 	APIAssistantMessage,
 	APIUserMessage,

--- a/packages/claude-runner/src/tools/sora-tools/index.ts
+++ b/packages/claude-runner/src/tools/sora-tools/index.ts
@@ -1,0 +1,319 @@
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import fs from "fs-extra";
+import { z } from "zod";
+
+/**
+ * Options for creating Sora tools
+ */
+export interface SoraToolsOptions {
+	/**
+	 * Azure OpenAI endpoint (e.g., "https://your-resource.openai.azure.com")
+	 */
+	endpoint: string;
+
+	/**
+	 * Azure OpenAI API key
+	 */
+	apiKey: string;
+
+	/**
+	 * Directory to save generated videos (default: current working directory)
+	 */
+	outputDirectory?: string;
+}
+
+/**
+ * Create an SDK MCP server with Sora video generation tools
+ */
+export function createSoraToolsServer(options: SoraToolsOptions) {
+	const { endpoint, apiKey, outputDirectory = process.cwd() } = options;
+
+	const generateVideoTool = tool(
+		"sora_generate_video",
+		"Generate a video using Sora 2. This starts an asynchronous video generation job and returns a job ID. Use sora_check_status to poll for completion.",
+		{
+			prompt: z
+				.string()
+				.describe("Text description of the video you want to generate"),
+			width: z
+				.number()
+				.optional()
+				.default(1920)
+				.describe("Video width in pixels (default: 1920)"),
+			height: z
+				.number()
+				.optional()
+				.default(1080)
+				.describe("Video height in pixels (default: 1080)"),
+			n_seconds: z
+				.number()
+				.optional()
+				.default(5)
+				.describe("Video duration in seconds (default: 5)"),
+		},
+		async ({ prompt, width, height, n_seconds }) => {
+			try {
+				console.log(
+					`Starting video generation: ${prompt.substring(0, 50)}... (${width}x${height}, ${n_seconds}s)`,
+				);
+
+				const url = `${endpoint}/openai/v1/video/generations/jobs?api-version=preview`;
+
+				const requestBody = {
+					model: "sora",
+					prompt,
+					width,
+					height,
+					n_seconds,
+				};
+
+				const response = await fetch(url, {
+					method: "POST",
+					headers: {
+						"api-key": apiKey,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(requestBody),
+				});
+
+				if (!response.ok) {
+					const errorText = await response.text();
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									success: false,
+									error: `Failed to start video generation: ${response.status} ${response.statusText} - ${errorText}`,
+								}),
+							},
+						],
+					};
+				}
+
+				const result = (await response.json()) as {
+					id: string;
+					status: string;
+				};
+
+				console.log(`Video generation job started: ${result.id}`);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								jobId: result.id,
+								status: result.status,
+								message:
+									"Video generation job started. Use sora_check_status to poll for completion.",
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+				};
+			}
+		},
+	);
+
+	const checkStatusTool = tool(
+		"sora_check_status",
+		"Check the status of a Sora video generation job. Poll this endpoint until status is 'succeeded' or 'failed'.",
+		{
+			jobId: z
+				.string()
+				.describe("The job ID returned from sora_generate_video"),
+		},
+		async ({ jobId }) => {
+			try {
+				console.log(`Checking status for job: ${jobId}`);
+
+				const url = `${endpoint}/openai/v1/video/generations/jobs/${jobId}?api-version=preview`;
+
+				const response = await fetch(url, {
+					method: "GET",
+					headers: {
+						"api-key": apiKey,
+					},
+				});
+
+				if (!response.ok) {
+					const errorText = await response.text();
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									success: false,
+									error: `Failed to check job status: ${response.status} ${response.statusText} - ${errorText}`,
+								}),
+							},
+						],
+					};
+				}
+
+				const result = (await response.json()) as {
+					id: string;
+					status: string;
+					generations?: Array<{ id: string }>;
+				};
+
+				console.log(`Job ${jobId} status: ${result.status}`);
+
+				// Include generation_id if available (needed for retrieving the video)
+				const responseData: {
+					success: boolean;
+					jobId: string;
+					status: string;
+					generationId?: string;
+					message: string;
+				} = {
+					success: true,
+					jobId: result.id,
+					status: result.status,
+					message: "",
+				};
+
+				// Check if we have generations in the response
+				if (result.generations && result.generations.length > 0) {
+					responseData.generationId = result.generations[0]?.id;
+					responseData.message =
+						result.status === "succeeded"
+							? "Video generation complete! Use sora_get_video to download the video."
+							: `Job is ${result.status}. Continue polling if not complete.`;
+				} else {
+					responseData.message = `Job is ${result.status}. ${result.status === "succeeded" ? "Waiting for generation ID..." : "Continue polling."}`;
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(responseData),
+						},
+					],
+				};
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+				};
+			}
+		},
+	);
+
+	const getVideoTool = tool(
+		"sora_get_video",
+		"Download a completed Sora video and save it to disk. Returns the local file path.",
+		{
+			generationId: z
+				.string()
+				.describe(
+					"The generation ID from sora_check_status when status is 'succeeded'",
+				),
+			filename: z
+				.string()
+				.optional()
+				.describe(
+					"Custom filename for the video (default: generated-{generationId}.mp4)",
+				),
+		},
+		async ({ generationId, filename }) => {
+			try {
+				console.log(`Downloading video for generation: ${generationId}`);
+
+				const url = `${endpoint}/openai/v1/video/generations/${generationId}/content/video?api-version=preview`;
+
+				const response = await fetch(url, {
+					method: "GET",
+					headers: {
+						"api-key": apiKey,
+					},
+				});
+
+				if (!response.ok) {
+					const errorText = await response.text();
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify({
+									success: false,
+									error: `Failed to download video: ${response.status} ${response.statusText} - ${errorText}`,
+								}),
+							},
+						],
+					};
+				}
+
+				// Get video data as buffer
+				const videoBuffer = Buffer.from(await response.arrayBuffer());
+
+				// Ensure output directory exists
+				await fs.ensureDir(outputDirectory);
+
+				// Determine final filename
+				const finalFilename =
+					filename || `generated-${generationId.substring(0, 8)}.mp4`;
+				const filePath = `${outputDirectory}/${finalFilename}`;
+
+				// Write video to disk
+				await fs.writeFile(filePath, videoBuffer);
+
+				console.log(`Video saved to: ${filePath}`);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								filePath,
+								filename: finalFilename,
+								size: videoBuffer.length,
+								message: `Video downloaded and saved to ${filePath}`,
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+				};
+			}
+		},
+	);
+
+	return createSdkMcpServer({
+		name: "sora-tools",
+		version: "1.0.0",
+		tools: [generateVideoTool, checkStatusTool, getVideoTool],
+	});
+}

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -18,6 +18,7 @@ import type {
 import {
 	ClaudeRunner,
 	createCyrusToolsServer,
+	createSoraToolsServer,
 	getAllTools,
 	getCoordinatorTools,
 	getReadOnlyTools,
@@ -2849,6 +2850,18 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 				},
 			}),
 		};
+
+		// Add Sora MCP server if API key and endpoint are configured
+		if (repository.soraApiKey && repository.soraEndpoint) {
+			mcpConfig["sora-tools"] = createSoraToolsServer({
+				apiKey: repository.soraApiKey,
+				endpoint: repository.soraEndpoint,
+				outputDirectory: repository.soraOutputDirectory,
+			});
+			console.log(
+				`[EdgeWorker] Configured Sora MCP server for repository: ${repository.name}`,
+			);
+		}
 
 		return mcpConfig;
 	}

--- a/packages/edge-worker/src/types.ts
+++ b/packages/edge-worker/src/types.ts
@@ -36,6 +36,11 @@ export interface RepositoryConfig {
 	model?: string; // Claude model to use for this repository (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
 
+	// Sora AI configuration (Azure OpenAI)
+	soraApiKey?: string; // Azure OpenAI API key for Sora video generation
+	soraEndpoint?: string; // Azure OpenAI endpoint (e.g., "https://your-resource.openai.azure.com")
+	soraOutputDirectory?: string; // Directory to save generated videos (defaults to workspace path)
+
 	// Label-based system prompt configuration
 	labelPrompts?: {
 		debugger?: {


### PR DESCRIPTION
## Summary

Implements custom MCP tools for Azure OpenAI Sora 2 video generation, enabling Claude to generate videos from text prompts.

## Implementation

### Three Sora Tools Added

1. **`mcp__sora-tools__sora_generate_video`** - Starts an async video generation job
   - Parameters: `prompt`, `width` (default: 1920), `height` (default: 1080), `n_seconds` (default: 5)
   - Returns: `jobId` and initial `status`

2. **`mcp__sora-tools__sora_check_status`** - Polls job status
   - Parameters: `jobId`
   - Returns: Current status and `generationId` when complete

3. **`mcp__sora-tools__sora_get_video`** - Downloads completed video
   - Parameters: `generationId`, optional `filename`
   - Returns: Local file path where video was saved

### Configuration

Add to repository config in `repositories.json`:
```json
{
  "soraApiKey": "your-azure-openai-api-key",
  "soraEndpoint": "https://your-resource.openai.azure.com",
  "soraOutputDirectory": "/path/to/save/videos"
}
```

### Key Changes

- **New file**: `packages/claude-runner/src/tools/sora-tools/index.ts` - Sora MCP server implementation
- **Updated**: `packages/edge-worker/src/types.ts` - Added Sora config fields to `RepositoryConfig`
- **Updated**: `packages/edge-worker/src/EdgeWorker.ts` - Integrated Sora tools into MCP config
- **Updated**: `packages/claude-runner/src/index.ts` - Exported Sora tools
- **Updated**: `apps/cli/repositories.example.json` - Added example Sora configuration
- **Updated**: `CHANGELOG.md` - Added release notes

## Test Plan

- [x] Build succeeds for all packages
- [x] TypeScript type checking passes
- [x] Linter runs successfully
- [ ] Manual testing with Azure OpenAI Sora API credentials (requires Azure setup)

## Related

Closes CYPACK-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)