### PR TITLE
Merge main into cypack-337 for RC release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Orchestrator label now enforces orchestrator procedure consistently - issues with the Orchestrator label always use the orchestrator-full procedure, even when receiving results from child sub-agents or processing new messages
+- Suppressed unnecessary error logs when stopping Claude sessions
+
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.30 - see [@anthropic-ai/claude-agent-sdk v0.1.30 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0130)
+- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 - see [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.67.0...sdk-v0.68.0)
+
 ## [0.2.0-rc.2] - 2025-10-30
 
 ### Fixed
@@ -128,6 +136,25 @@ All notable changes to this project will be documented in this file.
 
 #### cyrus-ai (CLI)
 - cyrus-ai@0.2.0-rc
+
+## [0.1.59] - 2025-10-31
+
+### Fixed
+- Skip loading 'primary' subroutine prompt to eliminate ENOENT error in logs - the "primary" promptPath is a placeholder with no corresponding file
+
+### Packages
+
+#### cyrus-core
+- cyrus-core@0.0.20
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.40
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.0.3
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.59
 
 ## [0.1.58] - 2025-10-29
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
-		"@anthropic-ai/sdk": "^0.67.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/edge-worker/prompts/orchestrator.md
+++ b/packages/edge-worker/prompts/orchestrator.md
@@ -1,4 +1,4 @@
-<version-tag value="orchestrator-v2.3.0" />
+<version-tag value="orchestrator-v2.3.1" />
 
 You are an expert software architect and designer responsible for decomposing complex issues into executable sub-tasks and orchestrating their completion through specialized agents.
 
@@ -60,12 +60,20 @@ Create sub-issues with:
 
 ### 2. Execute
 ```
-1. Start first sub-issue by triggering a new working session:
+1. **FIRST TIME ONLY**: Before creating the first sub-issue, push your orchestrator branch to remote:
+   - Check git status: `git status`
+   - If the branch is not yet pushed, push it: `git push -u origin <current-branch>`
+   - This ensures sub-issues can use your branch as their base_branch for PRs
+   - Skip this step if your branch is already pushed (check with `git status`)
+
+2. Start first sub-issue by triggering a new working session:
    - For issues: Use mcp__cyrus-tools__linear_agent_session_create with issueId
    - For root comment threads on child issues: Use mcp__cyrus-tools__linear_agent_session_create_on_comment with commentId (must be a root comment, not a reply)
    This creates a sub-agent session that will process the work independently
-2. HALT and await completion notification
-3. Upon completion, evaluate results
+
+3. HALT and await completion notification
+
+4. Upon completion, evaluate results
 ```
 
 ### 3. Evaluate Results
@@ -153,21 +161,23 @@ Include in every sub-issue:
 
 4. **MODEL SELECTION**: Always evaluate whether to add the `sonnet` label to ensure proper model selection based on task complexity.
 
-5. **BRANCH SYNCHRONIZATION**: Maintain remote branch synchronization after each successful verification and merge.
+5. **INITIAL BRANCH PUSH**: Before creating the first sub-issue, you MUST push your orchestrator branch to remote using `git push -u origin <current-branch>`. Sub-issues use your branch as their base_branch, and they cannot create PRs if your branch doesn't exist on remote.
 
-6. **DOCUMENTATION**: Document all verification results, decisions, and plan adjustments in the parent issue.
+6. **BRANCH SYNCHRONIZATION**: Maintain remote branch synchronization after each successful verification and merge.
 
-7. **DEPENDENCY MANAGEMENT**: Prioritize unblocking work when dependencies arise.
+7. **DOCUMENTATION**: Document all verification results, decisions, and plan adjustments in the parent issue.
 
-8. **CLEAR VERIFICATION REQUIREMENTS**: When creating sub-issues, be explicit about expected verification methods if you have preferences (e.g., "Use Playwright to screenshot the new dashboard at localhost:3000 and read the screenshot to confirm the dashboard renders correctly with all expected elements").
+8. **DEPENDENCY MANAGEMENT**: Prioritize unblocking work when dependencies arise.
 
-9. **USE** `linear_agent_session_create_on_comment` when you need to trigger a sub-agent on an existing issue's root comment thread (not a reply) - this creates a new working session without reassigning the issue
+9. **CLEAR VERIFICATION REQUIREMENTS**: When creating sub-issues, be explicit about expected verification methods if you have preferences (e.g., "Use Playwright to screenshot the new dashboard at localhost:3000 and read the screenshot to confirm the dashboard renders correctly with all expected elements").
 
-10. **READ ALL SCREENSHOTS**: When taking screenshots for visual verification, you MUST read/view every screenshot to confirm visual changes match expectations. Never take a screenshot without reading it - the visual confirmation is the entire purpose of the screenshot.
+10. **USE** `linear_agent_session_create_on_comment` when you need to trigger a sub-agent on an existing issue's root comment thread (not a reply) - this creates a new working session without reassigning the issue
 
-11. **❌ DO NOT POST LINEAR COMMENTS TO THE CURRENT ISSUE**: You are STRONGLY DISCOURAGED from posting comments to the Linear issue you are currently working on. Your orchestration work (status updates, verification logs, decisions) should be tracked internally through your responses, NOT posted as Linear comments. The ONLY acceptable use of Linear commenting is when preparing to trigger a sub-agent session using `mcp__cyrus-tools__linear_agent_session_create_on_comment` - in that case, create a root comment on a child issue to provide context for the sub-agent, then use the tool to create the session on that comment.
+11. **READ ALL SCREENSHOTS**: When taking screenshots for visual verification, you MUST read/view every screenshot to confirm visual changes match expectations. Never take a screenshot without reading it - the visual confirmation is the entire purpose of the screenshot.
 
-12. **❌ DO NOT ASSIGN YOURSELF AS DELEGATE**: Never use the `delegate` parameter when creating sub-issues. Do not assign Cyrus (yourself) as a delegate to any issues. The assignee (inherited from parent) is sufficient to trigger agent processing.
+12. **❌ DO NOT POST LINEAR COMMENTS TO THE CURRENT ISSUE**: You are STRONGLY DISCOURAGED from posting comments to the Linear issue you are currently working on. Your orchestration work (status updates, verification logs, decisions) should be tracked internally through your responses, NOT posted as Linear comments. The ONLY acceptable use of Linear commenting is when preparing to trigger a sub-agent session using `mcp__cyrus-tools__linear_agent_session_create_on_comment` - in that case, create a root comment on a child issue to provide context for the sub-agent, then use the tool to create the session on that comment.
+
+13. **❌ DO NOT ASSIGN YOURSELF AS DELEGATE**: Never use the `delegate` parameter when creating sub-issues. Do not assign Cyrus (yourself) as a delegate to any issues. The assignee (inherited from parent) is sufficient to trigger agent processing.
 
 
 ## Sub-Issue Creation Checklist

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -17,6 +17,7 @@ import type {
 	SDKMessage,
 } from "cyrus-claude-runner";
 import {
+	AbortError,
 	ClaudeRunner,
 	createCyrusToolsServer,
 	createImageToolsServer,
@@ -1864,9 +1865,13 @@ export class EdgeWorker extends EventEmitter {
 
 	/**
 	 * Handle Claude session error
-	 * TODO: improve this
+	 * Silently ignores AbortError (user-initiated stop), logs other errors
 	 */
 	private async handleClaudeError(error: Error): Promise<void> {
+		// AbortError is expected when user stops Claude process, don't log it
+		if (error instanceof AbortError) {
+			return;
+		}
 		console.error("Unhandled claude error:", error);
 	}
 
@@ -3754,6 +3759,11 @@ ${input.userComment}
 	private async loadSubroutinePrompt(
 		subroutine: SubroutineDefinition,
 	): Promise<string | null> {
+		// Skip loading for "primary" - it's a placeholder that doesn't have a file
+		if (subroutine.promptPath === "primary") {
+			return null;
+		}
+
 		const __filename = fileURLToPath(import.meta.url);
 		const __dirname = dirname(__filename);
 		const subroutinePromptPath = join(
@@ -4297,6 +4307,7 @@ ${input.userComment}
 		linearAgentActivitySessionId: string,
 		agentSessionManager: AgentSessionManager,
 		promptBody: string,
+		repository: RepositoryConfig,
 	): Promise<void> {
 		// Initialize procedure metadata using intelligent routing
 		if (!session.metadata) {
@@ -4306,11 +4317,62 @@ ${input.userComment}
 		// Post ephemeral "Routing..." thought
 		await agentSessionManager.postRoutingThought(linearAgentActivitySessionId);
 
-		// Route based on the prompt content
-		const routingDecision = await this.procedureRouter.determineRoutine(
-			promptBody.trim(),
-		);
-		const selectedProcedure = routingDecision.procedure;
+		// Fetch full issue and labels to check for Orchestrator label override
+		const linearClient = this.linearClients.get(repository.id);
+		let hasOrchestratorLabel = false;
+
+		if (linearClient) {
+			try {
+				const fullIssue = await linearClient.issue(session.issueId);
+				const labels = await this.fetchIssueLabels(fullIssue);
+
+				// Check for Orchestrator label (same logic as initial routing)
+				const orchestratorConfig = repository.labelPrompts?.orchestrator;
+				const orchestratorLabels = Array.isArray(orchestratorConfig)
+					? orchestratorConfig
+					: orchestratorConfig?.labels;
+				hasOrchestratorLabel =
+					orchestratorLabels?.some((label) => labels.includes(label)) || false;
+			} catch (error) {
+				console.error(
+					`[EdgeWorker] Failed to fetch issue labels for routing:`,
+					error,
+				);
+				// Continue with AI routing if label fetch fails
+			}
+		}
+
+		let selectedProcedure: ProcedureDefinition;
+		let finalClassification: RequestClassification;
+
+		// If Orchestrator label is present, ALWAYS use orchestrator-full procedure
+		if (hasOrchestratorLabel) {
+			const orchestratorProcedure =
+				this.procedureRouter.getProcedure("orchestrator-full");
+			if (!orchestratorProcedure) {
+				throw new Error("orchestrator-full procedure not found in registry");
+			}
+			selectedProcedure = orchestratorProcedure;
+			finalClassification = "orchestrator";
+			console.log(
+				`[EdgeWorker] Using orchestrator-full procedure due to Orchestrator label (skipping AI routing)`,
+			);
+		} else {
+			// No Orchestrator label - use AI routing based on prompt content
+			const routingDecision = await this.procedureRouter.determineRoutine(
+				promptBody.trim(),
+			);
+			selectedProcedure = routingDecision.procedure;
+			finalClassification = routingDecision.classification;
+
+			// Log AI routing decision
+			console.log(
+				`[EdgeWorker] AI routing decision for ${linearAgentActivitySessionId}:`,
+			);
+			console.log(`  Classification: ${routingDecision.classification}`);
+			console.log(`  Procedure: ${selectedProcedure.name}`);
+			console.log(`  Reasoning: ${routingDecision.reasoning}`);
+		}
 
 		// Initialize procedure metadata in session (resets currentSubroutine)
 		this.procedureRouter.initializeProcedureMetadata(
@@ -4322,16 +4384,8 @@ ${input.userComment}
 		await agentSessionManager.postProcedureSelectionThought(
 			linearAgentActivitySessionId,
 			selectedProcedure.name,
-			routingDecision.classification,
+			finalClassification,
 		);
-
-		// Log routing decision
-		console.log(
-			`[EdgeWorker] Routing decision for ${linearAgentActivitySessionId}:`,
-		);
-		console.log(`  Classification: ${routingDecision.classification}`);
-		console.log(`  Procedure: ${selectedProcedure.name}`);
-		console.log(`  Reasoning: ${routingDecision.reasoning}`);
 	}
 
 	/**
@@ -4377,6 +4431,7 @@ ${input.userComment}
 				linearAgentActivitySessionId,
 				agentSessionManager,
 				promptBody,
+				repository,
 			);
 			console.log(`[EdgeWorker] Routed procedure for ${logContext}`);
 		} else {

--- a/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
@@ -1,0 +1,444 @@
+import { LinearClient } from "@linear/sdk";
+import type { CyrusAgentSession } from "cyrus-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import type { EdgeWorkerConfig, RepositoryConfig } from "../src/types.js";
+
+// Mock dependencies
+vi.mock("@linear/sdk");
+vi.mock("../src/AgentSessionManager.js");
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(() => ({
+			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+		})),
+	};
+});
+
+describe("EdgeWorker - Orchestrator Label Rerouting", () => {
+	let edgeWorker: EdgeWorker;
+	let mockConfig: EdgeWorkerConfig;
+	let mockLinearClient: any;
+	let mockAgentSessionManager: any;
+
+	const mockRepository: RepositoryConfig = {
+		id: "test-repo",
+		name: "Test Repo",
+		repositoryPath: "/test/repo",
+		workspaceBaseDir: "/test/workspaces",
+		baseBranch: "main",
+		linearToken: "test-token",
+		linearWorkspaceId: "test-workspace",
+		isActive: true,
+		allowedTools: ["Read", "Edit"],
+		labelPrompts: {
+			orchestrator: ["Orchestrator", "orchestrator"],
+		},
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		// Mock console methods
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		// Mock LinearClient - default to issue WITHOUT Orchestrator label
+		mockLinearClient = {
+			issue: vi.fn().mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue",
+				description: "This is a test issue",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [], // No labels by default
+				}),
+			}),
+		};
+		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+
+		// Mock AgentSessionManager
+		mockAgentSessionManager = {
+			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
+		};
+		vi.mocked(AgentSessionManager).mockImplementation(
+			() => mockAgentSessionManager,
+		);
+
+		mockConfig = {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: "/tmp/test-cyrus-home",
+			repositories: [mockRepository],
+			handlers: {
+				createWorkspace: vi.fn().mockResolvedValue({
+					path: "/test/workspaces/TEST-123",
+					isGitWorktree: false,
+				}),
+			},
+		};
+
+		edgeWorker = new EdgeWorker(mockConfig);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("rerouteProcedureForSession - Orchestrator label enforcement", () => {
+		it("should use orchestrator-full procedure when Orchestrator label is present", async () => {
+			// Arrange - Mock issue WITH Orchestrator label
+			mockLinearClient.issue.mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue with Orchestrator",
+				description: "This is an orchestrator issue",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [{ name: "Orchestrator" }], // Has Orchestrator label
+				}),
+			});
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			const promptBody = "Here are the results from the child agent";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+			const procedureCallArgs =
+				mockAgentSessionManager.postProcedureSelectionThought.mock.calls[0];
+
+			// Should use orchestrator-full procedure
+			expect(procedureCallArgs[1]).toBe("orchestrator-full");
+			// Should classify as orchestrator
+			expect(procedureCallArgs[2]).toBe("orchestrator");
+
+			// Verify the console log indicates Orchestrator label override
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Using orchestrator-full procedure due to Orchestrator label (skipping AI routing)",
+				),
+			);
+
+			// Verify session metadata was initialized with orchestrator-full procedure
+			expect(session.metadata.procedure).toBeDefined();
+			expect(session.metadata.procedure.procedureName).toBe(
+				"orchestrator-full",
+			);
+		});
+
+		it("should use AI routing when Orchestrator label is NOT present", async () => {
+			// Arrange - Mock issue WITHOUT Orchestrator label (default)
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			const promptBody =
+				"Please implement a new feature with full testing and documentation";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+			const procedureCallArgs =
+				mockAgentSessionManager.postProcedureSelectionThought.mock.calls[0];
+
+			// Should NOT use orchestrator-full (will use AI routing)
+			expect(procedureCallArgs[1]).not.toBe("orchestrator-full");
+
+			// Verify the console log indicates AI routing was used
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining("AI routing decision"),
+			);
+		});
+
+		it("should consistently use orchestrator-full even with builder-like prompts when Orchestrator label is present", async () => {
+			// Arrange - Mock issue WITH Orchestrator label
+			mockLinearClient.issue.mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue with Orchestrator",
+				description: "This is an orchestrator issue",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [{ name: "Orchestrator" }], // Has Orchestrator label
+				}),
+			});
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			// This is a builder-like prompt that might trigger AI to classify as builder
+			const promptBody =
+				"Please implement this feature with full tests and documentation. Create a PR when done.";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+			const procedureCallArgs =
+				mockAgentSessionManager.postProcedureSelectionThought.mock.calls[0];
+
+			// Should STILL use orchestrator-full despite builder-like prompt
+			expect(procedureCallArgs[1]).toBe("orchestrator-full");
+			expect(procedureCallArgs[2]).toBe("orchestrator");
+
+			// Verify Orchestrator label override log
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Using orchestrator-full procedure due to Orchestrator label (skipping AI routing)",
+				),
+			);
+		});
+
+		it("should consistently use orchestrator-full when receiving child agent results", async () => {
+			// Arrange - Mock issue WITH Orchestrator label
+			mockLinearClient.issue.mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue with Orchestrator",
+				description: "This is an orchestrator issue",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [{ name: "orchestrator" }], // Lowercase variant
+				}),
+			});
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			// Simulating a child agent posting results - this was the problematic case
+			const promptBody = `## Summary
+
+Work completed on subtask TEST-124.
+
+## Status
+
+✅ Complete - PR created at https://github.com/org/repo/pull/123`;
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+			const procedureCallArgs =
+				mockAgentSessionManager.postProcedureSelectionThought.mock.calls[0];
+
+			// Should use orchestrator-full, NOT switch to builder based on the summary content
+			expect(procedureCallArgs[1]).toBe("orchestrator-full");
+			expect(procedureCallArgs[2]).toBe("orchestrator");
+
+			// Verify Orchestrator label override was used
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"Using orchestrator-full procedure due to Orchestrator label (skipping AI routing)",
+				),
+			);
+		});
+
+		it("should handle label fetch errors gracefully and fall back to AI routing", async () => {
+			// Arrange - Mock Linear client to throw error
+			mockLinearClient.issue.mockRejectedValue(new Error("Linear API error"));
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			const promptBody = "Test comment";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert - Should not throw, should fall back to AI routing
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining("Failed to fetch issue labels for routing"),
+				expect.any(Error),
+			);
+
+			// Should still have posted a procedure selection (via AI routing)
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+		});
+
+		it("should work with different Orchestrator label variants from config", async () => {
+			// Arrange - Mock issue with "orchestrator" (lowercase)
+			mockLinearClient.issue.mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue",
+				description: "Test description",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [{ name: "orchestrator" }], // lowercase
+				}),
+			});
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			const promptBody = "Test comment";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert
+			expect(
+				mockAgentSessionManager.postProcedureSelectionThought,
+			).toHaveBeenCalled();
+			const procedureCallArgs =
+				mockAgentSessionManager.postProcedureSelectionThought.mock.calls[0];
+
+			// Should recognize lowercase "orchestrator" from config
+			expect(procedureCallArgs[1]).toBe("orchestrator-full");
+			expect(procedureCallArgs[2]).toBe("orchestrator");
+		});
+
+		it("should skip AI routing entirely when Orchestrator label is present", async () => {
+			// Arrange - Mock issue WITH Orchestrator label
+			mockLinearClient.issue.mockResolvedValue({
+				id: "issue-123",
+				identifier: "TEST-123",
+				title: "Test Issue",
+				description: "Test description",
+				url: "https://linear.app/test/issue/TEST-123",
+				branchName: "test-branch",
+				state: { name: "In Progress", type: "started" },
+				team: { id: "team-123" },
+				labels: vi.fn().mockResolvedValue({
+					nodes: [{ name: "Orchestrator" }],
+				}),
+			});
+
+			const session: CyrusAgentSession = {
+				linearAgentActivitySessionId: "agent-session-123",
+				issueId: "issue-123",
+				workspace: { path: "/test/workspaces/TEST-123", isGitWorktree: false },
+				metadata: {},
+			};
+
+			const promptBody = "Test comment";
+
+			// Act
+			await (edgeWorker as any).rerouteProcedureForSession(
+				session,
+				"agent-session-123",
+				mockAgentSessionManager,
+				promptBody,
+				mockRepository,
+			);
+
+			// Assert - Should NOT see AI routing decision logs
+			const allLogCalls = (console.log as any).mock.calls.map(
+				(call: any[]) => call[0],
+			);
+
+			// Should NOT have any AI routing logs
+			const hasAIRoutingLogs = allLogCalls.some((msg: string) =>
+				msg.includes("AI routing decision"),
+			);
+			expect(hasAIRoutingLogs).toBe(false);
+
+			// SHOULD have the Orchestrator label override log
+			const hasOrchestratorOverrideLog = allLogCalls.some((msg: string) =>
+				msg.includes(
+					"Using orchestrator-full procedure due to Orchestrator label (skipping AI routing)",
+				),
+			);
+			expect(hasOrchestratorOverrideLog).toBe(true);
+		});
+	});
+});

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.28",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,11 +92,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.30
+        version: 0.1.30(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.67.0
-        version: 0.67.0(zod@3.25.76)
+        specifier: ^0.68.0
+        version: 0.68.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -251,8 +251,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.28
-        version: 0.1.28(zod@3.25.76)
+        specifier: ^0.1.30
+        version: 0.1.30(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -273,14 +273,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28':
-    resolution: {integrity: sha512-latceXkaJbtV4mn2kqnbZgTZYlve+dhCGCW2liWhYdUv6KuoUEY6DK1VDzzHGnd2996fIBO/7E5PAAEHpsDing==}
+  '@anthropic-ai/claude-agent-sdk@0.1.30':
+    resolution: {integrity: sha512-lo1tqxCr2vygagFp6kUMHKSN6AAWlULCskwGKtLB/JcIXy/8H8GsLSKX54anTsvc9mBbCR8wWASdFmiiL9NSKA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.67.0':
-    resolution: {integrity: sha512-Buxbf6jYJ+pPtfCgXe1pcFtZmdXPrbdqhBjiscFt9irS1G0hCsmR/fPA+DwKTk4GPjqeNnnCYNecXH6uVZ4G/A==}
+  '@anthropic-ai/sdk@0.68.0':
+    resolution: {integrity: sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2382,7 +2382,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.28(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.30(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2393,7 +2393,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.67.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.68.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary
Merges the latest changes from `main` branch into `cypack-337` to prepare for the RC release. This ensures the RC branch has all the latest fixes and improvements from main.

## Changes Merged
- **Orchestrator label routing fixes**: Enforces orchestrator procedure consistently for issues with the Orchestrator label (#428)
- **SDK updates**: Updated @anthropic-ai/claude-agent-sdk to v0.1.30 and @anthropic-ai/sdk to v0.68.0 (#421)
- **Error handling improvements**: Suppressed unnecessary AbortError logs when stopping Claude sessions (#418)
- **Bug fixes**: Fixed missing prompt files in edge-worker package and eliminated ENOENT errors for 'primary' subroutine (#406)

## Merge Conflicts Resolved
- `CHANGELOG.md`: Integrated v0.1.59 changes from main into the Unreleased section while preserving RC release entries
- `apps/cli/package.json`: Kept version 0.2.0-rc.2 as appropriate for the RC release branch

## Verification
- ✅ **219 tests passing** across all packages (`pnpm test:packages:run`)
  - claude-runner: 66 tests
  - edge-worker: 124 tests
  - simple-agent-runner: 24 tests
  - config-updater: 5 tests
- ✅ **TypeScript compilation succeeds** (`pnpm typecheck`)
- ✅ **Linting clean** (1 pre-existing warning in cloudflare-tunnel-client)
- ✅ **All packages build successfully** (`pnpm build`)

## Test Plan
This PR has been fully verified with automated testing. No manual testing required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)