### PR TITLE
Improve Linear agent session UX with readable tool parameters

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -216,9 +216,21 @@ export class AgentSessionManager {
 	 * Converts JSON objects into concise, readable descriptions
 	 */
 	private formatToolParameter(toolName: string, toolInput: any): string {
-		// If already a string, return as-is
+		// If it's a string, try to parse it as JSON first
 		if (typeof toolInput === "string") {
-			return toolInput;
+			try {
+				const parsed = JSON.parse(toolInput);
+				if (typeof parsed === "object" && parsed !== null) {
+					// Successfully parsed, use the object
+					toolInput = parsed;
+				} else {
+					// Parsed but not an object, return as-is
+					return toolInput;
+				}
+			} catch {
+				// Not JSON, return as-is
+				return toolInput;
+			}
 		}
 
 		// If not an object, stringify it


### PR DESCRIPTION
## Summary
Improved the readability of Linear's agent session surface by transforming verbose JSON blocks into concise, human-readable strings for tool parameters.

## Problem
The agent session surface in Linear was displaying raw JSON objects for tool calls, making it difficult to read and understand what actions were being performed. For example:
```
Bash { "command": "ls -la /home/cyrus/...", "description": "List root directo..." }
Glob { "pattern": "package.json" }
```

## Solution
Implemented a smart parameter formatting system (`formatToolParameter()`) that:
- Converts tool parameters into readable strings based on tool type
- Handles common tools (Bash, Glob, Grep, Read, Edit, Write, Task, WebFetch, WebSearch)
- Intelligently extracts relevant fields from MCP tools
- **Parses JSON strings before formatting** to handle fallback cases where metadata is missing
- Falls back to compact JSON for unknown tools

## After
```
Bash: ls -la /home/cyrus/... (List root directory)
Glob: package.json
```

## Bug Fix
Fixed critical logic error where the formatter was returning JSON strings immediately without processing them. The function now:
1. Attempts to parse JSON strings into objects first
2. Applies formatting logic to the parsed object
3. Handles edge cases where `entry.metadata.toolInput` is undefined

This ensures parameters display correctly even when tool metadata extraction fails and the code falls back to `entry.content` (which contains JSON strings).

## Changes
- Added `formatToolParameter()` method to `AgentSessionManager`
- Updated tool parameter formatting in both tool calls and tool results
- Added JSON string parsing logic to handle fallback scenarios
- Applied linting fixes for template literal usage

## Testing
- ✅ All 124 tests passing (22 test files)
- ✅ TypeScript compilation successful
- ✅ Linting clean
- ✅ Build completed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)