### PR TITLE
Rewrite tools/cli-platform as TypeScript app 'f1' using Bun and Commander

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,9 +448,9 @@ This integration is automatically available in all Cyrus sessions - the EdgeWork
 - Build all packages once at the start, then publish without rebuilding
 - This ensures `workspace:*` references resolve to published versions
 
-## 🏎️ Driving the Lambo
+## 🏎️ F1 - Fast CLI for Testing
 
-The **Cyrus CLI Platform** is a premium command-line interface for testing and controlling Cyrus agent sessions. It's designed with beautiful output, excellent help, activity pagination, and professional error handling - the "Lamborghini of CLIs."
+The **F1 CLI** is a modern TypeScript command-line interface for testing and controlling Cyrus agent sessions. Built with Bun and Commander.js, it features beautiful output, excellent help, activity pagination, and professional error handling.
 
 ### Quick Start
 
@@ -467,16 +467,16 @@ node tools/cli-platform/start-lambo.mjs
 
 The server will start on port 3457 (default) and display beautiful colored output with the RPC endpoint.
 
-**3. Use the CLI tool:**
+**3. Use F1:**
 ```bash
 # Check server health
-tools/cli-platform/lambo.mjs ping
+./apps/f1/f1 ping
 
 # View all commands
-tools/cli-platform/lambo.mjs help
+./apps/f1/f1 --help
 
 # Get command-specific help
-tools/cli-platform/lambo.mjs viewSession --help
+./apps/f1/f1 viewSession --help
 ```
 
 ### Premium Features
@@ -495,42 +495,42 @@ tools/cli-platform/lambo.mjs viewSession --help
 
 **Health & Status:**
 ```bash
-lambo.mjs ping              # Check if server is running
-lambo.mjs status            # Get version, uptime, platform info
-lambo.mjs version           # Show version only
+./apps/f1/f1 ping              # Check if server is running
+./apps/f1/f1 status            # Get version, uptime, platform info
+./apps/f1/f1 version           # Show version only
 ```
 
 **Working with Issues:**
 ```bash
 # Create an issue
-lambo.mjs createIssue --title "Fix bug" --description "Critical"
+./apps/f1/f1 createIssue --title "Fix bug" --description "Critical"
 
 # Assign to agent
-lambo.mjs assignIssue --issue-id issue-1 --assignee-id agent-user-1
+./apps/f1/f1 assignIssue --issue-id issue-1 --assignee-id agent-user-1
 
 # Create comment with agent mention (triggers session)
-lambo.mjs createComment --issue-id issue-1 --body "Fix this" --mention-agent
+./apps/f1/f1 createComment --issue-id issue-1 --body "Fix this" --mention-agent
 ```
 
 **Managing Sessions:**
 ```bash
 # Start a session
-lambo.mjs startSession --issue-id issue-1
+./apps/f1/f1 startSession --issue-id issue-1
 
 # View session (with pagination)
-lambo.mjs viewSession --session-id session-1 --limit 10
+./apps/f1/f1 viewSession --session-id session-1 --limit 10
 
 # View next page
-lambo.mjs viewSession --session-id session-1 --limit 10 --offset 10
+./apps/f1/f1 viewSession --session-id session-1 --limit 10 --offset 10
 
 # Search activities
-lambo.mjs viewSession --session-id session-1 --search "error"
+./apps/f1/f1 viewSession --session-id session-1 --search "error"
 
 # Send message to session
-lambo.mjs promptSession --session-id session-1 --message "Add tests"
+./apps/f1/f1 promptSession --session-id session-1 --message "Add tests"
 
 # Stop session
-lambo.mjs stopSession --session-id session-1
+./apps/f1/f1 stopSession --session-id session-1
 ```
 
 ### Testing the Lambo
@@ -558,26 +558,26 @@ The test drive runs completely automated (with pauses for review) and verifies e
 **Workflow 1: Create issue, assign to agent, monitor session**
 ```bash
 # Create issue
-lambo.mjs createIssue --title "Refactor API" --description "Clean up endpoints"
+./apps/f1/f1 createIssue --title "Refactor API" --description "Clean up endpoints"
 # Output: { "id": "issue-1", ... }
 
 # Assign to agent (triggers session via event)
-lambo.mjs assignIssue --issue-id issue-1 --assignee-id agent-user-1
+./apps/f1/f1 assignIssue --issue-id issue-1 --assignee-id agent-user-1
 
 # Or manually start session
-lambo.mjs startSession --issue-id issue-1
+./apps/f1/f1 startSession --issue-id issue-1
 # Output: { "agentSessionId": "session-1", ... }
 
 # Monitor progress (paginated)
-lambo.mjs viewSession --session-id session-1 --limit 5
+./apps/f1/f1 viewSession --session-id session-1 --limit 5
 
 # Add activities accumulate...
 
 # View next page
-lambo.mjs viewSession --session-id session-1 --limit 5 --offset 5
+./apps/f1/f1 viewSession --session-id session-1 --limit 5 --offset 5
 
 # Search for specific activity
-lambo.mjs viewSession --session-id session-1 --search "completed"
+./apps/f1/f1 viewSession --session-id session-1 --search "completed"
 ```
 
 **Workflow 2: Paginating large activity lists**
@@ -585,16 +585,16 @@ lambo.mjs viewSession --session-id session-1 --search "completed"
 # Session has 100+ activities
 
 # View most recent 20 (default)
-lambo.mjs viewSession --session-id session-1
+./apps/f1/f1 viewSession --session-id session-1
 
 # View most recent 10
-lambo.mjs viewSession --session-id session-1 --limit 10
+./apps/f1/f1 viewSession --session-id session-1 --limit 10
 
 # View activities 20-30
-lambo.mjs viewSession --session-id session-1 --limit 10 --offset 20
+./apps/f1/f1 viewSession --session-id session-1 --limit 10 --offset 20
 
 # Search for errors in last 50
-lambo.mjs viewSession --session-id session-1 --search "error" --limit 50
+./apps/f1/f1 viewSession --session-id session-1 --search "error" --limit 50
 ```
 
 **Workflow 3: Scripted automation**
@@ -608,7 +608,7 @@ LAST_OFFSET=0
 while true; do
   clear
   echo "=== Session $SESSION_ID (refreshing every 5s) ==="
-  lambo.mjs viewSession --session-id "$SESSION_ID" --limit 5 --offset $LAST_OFFSET
+  ./apps/f1/f1 viewSession --session-id "$SESSION_ID" --limit 5 --offset $LAST_OFFSET
   sleep 5
 done
 ```
@@ -626,16 +626,16 @@ done
 **Examples:**
 ```bash
 # First page (most recent 20)
-lambo.mjs viewSession --session-id S --limit 20 --offset 0
+./apps/f1/f1 viewSession --session-id S --limit 20 --offset 0
 
 # Second page (next 20)
-lambo.mjs viewSession --session-id S --limit 20 --offset 20
+./apps/f1/f1 viewSession --session-id S --limit 20 --offset 20
 
 # Third page (next 20)
-lambo.mjs viewSession --session-id S --limit 20 --offset 40
+./apps/f1/f1 viewSession --session-id S --limit 20 --offset 40
 
 # Search and paginate
-lambo.mjs viewSession --session-id S --search "test" --limit 10 --offset 0
+./apps/f1/f1 viewSession --session-id S --search "test" --limit 10 --offset 0
 ```
 
 ### Environment Variables
@@ -646,12 +646,12 @@ lambo.mjs viewSession --session-id S --search "test" --limit 10 --offset 0
 CYRUS_PORT=8080 node tools/cli-platform/start-lambo.mjs
 
 # Use CLI with custom port
-CYRUS_PORT=8080 tools/cli-platform/lambo.mjs ping
+CYRUS_PORT=8080 ./apps/f1/f1 ping
 ```
 
 **DEBUG**: Enable stack traces
 ```bash
-DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
+DEBUG=1 ./apps/f1/f1 createIssue --title "Test"
 ```
 
 ### Troubleshooting
@@ -663,12 +663,12 @@ DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
 
 **CLI can't connect:**
 - Verify server is running
-- Check port matches: `CYRUS_PORT=8080 tools/cli-platform/lambo.mjs ping`
+- Check port matches: `CYRUS_PORT=8080 ./apps/f1/f1 ping`
 - Look for errors in `/tmp/cyrus-cli-server.log`
 
 **Activities not showing:**
 - Session may be new (no activities yet)
-- Add test activity: `tools/cli-platform/lambo.mjs promptSession --session-id S --message "test"`
+- Add test activity: `./apps/f1/f1 promptSession --session-id S --message "test"`
 - Check offset isn't beyond total count
 
 **Module not found:**
@@ -679,7 +679,7 @@ DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
 
 - **tools/cli-platform/CLI_TOOL_README.md** - Comprehensive CLI documentation
 - **tools/cli-platform/test-drive-lambo.sh** - Automated test script
-- **tools/cli-platform/lambo.mjs** - CLI tool source
+- **./apps/f1/f1** - CLI tool source
 - **packages/core/src/issue-tracker/adapters/CLIRPCServer.ts** - RPC server
 - **tools/cli-platform/start-lambo.mjs** - Server startup script
 
@@ -687,7 +687,7 @@ DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
 
 ```
 ┌──────────────────┐
-│  lambo.mjs    │  ← Beautiful CLI with colors, help, pagination
+│  ./apps/f1/f1    │  ← Beautiful CLI with colors, help, pagination
 │  (Client)        │
 └────────┬─────────┘
          │ HTTP POST /cli/rpc (JSON-RPC)
@@ -709,7 +709,7 @@ DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
 
 **Adding a new command:**
 
-1. **Add to `tools/cli-platform/lambo.mjs`:**
+1. **Add to `./apps/f1/f1`:**
    - Add case to switch statement in `main()`
    - Add entry to `showHelp()` function
    - Add complete help to `showCommandHelp()` object
@@ -730,7 +730,7 @@ DEBUG=1 tools/cli-platform/lambo.mjs createIssue --title "Test"
 **Example: Adding `listSessions` command:**
 
 ```javascript
-// tools/cli-platform/lambo.mjs
+// ./apps/f1/f1
 case "listSessions": {
   method = "listAgentSessions";
   rpcParams = {};
@@ -743,9 +743,9 @@ console.log(`    ${c.command("listSessions")}             List all agent session
 // Add to showCommandHelp():
 listSessions: {
   description: "List all agent sessions",
-  usage: "lambo.mjs listSessions",
+  usage: "./apps/f1/f1 listSessions",
   options: [],
-  examples: ["lambo.mjs listSessions"],
+  examples: ["./apps/f1/f1 listSessions"],
 }
 
 // CLIRPCServer.ts
@@ -761,7 +761,7 @@ case "listAgentSessions": {
 
 ### Tips & Best Practices
 
-1. **Always check server is running first**: `tools/cli-platform/lambo.mjs ping`
+1. **Always check server is running first**: `./apps/f1/f1 ping`
 2. **Use --help liberally**: Every command has detailed help
 3. **Paginate large datasets**: Use `--limit` and `--offset` for 100+ activities
 4. **Search before paginating**: `--search "term"` filters first, then paginates
@@ -799,7 +799,7 @@ When asked to "test drive the system" or "run a real test drive", follow this pr
 **2. Start the Lambo server:**
 ```bash
 node tools/cli-platform/start-lambo.mjs &
-tools/cli-platform/lambo.mjs ping
+./apps/f1/f1 ping
 ```
 
 **3. Create a timestamped log file:**

--- a/apps/f1/README.md
+++ b/apps/f1/README.md
@@ -1,0 +1,64 @@
+# F1 - Fast CLI for Cyrus Platform
+
+A modern TypeScript CLI tool for testing the Cyrus agent platform. Built with Bun runtime and Commander.js.
+
+## Features
+
+- ✨ **TypeScript**: Fully typed with strict type checking
+- 🎨 **Beautiful Output**: Colored, formatted terminal output  
+- 📄 **Pagination**: View large datasets efficiently
+- 🔍 **Search**: Filter activities with full-text search
+- 💡 **Excellent Help**: Built-in help for every command
+- 🚀 **Fast**: Powered by Bun runtime
+- 🛠️ **Modular**: Clean, DRY code architecture
+
+## Quick Start
+
+```bash
+# From repository root
+./apps/f1/f1 --help
+
+# From f1 directory
+cd apps/f1
+./f1 --help
+```
+
+## Available Commands
+
+### Health & Status
+```bash
+./f1 ping        # Check server connectivity
+./f1 status      # Get server status
+./f1 version     # Show version
+```
+
+### Issue Management
+```bash
+./f1 createIssue --title "Fix bug" --description "Details"
+./f1 assignIssue --issue-id issue-1 --assignee-id user-1
+```
+
+### Agent Sessions
+```bash
+./f1 startSession --issue-id issue-1
+./f1 viewSession --session-id session-1 --limit 10
+./f1 promptSession --session-id session-1 --message "Add tests"
+./f1 stopSession --session-id session-1
+```
+
+## Development
+
+```bash
+# Type checking
+pnpm --filter cyrus-f1 typecheck
+
+# Linting
+pnpm biome check apps/f1/src/
+
+# Build
+pnpm --filter cyrus-f1 build
+```
+
+## License
+
+MIT

--- a/apps/f1/f1
+++ b/apps/f1/f1
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Convenience wrapper for F1 CLI
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bun run "$SCRIPT_DIR/src/index.ts" "$@"

--- a/apps/f1/package.json
+++ b/apps/f1/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "cyrus-f1",
+	"version": "1.0.0",
+	"description": "F1 - Fast CLI for Cyrus platform testing",
+	"type": "module",
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"start": "bun run src/index.ts",
+		"test": "vitest run",
+		"test:run": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"typecheck": "tsc --noEmit",
+		"lint": "biome check src/",
+		"lint:fix": "biome check --write src/"
+	},
+	"dependencies": {
+		"commander": "^12.1.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"@biomejs/biome": "^1.9.4",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	}
+}

--- a/apps/f1/src/client/RPCClient.ts
+++ b/apps/f1/src/client/RPCClient.ts
@@ -1,0 +1,95 @@
+import type {
+	RPCClientOptions,
+	RPCRequest,
+	RPCResponse,
+} from "../types/index.js";
+import { c } from "../utils/colors.js";
+
+const DEFAULT_PORT = 3457;
+
+/**
+ * Get the RPC URL from environment variables
+ */
+export function getRPCUrl(): string {
+	const port = process.env.CYRUS_PORT || DEFAULT_PORT;
+	return `http://localhost:${port}/cli/rpc`;
+}
+
+/**
+ * Make an RPC call to the Cyrus CLI platform
+ */
+export async function rpc<T = unknown>(
+	method: string,
+	params: Record<string, unknown> = {},
+	options: RPCClientOptions = {},
+): Promise<RPCResponse<T>> {
+	const { silent = false } = options;
+	const rpcUrl = getRPCUrl();
+
+	if (!silent) {
+		console.log(c.dim(`→ Connecting to ${rpcUrl}...`));
+	}
+
+	try {
+		const response = await fetch(rpcUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ method, params } as RPCRequest),
+		});
+
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+		}
+
+		const result = (await response.json()) as RPCResponse<T>;
+
+		if (!silent) {
+			console.log(c.success("✓ Connected\n"));
+		}
+
+		return result;
+	} catch (error) {
+		if (error instanceof Error && "cause" in error) {
+			const cause = error.cause as { code?: string };
+			if (cause.code === "ECONNREFUSED") {
+				handleConnectionError(rpcUrl);
+			}
+		}
+		throw error;
+	}
+}
+
+/**
+ * Handle connection errors with helpful messages
+ */
+function handleConnectionError(rpcUrl: string): never {
+	console.error(c.error("\n❌ Cannot connect to Cyrus server\n"));
+	console.error(c.dim(`   Server URL: ${rpcUrl}`));
+	console.error(c.dim("   Make sure the CLI server is running."));
+	console.error(
+		c.dim(`   Start it with: ${c.command("node start-cli-server.mjs")}\n`),
+	);
+
+	const customPort = process.env.CYRUS_PORT;
+	if (customPort && Number.parseInt(customPort, 10) !== DEFAULT_PORT) {
+		console.error(c.dim(`   Using custom port from CYRUS_PORT=${customPort}`));
+	}
+
+	console.error();
+	process.exit(1);
+}
+
+/**
+ * Display a standard RPC result
+ */
+export async function displayResult<T>(result: RPCResponse<T>): Promise<void> {
+	if (result.success) {
+		console.log(c.success("✅ Success\n"));
+		const { printJSON } = await import("../utils/formatter.js");
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/comment.ts
+++ b/apps/f1/src/commands/comment.ts
@@ -1,0 +1,34 @@
+import { rpc } from "../client/RPCClient.js";
+import { c } from "../utils/colors.js";
+import { printJSON } from "../utils/formatter.js";
+
+/**
+ * Create comment options
+ */
+export interface CreateCommentOptions {
+	issueId: string;
+	body: string;
+	mentionAgent?: boolean;
+}
+
+/**
+ * Create a comment on an issue
+ */
+export async function createComment(
+	options: CreateCommentOptions,
+): Promise<void> {
+	const result = await rpc("createComment", {
+		issueId: options.issueId,
+		body: options.body,
+		mentionAgent: options.mentionAgent === true,
+	});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/debug.ts
+++ b/apps/f1/src/commands/debug.ts
@@ -1,0 +1,19 @@
+import { rpc } from "../client/RPCClient.js";
+import { c } from "../utils/colors.js";
+import { printJSON } from "../utils/formatter.js";
+
+/**
+ * Get the entire in-memory state (for debugging)
+ */
+export async function getState(): Promise<void> {
+	const result = await rpc("getState", {});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/issue.ts
+++ b/apps/f1/src/commands/issue.ts
@@ -1,0 +1,79 @@
+import { rpc } from "../client/RPCClient.js";
+import type { Issue } from "../types/index.js";
+import { c } from "../utils/colors.js";
+import { printJSON } from "../utils/formatter.js";
+
+/**
+ * Create issue command options
+ */
+export interface CreateIssueOptions {
+	title: string;
+	description?: string;
+	assigneeId?: string;
+	teamId?: string;
+	stateId?: string;
+}
+
+/**
+ * Create a new issue
+ */
+export async function createIssue(options: CreateIssueOptions): Promise<void> {
+	const result = await rpc<Issue>("createIssue", {
+		title: options.title,
+		description: options.description,
+		options: {
+			assigneeId: options.assigneeId,
+			teamId: options.teamId,
+			stateId: options.stateId,
+		},
+	});
+
+	if (result.success && result.data) {
+		const issue = result.data;
+		console.log(c.success(`\n✅ Issue Created: ${c.bold(issue.identifier)}\n`));
+		printJSON(issue);
+		console.log();
+		console.log(c.dim("💡 Next steps:"));
+		console.log(
+			c.dim(
+				`   • Start session: ${c.command(`f1 startSession --issue-id ${issue.id}`)}`,
+			),
+		);
+		console.log(
+			c.dim(
+				`   • Assign issue: ${c.command(`f1 assignIssue --issue-id ${issue.id} --assignee-id <user-id>`)}`,
+			),
+		);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Assign issue options
+ */
+export interface AssignIssueOptions {
+	issueId: string;
+	assigneeId?: string;
+}
+
+/**
+ * Assign an issue to a user
+ */
+export async function assignIssue(options: AssignIssueOptions): Promise<void> {
+	const result = await rpc("assignIssue", {
+		issueId: options.issueId,
+		assigneeId: options.assigneeId || null,
+	});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/ping.ts
+++ b/apps/f1/src/commands/ping.ts
@@ -1,0 +1,19 @@
+import { getRPCUrl, rpc } from "../client/RPCClient.js";
+import { c } from "../utils/colors.js";
+
+/**
+ * Ping command - Check server connectivity
+ */
+export async function ping(): Promise<void> {
+	console.log(c.info("\n🏓 Pinging Cyrus server...\n"));
+
+	const result = await rpc("ping", {}, { silent: false });
+
+	if (result.success) {
+		console.log(c.success("✅ Server is responding"));
+		console.log(c.dim(`   URL: ${getRPCUrl()}\n`));
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/session.ts
+++ b/apps/f1/src/commands/session.ts
@@ -1,0 +1,285 @@
+import { rpc } from "../client/RPCClient.js";
+import type {
+	Activity,
+	ActivityDisplayOptions,
+	AgentSession,
+} from "../types/index.js";
+import { c } from "../utils/colors.js";
+import { displayActivities, printJSON } from "../utils/formatter.js";
+
+/**
+ * Start session on issue
+ */
+export async function startSession(issueId: string): Promise<void> {
+	const result = await rpc<{ agentSessionId: string }>(
+		"startAgentSessionOnIssue",
+		{
+			issueId,
+		},
+	);
+
+	if (result.success && result.data) {
+		const sessionId = result.data.agentSessionId;
+		console.log(c.success(`\n✅ Session Started: ${c.bold(sessionId)}\n`));
+		console.log(c.dim("💡 Next steps:"));
+		console.log(
+			c.dim(
+				`   • View progress: ${c.command(`f1 viewSession --session-id ${sessionId}`)}`,
+			),
+		);
+		console.log(
+			c.dim(
+				`   • Send message: ${c.command(`f1 promptSession --session-id ${sessionId} --message "..."`)}`,
+			),
+		);
+		console.log(
+			c.dim(
+				`   • Stop session: ${c.command(`f1 stopSession --session-id ${sessionId}`)}`,
+			),
+		);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Start session on comment
+ */
+export async function startSessionOnComment(commentId: string): Promise<void> {
+	const result = await rpc("startAgentSessionOnComment", { commentId });
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * View session options
+ */
+export interface ViewSessionOptions {
+	sessionId: string;
+	limit?: number;
+	offset?: number;
+	search?: string;
+	full?: boolean;
+	previewLength?: number;
+	summary?: boolean;
+}
+
+/**
+ * View an agent session
+ */
+export async function viewSession(options: ViewSessionOptions): Promise<void> {
+	const result = await rpc<{ session: AgentSession; activities: Activity[] }>(
+		"viewAgentSession",
+		{
+			sessionId: options.sessionId,
+		},
+	);
+
+	if (result.success && result.data) {
+		const { session, activities } = result.data;
+
+		// Status badge with emoji
+		let statusBadge: string;
+		switch (session.status) {
+			case "executing":
+				statusBadge = `🟢 ${c.success(session.status)}`;
+				break;
+			case "pending":
+				statusBadge = `⚪ ${c.dim(session.status)}`;
+				break;
+			case "waiting":
+				statusBadge = `🟡 ${c.warning(session.status)}`;
+				break;
+			case "stopped":
+			case "failed":
+				statusBadge = `🔴 ${c.error(session.status)}`;
+				break;
+			default:
+				statusBadge = c.value(session.status);
+		}
+
+		console.log(c.success("\n✅ Agent Session\n"));
+		console.log(`   ${c.bold("ID:")} ${c.value(session.id)}`);
+		console.log(`   ${c.bold("Status:")} ${statusBadge}`);
+		console.log(`   ${c.bold("Type:")} ${c.value(session.type)}`);
+		console.log(`   ${c.bold("Issue ID:")} ${c.value(session.issueId)}`);
+		if (session.commentId) {
+			console.log(`   ${c.bold("Comment ID:")} ${c.value(session.commentId)}`);
+		}
+		console.log(
+			`   ${c.bold("Activities:")} ${c.value(String(activities.length))} total`,
+		);
+
+		// Show last activity time to indicate if actively working
+		if (activities.length > 0) {
+			const lastActivity = [...activities].sort(
+				(a, b) =>
+					new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+			)[0];
+			if (!lastActivity) {
+				throw new Error("No last activity found");
+			}
+			const lastUpdate = new Date(lastActivity.createdAt);
+			const now = new Date();
+			const secAgo = Math.floor((now.getTime() - lastUpdate.getTime()) / 1000);
+			const timeAgo =
+				secAgo < 60
+					? `${secAgo}s ago`
+					: secAgo < 3600
+						? `${Math.floor(secAgo / 60)}m ago`
+						: `${Math.floor(secAgo / 3600)}h ago`;
+			console.log(`   ${c.bold("Last Activity:")} ${c.dim(timeAgo)}`);
+		}
+
+		console.log(
+			`   ${c.bold("Created:")} ${c.dim(new Date(session.createdAt).toLocaleString())}`,
+		);
+		console.log(
+			`   ${c.bold("Updated:")} ${c.dim(new Date(session.updatedAt).toLocaleString())}`,
+		);
+
+		// If --summary flag, find and display final response prominently
+		if (options.summary) {
+			const responseActivity = [...activities]
+				.sort(
+					(a, b) =>
+						new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+				)
+				.find((a) => a.content?.type === "response");
+
+			if (responseActivity) {
+				console.log();
+				console.log(c.success("📋 Final Response Summary"));
+				console.log();
+				const body = responseActivity.content?.body || "(no content)";
+				console.log(
+					body
+						.split("\n")
+						.map((line) => `   ${line}`)
+						.join("\n"),
+				);
+				console.log();
+			} else {
+				console.log();
+				console.log(c.dim("   No final response found yet."));
+				console.log();
+			}
+		}
+
+		// Display paginated activities
+		const displayOptions: ActivityDisplayOptions = {
+			limit: options.limit,
+			offset: options.offset,
+			search: options.search,
+			full: options.full,
+			previewLength: options.previewLength,
+		};
+		displayActivities(activities, displayOptions);
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Prompt session options
+ */
+export interface PromptSessionOptions {
+	sessionId: string;
+	message: string;
+}
+
+/**
+ * Send a prompt to an agent session
+ */
+export async function promptSession(
+	options: PromptSessionOptions,
+): Promise<void> {
+	const result = await rpc("promptAgentSession", {
+		sessionId: options.sessionId,
+		message: options.message,
+	});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Stop an agent session
+ */
+export async function stopSession(sessionId: string): Promise<void> {
+	const result = await rpc("stopAgentSession", { sessionId });
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Get activity options
+ */
+export interface GetActivityOptions {
+	sessionId: string;
+	activityId: string;
+}
+
+/**
+ * Get a single activity's details
+ */
+export async function getActivity(options: GetActivityOptions): Promise<void> {
+	const result = await rpc<Activity>("getActivity", {
+		sessionId: options.sessionId,
+		activityId: options.activityId,
+	});
+
+	if (result.success && result.data) {
+		const activity = result.data;
+		console.log(c.success("\n✅ Activity Details\n"));
+		console.log(`   ${c.bold("ID:")} ${c.value(activity.id)}`);
+		console.log(
+			`   ${c.bold("Type:")} ${c.value(activity.content?.type || "unknown")}`,
+		);
+		console.log(
+			`   ${c.bold("Created:")} ${c.dim(new Date(activity.createdAt).toLocaleString())}`,
+		);
+		if (activity.signal) {
+			console.log(
+				`   ${c.bold("Signal:")} ${c.warning(activity.signal.toUpperCase())}`,
+			);
+		}
+		console.log();
+		console.log(c.bold("Body:"));
+		console.log();
+		const body = activity.content?.body || "(no content)";
+		console.log(
+			body
+				.split("\n")
+				.map((line) => `   ${line}`)
+				.join("\n"),
+		);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/status.ts
+++ b/apps/f1/src/commands/status.ts
@@ -1,0 +1,40 @@
+import { getRPCUrl, rpc } from "../client/RPCClient.js";
+import type { ServerStatus } from "../types/index.js";
+import { c } from "../utils/colors.js";
+
+/**
+ * Status command - Get server status and version
+ */
+export async function status(): Promise<void> {
+	console.log(c.info("\n📊 Fetching server status...\n"));
+
+	const result = await rpc<ServerStatus>("status", {}, { silent: false });
+
+	if (result.success && result.data) {
+		console.log(c.success("✅ Server Status\n"));
+		console.log(`   ${c.bold("Version:")} ${c.value(result.data.version)}`);
+		console.log(`   ${c.bold("Platform:")} ${c.value(result.data.platform)}`);
+		console.log(`   ${c.bold("Mode:")} ${c.value(result.data.mode)}`);
+		console.log(
+			`   ${c.bold("Uptime:")} ${c.value(result.data.uptime || "N/A")}`,
+		);
+		console.log(`   ${c.bold("URL:")} ${c.url(getRPCUrl())}\n`);
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Version command - Show server version
+ */
+export async function version(): Promise<void> {
+	const result = await rpc<ServerStatus>("status", {}, { silent: true });
+
+	if (result.success && result.data) {
+		console.log(c.value(result.data.version));
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/commands/team.ts
+++ b/apps/f1/src/commands/team.ts
@@ -1,0 +1,91 @@
+import { rpc } from "../client/RPCClient.js";
+import { c } from "../utils/colors.js";
+import { printJSON } from "../utils/formatter.js";
+
+/**
+ * Fetch all labels
+ */
+export async function fetchLabels(): Promise<void> {
+	const result = await rpc("fetchLabels", {});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Fetch all members
+ */
+export async function fetchMembers(): Promise<void> {
+	const result = await rpc("fetchMembers", {});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Create label options
+ */
+export interface CreateLabelOptions {
+	name: string;
+	color?: string;
+}
+
+/**
+ * Create a new label
+ */
+export async function createLabel(options: CreateLabelOptions): Promise<void> {
+	const result = await rpc("createLabel", {
+		name: options.name,
+		options: options.color ? { color: options.color } : {},
+	});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}
+
+/**
+ * Create member options
+ */
+export interface CreateMemberOptions {
+	name: string;
+	email?: string;
+}
+
+/**
+ * Create a new team member
+ */
+export async function createMember(
+	options: CreateMemberOptions,
+): Promise<void> {
+	const result = await rpc("createMember", {
+		name: options.name,
+		options: options.email ? { email: options.email } : {},
+	});
+
+	if (result.success) {
+		console.log(c.success("\n✅ Success\n"));
+		printJSON(result.data);
+		console.log();
+	} else {
+		console.error(c.error(`\n❌ Error: ${result.error}\n`));
+		process.exit(1);
+	}
+}

--- a/apps/f1/src/index.ts
+++ b/apps/f1/src/index.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env bun
+/**
+ * F1 - Fast CLI for Cyrus Platform Testing
+ *
+ * A modern TypeScript CLI tool for testing Cyrus agent platform.
+ * Built with Bun and Commander.js.
+ */
+
+import { Command } from "commander";
+import { createComment } from "./commands/comment.js";
+import { getState } from "./commands/debug.js";
+import { assignIssue, createIssue } from "./commands/issue.js";
+import { ping } from "./commands/ping.js";
+import {
+	getActivity,
+	promptSession,
+	startSession,
+	startSessionOnComment,
+	stopSession,
+	viewSession,
+} from "./commands/session.js";
+import { status, version } from "./commands/status.js";
+import {
+	createLabel,
+	createMember,
+	fetchLabels,
+	fetchMembers,
+} from "./commands/team.js";
+
+const program = new Command();
+
+program
+	.name("f1")
+	.description("F1 - Fast CLI for testing Cyrus agent platform")
+	.version("1.0.0");
+
+// Health & Status Commands
+program
+	.command("ping")
+	.description("Check server connectivity")
+	.action(async () => {
+		await ping();
+	});
+
+program
+	.command("status")
+	.description("Get server status and version information")
+	.action(async () => {
+		await status();
+	});
+
+program
+	.command("version")
+	.description("Show server version")
+	.action(async () => {
+		await version();
+	});
+
+// Issue Management Commands
+program
+	.command("createIssue")
+	.description("Create a new issue")
+	.requiredOption("--title <title>", "Issue title")
+	.option("--description <description>", "Issue description")
+	.option("--assignee-id <assigneeId>", "User ID to assign the issue to")
+	.option("--team-id <teamId>", "Team ID")
+	.option("--state-id <stateId>", "Workflow state ID")
+	.action(async (options) => {
+		await createIssue({
+			title: options.title,
+			description: options.description,
+			assigneeId: options.assigneeId,
+			teamId: options.teamId,
+			stateId: options.stateId,
+		});
+	});
+
+program
+	.command("assignIssue")
+	.description("Assign an issue to a user or remove assignee")
+	.requiredOption("--issue-id <issueId>", "Issue ID")
+	.option("--assignee-id <assigneeId>", "User ID to assign (omit to unassign)")
+	.action(async (options) => {
+		await assignIssue({
+			issueId: options.issueId,
+			assigneeId: options.assigneeId,
+		});
+	});
+
+// Comment Management Commands
+program
+	.command("createComment")
+	.description("Create a comment on an issue")
+	.requiredOption("--issue-id <issueId>", "Issue ID")
+	.requiredOption("--body <body>", "Comment body text")
+	.option("--mention-agent", "Mention the agent (triggers session)")
+	.action(async (options) => {
+		await createComment({
+			issueId: options.issueId,
+			body: options.body,
+			mentionAgent: options.mentionAgent,
+		});
+	});
+
+// Agent Session Commands
+program
+	.command("startSession")
+	.description("Start an agent session on an issue")
+	.requiredOption("--issue-id <issueId>", "Issue ID")
+	.action(async (options) => {
+		await startSession(options.issueId);
+	});
+
+program
+	.command("startSessionOnComment")
+	.description("Start an agent session on a root comment")
+	.requiredOption("--comment-id <commentId>", "Comment ID")
+	.action(async (options) => {
+		await startSessionOnComment(options.commentId);
+	});
+
+program
+	.command("viewSession")
+	.description("View agent session details with pagination and search")
+	.requiredOption("--session-id <sessionId>", "Session ID")
+	.option("--limit <limit>", "Number of activities to show", "20")
+	.option("--offset <offset>", "Starting offset for pagination", "0")
+	.option("--search <search>", "Search term to filter activities")
+	.option("--full", "Show complete activity bodies (no truncation)")
+	.option(
+		"--preview-length <previewLength>",
+		"Characters to show in preview",
+		"200",
+	)
+	.option("--summary", "Show final response summary prominently")
+	.action(async (options) => {
+		await viewSession({
+			sessionId: options.sessionId,
+			limit: Number.parseInt(options.limit, 10),
+			offset: Number.parseInt(options.offset, 10),
+			search: options.search,
+			full: options.full,
+			previewLength: Number.parseInt(options.previewLength, 10),
+			summary: options.summary,
+		});
+	});
+
+program
+	.command("promptSession")
+	.description("Send a prompt/message to an agent session")
+	.requiredOption("--session-id <sessionId>", "Session ID")
+	.requiredOption("--message <message>", "Message to send")
+	.action(async (options) => {
+		await promptSession({
+			sessionId: options.sessionId,
+			message: options.message,
+		});
+	});
+
+program
+	.command("stopSession")
+	.description("Stop a running agent session")
+	.requiredOption("--session-id <sessionId>", "Session ID")
+	.action(async (options) => {
+		await stopSession(options.sessionId);
+	});
+
+program
+	.command("getActivity")
+	.description("View a single activity's complete details")
+	.requiredOption("--session-id <sessionId>", "Session ID")
+	.requiredOption("--activity-id <activityId>", "Activity ID")
+	.action(async (options) => {
+		await getActivity({
+			sessionId: options.sessionId,
+			activityId: options.activityId,
+		});
+	});
+
+// Team & Label Commands
+program
+	.command("fetchLabels")
+	.description("List all labels in the workspace")
+	.action(async () => {
+		await fetchLabels();
+	});
+
+program
+	.command("fetchMembers")
+	.description("List all team members")
+	.action(async () => {
+		await fetchMembers();
+	});
+
+program
+	.command("createLabel")
+	.description("Create a new label")
+	.requiredOption("--name <name>", "Label name")
+	.option("--color <color>", "Label color (hex code, e.g., #ff0000)")
+	.action(async (options) => {
+		await createLabel({
+			name: options.name,
+			color: options.color,
+		});
+	});
+
+program
+	.command("createMember")
+	.description("Create a new team member")
+	.requiredOption("--name <name>", "Member name")
+	.option("--email <email>", "Member email address")
+	.action(async (options) => {
+		await createMember({
+			name: options.name,
+			email: options.email,
+		});
+	});
+
+// Debug Command
+program
+	.command("getState")
+	.description("Get entire in-memory state (for debugging)")
+	.action(async () => {
+		await getState();
+	});
+
+// Parse arguments
+program.parse();

--- a/apps/f1/src/types/index.ts
+++ b/apps/f1/src/types/index.ts
@@ -1,0 +1,97 @@
+/**
+ * RPC response structure
+ */
+export interface RPCResponse<T = unknown> {
+	success: boolean;
+	data?: T;
+	error?: string;
+}
+
+/**
+ * RPC request structure
+ */
+export interface RPCRequest {
+	method: string;
+	params?: Record<string, unknown>;
+}
+
+/**
+ * Activity content structure
+ */
+export interface ActivityContent {
+	type: string;
+	body?: string;
+	action?: string;
+	parameter?: unknown;
+}
+
+/**
+ * Activity structure
+ */
+export interface Activity {
+	id: string;
+	createdAt: string;
+	content?: ActivityContent;
+	signal?: string;
+}
+
+/**
+ * Agent session structure
+ */
+export interface AgentSession {
+	id: string;
+	status: string;
+	type: string;
+	issueId: string;
+	commentId?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+/**
+ * Issue structure
+ */
+export interface Issue {
+	id: string;
+	identifier: string;
+	title: string;
+	description?: string;
+	teamId: string;
+	stateId: string;
+	assigneeId?: string;
+}
+
+/**
+ * Server status structure
+ */
+export interface ServerStatus {
+	version: string;
+	platform: string;
+	mode: string;
+	uptime?: string;
+}
+
+/**
+ * Options for pagination
+ */
+export interface PaginationOptions {
+	limit?: number;
+	offset?: number;
+	search?: string;
+	full?: boolean;
+	previewLength?: number;
+}
+
+/**
+ * Options for activity display
+ */
+export interface ActivityDisplayOptions extends PaginationOptions {
+	summary?: boolean;
+}
+
+/**
+ * RPC client options
+ */
+export interface RPCClientOptions {
+	silent?: boolean;
+}

--- a/apps/f1/src/utils/colors.ts
+++ b/apps/f1/src/utils/colors.ts
@@ -1,0 +1,31 @@
+/**
+ * ANSI color codes for terminal output
+ */
+const colors = {
+	reset: "\x1b[0m",
+	bold: "\x1b[1m",
+	dim: "\x1b[2m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	blue: "\x1b[34m",
+	cyan: "\x1b[36m",
+	gray: "\x1b[90m",
+};
+
+/**
+ * Color utility functions
+ */
+export const c = {
+	error: (text: string): string => `${colors.red}${text}${colors.reset}`,
+	success: (text: string): string => `${colors.green}${text}${colors.reset}`,
+	warning: (text: string): string => `${colors.yellow}${text}${colors.reset}`,
+	info: (text: string): string => `${colors.cyan}${text}${colors.reset}`,
+	dim: (text: string): string => `${colors.dim}${text}${colors.reset}`,
+	bold: (text: string): string => `${colors.bold}${text}${colors.reset}`,
+	command: (text: string): string => `${colors.cyan}${text}${colors.reset}`,
+	param: (text: string): string => `${colors.yellow}${text}${colors.reset}`,
+	value: (text: string): string => `${colors.green}${text}${colors.reset}`,
+	url: (text: string): string =>
+		`${colors.blue}${colors.dim}${text}${colors.reset}`,
+};

--- a/apps/f1/src/utils/formatter.ts
+++ b/apps/f1/src/utils/formatter.ts
@@ -1,0 +1,216 @@
+import type { Activity, ActivityDisplayOptions } from "../types/index.js";
+import { c } from "./colors.js";
+
+/**
+ * Pretty-print JSON with colors
+ */
+export function printJSON(obj: unknown, indent = 0): undefined | string {
+	const spaces = "  ".repeat(indent);
+
+	if (obj === null) return c.dim("null");
+	if (obj === undefined) return c.dim("undefined");
+	if (typeof obj === "string") return c.value(`"${obj}"`);
+	if (typeof obj === "number") return c.value(String(obj));
+	if (typeof obj === "boolean") return c.value(String(obj));
+
+	if (Array.isArray(obj)) {
+		if (obj.length === 0) return "[]";
+		console.log("[");
+		for (let i = 0; i < obj.length; i++) {
+			process.stdout.write(`${spaces}  `);
+			const value = printJSON(obj[i], indent + 1);
+			if (typeof value === "string") process.stdout.write(value);
+			console.log(i < obj.length - 1 ? "," : "");
+		}
+		console.log(`${spaces}]`);
+		return;
+	}
+
+	if (typeof obj === "object") {
+		const keys = Object.keys(obj);
+		if (keys.length === 0) return "{}";
+		console.log("{");
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i];
+			if (key !== undefined) {
+				process.stdout.write(`${spaces}  ${c.info(key)}: `);
+				const value = printJSON(
+					(obj as Record<string, unknown>)[key],
+					indent + 1,
+				);
+				if (typeof value === "string") process.stdout.write(value);
+				console.log(i < keys.length - 1 ? "," : "");
+			}
+		}
+		console.log(`${spaces}}`);
+		return;
+	}
+
+	return String(obj);
+}
+
+/**
+ * Display paginated activities with search
+ */
+export function displayActivities(
+	activities: Activity[],
+	options: ActivityDisplayOptions = {},
+): void {
+	const {
+		limit = 20,
+		offset = 0,
+		search = "",
+		full = false,
+		previewLength = 200,
+	} = options;
+
+	// Filter by search term
+	let filtered = activities;
+	if (search) {
+		const searchLower = search.toLowerCase();
+		filtered = activities.filter((activity) => {
+			const body = activity.content?.body || "";
+			const type = activity.content?.type || "";
+			return (
+				body.toLowerCase().includes(searchLower) ||
+				type.toLowerCase().includes(searchLower) ||
+				activity.id.toLowerCase().includes(searchLower)
+			);
+		});
+	}
+
+	// Sort by most recent first
+	const sorted = [...filtered].sort((a, b) => {
+		return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+	});
+
+	// Apply pagination
+	const paginated = sorted.slice(offset, offset + limit);
+	const total = sorted.length;
+
+	console.log(
+		c.bold(
+			`\n📝 Activities (showing ${Math.min(limit, total - offset)} of ${total})`,
+		),
+	);
+
+	if (search) {
+		console.log(c.dim(`   Filtered by: "${search}"`));
+	}
+
+	if (offset > 0) {
+		console.log(c.dim(`   Starting from: ${offset}`));
+	}
+
+	console.log();
+
+	if (paginated.length === 0) {
+		console.log(c.dim("   No activities found."));
+		return;
+	}
+
+	for (let i = 0; i < paginated.length; i++) {
+		const activity = paginated[i];
+		if (!activity) continue;
+
+		const num = offset + i + 1;
+		const date = new Date(activity.createdAt).toLocaleString();
+		const type = activity.content?.type || "unknown";
+		const body = activity.content?.body || "";
+		const signal = activity.signal
+			? ` [${c.warning(activity.signal.toUpperCase())}]`
+			: "";
+
+		// Color-code activity types with emojis
+		let typeDisplay: string;
+		switch (type) {
+			case "thought":
+				typeDisplay = `💭 ${c.info(type)}`;
+				break;
+			case "action":
+				typeDisplay = `⚡ ${c.warning(type)}`;
+				break;
+			case "tool_use":
+				typeDisplay = `🔧 ${c.success(type)}`;
+				break;
+			case "error":
+				typeDisplay = `❌ ${c.error(type)}`;
+				break;
+			default:
+				typeDisplay = c.dim(type);
+		}
+
+		console.log(c.bold(`${num}. ${activity.id}`) + signal);
+		console.log(c.dim(`   ${date} • `) + typeDisplay);
+
+		// For action/tool_use activities, show action details if available
+		if (
+			(type === "action" || type === "tool_use") &&
+			activity.content?.action
+		) {
+			const action = activity.content.action;
+			const parameter = activity.content.parameter;
+			let actionSummary = c.dim(`${action}`);
+
+			// Try to extract useful info from parameter
+			if (parameter) {
+				if (typeof parameter === "string") {
+					const preview =
+						parameter.length > 50 ? `${parameter.slice(0, 50)}...` : parameter;
+					actionSummary += c.dim(`: ${preview}`);
+				} else if (
+					typeof parameter === "object" &&
+					parameter !== null &&
+					"path" in parameter
+				) {
+					actionSummary += c.dim(`: ${parameter.path}`);
+				} else if (
+					typeof parameter === "object" &&
+					parameter !== null &&
+					"file_path" in parameter
+				) {
+					actionSummary += c.dim(`: ${parameter.file_path}`);
+				} else if (
+					typeof parameter === "object" &&
+					parameter !== null &&
+					"command" in parameter
+				) {
+					const cmd =
+						typeof parameter.command === "string" &&
+						parameter.command.length > 50
+							? `${parameter.command.slice(0, 50)}...`
+							: parameter.command;
+					actionSummary += c.dim(`: ${cmd}`);
+				}
+			}
+
+			console.log(`   ${actionSummary}`);
+		} else if (body) {
+			const displayBody = full
+				? body
+				: body.length > previewLength
+					? `${body.slice(0, previewLength)}...`
+					: body;
+			console.log(`   ${displayBody.split("\n").join("\n   ")}`);
+		}
+
+		console.log();
+	}
+
+	// Show pagination hints
+	if (offset + limit < total) {
+		const nextOffset = offset + limit;
+		console.log(
+			c.dim(
+				`→ More activities available. Use ${c.param(`--offset ${nextOffset}`)} to see next page.`,
+			),
+		);
+	}
+
+	if (offset > 0) {
+		const prevOffset = Math.max(0, offset - limit);
+		console.log(c.dim(`← Previous page: ${c.param(`--offset ${prevOffset}`)}`));
+	}
+
+	console.log();
+}

--- a/apps/f1/tsconfig.json
+++ b/apps/f1/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,25 @@ importers:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(yaml@2.8.1)
 
+  apps/test-driver:
+    dependencies:
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.21
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(yaml@2.8.1)
+
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
@@ -330,15 +349,32 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
   '@biomejs/biome@2.2.5':
     resolution: {integrity: sha512-zcIi+163Rc3HtyHbEO7CjeHq8DjQRs40HsGbW6vx2WI0tg8mYQOPouhvHSyEnCBAorfYNnKdR64/IxO7xQ5faw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@biomejs/cli-darwin-arm64@2.2.5':
     resolution: {integrity: sha512-MYT+nZ38wEIWVcL5xLyOhYQQ7nlWD0b/4mgATW2c8dvq7R4OQjt/XGXFkXrmtWmQofaIM14L7V8qIz/M+bx5QQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@2.2.5':
@@ -347,8 +383,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
   '@biomejs/cli-linux-arm64-musl@2.2.5':
     resolution: {integrity: sha512-5Ov2wgAFwqDvQiESnu7b9ufD1faRa+40uwrohgBopeY84El2TnBDoMNXx6iuQdreoFGjwW8vH6k68G21EpNERw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
@@ -359,8 +407,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
   '@biomejs/cli-linux-x64-musl@2.2.5':
     resolution: {integrity: sha512-AVqLCDb/6K7aPNIcxHaTQj01sl1m989CJIQFQEaiQkGr2EQwyOpaATJ473h+nXDUuAcREhccfRpe/tu+0wu0eQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
@@ -371,10 +431,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
   '@biomejs/cli-win32-arm64@2.2.5':
     resolution: {integrity: sha512-xaOIad4wBambwJa6mdp1FigYSIF9i7PCqRbvBqtIi9y29QtPVQ13sDGtUnsRoe6SjL10auMzQ6YAe+B3RpZXVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@2.2.5':
@@ -1117,6 +1189,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.1:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
@@ -2430,6 +2506,17 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
   '@biomejs/biome@2.2.5':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.2.5
@@ -2441,25 +2528,49 @@ snapshots:
       '@biomejs/cli-win32-arm64': 2.2.5
       '@biomejs/cli-win32-x64': 2.2.5
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-darwin-arm64@2.2.5':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-darwin-x64@2.2.5':
     optional: true
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-arm64-musl@2.2.5':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-arm64@2.2.5':
     optional: true
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-x64-musl@2.2.5':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-x64@2.2.5':
     optional: true
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-win32-arm64@2.2.5':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-win32-x64@2.2.5':
@@ -3113,6 +3224,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   commander@14.0.1: {}
 


### PR DESCRIPTION
## Summary

Rewrote `tools/cli-platform` as a modern TypeScript application called `f1` (Fast CLI) using Bun runtime and Commander.js. All code passes linting and type checking with zero errors.

## Implementation

**New Structure:**
- `apps/f1/` - Modern TypeScript CLI application
- Modular command architecture (12 TypeScript files)
- Clean separation: client, commands, types, utils
- DRY principles: reusable RPC client, formatters, color utilities

**Technology Stack:**
- TypeScript 5.9 (strict mode, no `any` types)
- Bun runtime for execution
- Commander.js 12.1 for CLI parsing
- Biome for linting

**All Commands Working:**
- Health: `ping`, `status`, `version`
- Issues: `createIssue`, `assignIssue`
- Comments: `createComment`
- Sessions: `startSession`, `viewSession`, `promptSession`, `stopSession`, `getActivity`
- Team: `fetchLabels`, `fetchMembers`, `createLabel`, `createMember`
- Debug: `getState`

## Testing Performed

✅ TypeScript compilation - zero errors
✅ Biome linting - zero errors
✅ CLI functionality - all commands work
✅ Help system - general and per-command
✅ Code quality - DRY, modular, type-safe

## Code Quality

- **Modular**: Each command in separate file
- **DRY**: Common logic extracted (RPC client, formatting, colors)
- **Type-safe**: Strict TypeScript, zero `any` types
- **Clean**: ~1200 lines across 12 files
- **Tested**: All commands verified working

## Documentation

- Updated `CLAUDE.md` to reference F1 instead of lambo/test-driver
- Created `apps/f1/README.md` with usage instructions
- Inline code comments for clarity

## Breaking Changes

None - this is a new application alongside existing tools.

## Migration Notes

Old `tools/cli-platform/` remains functional. To use F1:
```bash
./apps/f1/f1 --help
```

Resolves CYPACK-372

🤖 Generated with [Claude Code](https://claude.com/claude-code)