### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.11 to v0.1.13 - includes parity updates with Claude Code v2.0.13. See [@anthropic-ai/claude-agent-sdk v0.1.13 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0113---2025-01-10)
+
 ## [0.1.55] - 2025-10-09
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.11",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.13",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.11
-        version: 0.1.11(zod@3.25.75)
+        specifier: ^0.1.13
+        version: 0.1.13(zod@3.25.75)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -232,8 +232,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.11':
-    resolution: {integrity: sha512-twlHobV2rK5+2Osr/FVTFiWjG0ah+37yhwNxdloLW7ldE84qVauENKjkJT3HzM8sRqvD0CmeAHYzF1foGf4SIA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.13':
+    resolution: {integrity: sha512-9/+/iVdVQx2o3INUxwNWuZQOhff3ISXgSc/G7jfD85qtEN/7ZK/uOnAtCH1PChMNBN5CGXgVKNMce++52tfZ5A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2571,7 +2571,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.11(zod@3.25.75)':
+  '@anthropic-ai/claude-agent-sdk@0.1.13(zod@3.25.75)':
     dependencies:
       zod: 3.25.75
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Updated @anthropic-ai/claude-agent-sdk from v0.1.11 to v0.1.13
- @anthropic-ai/sdk is already on the latest version (v0.65.0)

## Changes
- Bumped `@anthropic-ai/claude-agent-sdk` to `^0.1.13` in `packages/claude-runner/package.json`
- Updated CHANGELOG.md with SDK version change and link to release notes

## Version Details
The claude-agent-sdk update includes parity updates with Claude Code v2.0.13:
- v0.1.12: Updated to parity with Claude Code v2.0.12
- v0.1.13: Updated to parity with Claude Code v2.0.13

See: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0113---2025-01-10

## Testing
- ✅ All package tests passing
- ✅ Build successful
- ✅ TypeScript compilation successful

Closes CYPACK-171

🤖 Generated with [Claude Code](https://claude.com/claude-code)