### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.26 to v0.1.27 - includes parity updates with Claude Code v2.0.27 and adds support for plugins field in Options. See [@anthropic-ai/claude-agent-sdk v0.1.27 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0127)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.27 to v0.1.28 - includes parity updates with Claude Code v2.0.28 and fixes custom tools timing out after 30 seconds instead of respecting the MCP_TOOL_TIMEOUT environment variable. See [@anthropic-ai/claude-agent-sdk v0.1.28 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0128)
 
 ## [0.1.57] - 2025-10-12
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.27",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
 		"@anthropic-ai/sdk": "^0.67.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.27",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.27
-        version: 0.1.27(zod@3.25.76)
+        specifier: ^0.1.28
+        version: 0.1.28(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.67.0
         version: 0.67.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.27
-        version: 0.1.27(zod@3.25.76)
+        specifier: ^0.1.28
+        version: 0.1.28(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.27':
-    resolution: {integrity: sha512-HuMPW6spj2q8FODiP/WBCqUZAYGwDPoI1EpicP9KUXvuYk+2MZQYSaD7oiN6iNPupR2T5oJ2HY/D9OzjyCD2Mw==}
+  '@anthropic-ai/claude-agent-sdk@0.1.28':
+    resolution: {integrity: sha512-latceXkaJbtV4mn2kqnbZgTZYlve+dhCGCW2liWhYdUv6KuoUEY6DK1VDzzHGnd2996fIBO/7E5PAAEHpsDing==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.27(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.28(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates @anthropic-ai/claude-agent-sdk from v0.1.27 to v0.1.28 in both `claude-runner` and `simple-agent-runner` packages.

## Changes
- Updated `packages/claude-runner/package.json`: @anthropic-ai/claude-agent-sdk ^0.1.27 → ^0.1.28
- Updated `packages/simple-agent-runner/package.json`: @anthropic-ai/claude-agent-sdk ^0.1.27 → ^0.1.28
- Updated CHANGELOG.md with version change and link to upstream changelog
- @anthropic-ai/sdk remains at v0.67.0 (already latest)

## Key Improvements in v0.1.28
- Parity updates with Claude Code v2.0.28
- Fixed bug where custom tools would timeout after 30 seconds instead of respecting the `MCP_TOOL_TIMEOUT` environment variable

See upstream changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0128

## Testing
- ✅ All 94 package tests passing
- ✅ Linting clean (biome)
- ✅ TypeScript type checking passed
- ✅ Build successful

## Related
Closes CYPACK-247