### PR TITLE
Remove approval step from debugger procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
 - Updated @anthropic-ai/claude-agent-sdk from v0.1.19 to v0.1.21 - includes parity with Claude Code v2.0.21. See [@anthropic-ai/claude-agent-sdk v0.1.21 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0121)
 - Updated @anthropic-ai/sdk from v0.66.0 to v0.67.0 - see [@anthropic-ai/sdk v0.67.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.66.0...sdk-v0.67.0)
 

--- a/packages/edge-worker/src/procedures/registry.ts
+++ b/packages/edge-worker/src/procedures/registry.ts
@@ -91,10 +91,9 @@ export const PROCEDURES: Record<string, ProcedureDefinition> = {
 	"debugger-full": {
 		name: "debugger-full",
 		description:
-			"Full debugging workflow with reproduction, approval, fix, and verification",
+			"Full debugging workflow with reproduction, fix, and verification",
 		subroutines: [
 			SUBROUTINES.debuggerReproduction,
-			SUBROUTINES.getApproval,
 			SUBROUTINES.debuggerFix,
 			SUBROUTINES.verifications,
 			SUBROUTINES.gitGh,

--- a/packages/edge-worker/src/prompts/subroutines/debugger-fix.md
+++ b/packages/edge-worker/src/prompts/subroutines/debugger-fix.md
@@ -4,11 +4,10 @@ You are in the **Bug Fix Implementation Phase** of the debugging workflow.
 
 ## Context
 
-The reproduction phase is complete and the user has **approved** proceeding with the fix. You have:
+The reproduction phase is complete. You have:
 
 - ✅ A failing test case that reproduces the bug
 - ✅ Root cause analysis from the reproduction phase
-- ✅ Approval to implement the fix
 - ✅ A proposed fix approach
 
 ## Objective
@@ -105,4 +104,4 @@ Your fix should be **production-ready** and **thoroughly tested** at this point.
 
 ## Remember
 
-You're implementing an **approved fix** based on a clear root cause analysis. Stay focused on resolving the specific bug - the verification and git workflows will handle the rest.
+You're implementing a fix based on a clear root cause analysis. Stay focused on resolving the specific bug - the verification and git workflows will handle the rest.

--- a/packages/edge-worker/src/prompts/subroutines/debugger-reproduction.md
+++ b/packages/edge-worker/src/prompts/subroutines/debugger-reproduction.md
@@ -68,17 +68,13 @@ After completing your investigation, you MUST present your findings in this exac
 - User impact: [description]
 
 ## Proposed Fix Approach
-[High-level description of how you plan to fix it - do NOT implement yet]
+[High-level description of how you plan to fix it]
 
 ---
 
-**🔴 APPROVAL REQUIRED**
+**✅ REPRODUCTION COMPLETE**
 
-I have completed the reproduction phase and identified the root cause.
-
-**Please review the above findings and approve to proceed with implementing the fix.**
-
-I will wait for your approval before making any code changes.
+I have completed the reproduction phase and identified the root cause. The fix implementation phase will begin automatically.
 ```
 
 ## Critical Constraints
@@ -86,21 +82,18 @@ I will wait for your approval before making any code changes.
 - ❌ **DO NOT implement any fixes** - this is reproduction only
 - ❌ **DO NOT modify production code** - only test files
 - ❌ **DO NOT commit or push anything** - that happens in later phases
-- ❌ **DO NOT create todos for fixing the issue** - fix planning happens after approval in debugger-fix phase
+- ❌ **DO NOT create todos for fixing the issue** - fix planning happens in debugger-fix phase
 - ✅ **DO use Task extensively** for all analysis
 - ✅ **DO create a clear, failing test**
 - ✅ **DO provide detailed root cause analysis**
-- ✅ **DO explicitly request approval** at the end
 - ✅ **DO use TodoWrite for tracking reproduction/analysis tasks** if helpful (e.g., "Investigate error X", "Create test for Y")
 
 ## What Happens Next
 
-After you present your findings and request approval:
+After you present your findings:
 
-1. The system will pause this subroutine
-2. An **approval elicitation** will be posted to Linear
-3. The user will review and either approve or provide feedback
-4. If approved, the next subroutine (fix implementation) will begin
-5. If feedback is given, you'll incorporate it and re-present
+1. This subroutine will complete
+2. The next subroutine (fix implementation) will begin automatically
+3. You will implement the fix based on your reproduction and analysis
 
 **Remember**: Your job is to UNDERSTAND and REPRODUCE the bug, not to fix it yet!


### PR DESCRIPTION
## Summary

Removes the manual approval step from the debugger workflow. The debugger now proceeds directly from bug reproduction to fix implementation without requiring user approval in the middle of the work.

## Changes

- **Removed approval subroutine**: Deleted `SUBROUTINES.getApproval` from the `debugger-full` procedure in `registry.ts`
- **Updated reproduction prompt**: Changed `debugger-reproduction.md` to indicate automatic continuation instead of requesting approval
- **Updated fix prompt**: Removed approval context from `debugger-fix.md`
- **Updated CHANGELOG**: Added user-facing description of the workflow change

## Implementation Approach

The debugger workflow previously had these steps:
1. Bug reproduction
2. **Request user approval** ⬅️ REMOVED
3. Implement fix
4. Run verifications
5. Create PR

Now it flows seamlessly:
1. Bug reproduction
2. Implement fix (automatic)
3. Run verifications
4. Create PR

## Testing Performed

✅ All package tests pass (204+ tests)
- claude-runner: 66 tests
- ndjson-client: 15 tests
- edge-worker: 99 tests
- simple-agent-runner: 24 tests

✅ TypeScript type checking passes (8 packages)
✅ Biome linting passes (132 files)
✅ Pre-commit hooks pass

## Impact

This change streamlines the debugging workflow by removing an unnecessary manual interruption. Users will experience:
- Faster debugging cycles
- No mid-workflow approval gates
- Continuous flow from reproduction to fix to PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)