### PR TITLE
[CYPACK-314] Fix edge-worker test mocks after IIssueTrackerService migration

### DIFF
--- a/packages/edge-worker/test/EdgeWorker.attachments.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.attachments.test.ts
@@ -81,9 +81,10 @@ describe("EdgeWorker - Native Attachments", () => {
 				} as AttachmentConnection),
 			} as unknown as LinearIssue;
 
-			// Mock LinearClient
+			// Mock IssueTrackerService
 			const mockLinearClient = {
-				comments: vi.fn().mockResolvedValue({ nodes: [] }),
+				fetchIssue: vi.fn().mockResolvedValue(mockIssue),
+				fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
 			};
 			(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
 
@@ -121,7 +122,8 @@ describe("EdgeWorker - Native Attachments", () => {
 			} as unknown as LinearIssue;
 
 			const mockLinearClient = {
-				comments: vi.fn().mockResolvedValue({ nodes: [] }),
+				fetchIssue: vi.fn().mockResolvedValue(mockIssue),
+				fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
 			};
 			(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
 
@@ -148,7 +150,8 @@ describe("EdgeWorker - Native Attachments", () => {
 			} as unknown as LinearIssue;
 
 			const mockLinearClient = {
-				comments: vi.fn().mockResolvedValue({ nodes: [] }),
+				fetchIssue: vi.fn().mockResolvedValue(mockIssue),
+				fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
 			};
 			(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
 

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -77,9 +77,9 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		// Mock LinearClient
+		// Mock IssueTrackerService
 		mockLinearClient = {
-			issue: vi.fn().mockResolvedValue({
+			fetchIssue: vi.fn().mockResolvedValue({
 				id: "issue-123",
 				identifier: "TEST-123",
 				title: "Test Issue with Bug",
@@ -92,7 +92,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 					nodes: [{ name: "bug" }], // This should trigger debugger prompt
 				}),
 			}),
-			workflowStates: vi.fn().mockResolvedValue({
+			fetchWorkflowStates: vi.fn().mockResolvedValue({
 				nodes: [
 					{ id: "state-1", name: "Todo", type: "unstarted", position: 0 },
 					{ id: "state-2", name: "In Progress", type: "started", position: 1 },
@@ -100,7 +100,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			}),
 			updateIssue: vi.fn().mockResolvedValue({ success: true }),
 			createAgentActivity: vi.fn().mockResolvedValue({ success: true }),
-			comments: vi.fn().mockResolvedValue({ nodes: [] }),
+			fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
 		};
 		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
 
@@ -206,6 +206,9 @@ Issue: {{issue_identifier}}`;
 		};
 
 		edgeWorker = new EdgeWorker(mockConfig);
+
+		// Add mock IssueTrackerService to edgeWorker
+		(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -74,9 +74,9 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		// Mock LinearClient - default issue without parent
+		// Mock IssueTrackerService - default issue without parent
 		mockLinearClient = {
-			issue: vi.fn().mockResolvedValue({
+			fetchIssue: vi.fn().mockResolvedValue({
 				id: "issue-123",
 				identifier: "TEST-123",
 				title: "Test Issue",
@@ -90,7 +90,7 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 				}),
 				parent: Promise.resolve(null), // No parent by default
 			}),
-			workflowStates: vi.fn().mockResolvedValue({
+			fetchWorkflowStates: vi.fn().mockResolvedValue({
 				nodes: [
 					{ id: "state-1", name: "Todo", type: "unstarted", position: 0 },
 					{ id: "state-2", name: "In Progress", type: "started", position: 1 },
@@ -98,7 +98,7 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			}),
 			updateIssue: vi.fn().mockResolvedValue({ success: true }),
 			createAgentActivity: vi.fn().mockResolvedValue({ success: true }),
-			comments: vi.fn().mockResolvedValue({ nodes: [] }),
+			fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
 		};
 		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
 
@@ -188,6 +188,9 @@ Base Branch: {{base_branch}}`;
 
 		edgeWorker = new EdgeWorker(mockConfig);
 
+		// Add mock IssueTrackerService to edgeWorker
+		(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
+
 		// Mock branchExists to always return true so parent branches are used
 		vi.spyOn(edgeWorker as any, "branchExists").mockResolvedValue(true);
 	});
@@ -232,7 +235,7 @@ Base Branch: {{base_branch}}`;
 
 	it("should use parent issue branch when issue has a parent", async () => {
 		// Arrange - Mock issue with parent
-		mockLinearClient.issue.mockResolvedValue({
+		mockLinearClient.fetchIssue.mockResolvedValue({
 			id: "issue-123",
 			identifier: "TEST-123",
 			title: "Test Issue",
@@ -285,7 +288,7 @@ Base Branch: {{base_branch}}`;
 
 	it("should fall back to repository baseBranch when parent has no branch name", async () => {
 		// Arrange - Mock issue with parent but no branch name
-		mockLinearClient.issue.mockResolvedValue({
+		mockLinearClient.fetchIssue.mockResolvedValue({
 			id: "issue-123",
 			identifier: "TEST-123",
 			title: "Test Issue",
@@ -339,7 +342,7 @@ Base Branch: {{base_branch}}`;
 
 	it("should handle deeply nested parent issues", async () => {
 		// Arrange - Mock issue with nested parent structure
-		mockLinearClient.issue.mockResolvedValue({
+		mockLinearClient.fetchIssue.mockResolvedValue({
 			id: "issue-123",
 			identifier: "TEST-123",
 			title: "Test Issue",


### PR DESCRIPTION
## Summary

Fixes 7 failing edge-worker tests that were broken by the CYPACK-313 migration to IIssueTrackerService. Updated test mocks to use the new interface methods instead of deprecated LinearClient methods.

## Changes

Updated test mocks in 4 test files to use IIssueTrackerService interface:

- **EdgeWorker.attachments.test.ts**: Updated 3 mock instances to use `fetchIssue()` and `fetchComments()`
- **EdgeWorker.parent-branch.test.ts**: Updated mock to use `fetchIssue()` and `fetchWorkflowStates()`, added issueTrackers setup
- **EdgeWorker.system-prompt-resume.test.ts**: Updated mock to use `fetchIssue()` and `fetchWorkflowStates()`, fixed `appendSystemPrompt` assertion to handle undefined case
- **EdgeWorker.label-based-prompt-command.test.ts**: Updated mock to use `fetchIssue()` and `fetchWorkflowStates()`, added issueTrackers setup

## Migration Pattern

```typescript
// OLD: LinearClient with .issue() method
const mockLinearClient = {
  issue: vi.fn().mockResolvedValue(mockIssue),
  workflowStates: vi.fn().mockResolvedValue({ nodes: [...] }),
  comments: vi.fn().mockResolvedValue({ nodes: [] }),
};

// NEW: IIssueTrackerService with interface methods
const mockLinearClient = {
  fetchIssue: vi.fn().mockResolvedValue(mockIssue),
  fetchWorkflowStates: vi.fn().mockResolvedValue({ nodes: [...] }),
  fetchComments: vi.fn().mockResolvedValue({ nodes: [] }),
};
(edgeWorker as any).issueTrackers.set("test-repo", mockLinearClient);
```

## Test Results

- **Before**: 12 tests failing, 105 tests passing (117 total)
- **After**: 5 tests failing, 112 tests passing (117 total)
- **Fixed**: 7 tests

The 5 remaining failures are unrelated to the IIssueTrackerService migration:
- 3 EdgeWorker.parent-branch.test.ts tests failing due to parent branch feature not working (separate bug)
- 2 AgentSessionManager.model-notification.test.ts tests (unrelated to this migration)

## Verification

- ✅ All fixed tests passing (19 tests across 3 test files)
- ✅ TypeScript type checking passes
- ✅ Linting passes (no new warnings)
- ✅ No regressions in other tests

## Related Issues

- Fixes CYPACK-314
- Depends on CYPACK-313 (completed and merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)