### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.31 to v0.1.36 - see [@anthropic-ai/claude-agent-sdk v0.1.36 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0136)
+
 ## [0.2.0] - 2025-11-07
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.36",
 		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.36",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.31
-        version: 0.1.31(zod@3.25.76)
+        specifier: ^0.1.36
+        version: 0.1.36(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.68.0
         version: 0.68.0(zod@3.25.76)
@@ -251,8 +251,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.31
-        version: 0.1.31(zod@3.25.76)
+        specifier: ^0.1.36
+        version: 0.1.36(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -273,8 +273,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.31':
-    resolution: {integrity: sha512-cwzgM2ntyzfr0aaiDEVwrQJawRlGi/8sq4raWyNPQqfS3uEXhw+IDmPdPS+HhjO2e4LCf1y+SkJKeBjxleHOYA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.36':
+    resolution: {integrity: sha512-k42Aff3UXtVRxlXEou74stx/8BArMVxxIaOij7Vx7aYoF5eSwxtIQE9NT0ACysXAh5joGN/PfPs/Wkg4O3vOYg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2382,7 +2382,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.31(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.36(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.31 to v0.1.36 across the monorepo. The `@anthropic-ai/sdk` is already on the latest version (v0.68.0).

## Changes

### Updated Packages
- **@anthropic-ai/claude-agent-sdk**: `0.1.31` → `0.1.36`
  - Updated in: `packages/claude-runner` and `packages/simple-agent-runner`
  - [Release notes](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0136)

- **@anthropic-ai/sdk**: Already on latest `0.68.0` ✓

### Files Modified
- `packages/claude-runner/package.json`
- `packages/simple-agent-runner/package.json`
- `CHANGELOG.md`
- `pnpm-lock.yaml`

## Testing

✅ All package tests passing (1235 tests across 62 test files)
✅ Linting clean (biome check)
✅ TypeScript type checking valid
✅ All packages built successfully

## Implementation Approach

1. Checked current versions against npm registry
2. Updated package.json files in affected packages
3. Ran `pnpm install` to update lockfile
4. Built all packages to ensure compatibility
5. Ran full test suite to verify no breaking changes
6. Updated CHANGELOG.md following project conventions

## Related

Closes CYPACK-359

🤖 Generated with [Claude Code](https://claude.com/claude-code)