### PR TITLE
Fix F1 activity rendering for all 6 Linear types + signals

### DIFF
--- a/apps/f1/src/types/index.ts
+++ b/apps/f1/src/types/index.ts
@@ -33,6 +33,7 @@ export interface Activity {
 	createdAt: string;
 	content?: ActivityContent;
 	signal?: string;
+	signalMetadata?: Record<string, unknown>;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         specifier: ^3.1.4
         version: 3.2.4(@types/node@20.19.21)(@vitest/ui@3.2.4)(yaml@2.8.1)
 
-  apps/test-driver:
+  apps/f1:
     dependencies:
       commander:
         specifier: ^12.1.0


### PR DESCRIPTION
## Summary

Fixes the F1 CLI activity formatter to properly render all 6 Linear activity types with appropriate visual styling and adds support for displaying agent signals (auth, select, continue, stop).

## Changes

### Fixed Issues
- **Removed invalid `tool_use` case** (line 133) - This was a Claude SDK content block type, not a Linear activity type
- **Added 3 missing activity types** - `prompt`, `response`, and `elicitation` now have proper emoji/color rendering

### Activity Type Rendering (All 6 Types)
1. **thought** - 💭 Agent reasoning (cyan)
2. **action** - ⚡ Tool execution (yellow) 
3. **error** - ❌ Error messages (red)
4. **prompt** - 💬 User input (green, visually distinct from model outputs)
5. **response** - ✅ Agent final response (green)
6. **elicitation** - 🤔 Agent asking for input (cyan)

### Signal Support (All 4 Signals)
- **auth** - [AUTH] badge (yellow) with URL display
- **select** - [SELECT] badge (cyan) with options display
- **continue** - [CONTINUE] badge (green)
- **stop** - [STOP] badge (red)

### Technical Changes
- Added `signalMetadata` field to Activity interface (apps/f1/src/types/index.ts)
- Implemented signal badge rendering with color-coding
- Added signal metadata display for auth URLs and select options
- Fixed action detail extraction to only work with `action` type (removed `tool_use` reference)

## Testing

Comprehensive visual testing performed with mock activities of all 6 types + all 4 signals:

```bash
node /tmp/test-formatter.mjs
```

**Verified:**
- ✅ All 6 activity types render with correct emoji and color
- ✅ `prompt` type is visually distinct from model output types
- ✅ All 4 signal types render as colored badges
- ✅ Signal metadata displays correctly (auth URLs, select options)
- ✅ Action details show correctly for action-type activities only
- ✅ No `tool_use` references remain
- ✅ TypeScript build passes cleanly
- ✅ All type checks pass

## Visual Output Example

Activities now display with proper styling:
- Thought activities: 💭 with cyan text
- Action activities: ⚡ with yellow text + action details
- Error activities: ❌ with red text
- User prompts: 💬 with green text (distinct from agent responses)
- Agent responses: ✅ with green text
- Elicitations: 🤔 with cyan text
- Signals shown as colored badges: [AUTH], [SELECT], [CONTINUE], [STOP]

## Related

Resolves CYPACK-373

🤖 Generated with [Claude Code](https://claude.com/claude-code)