### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.14 to v0.1.15 - includes parity with Claude Code v2.0.15, environment type improvements, and startup performance improvements for MCP servers. See [@anthropic-ai/claude-agent-sdk v0.1.15 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0115)
+
 ## [0.1.57] - 2025-10-12
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.14",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.15",
 		"@anthropic-ai/sdk": "^0.65.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.11",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.15",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.14
-        version: 0.1.14(zod@3.25.76)
+        specifier: ^0.1.15
+        version: 0.1.15(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.65.0
         version: 0.65.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.11
-        version: 0.1.14(zod@3.25.76)
+        specifier: ^0.1.15
+        version: 0.1.15(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.14':
-    resolution: {integrity: sha512-FdFPxeogLCOzk+ok5ITTwaemr1gGj104ynHt3LJdTADE8idsWlbJjaWlybx5WYpN+UtJTeVi3bQ8BQLojpO8ww==}
+  '@anthropic-ai/claude-agent-sdk@0.1.15':
+    resolution: {integrity: sha512-x0UR/YW87lRel3wYVimWjAkUOEGapg/nXx2GYNLbUD1ORsetRHeXZGFdJMuhRkk1Jt9sbn5m/RpT42b5R0pgYg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.14(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.15(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.14 to v0.1.15 across both packages that use it.

## Changes

- **packages/claude-runner**: Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.14` to `^0.1.15`
- **packages/simple-agent-runner**: Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.11` to `^0.1.15`
- **CHANGELOG.md**: Added entry documenting the update with link to [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0115)

## What's New in v0.1.15

From the [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0115):
- Updated to parity with Claude Code v2.0.15
- Updated `env` type to not use Bun `Dict` type
- Startup performance improvements when using multiple SDK MCP servers

## Testing Performed

✅ All package tests passing (204 tests across 22 test files)
✅ TypeScript type checking passes for all packages  
✅ Biome linting passes (132 files checked)
✅ No regressions detected

### Test Results Summary:
- **ndjson-client**: 2 test files, 15 tests passed
- **claude-runner**: 5 test files, 66 tests passed
- **simple-agent-runner**: 2 test files, 24 tests passed
- **edge-worker**: 13 test files, 99 tests passed

## Notes

- `@anthropic-ai/sdk` is already at the latest version (v0.65.0), so no update was needed for that package
- The simple-agent-runner package was significantly behind (v0.1.11) and has been brought up to date with claude-runner

## Linear Issue

Closes CYPACK-190

🤖 Generated with [Claude Code](https://claude.com/claude-code)