### PR TITLE
Update Anthropic SDKs to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.21 to v0.1.23 - includes parity with Claude Code v2.0.22 and v2.0.23. See [@anthropic-ai/claude-agent-sdk v0.1.23 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0123)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.23 to v0.1.25 - includes bug fixes for project-level skills loading, system message skills field, type exports, and parity with Claude Code v2.0.25. See [@anthropic-ai/claude-agent-sdk v0.1.25 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0125)
 
 ## [0.1.57] - 2025-10-12
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.23",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.25",
 		"@anthropic-ai/sdk": "^0.67.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.23",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.25",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.23
-        version: 0.1.23(zod@3.25.76)
+        specifier: ^0.1.25
+        version: 0.1.25(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.67.0
         version: 0.67.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.23
-        version: 0.1.23(zod@3.25.76)
+        specifier: ^0.1.25
+        version: 0.1.25(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.23':
-    resolution: {integrity: sha512-DktXOjzS2hOuuj2Zpo7fEooONfMa5bm09pt1/Vt4vn30YugELoezn/ZQ/TG5uSQ7+Zl/ElxAvi4vGDorj1Tirg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.25':
+    resolution: {integrity: sha512-qwuydYaA3uamz4ivDzYXfL2PBjGwc0+beeIyo3nvtZQOtFLjH7xPdBK2w3+9KnB3L6V7VooAMdTXPpQyxCwcOg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.23(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.25(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR updates the Anthropic SDK packages to their latest versions:

- **@anthropic-ai/claude-agent-sdk**: v0.1.23 → v0.1.25
- **@anthropic-ai/sdk**: Already at latest v0.67.0 ✓

## Changes

### Updated Packages
- `packages/claude-runner/package.json` - Updated claude-agent-sdk dependency
- `packages/simple-agent-runner/package.json` - Updated claude-agent-sdk dependency
- `CHANGELOG.md` - Documented the update with link to upstream changelog
- `pnpm-lock.yaml` - Automatically updated by pnpm

## What's New in v0.1.25

The update includes important bug fixes and improvements:

- **Bug fix**: Fixed project-level skills not loading when 'project' settings source is specified
- **Enhancement**: Added `skills` field to `SDKSystemMessage` containing available skills
- **Bug fix**: Fixed type export bug preventing some types from importing correctly
- **Parity**: Updated to parity with Claude Code v2.0.25

See the full changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0125

## Testing & Verification

✅ **All quality checks passed:**

- **Tests**: 204+ tests passing across all packages
  - packages/ndjson-client: 15 tests ✓
  - packages/claude-runner: 66 tests ✓
  - packages/simple-agent-runner: 24 tests ✓
  - packages/edge-worker: 99 tests ✓
  
- **Linting**: Biome check passed (132 files checked)
- **Type Checking**: TypeScript compilation successful across all 8 packages
- **Build**: All packages build successfully

## Migration Notes

No breaking changes or migration steps required. This is a minor version update with bug fixes and improvements.

---

Closes CYPACK-218