### PR TITLE
[Refactor] Remove proxy-worker package and all references

### DIFF
--- a/ANALYSIS_SUMMARY.md
+++ b/ANALYSIS_SUMMARY.md
@@ -213,7 +213,6 @@ registerWebhookHandler(
 
 ### Configuration
 - CLI App: `/apps/cli/src/Application.ts`
-- Proxy Worker: `/apps/proxy-worker/` (OAuth/webhook proxy)
 
 ---
 

--- a/apps/cli/app.ts.old
+++ b/apps/cli/app.ts.old
@@ -905,9 +905,6 @@ class EdgeApp {
 						"• Linear OAuth setup: https://linear.app/developers/agents",
 					);
 					console.log(
-						"• Proxy implementation: https://github.com/ceedaragents/cyrus/tree/main/apps/proxy-worker",
-					);
-					console.log(
 						"\nOnce deployed, set the PROXY_URL environment variable:",
 					);
 					console.log("export PROXY_URL=https://your-proxy-url.com");


### PR DESCRIPTION
## Summary

Completely removed the `apps/proxy-worker` package and all references to it throughout the codebase as part of the architecture simplification. The Cyrus project is consolidating around the proxy server architecture (`apps/proxy`), making the deprecated proxy-worker package unnecessary.

**Linear Issue**: [CYPACK-241](https://linear.app/ceedar/issue/CYPACK-241)

## Changes Made

### Removed Files
- **apps/proxy-worker/** - Complete directory with all OAuth/webhook handling code
  - Service modules: OAuthService, WebhookReceiver, WebhookSender, EdgeWorkerRegistry
  - Durable Objects: EventStreamDurableObject, EventStreamer
  - Configuration: wrangler.toml, tsconfig.json, package.json

### Updated Files
- **apps/cli/src/commands/StartCommand.ts** - Removed proxy-worker documentation link
- **apps/cli/app.ts.old** - Removed proxy-worker documentation link
- **CODEBASE_ARCHITECTURE.md** - Updated architecture overview and package structure
- **ANALYSIS_SUMMARY.md** - Removed proxy-worker configuration section
- **pnpm-lock.yaml** - Auto-updated to remove proxy-worker dependencies

### Workspace Updates
- No explicit changes needed to `pnpm-workspace.yaml` (uses wildcard pattern `apps/*`)
- Lockfile automatically cleaned up by pnpm

## Implementation Approach

1. **Complete Package Removal**: Deleted entire `apps/proxy-worker` directory
2. **Reference Cleanup**: Systematically searched and removed all references
3. **Documentation Updates**: Updated architecture and analysis documentation
4. **Dependency Management**: Ran `pnpm install` to update lockfile

## Testing Performed

### ✅ Type Checking
```bash
pnpm typecheck
```
- All 8 packages compiled successfully with no errors

### ✅ Test Suite
```bash
pnpm test:packages:run
```
- **263 tests passed** across 5 packages:
  - linear-event-transport: 20 tests
  - claude-runner: 66 tests
  - config-updater: 54 tests
  - simple-agent-runner: 24 tests
  - edge-worker: 99 tests

### ✅ Build Verification
```bash
pnpm build
```
- All packages built successfully

### ✅ Reference Verification
```bash
grep -r "proxy-worker" --exclude-dir=node_modules --exclude-dir=.git
```
- **Zero references found** - complete removal confirmed

### ✅ Linting
```bash
biome check
```
- Modified files pass linting checks

## Acceptance Criteria Met

- ✅ apps/proxy-worker directory completely removed
- ✅ All references to proxy-worker removed from monorepo configuration
- ✅ pnpm-workspace.yaml updated (wildcard pattern automatically excludes)
- ✅ All build scripts work correctly
- ✅ No TypeScript compilation errors
- ✅ All tests pass (263/263)
- ✅ No broken dependencies in remaining packages
- ✅ Documentation updated to remove proxy-worker references

## Breaking Changes

**None.** The proxy-worker package was already deprecated and not in active use.

## Migration Notes

**No migration required.** The proxy server architecture (`apps/proxy`) continues to handle OAuth and webhook functionality.

## Dependencies

- Depends on CYPACK-240 (ndjson-client removed first)
- Should be completed before EdgeWorker refactoring

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)