### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.5 to v0.1.8 for latest Claude Agent SDK improvements
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.8 to v0.1.9 - fixes critical bug where custom system prompts were not being properly respected. See [@anthropic-ai/claude-agent-sdk v0.1.9 release notes](https://github.com/anthropics/claude-agent-sdk-typescript/releases/tag/v0.1.9)
 
 ## [0.1.54] - 2025-10-04
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.8",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.9",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.8
-        version: 0.1.8
+        specifier: ^0.1.9
+        version: 0.1.9
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -229,8 +229,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.8':
-    resolution: {integrity: sha512-QaylzHEweHI4FOKAfFd8FNzbyFd+WSA8Hb5V8+O0gOi0X1iV5xa+f6lFjBI9AlGP3frfb1ONn6LYmn0d+szV3g==}
+  '@anthropic-ai/claude-agent-sdk@0.1.9':
+    resolution: {integrity: sha512-vQ1pJWGvc9f7qmfkgRoq/RUeqtXCbBE5jnn8zqXcY/nArZzL7nlwYQbsLDse53U105Idx3tBl6AdjHgisSww/w==}
     engines: {node: '>=18.0.0'}
 
   '@anthropic-ai/sdk@0.65.0':
@@ -2558,7 +2558,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.8':
+  '@anthropic-ai/claude-agent-sdk@0.1.9':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-agent-sdk from v0.1.8 to v0.1.9
- Updated CHANGELOG.md with reference to release notes

## What's Fixed
This update includes a critical bug fix where custom system prompts were not being properly respected by the SDK. Previously, even when setting non-coding-related system prompts, the SDK would still inject default coding-oriented context.

## Changes
- `packages/claude-runner/package.json`: Updated dependency version
- `CHANGELOG.md`: Added changelog entry with link to release notes

## Test Plan
- [x] Dependencies installed successfully
- [x] Build completed without errors
- [x] TypeScript type checking passed

## References
- [claude-agent-sdk v0.1.9 release notes](https://github.com/anthropics/claude-agent-sdk-typescript/releases/tag/v0.1.9)
- [GitHub Issue #8](https://github.com/anthropics/claude-agent-sdk-typescript/issues/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)