### PR TITLE
[Refactor] Eliminate rawRESTRequest and make concrete typed methods

### DIFF
--- a/packages/core/src/issue-tracker/IIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/IIssueTrackerService.ts
@@ -591,44 +591,6 @@ export interface IIssueTrackerService {
 	requestFileUpload(request: FileUploadRequest): Promise<FileUploadResponse>;
 
 	// ========================================================================
-	// RAW API ACCESS
-	// ========================================================================
-
-	/**
-	 * Execute a raw REST API request (for platform-specific operations).
-	 *
-	 * This method provides direct access to the platform's REST API
-	 * for operations not covered by standard interface methods.
-	 *
-	 * @param endpoint - API endpoint path
-	 * @param options - Request options (method, headers, body)
-	 * @returns Promise resolving to the response data
-	 * @throws Error if request fails
-	 *
-	 * @example
-	 * ```typescript
-	 * // Execute custom REST request
-	 * const result = await service.rawRESTRequest('/api/v1/custom', {
-	 *   method: 'POST',
-	 *   headers: { 'Content-Type': 'application/json' },
-	 *   body: JSON.stringify({ custom: 'data' })
-	 * });
-	 * ```
-	 *
-	 * @remarks
-	 * Use this method for platforms that don't support GraphQL.
-	 * Platform-specific REST calls may not work across different implementations.
-	 */
-	rawRESTRequest<T = unknown>(
-		endpoint: string,
-		options?: {
-			method?: string;
-			headers?: Record<string, string>;
-			body?: unknown;
-		},
-	): Promise<T>;
-
-	// ========================================================================
 	// PLATFORM METADATA
 	// ========================================================================
 

--- a/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
@@ -832,23 +832,6 @@ export class CLIIssueTrackerService
 	}
 
 	// ========================================================================
-	// RAW API ACCESS
-	// ========================================================================
-
-	async rawRESTRequest<T = unknown>(
-		_endpoint: string,
-		_options?: {
-			method?: string;
-			headers?: Record<string, string>;
-			body?: unknown;
-		},
-	): Promise<T> {
-		throw new Error(
-			"CLI issue tracker does not support REST requests. Use the high-level API methods instead.",
-		);
-	}
-
-	// ========================================================================
 	// PLATFORM METADATA
 	// ========================================================================
 

--- a/packages/core/src/issue-tracker/adapters/LinearIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/adapters/LinearIssueTrackerService.ts
@@ -873,27 +873,6 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 	}
 
 	// ========================================================================
-	// RAW API ACCESS
-	// ========================================================================
-
-	/**
-	 * Execute a raw REST API request.
-	 *
-	 * @remarks
-	 * Linear primarily uses GraphQL, so this method is not implemented.
-	 */
-	async rawRESTRequest<T = unknown>(
-		_endpoint: string,
-		_options?: {
-			method?: string;
-			headers?: Record<string, string>;
-			body?: unknown;
-		},
-	): Promise<T> {
-		throw new Error("Linear API does not support REST requests.");
-	}
-
-	// ========================================================================
 	// PLATFORM METADATA
 	// ========================================================================
 

--- a/packages/core/src/issue-tracker/adapters/__tests__/CLIIssueTrackerService.test.ts
+++ b/packages/core/src/issue-tracker/adapters/__tests__/CLIIssueTrackerService.test.ts
@@ -610,11 +610,5 @@ describe("CLIIssueTrackerService", () => {
 				"Agent session not found",
 			);
 		});
-
-		it("should throw error for REST requests", async () => {
-			await expect(service.rawRESTRequest("/test")).rejects.toThrow(
-				"CLI issue tracker does not support REST",
-			);
-		});
 	});
 });

--- a/packages/core/src/issue-tracker/adapters/__tests__/LinearIssueTrackerService.test.ts
+++ b/packages/core/src/issue-tracker/adapters/__tests__/LinearIssueTrackerService.test.ts
@@ -767,12 +767,4 @@ describe("LinearIssueTrackerService", () => {
 			expect(result.assetUrl).toBe("https://assets.example.com/file.png");
 		});
 	});
-
-	describe("rawRESTRequest", () => {
-		it("should throw error for REST requests", async () => {
-			await expect(service.rawRESTRequest("/api/endpoint")).rejects.toThrow(
-				"Linear API does not support REST requests",
-			);
-		});
-	});
 });


### PR DESCRIPTION
## Summary

Removed the unused `rawRESTRequest` method from `IIssueTrackerService` interface and all implementations. This method was never actually called in the codebase - both `LinearIssueTrackerService` and `CLIIssueTrackerService` only threw errors when invoked.

## Changes Made

- Removed `rawRESTRequest` method from `IIssueTrackerService` interface (lines 597-629)
- Removed implementation from `LinearIssueTrackerService` (lines 875-894)
- Removed implementation from `CLIIssueTrackerService` (lines 838-849)
- Removed associated test cases from both service test files (2 tests total)
- Fixed formatting issue in LinearIssueTrackerService.test.ts

## Implementation Approach

1. Searched codebase for all usages of `rawRESTRequest` - found zero actual callers
2. Removed method definition from interface
3. Removed implementations from both services (both threw errors)
4. Removed test cases that verified the errors were thrown
5. Verified TypeScript compilation and all tests pass

## Testing Performed

- ✅ All 58 core package tests passing (previously 60 - removed 2 rawRESTRequest tests)
- ✅ TypeScript compilation clean across all packages
- ✅ Linting clean (formatting issue fixed)
- ✅ No actual usages existed - method was never called

## Files Modified (5)

- `packages/core/src/issue-tracker/IIssueTrackerService.ts`
- `packages/core/src/issue-tracker/adapters/LinearIssueTrackerService.ts`
- `packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts`
- `packages/core/src/issue-tracker/adapters/__tests__/LinearIssueTrackerService.test.ts`
- `packages/core/src/issue-tracker/adapters/__tests__/CLIIssueTrackerService.test.ts`

## Breaking Changes

None - the method was never used.

## Migration Notes

None required.

Resolves CYPACK-325