### PR TITLE
[Abstraction] Restore agent activity expressiveness and ephemeral support

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export type {
 } from "./issue-tracker/index.js";
 export {
 	AgentActivityContentType,
+	AgentActivitySignal,
 	CLIEventTransport,
 	CLIIssueTrackerService,
 	CLIRPCServer,

--- a/packages/core/src/issue-tracker/IIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/IIssueTrackerService.ts
@@ -15,6 +15,7 @@ import type {
 import type {
 	AgentActivity,
 	AgentActivityContent,
+	AgentActivitySignal,
 	AgentSession,
 	AgentSessionCreateOnCommentInput,
 	AgentSessionCreateOnIssueInput,
@@ -507,6 +508,7 @@ export interface IIssueTrackerService {
 	 *
 	 * @param sessionId - Agent session ID to post activity to
 	 * @param content - Activity content and type
+	 * @param options - Optional activity options (ephemeral, signal, signalMetadata)
 	 * @returns Promise resolving to the created activity
 	 * @throws Error if session not found or creation fails
 	 *
@@ -518,26 +520,32 @@ export interface IIssueTrackerService {
 	 *   body: 'I need to analyze the issue requirements'
 	 * });
 	 *
-	 * // Post an action activity
+	 * // Post an ephemeral action activity (will be replaced by next activity)
 	 * await service.createAgentActivity(sessionId, {
 	 *   type: AgentActivityContentType.Action,
 	 *   body: 'Running tests to verify the fix'
-	 * });
+	 * }, { ephemeral: true });
 	 *
-	 * // Post a response activity
+	 * // Post a response activity with signal
 	 * await service.createAgentActivity(sessionId, {
 	 *   type: AgentActivityContentType.Response,
 	 *   body: 'I have completed the requested changes'
-	 * });
+	 * }, { signal: AgentActivitySignal.Stop });
 	 * ```
 	 *
 	 * @remarks
 	 * This is the primary method for posting agent updates to Linear.
 	 * Activities are visible in the Linear UI as part of the agent session.
+	 * Ephemeral activities disappear when replaced by the next activity.
 	 */
 	createAgentActivity(
 		sessionId: string,
 		content: AgentActivityContent,
+		options?: {
+			ephemeral?: boolean;
+			signal?: AgentActivitySignal;
+			signalMetadata?: Record<string, any>;
+		},
 	): Promise<AgentActivity>;
 
 	// ========================================================================

--- a/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
@@ -39,7 +39,11 @@ import type {
 	User,
 	WorkflowState,
 } from "../types.js";
-import { AgentActivityContentType, WorkflowStateType } from "../types.js";
+import {
+	AgentActivityContentType,
+	AgentActivitySignal,
+	WorkflowStateType,
+} from "../types.js";
 import { CLIEventTransport } from "./CLIEventTransport.js";
 
 /**
@@ -697,8 +701,24 @@ export class CLIIssueTrackerService
 	async createAgentActivity(
 		sessionId: string,
 		content: AgentActivityContent,
+		options?: {
+			ephemeral?: boolean;
+			signal?: AgentActivitySignal;
+			signalMetadata?: Record<string, any>;
+		},
 	): Promise<AgentActivity> {
 		await this.fetchAgentSession(sessionId); // Ensure session exists
+
+		const activities = this.state.agentActivities.get(sessionId) || [];
+
+		// Ephemeral behavior: Remove the previous ephemeral activity if it exists
+		if (activities.length > 0) {
+			const lastActivity = activities[activities.length - 1];
+			if (lastActivity?.ephemeral) {
+				// Remove the last ephemeral activity
+				activities.pop();
+			}
+		}
 
 		const now = this.now();
 		const activity: AgentActivity = {
@@ -706,12 +726,14 @@ export class CLIIssueTrackerService
 			agentSessionId: sessionId,
 			agentContextId: null,
 			content,
+			signal: options?.signal,
+			signalMetadata: options?.signalMetadata,
+			ephemeral: options?.ephemeral ?? false,
 			createdAt: now,
 			updatedAt: now,
 			archivedAt: null,
 		};
 
-		const activities = this.state.agentActivities.get(sessionId) || [];
 		activities.push(activity);
 		this.state.agentActivities.set(sessionId, activities);
 
@@ -762,7 +784,7 @@ export class CLIIssueTrackerService
 				type: AgentActivityContentType.Prompt,
 				body: "STOP",
 			},
-			signal: "stop",
+			signal: AgentActivitySignal.Stop,
 			createdAt: now,
 			updatedAt: now,
 			archivedAt: null,

--- a/packages/core/src/issue-tracker/adapters/LinearIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/adapters/LinearIssueTrackerService.ts
@@ -17,6 +17,7 @@ import type { IIssueTrackerService } from "../IIssueTrackerService.js";
 import type {
 	AgentActivity,
 	AgentActivityContent,
+	AgentActivitySignal,
 	AgentSession,
 	AgentSessionCreateOnCommentInput,
 	AgentSessionCreateOnIssueInput,
@@ -676,12 +677,24 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 	async createAgentActivity(
 		sessionId: string,
 		content: AgentActivityContent,
+		options?: {
+			ephemeral?: boolean;
+			signal?: AgentActivitySignal;
+			signalMetadata?: Record<string, any>;
+		},
 	): Promise<AgentActivity> {
 		try {
 			const activityContent = toLinearActivityContent(content);
 			const createPayload = await this.linearClient.createAgentActivity({
 				agentSessionId: sessionId,
 				content: activityContent,
+				...(options?.ephemeral !== undefined && {
+					ephemeral: options.ephemeral,
+				}),
+				...(options?.signal !== undefined && { signal: options.signal }),
+				...(options?.signalMetadata !== undefined && {
+					signalMetadata: options.signalMetadata,
+				}),
 			});
 
 			if (!createPayload.success) {
@@ -703,6 +716,11 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 					type: content.type,
 					body: content.body,
 				},
+				signal: createdActivity.signal as AgentActivitySignal | undefined,
+				signalMetadata: createdActivity.signalMetadata as
+					| Record<string, any>
+					| undefined,
+				ephemeral: createdActivity.ephemeral,
 				createdAt: createdActivity.createdAt.toISOString(),
 				updatedAt: createdActivity.updatedAt.toISOString(),
 				archivedAt: createdActivity.archivedAt?.toISOString() ?? null,

--- a/packages/core/src/issue-tracker/adapters/__tests__/CLIIssueTrackerService.test.ts
+++ b/packages/core/src/issue-tracker/adapters/__tests__/CLIIssueTrackerService.test.ts
@@ -353,6 +353,123 @@ describe("CLIIssueTrackerService", () => {
 			expect(activities).toHaveLength(2);
 		});
 
+		it("should create an ephemeral activity that gets replaced", async () => {
+			const issue = await service.createIssue({
+				title: "Test Issue",
+			});
+
+			const response = await service.createAgentSessionOnIssue({
+				issueId: issue.id,
+			});
+
+			// Create first ephemeral activity
+			const ephemeralActivity1 = await service.createAgentActivity(
+				response.agentSessionId,
+				{
+					type: AgentActivityContentType.Action,
+					body: "Ephemeral activity 1",
+				},
+				{ ephemeral: true },
+			);
+
+			expect(ephemeralActivity1.ephemeral).toBe(true);
+
+			// Verify it exists
+			let activities = await service.fetchAgentActivities(
+				response.agentSessionId,
+			);
+			expect(activities).toHaveLength(1);
+			expect(activities[0].content.body).toBe("Ephemeral activity 1");
+
+			// Create second ephemeral activity - should replace the first
+			const ephemeralActivity2 = await service.createAgentActivity(
+				response.agentSessionId,
+				{
+					type: AgentActivityContentType.Action,
+					body: "Ephemeral activity 2",
+				},
+				{ ephemeral: true },
+			);
+
+			// Verify the first ephemeral was replaced
+			activities = await service.fetchAgentActivities(response.agentSessionId);
+			expect(activities).toHaveLength(1);
+			expect(activities[0].content.body).toBe("Ephemeral activity 2");
+			expect(activities[0].id).toBe(ephemeralActivity2.id);
+		});
+
+		it("should replace ephemeral activity with non-ephemeral", async () => {
+			const issue = await service.createIssue({
+				title: "Test Issue",
+			});
+
+			const response = await service.createAgentSessionOnIssue({
+				issueId: issue.id,
+			});
+
+			// Create ephemeral activity
+			await service.createAgentActivity(
+				response.agentSessionId,
+				{
+					type: AgentActivityContentType.Action,
+					body: "Ephemeral progress",
+				},
+				{ ephemeral: true },
+			);
+
+			// Create non-ephemeral activity - should replace the ephemeral
+			await service.createAgentActivity(
+				response.agentSessionId,
+				{
+					type: AgentActivityContentType.Response,
+					body: "Final result",
+				},
+				{ ephemeral: false },
+			);
+
+			// Verify ephemeral was replaced by non-ephemeral
+			const activities = await service.fetchAgentActivities(
+				response.agentSessionId,
+			);
+			expect(activities).toHaveLength(1);
+			expect(activities[0].content.body).toBe("Final result");
+			expect(activities[0].ephemeral).toBe(false);
+		});
+
+		it("should not replace non-ephemeral activities", async () => {
+			const issue = await service.createIssue({
+				title: "Test Issue",
+			});
+
+			const response = await service.createAgentSessionOnIssue({
+				issueId: issue.id,
+			});
+
+			// Create non-ephemeral activity
+			await service.createAgentActivity(
+				response.agentSessionId,
+				{
+					type: AgentActivityContentType.Response,
+					body: "Permanent activity",
+				},
+				{ ephemeral: false },
+			);
+
+			// Create another activity - should NOT replace the previous
+			await service.createAgentActivity(response.agentSessionId, {
+				type: AgentActivityContentType.Response,
+				body: "Another activity",
+			});
+
+			// Verify both exist
+			const activities = await service.fetchAgentActivities(
+				response.agentSessionId,
+			);
+			expect(activities).toHaveLength(2);
+			expect(activities[0].content.body).toBe("Permanent activity");
+			expect(activities[1].content.body).toBe("Another activity");
+		});
+
 		it("should send prompt to agent session", async () => {
 			const issue = await service.createIssue({
 				title: "Test Issue",

--- a/packages/core/src/issue-tracker/types.ts
+++ b/packages/core/src/issue-tracker/types.ts
@@ -316,12 +316,30 @@ export enum AgentActivityContentType {
 
 /**
  * Agent activity content structure.
+ * Matches Linear SDK's agentActivity.content structure with full expressiveness.
  */
 export interface AgentActivityContent {
 	/** Content type */
 	type: AgentActivityContentType;
 	/** Content body */
 	body: string;
+	/** Action name (for Action type activities) */
+	action?: string;
+	/** Action parameter (for Action type activities) */
+	parameter?: any;
+	/** Action result (for Action type activities) */
+	result?: any;
+}
+
+/**
+ * Agent activity signal enumeration.
+ * Matches Linear SDK's AgentActivitySignal enum.
+ */
+export enum AgentActivitySignal {
+	Auth = "auth",
+	Continue = "continue",
+	Select = "select",
+	Stop = "stop",
 }
 
 /**
@@ -338,8 +356,12 @@ export interface AgentActivity {
 	sourceCommentId?: string;
 	/** Activity content */
 	content: AgentActivityContent;
-	/** Optional signal modifier (e.g., "stop" for user interrupt) */
-	signal?: "stop";
+	/** Optional signal modifier (auth, continue, select, stop) */
+	signal?: AgentActivitySignal;
+	/** Signal metadata (additional context for the signal) */
+	signalMetadata?: Record<string, any>;
+	/** Whether this activity is ephemeral and should disappear after the next activity */
+	ephemeral?: boolean;
 	/** Creation timestamp (ISO 8601) */
 	createdAt: string;
 	/** Last update timestamp (ISO 8601) */


### PR DESCRIPTION
## Summary

Restores full agent activity expressiveness by matching Linear SDK's agentActivity parameter type and brings back ephemeral flag functionality that was removed during CYPACK-306 platform abstraction.

## Changes

### Type System Enhancements
- **AgentActivityContent**: Added `action`, `parameter`, `result` fields to match Linear SDK structure
- **AgentActivitySignal**: New enum with `Auth`, `Continue`, `Select`, `Stop` values
- **AgentActivity**: Added `ephemeral`, `signal`, `signalMetadata` fields

### Implementation
- **CLIIssueTrackerService**: Implements ephemeral behavior where next activity overwrites previous ephemeral activity
- **LinearIssueTrackerService**: Passes ephemeral/signal options through to Linear SDK
- **IIssueTrackerService**: Updated interface to accept optional ephemeral/signal parameters

### Ephemeral UX Paradigm
The ephemeral flag enables smooth progress updates:
- Ephemeral activities are replaced by the next activity (ephemeral or not)
- Non-ephemeral activities persist in the activity stream
- Prevents clutter from transient progress indicators

## Testing

### New Tests (3)
1. Ephemeral activities replace each other
2. Non-ephemeral activities replace ephemeral
3. Non-ephemeral activities accumulate (don't replace)

### Test Results
```
✓ CLIIssueTrackerService.test.ts (37 tests)
✓ LinearIssueTrackerService.test.ts (18 tests)
Total: 55 tests passing
```

## Code Quality
- All modified files pass linting
- No breaking changes to existing functionality
- Backwards compatible (ephemeral defaults to false)

## Related Issues
- Closes CYPACK-320
- Parent: CYPACK-306
- Reference: cypack-198 (original ephemeral implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)