### PR TITLE
Update @anthropic-ai/sdk to v0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Debugger workflow now proceeds directly from bug reproduction to fix implementation without requiring manual approval
 - Updated @anthropic-ai/claude-agent-sdk from v0.1.25 to v0.1.28 - includes parity updates with Claude Code v2.0.28 and fixes custom tools timing out after 30 seconds instead of respecting the MCP_TOOL_TIMEOUT environment variable. See [@anthropic-ai/claude-agent-sdk v0.1.28 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0128)
+- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 - adds ability to clear thinking in context management. See [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0680-2025-10-28)
 - All workflows (full-development, debugger-full, orchestrator-full) now end with concise summary instead of verbose summary
 - Non-summary subroutines (debugger-fix, debugger-reproduction, verifications, git-gh) now explicitly avoid posting Linear comments and end with brief 1-sentence completion messages
 - Orchestrator agents are now strongly discouraged from posting Linear comments to current issues; comments only used when triggering sub-agent sessions on child issues

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
-		"@anthropic-ai/sdk": "^0.67.0",
+		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^0.1.28
         version: 0.1.28(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.67.0
-        version: 0.67.0(zod@3.25.76)
+        specifier: ^0.68.0
+        version: 0.68.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -263,8 +263,8 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.67.0':
-    resolution: {integrity: sha512-Buxbf6jYJ+pPtfCgXe1pcFtZmdXPrbdqhBjiscFt9irS1G0hCsmR/fPA+DwKTk4GPjqeNnnCYNecXH6uVZ4G/A==}
+  '@anthropic-ai/sdk@0.68.0':
+    resolution: {integrity: sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2548,7 +2548,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.67.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.68.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates `@anthropic-ai/sdk` from v0.67.0 to v0.68.0 in the `cyrus-claude-runner` package.

## Changes
- Updated `@anthropic-ai/sdk` dependency to v0.68.0 in `packages/claude-runner/package.json`
- Updated `pnpm-lock.yaml` with new package version
- Updated `CHANGELOG.md` with version change and link to SDK changelog

## What's New in v0.68.0
This release adds the ability to clear thinking in context management. See the [full changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0680-2025-10-28) for details.

## Testing
- ✅ All 222 package tests passing
- ✅ Linting clean (Biome)
- ✅ TypeScript type checking passed
- ✅ All packages built successfully

## Notes
- `@anthropic-ai/claude-agent-sdk` was already at the latest version (v0.1.28), so no update was needed
- No breaking changes or migration required

Resolves CYPACK-256

🤖 Generated with [Claude Code](https://claude.com/claude-code)