### PR TITLE
Release v0.1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.60] - 2025-11-03
+
 ### Fixed
 - Orchestrator label now enforces orchestrator procedure consistently - issues with the Orchestrator label always use the orchestrator-full procedure, even when receiving results from child sub-agents or processing new messages
 - Suppressed unnecessary error logs when stopping Claude sessions
@@ -11,6 +13,26 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.31
 - Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 - see [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.67.0...sdk-v0.68.0)
+
+### Packages
+
+#### cyrus-core
+- cyrus-core@0.0.21
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.32
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.41
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.25
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.0.4
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.60
 
 ## [0.1.59] - 2025-10-31
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.59",
+	"version": "0.1.60",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.31",
+	"version": "0.0.32",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.40",
+	"version": "0.0.41",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/ndjson-client/package.json
+++ b/packages/ndjson-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ndjson-client",
-	"version": "0.0.24",
+	"version": "0.0.25",
 	"description": "NDJSON streaming client for proxy communication",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
NOTE this branch was badly named, by the release agent. This is for release 0.1.60, not `release-v0.2.0-rc.3`

## Summary
- Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.31
- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0
- Fixed orchestrator label enforcement to consistently use orchestrator-full procedure
- Suppressed unnecessary error logs when stopping Claude sessions

## Packages Published
- cyrus-core@0.0.21
- cyrus-claude-runner@0.0.32
- cyrus-edge-worker@0.0.41
- cyrus-ndjson-client@0.0.25
- cyrus-simple-agent-runner@0.0.4
- cyrus-ai@0.1.60

🤖 Generated with [Claude Code](https://claude.com/claude-code)