### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to this project will be documented in this file.
 - Suppressed unnecessary error logs when stopping Claude sessions
 
 ### Changed
-- Updated @anthropic-ai/claude-agent-sdk from v0.1.28 to v0.1.30 - see [@anthropic-ai/claude-agent-sdk v0.1.30 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0130)
-- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 - see [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.67.0...sdk-v0.68.0)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.30 to v0.1.35 - see [@anthropic-ai/claude-agent-sdk v0.1.35 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0135)
+  - Note: Changelog entries for versions 0.1.31-0.1.35 are not yet documented in the repository
+- Updated @anthropic-ai/sdk from v0.67.0 to v0.68.0 (already on latest) - see [@anthropic-ai/sdk v0.68.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/compare/sdk-v0.67.0...sdk-v0.68.0)
 
 ## [0.2.0-rc.3] - 2025-11-04
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.35",
 		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.30",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.35",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30(zod@3.25.76)
+        specifier: ^0.1.35
+        version: 0.1.35(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.68.0
         version: 0.68.0(zod@3.25.76)
@@ -251,8 +251,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.30
-        version: 0.1.30(zod@3.25.76)
+        specifier: ^0.1.35
+        version: 0.1.35(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -273,8 +273,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.30':
-    resolution: {integrity: sha512-lo1tqxCr2vygagFp6kUMHKSN6AAWlULCskwGKtLB/JcIXy/8H8GsLSKX54anTsvc9mBbCR8wWASdFmiiL9NSKA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.35':
+    resolution: {integrity: sha512-ktpRBzecNKhHvd9hgi5oFXP+BtND0QuJAMZZbeH0t4BNgwb/6mG7ojY+ZyJ6a0qnFOkItxeOgdW3asAYEY/iLA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2382,7 +2382,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.30(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.35(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updated `@anthropic-ai/claude-agent-sdk` from v0.1.30 to v0.1.35 in `packages/claude-runner` and `packages/simple-agent-runner`.

`@anthropic-ai/sdk` is already on the latest version (v0.68.0), so no changes were needed there.

## Changes
- ✅ Updated `packages/claude-runner/package.json` - changed `@anthropic-ai/claude-agent-sdk` from ^0.1.30 to ^0.1.35
- ✅ Updated `packages/simple-agent-runner/package.json` - changed `@anthropic-ai/claude-agent-sdk` from ^0.1.30 to ^0.1.35
- ✅ Updated `CHANGELOG.md` with version changes and link to SDK changelog
- ✅ Updated `pnpm-lock.yaml` with new package versions

## Implementation
- Checked current and latest versions using `npm view`
- Updated package.json files with new version
- Ran `pnpm install` to update lockfile
- Ran `pnpm build` to rebuild packages
- Verified all tests pass (219 tests passing)

## Testing
- ✅ All package tests passing: 219 tests across all packages
  - claude-runner: 66 tests
  - simple-agent-runner: 24 tests
  - edge-worker: 124 tests
  - config-updater: 5 tests
- ✅ TypeScript compilation successful
- ✅ Linting clean (1 pre-existing warning unrelated to changes)

## Notes
- Changelog entries for versions 0.1.31-0.1.35 are not yet documented in the SDK's repository, but the packages have been published to npm
- See [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0135) for details

Related: CYPACK-353