### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.14 in simple-agent-runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.11 to v0.1.14 in `simple-agent-runner` package to match the version used in `claude-runner`. See [@anthropic-ai/claude-agent-sdk v0.1.14 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0114)
+
 ## [0.1.57] - 2025-10-12
 
 ### Fixed

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.11",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.14",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.11
+        specifier: ^0.1.14
         version: 0.1.14(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Updates the `@anthropic-ai/claude-agent-sdk` package from v0.1.11 to v0.1.14 in the `simple-agent-runner` package to match the version used in `claude-runner`.

## Changes Made

- Updated `packages/simple-agent-runner/package.json` dependency from `^0.1.11` to `^0.1.14`
- Updated `CHANGELOG.md` with the version change and link to the SDK changelog
- Updated `pnpm-lock.yaml` with resolved dependencies

## Implementation Approach

This is a straightforward dependency update to ensure consistency across packages. The `claude-runner` package was already on v0.1.14, so this brings `simple-agent-runner` in sync.

## Testing Performed

✅ All tests pass:
- `simple-agent-runner`: 24/24 tests passed
- `claude-runner`: 66/66 tests passed

✅ Quality checks pass:
- TypeScript type checking: Passed across all packages
- Biome linting: No issues found
- Build: All packages built successfully

✅ Verification:
- No breaking changes detected
- Backward compatible update
- All pre-commit hooks passed

## Additional Notes

- See [@anthropic-ai/claude-agent-sdk v0.1.14 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0114) for SDK changes
- Both Anthropic packages now on latest versions:
  - `@anthropic-ai/claude-agent-sdk`: v0.1.14
  - `@anthropic-ai/sdk`: v0.65.0

Fixes CYPACK-182