### PR TITLE
[Browser Demo] Fix timeline navigation scroll behavior

### DIFF
--- a/apps/browser-demo/public/app.js
+++ b/apps/browser-demo/public/app.js
@@ -539,7 +539,13 @@ class CyrusDemoClient {
 	scrollToActivity(activityId) {
 		const activity = document.getElementById(`activity-${activityId}`);
 		if (activity) {
-			activity.scrollIntoView({ behavior: "smooth", block: "center" });
+			// Use 'nearest' to prevent unwanted page scrolling
+			// This keeps the activity visible without disrupting the overall layout
+			activity.scrollIntoView({
+				behavior: "smooth",
+				block: "nearest",
+				inline: "nearest",
+			});
 			activity.classList.add("highlight");
 			setTimeout(() => activity.classList.remove("highlight"), 2000);
 


### PR DESCRIPTION
## Summary
Fixed the timeline dot navigation feature that was causing unwanted page scrolling when clicking timeline items.

## Root Cause
The `scrollIntoView` method was using `block: "center"`, which forced the entire page to scroll to center the target activity. This caused jarring page jumps, especially when clicking later timeline items.

## Implementation
Changed `scrollToActivity()` method in `apps/browser-demo/public/app.js`:
- **Before**: `scrollIntoView({ behavior: "smooth", block: "center" })`
- **After**: `scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" })`

The `"nearest"` option scrolls minimally to make the target visible without disrupting the overall page layout.

## Testing Performed
- ✅ Linting passed (biome check clean for browser-demo)
- ✅ Code review: minimal change, well-commented
- ✅ Follows existing code patterns
- ✅ No TypeScript issues (public/app.js excluded from TS compilation)

## Manual Testing Required
To verify the fix:
1. Start demo: `cd apps/browser-demo && pnpm start`
2. Navigate to http://localhost:3000
3. Generate long session (50+ activities)
4. Click various timeline dots (first, middle, last)
5. Try rapid clicking between dots
6. Verify smooth scroll without jarring page jumps

## Related
Closes CYPACK-293

🤖 Generated with [Claude Code](https://claude.com/claude-code)