### PR TITLE
Update Anthropic SDK packages to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.30 - includes parity updates with Claude Code v2.0.31, --max-budget-usd flag support, and fixes for stream mode hook failures. See [@anthropic-ai/claude-agent-sdk v0.1.30 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0130)
+- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0
+
 ## [0.1.58] - 2025-10-29
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
-		"@anthropic-ai/sdk": "^0.67.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.30
+        version: 0.1.30(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.67.0
-        version: 0.67.0(zod@3.25.76)
+        specifier: ^0.68.0
+        version: 0.68.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.30
+        version: 0.1.30(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,14 +257,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28':
-    resolution: {integrity: sha512-latceXkaJbtV4mn2kqnbZgTZYlve+dhCGCW2liWhYdUv6KuoUEY6DK1VDzzHGnd2996fIBO/7E5PAAEHpsDing==}
+  '@anthropic-ai/claude-agent-sdk@0.1.30':
+    resolution: {integrity: sha512-lo1tqxCr2vygagFp6kUMHKSN6AAWlULCskwGKtLB/JcIXy/8H8GsLSKX54anTsvc9mBbCR8wWASdFmiiL9NSKA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.67.0':
-    resolution: {integrity: sha512-Buxbf6jYJ+pPtfCgXe1pcFtZmdXPrbdqhBjiscFt9irS1G0hCsmR/fPA+DwKTk4GPjqeNnnCYNecXH6uVZ4G/A==}
+  '@anthropic-ai/sdk@0.68.0':
+    resolution: {integrity: sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.30(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2548,7 +2548,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.67.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.68.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates the Anthropic SDK packages to their latest versions:
- `@anthropic-ai/claude-agent-sdk`: v0.1.28 → v0.1.30
- `@anthropic-ai/sdk`: v0.67.0 → v0.68.0

## Changes Made

### Package Updates
- **claude-runner**: Updated both `@anthropic-ai/claude-agent-sdk` and `@anthropic-ai/sdk` dependencies
- **simple-agent-runner**: Updated `@anthropic-ai/claude-agent-sdk` dependency
- **pnpm-lock.yaml**: Refreshed lockfile with new package versions

### Documentation
- Updated `CHANGELOG.md` with detailed information about SDK changes
- Added link to upstream changelog for reference

## What's New in SDK v0.1.30

From the [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0130):
- Parity with Claude Code v2.0.31
- Added --max-budget-usd flag support
- Fixed bugs where hooks were sometimes failing in stream mode

## Testing Performed

✅ All package tests passing (222 tests total across all packages)
✅ TypeScript type checking clean across all packages
✅ Linting clean (biome check)
✅ Full build successful

### Test Breakdown
- ndjson-client: 15 tests passed
- claude-runner: 66 tests passed
- simple-agent-runner: 24 tests passed
- edge-worker: 117 tests passed

## Breaking Changes

None - these are minor/patch version updates with backward compatibility.

## Related

Resolves CYPACK-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)