### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Upgraded to official Linear MCP server**: Replaced the unofficial `@tacticlaunch/mcp-linear` stdio-based server with Linear's official HTTP-based MCP server (`https://mcp.linear.app/mcp`). This provides better stability and access to the latest Linear API features.
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.9 to v0.1.10 - includes parity updates with Claude Code v2.0.10 and adds zod ^3.24.1 as peer dependency. See [@anthropic-ai/claude-agent-sdk v0.1.10 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0110---2025-01-08)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.10 to v0.1.11 - includes parity updates with Claude Code v2.0.11. See [@anthropic-ai/claude-agent-sdk v0.1.11 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0111---2025-01-09)
 
 ## [0.1.54] - 2025-10-04
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.10",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.11",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.10
-        version: 0.1.10(zod@3.25.75)
+        specifier: ^0.1.11
+        version: 0.1.11(zod@3.25.75)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -229,8 +229,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.10':
-    resolution: {integrity: sha512-FDcJ0VI4x5u8/QRNJsYn+UnNqbVZMaf/DTHwJSaq+v3CqW8m+rW529H/DzGraw2F8YT9WqnJ9LCQdtPf9J5BNQ==}
+  '@anthropic-ai/claude-agent-sdk@0.1.11':
+    resolution: {integrity: sha512-twlHobV2rK5+2Osr/FVTFiWjG0ah+37yhwNxdloLW7ldE84qVauENKjkJT3HzM8sRqvD0CmeAHYzF1foGf4SIA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2560,7 +2560,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.10(zod@3.25.75)':
+  '@anthropic-ai/claude-agent-sdk@0.1.11(zod@3.25.75)':
     dependencies:
       zod: 3.25.75
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-agent-sdk from v0.1.10 to v0.1.11
- @anthropic-ai/sdk is already on the latest version (v0.65.0)
- Updated CHANGELOG.md with the package update and link to the SDK changelog

## Changes
- **packages/claude-runner/package.json**: Bumped `@anthropic-ai/claude-agent-sdk` from `^0.1.10` to `^0.1.11`
- **CHANGELOG.md**: Added entry documenting the SDK update with changelog link
- **pnpm-lock.yaml**: Updated lockfile with new dependency versions

## SDK Changes (v0.1.11)
The new version includes parity updates with Claude Code v2.0.11. See the [full changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0111---2025-01-09) for details.

## Testing
- ✅ All package tests pass
- ✅ TypeScript compilation successful
- ✅ Build completes without errors

Resolves CYPACK-162

🤖 Generated with [Claude Code](https://claude.com/claude-code)