### PR TITLE
Update Anthropic SDKs to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.23 to v0.1.25 - includes bug fixes for project-level skills loading, system message skills field, type exports, and parity with Claude Code v2.0.25. See [@anthropic-ai/claude-agent-sdk v0.1.25 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0125)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.25 to v0.1.26 - includes parity updates with Claude Code v2.0.26. See [@anthropic-ai/claude-agent-sdk v0.1.26 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0126)
 
 ## [0.1.57] - 2025-10-12
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.25",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.26",
 		"@anthropic-ai/sdk": "^0.67.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.25",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.26",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.25
-        version: 0.1.25(zod@3.25.76)
+        specifier: ^0.1.26
+        version: 0.1.26(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.67.0
         version: 0.67.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.25
-        version: 0.1.25(zod@3.25.76)
+        specifier: ^0.1.26
+        version: 0.1.26(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.25':
-    resolution: {integrity: sha512-qwuydYaA3uamz4ivDzYXfL2PBjGwc0+beeIyo3nvtZQOtFLjH7xPdBK2w3+9KnB3L6V7VooAMdTXPpQyxCwcOg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.26':
+    resolution: {integrity: sha512-daVGe5x6KOFy9DKyDojw15eljBP+tPx+spAyGll/Rp/B6t+NP0Oiwpaiib0afjbCRbqXkWEHUJPE3yDFrMcZlA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.25(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.26(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates `@anthropic-ai/claude-agent-sdk` from v0.1.25 to v0.1.26 to maintain parity with Claude Code v2.0.26.

## Changes
- Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.25` to `^0.1.26` in:
  - `packages/claude-runner/package.json`
  - `packages/simple-agent-runner/package.json`
- Updated `CHANGELOG.md` with version change details and link to [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0126)
- Updated `pnpm-lock.yaml` with new package resolutions

**Note:** `@anthropic-ai/sdk` was already at the latest version `^0.67.0` and required no changes.

## Implementation Approach
This is a straightforward dependency version bump with no code changes required. The update includes:
- Parity updates with Claude Code v2.0.26
- No breaking changes
- No API modifications

## Testing Performed
✅ **All Tests Passing (204 tests across 22 test files):**
- `ndjson-client`: 15 tests passed
- `claude-runner`: 66 tests passed  
- `simple-agent-runner`: 24 tests passed
- `edge-worker`: 99 tests passed

✅ **Quality Checks:**
- Linting: All 132 files passed
- TypeScript: All 8 packages type-checked successfully
- Pre-commit hooks: Passed

## Breaking Changes
None - this is a minor version update that maintains full backward compatibility.

## Related
Closes CYPACK-220

🤖 Generated with [Claude Code](https://claude.com/claude-code)