### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.8 to v0.1.9 - fixes critical bug where custom system prompts were not being properly respected. See [@anthropic-ai/claude-agent-sdk v0.1.9 release notes](https://github.com/anthropics/claude-agent-sdk-typescript/releases/tag/v0.1.9)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.9 to v0.1.10 - includes parity updates with Claude Code v2.0.10 and adds zod ^3.24.1 as peer dependency. See [@anthropic-ai/claude-agent-sdk v0.1.10 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0110---2025-01-08)
 
 ## [0.1.54] - 2025-10-04
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.9",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.10",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.9
-        version: 0.1.9
+        specifier: ^0.1.10
+        version: 0.1.10(zod@3.25.75)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -229,9 +229,11 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.9':
-    resolution: {integrity: sha512-vQ1pJWGvc9f7qmfkgRoq/RUeqtXCbBE5jnn8zqXcY/nArZzL7nlwYQbsLDse53U105Idx3tBl6AdjHgisSww/w==}
+  '@anthropic-ai/claude-agent-sdk@0.1.10':
+    resolution: {integrity: sha512-FDcJ0VI4x5u8/QRNJsYn+UnNqbVZMaf/DTHwJSaq+v3CqW8m+rW529H/DzGraw2F8YT9WqnJ9LCQdtPf9J5BNQ==}
     engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.1
 
   '@anthropic-ai/sdk@0.65.0':
     resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
@@ -2558,7 +2560,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.9':
+  '@anthropic-ai/claude-agent-sdk@0.1.10(zod@3.25.75)':
+    dependencies:
+      zod: 3.25.75
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5


### PR DESCRIPTION
## Summary
Updated `@anthropic-ai/claude-agent-sdk` from v0.1.9 to v0.1.10

## Changes in v0.1.10
- Updated to parity with Claude Code v2.0.10
- Added zod ^3.24.1 as peer dependency

## What Changed
- `packages/claude-runner/package.json`: Updated SDK version to ^0.1.10
- `CHANGELOG.md`: Added changelog entry with link to SDK release notes
- `pnpm-lock.yaml`: Updated lockfile with new peer dependency

## Testing
✅ All claude-runner tests pass (66/66)
✅ Linting passes
✅ TypeScript compilation succeeds for claude-runner package
✅ Build succeeds

## Notes
- `@anthropic-ai/sdk` is already at the latest version (0.65.0) - no update needed
- Pre-existing type errors in packages/core and packages/edge-worker are unrelated to this change

## References
- [claude-agent-sdk v0.1.10 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0110---2025-01-08)
- Closes CYPACK-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)