### PR TITLE
Fix unhandled webhook logging to always warn users

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1163,11 +1163,10 @@ export class EdgeWorker extends EventEmitter {
 			} else if (isAgentSessionPromptedWebhook(webhook)) {
 				await this.handleUserPostedAgentActivity(webhook, repository);
 			} else {
-				if (process.env.CYRUS_WEBHOOK_DEBUG === "true") {
-					console.log(
-						`[handleWebhook] Unhandled webhook type: ${(webhook as any).action} for repository ${repository.name}`,
-					);
-				}
+				console.warn(
+					`[EdgeWorker] Unhandled webhook - type: "${(webhook as any).type}", action: "${(webhook as any).action}" for repository "${repository.name}". ` +
+						`Set CYRUS_WEBHOOK_DEBUG=true for full payload details.`,
+				);
 			}
 		} catch (error) {
 			console.error(

--- a/packages/edge-worker/test/EdgeWorker.unhandled-webhook-logging.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.unhandled-webhook-logging.test.ts
@@ -1,0 +1,156 @@
+import type {
+	LinearAgentSessionCreatedWebhook,
+	LinearWebhook,
+} from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type MockProxy, mockDeep } from "vitest-mock-extended";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import type { EdgeWorkerConfig } from "../src/types.js";
+
+describe("EdgeWorker - Unhandled Webhook Logging", () => {
+	let edgeWorker: EdgeWorker;
+	let mockConfig: EdgeWorkerConfig;
+	let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// Mock configuration with a single repository
+		mockConfig = {
+			proxyUrl: "https://test-proxy.com",
+			cyrusHome: "/tmp/test-cyrus-home",
+			repositories: [
+				{
+					id: "test-repo",
+					name: "Test Repository",
+					repositoryPath: "/repos/test",
+					baseBranch: "main",
+					workspaceBaseDir: "/tmp/workspaces",
+					linearToken: "linear-token-1",
+					linearWorkspaceId: "workspace-1",
+					linearWorkspaceName: "Test Workspace",
+					teamKeys: ["TEST"],
+					isActive: true,
+				},
+			],
+		};
+
+		// Spy on console.log to verify logging behavior
+		consoleWarnSpy = vi.spyOn(console, "warn");
+
+		// Ensure CYRUS_WEBHOOK_DEBUG is not set (default user experience)
+		delete process.env.CYRUS_WEBHOOK_DEBUG;
+
+		edgeWorker = new EdgeWorker(mockConfig);
+	});
+
+	afterEach(() => {
+		consoleWarnSpy.mockRestore();
+	});
+
+	it("should log unhandled webhooks even when CYRUS_WEBHOOK_DEBUG is not set", async () => {
+		// Create a webhook with invalid type/action combination that won't match any type guard
+		// This simulates a webhook from Linear that doesn't match our expected structure
+		const invalidWebhook: MockProxy<LinearWebhook> = mockDeep<LinearWebhook>();
+		(invalidWebhook as any).type = "AgentSessionEvent"; // Type is correct
+		(invalidWebhook as any).action = "unknown_action"; // But action is not recognized
+		(invalidWebhook as any).organizationId = "workspace-1";
+		(invalidWebhook as any).agentSession = {
+			id: "session-123",
+			issue: {
+				id: "issue-123",
+				identifier: "TEST-42",
+				title: "Test Issue",
+				team: {
+					key: "TEST",
+					id: "team-123",
+					name: "Test Team",
+				},
+			},
+		};
+
+		// Access the private handleWebhook method through reflection
+		// @ts-expect-error - accessing private method for testing
+		await edgeWorker.handleWebhook(invalidWebhook, mockConfig.repositories);
+
+		// Verify that a warning was logged about the unhandled webhook
+		// This should happen even without CYRUS_WEBHOOK_DEBUG=true
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Unhandled webhook"),
+		);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("unknown_action"),
+		);
+	});
+
+	it("should log unhandled webhooks with type mismatch", async () => {
+		// Create a webhook that looks like AgentSessionCreated but with wrong type field
+		const mismatchedWebhook: MockProxy<LinearAgentSessionCreatedWebhook> =
+			mockDeep<LinearAgentSessionCreatedWebhook>();
+		(mismatchedWebhook as any).type = "AgentSession"; // Wrong: should be "AgentSessionEvent"
+		(mismatchedWebhook as any).action = "created";
+		(mismatchedWebhook as any).organizationId = "workspace-1";
+		(mismatchedWebhook as any).agentSession = {
+			id: "session-456",
+			issue: {
+				id: "issue-456",
+				identifier: "TEST-99",
+				title: "Another Test",
+				team: {
+					key: "TEST",
+					id: "team-123",
+					name: "Test Team",
+				},
+			},
+		};
+
+		// Access the private handleWebhook method through reflection
+		// @ts-expect-error - accessing private method for testing
+		await edgeWorker.handleWebhook(
+			mismatchedWebhook as LinearWebhook,
+			mockConfig.repositories,
+		);
+
+		// Verify that a warning was logged
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Unhandled webhook"),
+		);
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("created"),
+		);
+	});
+
+	it("should provide actionable debug information in unhandled webhook logs", async () => {
+		// Create an unhandled webhook
+		const unhandledWebhook: MockProxy<LinearWebhook> =
+			mockDeep<LinearWebhook>();
+		(unhandledWebhook as any).type = "SomeNewType";
+		(unhandledWebhook as any).action = "someNewAction";
+		(unhandledWebhook as any).organizationId = "workspace-1";
+		(unhandledWebhook as any).agentSession = {
+			issue: {
+				identifier: "TEST-123",
+				team: { key: "TEST" },
+			},
+		};
+
+		// Access the private handleWebhook method through reflection
+		// @ts-expect-error - accessing private method for testing
+		await edgeWorker.handleWebhook(unhandledWebhook, mockConfig.repositories);
+
+		// Verify that the log includes helpful debug information
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Unhandled webhook"),
+		);
+
+		// Should include the webhook type and action for debugging
+		const logCalls = consoleWarnSpy.mock.calls;
+		const relevantLog = logCalls.find((call) =>
+			call.some((arg) => String(arg).includes("Unhandled webhook")),
+		);
+
+		expect(relevantLog).toBeTruthy();
+		// Log should contain type and action information
+		const logString = relevantLog?.join(" ");
+		expect(logString).toContain("type");
+		expect(logString).toContain("action");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes silent failures when Linear webhooks don't match expected type guards. Previously, unhandled webhooks were only logged when `CYRUS_WEBHOOK_DEBUG=true`, causing users to see "Repository selected" but no further output or workspace creation.

## Problem

The user reported in CYPACK-255 that after completing interactive setup:
- ✅ Edge worker was receiving webhooks successfully
- ✅ Repository routing was working correctly
- ❌ No git worktrees were being created for delegated issues
- ❌ No error messages or warnings were shown

Root cause: When webhooks didn't match any type guard (e.g., unexpected `type` or `action` fields), they fell through to an `else` block that only logged when debug mode was enabled. This caused silent failures that were extremely difficult to diagnose.

## Changes

### Core Fix (EdgeWorker.ts:1166-1169)
- **Removed** `CYRUS_WEBHOOK_DEBUG` conditional for unhandled webhook logging
- **Changed** from `console.log` to `console.warn` for better visibility
- **Enhanced** message to include type, action, and repository name
- **Added** helpful pointer to enable debug mode for full payload details

### Test Coverage (EdgeWorker.unhandled-webhook-logging.test.ts)
- Test unhandled webhooks log even without debug mode
- Test webhooks with type mismatches are logged
- Test logs include actionable debug information (type/action)
- All 3 new tests passing, bringing edge-worker to 102 total tests

## Implementation Approach

1. **Analyzed root cause**: Traced webhook handling flow from reception through type guards to the silent failure point
2. **Minimal fix**: Changed only the unhandled webhook logging logic without touching type guards or handlers
3. **Followed patterns**: Used `console.warn` consistently with similar warnings in the codebase (e.g., failed connections, missing data)
4. **Added guidance**: Message points users to `CYRUS_WEBHOOK_DEBUG=true` for detailed debugging

## Testing Performed

- ✅ All 207 package tests passing (102 in edge-worker including 3 new tests)
- ✅ TypeScript compilation successful
- ✅ Linting clean (biome check)
- ✅ No regressions in existing webhook handling
- ✅ Verified warning appears for unhandled webhooks without debug mode

## Breaking Changes

None. This is purely an improvement to error visibility.

## User Impact

Users will now see clear warnings when webhooks aren't recognized:
```
[EdgeWorker] Unhandled webhook - type: "SomeType", action: "someAction" for repository "MyRepo". Set CYRUS_WEBHOOK_DEBUG=true for full payload details.
```

This makes it much easier to diagnose:
- API changes from Linear
- Configuration mismatches
- Network/proxy issues
- Integration problems

Fixes: CYPACK-255

🤖 Generated with [Claude Code](https://claude.com/claude-code)