### PR TITLE
Stream compacting status to agent activity

### DIFF
--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -39,6 +39,7 @@ export type {
 	SDKAssistantMessage,
 	SDKMessage,
 	SDKResultMessage,
+	SDKStatusMessage,
 	SDKSystemMessage,
 	SDKUserMessage,
 } from "./types.js";

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -57,6 +57,7 @@ export type {
 	SDKAssistantMessage,
 	SDKMessage,
 	SDKResultMessage,
+	SDKStatusMessage,
 	SDKSystemMessage,
 	SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -6,6 +6,7 @@ import type {
 	SDKAssistantMessage,
 	SDKMessage,
 	SDKResultMessage,
+	SDKStatusMessage,
 	SDKSystemMessage,
 	SDKUserMessage,
 } from "cyrus-claude-runner";
@@ -34,6 +35,7 @@ export class AgentSessionManager {
 	private activeTasksBySession: Map<string, string> = new Map(); // Maps session ID to active Task tool use ID
 	private toolCallsByToolUseId: Map<string, { name: string; input: any }> =
 		new Map(); // Track tool calls by their tool_use_id
+	private activeStatusActivitiesBySession: Map<string, string> = new Map(); // Maps session ID to active compacting status activity ID
 	private procedureRouter?: ProcedureRouter;
 	private sharedApplicationServer?: SharedApplicationServer;
 	private getParentSessionId?: (childSessionId: string) => string | undefined;
@@ -506,6 +508,12 @@ export class AgentSessionManager {
 								systemMessage.model,
 							);
 						}
+					} else if (message.subtype === "status") {
+						// Handle status updates (compacting, etc.)
+						await this.handleStatusMessage(
+							linearAgentActivitySessionId,
+							message as SDKStatusMessage,
+						);
 					}
 					break;
 
@@ -1503,6 +1511,83 @@ export class AgentSessionManager {
 		} catch (error) {
 			console.error(
 				`[AgentSessionManager] Error posting procedure selection:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Handle status messages (compacting, etc.)
+	 */
+	private async handleStatusMessage(
+		linearAgentActivitySessionId: string,
+		message: SDKStatusMessage,
+	): Promise<void> {
+		const session = this.sessions.get(linearAgentActivitySessionId);
+		if (!session || !session.linearAgentActivitySessionId) {
+			console.warn(
+				`[AgentSessionManager] No Linear session ID for session ${linearAgentActivitySessionId}`,
+			);
+			return;
+		}
+
+		try {
+			if (message.status === "compacting") {
+				// Create an ephemeral thought for the compacting status
+				const result = await this.linearClient.createAgentActivity({
+					agentSessionId: session.linearAgentActivitySessionId,
+					content: {
+						type: "thought",
+						body: "Compacting conversation history…",
+					},
+					ephemeral: true,
+				});
+
+				if (result.success && result.agentActivity) {
+					const activity = await result.agentActivity;
+					// Store the activity ID so we can replace it later
+					this.activeStatusActivitiesBySession.set(
+						linearAgentActivitySessionId,
+						activity.id,
+					);
+					console.log(
+						`[AgentSessionManager] Posted ephemeral compacting status for session ${linearAgentActivitySessionId}`,
+					);
+				} else {
+					console.error(
+						`[AgentSessionManager] Failed to post compacting status:`,
+						result,
+					);
+				}
+			} else if (message.status === null) {
+				// Clear the status - post a non-ephemeral thought to replace the ephemeral one
+				const result = await this.linearClient.createAgentActivity({
+					agentSessionId: session.linearAgentActivitySessionId,
+					content: {
+						type: "thought",
+						body: "Conversation history compacted",
+					},
+					ephemeral: false,
+				});
+
+				if (result.success) {
+					// Clean up the stored activity ID
+					this.activeStatusActivitiesBySession.delete(
+						linearAgentActivitySessionId,
+					);
+					console.log(
+						`[AgentSessionManager] Posted non-ephemeral status clear for session ${linearAgentActivitySessionId}`,
+					);
+				} else {
+					console.error(
+						`[AgentSessionManager] Failed to post status clear:`,
+						result,
+					);
+				}
+			}
+		} catch (error) {
+			console.error(
+				`[AgentSessionManager] Error handling status message:`,
 				error,
 			);
 		}

--- a/packages/edge-worker/test/AgentSessionManager.status-message.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.status-message.test.ts
@@ -1,0 +1,262 @@
+import { LinearClient } from "@linear/sdk";
+import type { SDKStatusMessage } from "cyrus-claude-runner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+
+// Mock LinearClient
+vi.mock("@linear/sdk", () => ({
+	LinearClient: vi.fn().mockImplementation(() => ({
+		createAgentActivity: vi.fn(),
+	})),
+	LinearDocument: {
+		AgentSessionType: {
+			CommentThread: "comment_thread",
+		},
+		AgentSessionStatus: {
+			Active: "active",
+			Complete: "complete",
+			Error: "error",
+		},
+	},
+}));
+
+describe("AgentSessionManager - Status Messages", () => {
+	let manager: AgentSessionManager;
+	let mockLinearClient: any;
+	let createAgentActivitySpy: any;
+	const sessionId = "test-session-123";
+	const issueId = "issue-123";
+
+	beforeEach(() => {
+		mockLinearClient = new LinearClient({ apiKey: "test" });
+		createAgentActivitySpy = vi.spyOn(mockLinearClient, "createAgentActivity");
+		createAgentActivitySpy.mockResolvedValue({
+			success: true,
+			agentActivity: Promise.resolve({ id: "activity-123" }),
+		});
+
+		manager = new AgentSessionManager(mockLinearClient);
+
+		// Create a test session
+		manager.createLinearAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "TEST-123",
+				title: "Test Issue",
+				description: "Test description",
+				branchName: "test-branch",
+			},
+			{
+				path: "/test/workspace",
+				isGitWorktree: false,
+			},
+		);
+	});
+
+	it("should post ephemeral activity when compacting status is received", async () => {
+		// Create a status message with compacting status
+		const statusMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+
+		// Handle the status message
+		await manager.handleClaudeMessage(sessionId, statusMessage);
+
+		// Verify that createAgentActivity was called with ephemeral thought
+		expect(createAgentActivitySpy).toHaveBeenCalledWith({
+			agentSessionId: sessionId,
+			content: {
+				type: "thought",
+				body: "Compacting conversation history…",
+			},
+			ephemeral: true,
+		});
+	});
+
+	it("should post non-ephemeral activity when status is cleared (null)", async () => {
+		// First, send a compacting status
+		const compactingMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+		await manager.handleClaudeMessage(sessionId, compactingMessage);
+
+		// Clear the mock calls
+		createAgentActivitySpy.mockClear();
+
+		// Now send a status clear message
+		const statusClearMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: null,
+			session_id: "claude-session-123",
+		};
+
+		// Handle the status clear message
+		await manager.handleClaudeMessage(sessionId, statusClearMessage);
+
+		// Verify that createAgentActivity was called with non-ephemeral thought
+		expect(createAgentActivitySpy).toHaveBeenCalledWith({
+			agentSessionId: sessionId,
+			content: {
+				type: "thought",
+				body: "Conversation history compacted",
+			},
+			ephemeral: false,
+		});
+	});
+
+	it("should handle compacting status followed by clear status", async () => {
+		// Send compacting status
+		const compactingMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+		await manager.handleClaudeMessage(sessionId, compactingMessage);
+
+		// Verify ephemeral activity was created
+		expect(createAgentActivitySpy).toHaveBeenCalledWith({
+			agentSessionId: sessionId,
+			content: {
+				type: "thought",
+				body: "Compacting conversation history…",
+			},
+			ephemeral: true,
+		});
+
+		// Clear the mock calls
+		createAgentActivitySpy.mockClear();
+
+		// Send status clear
+		const statusClearMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: null,
+			session_id: "claude-session-123",
+		};
+		await manager.handleClaudeMessage(sessionId, statusClearMessage);
+
+		// Verify non-ephemeral activity was created
+		expect(createAgentActivitySpy).toHaveBeenCalledWith({
+			agentSessionId: sessionId,
+			content: {
+				type: "thought",
+				body: "Conversation history compacted",
+			},
+			ephemeral: false,
+		});
+	});
+
+	it("should handle error when posting compacting status fails", async () => {
+		// Mock createAgentActivity to fail
+		createAgentActivitySpy.mockResolvedValueOnce({
+			success: false,
+			error: "Failed to create activity",
+		});
+
+		// Spy on console.error
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		// Create a status message with compacting status
+		const statusMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+
+		// Handle the status message
+		await manager.handleClaudeMessage(sessionId, statusMessage);
+
+		// Verify error was logged
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"[AgentSessionManager] Failed to post compacting status:",
+			expect.objectContaining({ success: false }),
+		);
+
+		// Clean up
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should handle error when posting status clear fails", async () => {
+		// First send compacting status successfully
+		const compactingMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+		await manager.handleClaudeMessage(sessionId, compactingMessage);
+
+		// Mock createAgentActivity to fail for the next call
+		createAgentActivitySpy.mockResolvedValueOnce({
+			success: false,
+			error: "Failed to create activity",
+		});
+
+		// Spy on console.error
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		// Send status clear
+		const statusClearMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: null,
+			session_id: "claude-session-123",
+		};
+
+		// Handle the status clear message
+		await manager.handleClaudeMessage(sessionId, statusClearMessage);
+
+		// Verify error was logged
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"[AgentSessionManager] Failed to post status clear:",
+			expect.objectContaining({ success: false }),
+		);
+
+		// Clean up
+		consoleErrorSpy.mockRestore();
+	});
+
+	it("should not crash if session is not found", async () => {
+		// Spy on console.warn
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => {});
+
+		// Create a status message for a non-existent session
+		const statusMessage: SDKStatusMessage = {
+			type: "system",
+			subtype: "status",
+			status: "compacting",
+			session_id: "claude-session-123",
+		};
+
+		// Handle the status message for a non-existent session
+		await manager.handleClaudeMessage("non-existent-session", statusMessage);
+
+		// Verify warning was logged
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			"[AgentSessionManager] No Linear session ID for session non-existent-session",
+		);
+
+		// Verify createAgentActivity was not called
+		expect(createAgentActivitySpy).not.toHaveBeenCalled();
+
+		// Clean up
+		consoleWarnSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
STATUS: Friday November 7, we haven't got to test yet.

## Summary

Implements streaming of compacting status updates to Linear agent activity panel using the official SDK types from `@anthropic-ai/claude-agent-sdk@0.1.31`.

## Changes

- **Added `SDKStatusMessage` support** - Import and re-export from official SDK v0.1.31
- **Implemented status message handling** in `AgentSessionManager`:
  - Added `activeStatusActivitiesBySession` Map to track ephemeral status activities
  - Implemented `handleStatusMessage()` method to process status events
  - Posts **ephemeral** "Compacting conversation history…" thought when `status === "compacting"`
  - Posts **non-ephemeral** "Conversation history compacted" thought when `status === null`
- **Added comprehensive test suite** with 6 test cases in `AgentSessionManager.status-message.test.ts`

## How It Works

1. When Claude starts compacting, it emits: `{ type: "system", subtype: "status", status: "compacting" }`
2. AgentSessionManager posts an ephemeral thought activity to Linear
3. When compacting completes, Claude emits: `{ type: "system", subtype: "status", status: null }`
4. AgentSessionManager posts a non-ephemeral thought activity, replacing the ephemeral one

## Test Plan

- ✅ All 130 edge-worker tests passing (including 6 new status message tests)
- ✅ TypeScript type checking passes with official SDK types
- ✅ Linting passes
- ✅ No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)