### PR TITLE
Update @anthropic-ai/claude-agent-sdk to 0.1.31

### DIFF
--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
 		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30(zod@3.25.76)
+        specifier: ^0.1.31
+        version: 0.1.31(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.68.0
         version: 0.68.0(zod@3.25.76)
@@ -235,8 +235,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30(zod@3.25.76)
+        specifier: ^0.1.31
+        version: 0.1.31(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.30':
-    resolution: {integrity: sha512-lo1tqxCr2vygagFp6kUMHKSN6AAWlULCskwGKtLB/JcIXy/8H8GsLSKX54anTsvc9mBbCR8wWASdFmiiL9NSKA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.31':
+    resolution: {integrity: sha512-cwzgM2ntyzfr0aaiDEVwrQJawRlGi/8sq4raWyNPQqfS3uEXhw+IDmPdPS+HhjO2e4LCf1y+SkJKeBjxleHOYA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2537,7 +2537,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.30(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.31(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updated the `@anthropic-ai/claude-agent-sdk` dependency from version 0.1.30 to 0.1.31 in both the `claude-runner` and `simple-agent-runner` packages.

## Changes
- Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.30` to `^0.1.31` in:
  - `packages/claude-runner/package.json`
  - `packages/simple-agent-runner/package.json`
- Updated `pnpm-lock.yaml` to reflect the new dependency version

## Testing
- ✅ All 229 package tests passing (15 + 66 + 24 + 124 tests)
- ✅ Linting clean (143 files checked)
- ✅ TypeScript type checking passed across all packages
- ✅ Build successful for all packages

## Implementation Approach
1. Reset the `cypack-342` branch to `main`
2. Updated the SDK version in both package.json files
3. Ran `pnpm install` to update the lockfile
4. Verified all tests, linting, and type checking pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)