### PR TITLE
[Refactor] Move 'platform' field from RepositoryConfig to EdgeWorkerConfig

### DIFF
--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -44,10 +44,7 @@ export interface RepositoryConfig {
 	repositoryPath: string; // Local git repository path
 	baseBranch: string; // Branch to create worktrees from (main, master, etc.)
 
-	// Issue tracker platform configuration
-	platform?: "linear" | "cli"; // Issue tracker platform type (default: "linear")
-
-	// Linear configuration (used when platform === "linear" or not specified)
+	// Linear configuration
 	linearWorkspaceId: string; // Linear workspace/team ID
 	linearWorkspaceName?: string; // Linear workspace display name (optional, for UI)
 	linearToken: string; // OAuth token for this Linear workspace
@@ -109,6 +106,9 @@ export interface EdgeWorkerConfig {
 	serverPort?: number; // Unified server port for both webhooks and OAuth callbacks (default: 3456)
 	serverHost?: string; // Server host address ('localhost' or '0.0.0.0', default: 'localhost')
 	ngrokAuthToken?: string; // Ngrok auth token for tunnel creation
+
+	// Issue tracker platform configuration
+	platform?: "linear" | "cli"; // Issue tracker platform type (default: "linear")
 
 	// Claude config (shared across all repos)
 	defaultAllowedTools?: string[];

--- a/packages/edge-worker/test/EdgeWorker.cli-session-execution.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.cli-session-execution.test.ts
@@ -25,6 +25,7 @@ describe("EdgeWorker - CLI Platform Repository Routing", () => {
 			proxyUrl: "https://test-proxy.com",
 			cyrusHome: "/tmp/test-cyrus-home-cli",
 			serverPort: 3456,
+			platform: "cli" as const, // Use CLI platform (now at EdgeWorker level)
 			repositories: [
 				{
 					id: "test-cli-repo",
@@ -32,7 +33,6 @@ describe("EdgeWorker - CLI Platform Repository Routing", () => {
 					repositoryPath: "/tmp/test-repo",
 					baseBranch: "main",
 					workspaceBaseDir: "/tmp/workspaces",
-					platform: "cli" as const, // Use CLI platform
 					isActive: true,
 				},
 			],
@@ -67,13 +67,13 @@ describe("EdgeWorker - CLI Platform Repository Routing", () => {
 		// Verify the correct repository was returned
 		expect(result).toBeTruthy();
 		expect(result?.id).toBe("test-cli-repo");
-		expect(result?.platform).toBe("cli");
 	});
 
 	it("should route CLI events when multiple repositories exist", async () => {
 		// Add a Linear repository to the configuration
 		const multiRepoConfig: EdgeWorkerConfig = {
 			...mockConfig,
+			platform: "cli" as const, // CLI platform at EdgeWorker level
 			repositories: [
 				{
 					id: "linear-repo",
@@ -92,7 +92,6 @@ describe("EdgeWorker - CLI Platform Repository Routing", () => {
 					repositoryPath: "/tmp/test-repo",
 					baseBranch: "main",
 					workspaceBaseDir: "/tmp/workspaces",
-					platform: "cli" as const,
 					isActive: true,
 				},
 			],
@@ -117,10 +116,9 @@ describe("EdgeWorker - CLI Platform Repository Routing", () => {
 			multiRepoConfig.repositories,
 		);
 
-		// Verify it selected the CLI repository, not the Linear one
+		// Verify it selected the first repository (in CLI mode, platform is global)
 		expect(result).toBeTruthy();
-		expect(result?.id).toBe("test-cli-repo");
-		expect(result?.platform).toBe("cli");
+		expect(result?.id).toBe("linear-repo");
 	});
 
 	it("should fallback to first repo if no CLI repo exists but CLI event received", async () => {


### PR DESCRIPTION
## Summary

This PR moves the `platform` field from `RepositoryConfig` to `EdgeWorkerConfig` where it belongs. The platform type ("linear" or "cli") is a global EdgeWorker configuration about which issue tracker backend to use, not a per-repository setting.

## Changes Made

### Configuration Types (`packages/core/src/config-types.ts`)
- ✅ Added `platform?: "linear" | "cli"` to `EdgeWorkerConfig` interface
- ✅ Removed `platform` field from `RepositoryConfig` interface

### EdgeWorker Implementation (`packages/edge-worker/src/EdgeWorker.ts`)
- ✅ Updated constructor to check `config.platform` instead of `repo.platform`
- ✅ Updated `findRepositoryForEvent()` to use global platform configuration
- ✅ Updated `start()` method RPC server logic to use `config.platform`
- ✅ Updated `buildMcpConfig()` to check EdgeWorker-level platform for Linear/CLI mode

### Tests (`packages/edge-worker/test/EdgeWorker.cli-session-execution.test.ts`)
- ✅ Updated test configuration to set platform at EdgeWorker level
- ✅ Removed assertions checking `result?.platform` (no longer on repositories)
- ✅ Updated multi-repo test to reflect global platform behavior

## Architectural Improvement

This refactoring provides cleaner architecture:
- Platform is now correctly positioned as a global EdgeWorker concern
- Reflects the reality that the platform type determines which issue tracker backend the EdgeWorker uses globally
- Eliminates confusion about per-repository platform settings (which didn't make sense architecturally)

## Testing

✅ **All tests passing**: 197/197 (58 core + 139 edge-worker)
✅ **TypeScript compilation**: Clean across all packages
✅ **Linting**: Clean on modified files
✅ **CLI session execution tests**: 3/3 pass (specifically tests platform routing logic)

## Test Plan

```bash
# Build and test
pnpm install
pnpm build
pnpm --filter cyrus-core test:run
pnpm --filter cyrus-edge-worker test:run

# Verify specific CLI platform routing
pnpm --filter cyrus-edge-worker test:run EdgeWorker.cli-session-execution.test.ts
```

## Migration Notes

**Breaking Change**: Any configuration that sets `platform` on individual repositories should move it to the top-level EdgeWorkerConfig instead.

**Before:**
```typescript
{
  repositories: [
    {
      id: "repo-1",
      platform: "cli", // ❌ No longer valid
      // ...
    }
  ]
}
```

**After:**
```typescript
{
  platform: "cli", // ✅ Set at EdgeWorker level
  repositories: [
    {
      id: "repo-1",
      // ...
    }
  ]
}
```

Resolves CYPACK-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)