### PR TITLE
[Refactor] Rename 'demo' to 'emulator' in browser-demo for clarity

### DIFF
--- a/apps/browser-demo/README.md
+++ b/apps/browser-demo/README.md
@@ -19,7 +19,7 @@ This is a **key deliverable for CYPACK-278**, demonstrating:
 - 📝 **Interactive Messaging**: Send messages to the agent during execution
 - 🛑 **Stop Signal**: Click button to send stop signal to agent
 - 📜 **Scrollable History**: Auto-scrolling activity log
-- 🎭 **Demo Mode**: Mock components for testing without credentials
+- 🎭 **Emulator Mode**: Mock components for testing without credentials
 - 🔌 **WebSocket Communication**: Efficient real-time bidirectional updates
 
 ## Architecture
@@ -55,8 +55,8 @@ This is a **key deliverable for CYPACK-278**, demonstrating:
 
 ### Component Responsibilities
 
-1. **MockAgentRunner**: Simulates Claude with realistic events
-2. **MockIssueTracker**: Simulates Linear with a demo issue
+1. **MockAgentRunner**: Simulates Claude with realistic events (emulator mode)
+2. **MockIssueTracker**: Simulates Linear with an emulated issue
 3. **BrowserRenderer**: Sends activity updates to browser via WebSocket
 4. **FileSessionStorage**: Persists session state to filesystem
 5. **Orchestrator**: Coordinates all components and routes events
@@ -83,9 +83,9 @@ pnpm start
 
 Then open your browser to: **http://localhost:3000**
 
-The demo will automatically:
+The application will automatically:
 - Start the orchestrator
-- Detect the pre-assigned demo issue
+- Detect the pre-assigned emulated issue
 - Begin a mock agent session
 - Display real-time activity in the browser
 
@@ -108,8 +108,8 @@ CYRUS_HOME=/tmp/cyrus pnpm start
 1. **Express Server**: Serves static HTML/CSS/JS files
 2. **WebSocket Server**: Handles real-time bidirectional communication
 3. **BrowserRenderer**: Implements the `Renderer` interface, sends JSON messages to browser
-4. **Orchestrator**: Same orchestration logic as CLI demo
-5. **Mock Components**: Mock implementations for testing
+4. **Orchestrator**: Same orchestration logic as CLI implementation
+5. **Mock Components**: Mock implementations for emulator mode
 
 ### Browser Side
 
@@ -183,8 +183,8 @@ apps/browser-demo/
 ├── src/
 │   ├── server.ts              # Main server entry point
 │   ├── BrowserRenderer.ts     # Renderer implementation for browser
-│   ├── MockAgentRunner.ts     # Simulated agent (reused from CLI demo)
-│   └── MockIssueTracker.ts    # Simulated issue tracker (reused)
+│   ├── MockAgentRunner.ts     # Simulated agent (for emulator mode)
+│   └── MockIssueTracker.ts    # Simulated issue tracker (for emulator mode)
 ├── public/
 │   ├── index.html             # Browser UI structure
 │   └── app.js                 # Browser client logic
@@ -193,23 +193,23 @@ apps/browser-demo/
 └── README.md                  # This file
 ```
 
-## Comparison with CLI Demo
+## Comparison with CLI Implementation
 
-| Feature | CLI Demo | Browser Demo |
+| Feature | CLI Implementation | Browser Implementation |
 |---------|----------|--------------|
 | **UI Framework** | React/Ink (terminal) | Vanilla HTML/JS (browser) |
 | **Renderer** | CLIRenderer | BrowserRenderer |
 | **Communication** | Direct (same process) | WebSocket |
 | **Display** | Terminal UI | Web page |
 | **Accessibility** | Requires terminal access | Access via browser |
-| **Use Case** | Local development | Remote demos, screenshots |
+| **Use Case** | Local development | Remote access, screenshots |
 
 ## Verification
 
 This app fulfills all acceptance criteria from CYPACK-278:
 
 - ✅ Simple web page (HTML + vanilla JS) that runs locally
-- ✅ Reuses MockAgentRunner and MockIssueTracker from CLI demo
+- ✅ Includes MockAgentRunner and MockIssueTracker for emulator mode
 - ✅ Displays real-time activity log (text events, tool-use events)
 - ✅ Shows message input field at bottom (like Linear's "message Cyrus")
 - ✅ Supports stop button during agent execution
@@ -342,7 +342,7 @@ Then open: http://localhost:8080
 - **No build step for browser code**: HTML/JS served directly
 - **TypeScript only for server**: Browser uses vanilla JavaScript
 - **WebSocket for real-time**: Efficient bidirectional communication
-- **Reuses demo components**: Same MockAgentRunner and MockIssueTracker as CLI demo
+- **Mock components available**: MockAgentRunner and MockIssueTracker for emulator mode
 - **Same orchestrator**: Proves architecture works with different renderers
 
 ## Future Enhancements

--- a/apps/browser-demo/TESTING_GUIDE.md
+++ b/apps/browser-demo/TESTING_GUIDE.md
@@ -40,7 +40,7 @@ Test switching between Mock and Claude agent implementations:
 - **Mock**: Simulated agent responses (no credentials needed)
 - **Claude**: Real Claude Code execution (requires authentication)
 
-**Note**: Changing runner modes requires server restart. Use `--demo` flag for mock mode, omit for Claude mode.
+**Note**: Changing runner modes requires server restart. Use `--emulator` flag for mock mode, omit for Claude mode.
 
 ### Issue Tracker Controls
 
@@ -283,7 +283,7 @@ pnpm start
 
 1. Verify WebSocket connection
 2. Check server logs for test control messages
-3. Ensure server is in correct mode (demo vs. real)
+3. Ensure server is in correct mode (emulator vs. real)
 
 ### Session Storage Issues
 

--- a/apps/browser-demo/src/server.ts
+++ b/apps/browser-demo/src/server.ts
@@ -45,7 +45,7 @@ function handleTestControlMessage(
 				JSON.stringify({
 					type: "test:response",
 					action: "success",
-					message: `Note: Switching runner modes requires server restart with --demo flag or without`,
+					message: `Note: Switching runner modes requires server restart with --emulator flag or without`,
 				}),
 			);
 			break;
@@ -231,7 +231,7 @@ function runTestScenario(
 
 // Parse command-line arguments
 interface CLIArgs {
-	demo?: boolean;
+	emulator?: boolean;
 	port?: number;
 	help?: boolean;
 }
@@ -244,8 +244,8 @@ function parseArgs(args: string[]): CLIArgs {
 
 		if (arg === "--help" || arg === "-h") {
 			parsed.help = true;
-		} else if (arg === "--demo") {
-			parsed.demo = true;
+		} else if (arg === "--emulator") {
+			parsed.emulator = true;
 		} else if (arg === "--port" || arg === "-p") {
 			const portArg = args[++i];
 			if (portArg) {
@@ -265,13 +265,13 @@ USAGE:
   cyrus-browser-demo [OPTIONS]
 
 OPTIONS:
-  --demo              Run in demo mode with mock components (no real Claude/Linear)
+  --emulator          Run in emulator mode with mock components (no real Claude/Linear)
   --port, -p <PORT>   Port to run the server on (default: 3000)
   --help, -h          Show this help message
 
 EXAMPLES:
-  # Run in demo mode (no credentials needed)
-  cyrus-browser-demo --demo
+  # Run in emulator mode (no credentials needed)
+  cyrus-browser-demo --emulator
 
   # Run with real Claude (requires authentication)
   cyrus-browser-demo
@@ -299,7 +299,7 @@ if (args.help) {
 }
 
 // Configuration
-const DEMO_MODE = args.demo ?? false;
+const EMULATOR_MODE = args.emulator ?? false;
 const PORT = args.port || Number.parseInt(process.env.PORT || "3000", 10);
 const CYRUS_HOME = process.env.CYRUS_HOME || path.join(os.homedir(), ".cyrusd");
 const SESSIONS_DIR = path.join(CYRUS_HOME, "sessions", "browser-demo");
@@ -310,13 +310,13 @@ const CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
  * Browser Demo Server
  *
  * Serves the browser UI and manages WebSocket connections for real-time updates.
- * Supports both demo mode (mock) and real mode (Claude Code).
+ * Supports both emulator mode (mock) and real mode (Claude Code).
  */
 async function main() {
 	console.log("🚀 Starting Cyrus Browser Demo Server...\n");
 
 	// Validate authentication for real mode
-	if (!DEMO_MODE) {
+	if (!EMULATOR_MODE) {
 		const hasApiKey = !!ANTHROPIC_API_KEY;
 		const hasOAuthToken = !!CLAUDE_CODE_OAUTH_TOKEN;
 
@@ -327,7 +327,7 @@ async function main() {
 				"   - CLAUDE_CODE_OAUTH_TOKEN (recommended, get via: claude setup-token)",
 			);
 			console.error("   - ANTHROPIC_API_KEY");
-			console.error("   Or run with --demo flag for demo mode\n");
+			console.error("   Or run with --emulator flag for emulator mode\n");
 			process.exit(1);
 		}
 
@@ -368,9 +368,9 @@ async function main() {
 
 	let agentRunner: AgentRunner;
 
-	if (DEMO_MODE) {
+	if (EMULATOR_MODE) {
 		agentRunner = new MockAgentRunner();
-		console.log(`   ✓ Mock Agent Runner (demo mode)`);
+		console.log(`   ✓ Mock Agent Runner (emulator mode)`);
 	} else {
 		agentRunner = new ClaudeAgentRunner({
 			cyrusHome: CYRUS_HOME,
@@ -492,12 +492,12 @@ async function main() {
 		console.log(`   📂 Public directory: ${publicDir}`);
 		console.log(`   💾 Sessions directory: ${SESSIONS_DIR}`);
 		console.log(
-			`   🎭 Mode: ${DEMO_MODE ? "Demo (mock responses)" : "Real (Claude Code)"}`,
+			`   🎭 Mode: ${EMULATOR_MODE ? "Emulator mode (mock responses)" : "Real (Claude Code)"}`,
 		);
 		console.log(
 			`\n   🎯 Open the URL in your browser to see the interactive demo`,
 		);
-		if (!DEMO_MODE) {
+		if (!EMULATOR_MODE) {
 			console.log(
 				`   🤖 Using real Claude Code agent - sessions will show actual Claude responses`,
 			);


### PR DESCRIPTION
## Summary

Renames all references of "demo" to "emulator" in the browser-demo application to clarify that the `--emulator` flag enables emulator mode (using mock/simulated data) rather than just being a generic "demo".

## Changes Made

- **CLI flag**: Changed from `--demo` to `--emulator` in server.ts
- **Environment variable**: Renamed `DEMO_MODE` to `EMULATOR_MODE`
- **Console logs**: Updated all messages to use "Emulator mode" instead of "Demo mode"
- **Code comments**: Updated to use "emulator" terminology
- **Documentation**: Updated README.md and TESTING_GUIDE.md with new flag and terminology

## Implementation Approach

This is a straightforward find-and-replace refactoring with the following scope:
- `apps/browser-demo/src/server.ts` - Primary changes to CLI parsing, environment variables, and log messages
- `apps/browser-demo/README.md` - Documentation updates
- `apps/browser-demo/TESTING_GUIDE.md` - Testing guide updates

Appropriate uses of "demo" were preserved (e.g., "Browser Demo" as the app name, "browser-demo" as the package name, and demo data in mock components).

## Testing Performed

✅ **TypeScript type checking**: All types valid across monorepo
✅ **Linting**: Clean (1 pre-existing warning unrelated to changes)
✅ **Server startup with --emulator**: Verified server starts correctly and displays "Emulator mode (mock responses)"
✅ **Help output**: Confirmed `--help` shows correct `--emulator` flag documentation
✅ **Old references removed**: Verified no `--demo` or `DEMO_MODE` references remain in code

**Verification Commands:**
```bash
# Start server in emulator mode
cd apps/browser-demo
node dist/server.js --emulator

# Verify help output
node dist/server.js --help

# Check for old references
grep -r "\-\-demo\|DEMO_MODE" apps/browser-demo/src apps/browser-demo/README.md apps/browser-demo/TESTING_GUIDE.md
```

## Breaking Changes

⚠️ **Breaking Change**: The `--demo` CLI flag is no longer recognized. Users must update to use `--emulator` instead.

**Migration:**
- Old: `cyrus-browser-demo --demo`
- New: `cyrus-browser-demo --emulator`

The environment variable `DEMO_MODE` has been renamed to `EMULATOR_MODE`, though this was an internal variable not documented for external use.

## Checklist

- [x] All acceptance criteria met
- [x] Code quality reviewed
- [x] TypeScript types valid
- [x] Linting clean
- [x] Server tested with new flag
- [x] Documentation updated
- [x] No debug code or console.logs added

Fixes CYPACK-298