### PR TITLE
Update Anthropic SDKs to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.15 to v0.1.19 - includes parity with Claude Code v2.0.19. See [@anthropic-ai/claude-agent-sdk v0.1.19 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0119)
-- Updated @anthropic-ai/sdk from v0.65.0 to v0.66.0 - see [@anthropic-ai/sdk v0.66.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.65.0...sdk-v0.66.0)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.19 to v0.1.21 - includes parity with Claude Code v2.0.21. See [@anthropic-ai/claude-agent-sdk v0.1.21 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0121)
+- Updated @anthropic-ai/sdk from v0.66.0 to v0.67.0 - see [@anthropic-ai/sdk v0.67.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.66.0...sdk-v0.67.0)
 
 ## [0.1.57] - 2025-10-12
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.19",
-		"@anthropic-ai/sdk": "^0.66.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.21",
+		"@anthropic-ai/sdk": "^0.67.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.19",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.21",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.19
-        version: 0.1.19(zod@3.25.76)
+        specifier: ^0.1.21
+        version: 0.1.21(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.66.0
-        version: 0.66.0(zod@3.25.76)
+        specifier: ^0.67.0
+        version: 0.67.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.19
-        version: 0.1.19(zod@3.25.76)
+        specifier: ^0.1.21
+        version: 0.1.21(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,14 +257,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.19':
-    resolution: {integrity: sha512-k4GtWygAkp3d0Npo/cS16MAfnSEcjttT5ijZzEWIzpWClL5wOYCpVyuMjnZGsYPDDZCb26pVb7Wm0ZDFj149Cg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.21':
+    resolution: {integrity: sha512-8qUD//GfS/SXHx2nnVOg4uwS2aqrULp/KKi6HvPqQpkTAOH0o393uWHNIi69WCshy9RLGO7NZWodlxTT3v+RdQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.66.0':
-    resolution: {integrity: sha512-GBSSby0P4BW/sOdvsTXaHJDPnGEL5tuB4TtsU4SXG7+dVULQ9MkKgNznCALDCgSV5yhrtQlctvEdMqePVIXTiw==}
+  '@anthropic-ai/sdk@0.67.0':
+    resolution: {integrity: sha512-Buxbf6jYJ+pPtfCgXe1pcFtZmdXPrbdqhBjiscFt9irS1G0hCsmR/fPA+DwKTk4GPjqeNnnCYNecXH6uVZ4G/A==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.19(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.21(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2548,7 +2548,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.66.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.67.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates both Anthropic SDK packages to their latest versions to ensure compatibility with the latest Claude Code features and improvements.

## Changes

### Package Updates
- **@anthropic-ai/claude-agent-sdk**: `v0.1.19` → `v0.1.21`
  - Includes parity with Claude Code v2.0.21
  - [Changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0121)
  
- **@anthropic-ai/sdk**: `v0.66.0` → `v0.67.0`
  - Adds support for agent skills API
  - [Changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.66.0...sdk-v0.67.0)

### Updated Packages
- `cyrus-claude-runner`: Both SDKs updated
- `cyrus-simple-agent-runner`: claude-agent-sdk only

## Testing Performed

✅ All tests passing (90/90 total):
- cyrus-claude-runner: 66/66 tests passed
- cyrus-simple-agent-runner: 24/24 tests passed

✅ Code quality checks:
- Linting: 132 files checked, no issues
- TypeScript: All packages type-check successfully
- Build: All packages compile without errors

## Implementation Approach

1. Updated version numbers in package.json files
2. Ran `pnpm install` to update lockfile
3. Updated CHANGELOG.md with version changes and links
4. Verified all tests pass with new SDK versions
5. Confirmed build and type checking succeed

## Breaking Changes

None - these are minor version updates with backwards compatibility.

## Migration Notes

No migration required. The updates are drop-in replacements.

---

Fixes CYPACK-200