### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.25 to v0.1.26 - includes parity updates with Claude Code v2.0.26. See [@anthropic-ai/claude-agent-sdk v0.1.26 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0126)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.26 to v0.1.27 - includes parity updates with Claude Code v2.0.27 and adds support for plugins field in Options. See [@anthropic-ai/claude-agent-sdk v0.1.27 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0127)
 
 ## [0.1.57] - 2025-10-12
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.26",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.27",
 		"@anthropic-ai/sdk": "^0.67.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.26",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.27",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.26
-        version: 0.1.26(zod@3.25.76)
+        specifier: ^0.1.27
+        version: 0.1.27(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.67.0
         version: 0.67.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.26
-        version: 0.1.26(zod@3.25.76)
+        specifier: ^0.1.27
+        version: 0.1.27(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.26':
-    resolution: {integrity: sha512-daVGe5x6KOFy9DKyDojw15eljBP+tPx+spAyGll/Rp/B6t+NP0Oiwpaiib0afjbCRbqXkWEHUJPE3yDFrMcZlA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.27':
+    resolution: {integrity: sha512-HuMPW6spj2q8FODiP/WBCqUZAYGwDPoI1EpicP9KUXvuYk+2MZQYSaD7oiN6iNPupR2T5oJ2HY/D9OzjyCD2Mw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.26(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.27(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates the Anthropic Claude Agent SDK from v0.1.26 to v0.1.27 in both packages that depend on it (`cyrus-claude-runner` and `cyrus-simple-agent-runner`).

## Changes

- Updated `@anthropic-ai/claude-agent-sdk` to `^0.1.27` in `packages/claude-runner/package.json`
- Updated `@anthropic-ai/claude-agent-sdk` to `^0.1.27` in `packages/simple-agent-runner/package.json`
- Updated `CHANGELOG.md` with SDK version bump details and link to upstream changelog
- `@anthropic-ai/sdk` remains at `v0.67.0` (already on latest version)

## What's New in v0.1.27

From the [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0127):
- Parity updates with Claude Code v2.0.27
- Added support for `plugins` field in Options

## Testing Performed

- ✅ All 204 package tests passing (66 claude-runner, 15 ndjson-client, 24 simple-agent-runner, 99 edge-worker)
- ✅ Linting clean (biome check)
- ✅ TypeScript type checking valid across all packages
- ✅ Build successful for all packages
- ✅ Dependencies properly resolved via pnpm

## Migration Notes

No breaking changes. The update is backward compatible with existing code.

Fixes CYPACK-230