### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.29 and @anthropic-ai/sdk to v0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.29 - includes parity updates with Claude Code v2.0.29. See [@anthropic-ai/claude-agent-sdk v0.1.29 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0129)
+- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 - adds ability to clear thinking in context management. See [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0680---2025-10-28)
+
 ## [0.1.58] - 2025-10-29
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
-		"@anthropic-ai/sdk": "^0.67.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.29",
+		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.29",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.29
+        version: 0.1.29(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.67.0
-        version: 0.67.0(zod@3.25.76)
+        specifier: ^0.68.0
+        version: 0.68.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.29
+        version: 0.1.29(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,14 +257,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28':
-    resolution: {integrity: sha512-latceXkaJbtV4mn2kqnbZgTZYlve+dhCGCW2liWhYdUv6KuoUEY6DK1VDzzHGnd2996fIBO/7E5PAAEHpsDing==}
+  '@anthropic-ai/claude-agent-sdk@0.1.29':
+    resolution: {integrity: sha512-VbR2ybPdJHVKAD3pQdruVw8LdXoPbk5J59xU/bQoMNzAsBckHrD2LhupMJrBxLUWxLaPkIUlNKquGBRbkoK84Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.67.0':
-    resolution: {integrity: sha512-Buxbf6jYJ+pPtfCgXe1pcFtZmdXPrbdqhBjiscFt9irS1G0hCsmR/fPA+DwKTk4GPjqeNnnCYNecXH6uVZ4G/A==}
+  '@anthropic-ai/sdk@0.68.0':
+    resolution: {integrity: sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.29(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2548,7 +2548,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.67.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.68.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates Anthropic SDK packages to their latest versions:
- `@anthropic-ai/claude-agent-sdk`: v0.1.28 → v0.1.29
- `@anthropic-ai/sdk`: v0.67.0 → v0.68.0

## Changes Made

### SDK Updates
- **@anthropic-ai/claude-agent-sdk v0.1.29**
  - Updated to parity with Claude Code v2.0.29
  - [Changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0129)
  
- **@anthropic-ai/sdk v0.68.0**
  - Adds ability to clear thinking in context management
  - [Changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0680---2025-10-28)

### Files Modified
- `packages/claude-runner/package.json` - Updated both SDK versions
- `packages/simple-agent-runner/package.json` - Updated claude-agent-sdk version
- `CHANGELOG.md` - Added changelog entries with upstream links
- `pnpm-lock.yaml` - Updated with new package versions

## Testing Performed
✅ All tests passing (222 tests across all packages)
- claude-runner: 66 tests passed
- simple-agent-runner: 24 tests passed
- edge-worker: 117 tests passed
- ndjson-client: 15 tests passed

✅ Linting clean (biome check passed)
✅ TypeScript type checking passed for all packages
✅ Build successful

## Breaking Changes
None - these are minor version updates with backward compatibility.

Closes CYPACK-261