### PR TITLE
Fix missing prompt files in edge-worker published package

### DIFF
--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -14,7 +14,7 @@
 	],
 	"scripts": {
 		"build": "tsc && npm run copy-prompts",
-		"copy-prompts": "mkdir -p dist/prompts/subroutines && cp -r src/prompts/subroutines/*.md dist/prompts/subroutines/",
+		"copy-prompts": "mkdir -p dist/prompts/subroutines && cp -r src/prompts/subroutines/*.md dist/prompts/subroutines/ && cp -r prompts/*.md dist/prompts/",
 		"dev": "tsc --watch",
 		"test": "vitest",
 		"test:run": "vitest run",


### PR DESCRIPTION
## Summary

Fixes the ENOENT error when Cyrus tries to load prompt files from the published edge-worker npm package. The root-level prompt files (builder.md, debugger.md, orchestrator.md, scoper.md) were not being copied to the dist directory during the build process.

## Implementation Approach

Updated the `copy-prompts` build script in `packages/edge-worker/package.json` to copy both:
1. Subroutine prompts: `src/prompts/subroutines/*.md` → `dist/prompts/subroutines/`
2. Root-level prompts: `prompts/*.md` → `dist/prompts/`

This ensures all required prompt files are included in the published npm package at the correct paths relative to the compiled JavaScript code.

## Testing Performed

- ✅ Built the edge-worker package successfully
- ✅ Verified all prompt files are present in `dist/prompts/` directory
- ✅ All 117 edge-worker tests pass
- ✅ All package tests pass (227+ tests total)
- ✅ Linting clean
- ✅ TypeScript type checking passes

## Changes

- Modified `packages/edge-worker/package.json` to extend the `copy-prompts` script

## Related Issue

Fixes CYPACK-265

🤖 Generated with [Claude Code](https://claude.com/claude-code)