### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - **Environment variable support in MCP configs**: MCP configuration files can now reference environment variables from repository `.env` files using `${VAR}` and `${VAR:-default}` syntax, making it easier to manage API tokens and other sensitive configuration values
 
 ### Changed
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.11 to v0.1.13 - includes parity updates with Claude Code v2.0.13. See [@anthropic-ai/claude-agent-sdk v0.1.13 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0113---2025-01-10)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.13 to v0.1.14 - includes parity updates with Claude Code v2.0.14. See [@anthropic-ai/claude-agent-sdk v0.1.14 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0114)
 
 ## [0.1.55] - 2025-10-09
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.13",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.14",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.13
-        version: 0.1.13(zod@3.25.75)
+        specifier: ^0.1.14
+        version: 0.1.14(zod@3.25.75)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.75)
@@ -232,8 +232,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.13':
-    resolution: {integrity: sha512-9/+/iVdVQx2o3INUxwNWuZQOhff3ISXgSc/G7jfD85qtEN/7ZK/uOnAtCH1PChMNBN5CGXgVKNMce++52tfZ5A==}
+  '@anthropic-ai/claude-agent-sdk@0.1.14':
+    resolution: {integrity: sha512-FdFPxeogLCOzk+ok5ITTwaemr1gGj104ynHt3LJdTADE8idsWlbJjaWlybx5WYpN+UtJTeVi3bQ8BQLojpO8ww==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2571,7 +2571,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@anthropic-ai/claude-agent-sdk@0.1.13(zod@3.25.75)':
+  '@anthropic-ai/claude-agent-sdk@0.1.14(zod@3.25.75)':
     dependencies:
       zod: 3.25.75
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates @anthropic-ai/claude-agent-sdk from v0.1.13 to v0.1.14

## Changes
- Updated @anthropic-ai/claude-agent-sdk from v0.1.13 to v0.1.14
- Includes parity updates with Claude Code v2.0.14
- @anthropic-ai/sdk remains at v0.65.0 (already latest)
- All tests pass successfully

## Test plan
- [x] Ran `pnpm install` to update dependencies
- [x] Ran `pnpm build` to build all packages
- [x] Ran `pnpm --filter cyrus-claude-runner test:run` - all 66 tests passed
- [x] Ran `pnpm typecheck` - no type errors

## Links
- [claude-agent-sdk v0.1.14 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)