### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.31 to v0.1.37 - see [@anthropic-ai/claude-agent-sdk v0.1.37 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0137)
+
 ## [0.2.0] - 2025-11-07
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.37",
 		"@anthropic-ai/sdk": "^0.68.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.31",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.37",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.31
-        version: 0.1.31(zod@3.25.76)
+        specifier: ^0.1.37
+        version: 0.1.37(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.68.0
         version: 0.68.0(zod@3.25.76)
@@ -251,8 +251,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.31
-        version: 0.1.31(zod@3.25.76)
+        specifier: ^0.1.37
+        version: 0.1.37(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -273,8 +273,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.31':
-    resolution: {integrity: sha512-cwzgM2ntyzfr0aaiDEVwrQJawRlGi/8sq4raWyNPQqfS3uEXhw+IDmPdPS+HhjO2e4LCf1y+SkJKeBjxleHOYA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.37':
+    resolution: {integrity: sha512-LMfqMIPLTz0vRhpcO7hpPJ5L6Bg24y5/PaqZvwAUNZ/GR3OAl7xmJR7IryIR6m8Pyd/6Hs2yBU8j86Os+wHFQQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2382,7 +2382,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.31(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.37(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.31 to v0.1.37, bringing the codebase to parity with Claude Code v2.0.37.

## Changes Made

- Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.31` to `^0.1.37` in:
  - `packages/claude-runner/package.json`
  - `packages/simple-agent-runner/package.json`
- Verified `@anthropic-ai/sdk` is already at the latest version (v0.68.0)
- Updated `CHANGELOG.md` with SDK update details and changelog link
- Ran `pnpm install` to update lockfile

## SDK Version Changes

The SDK update incorporates improvements and bug fixes from versions 0.1.32 through 0.1.37. Each version brings updates to parity with corresponding Claude Code releases.

See: [SDK v0.1.37 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0137)

## Testing Performed

- ✅ All 219 tests passing across all packages
- ✅ TypeScript type checking passed
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Build successful for all packages

## Migration Notes

No breaking changes or migration steps required. This is a minor version update with backward compatibility.

Resolves CYPACK-375