### PR TITLE
Fix workspace slug in Linear profile URLs for summary sub-routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Improved webhook routing to eliminate misleading log messages after repository selection - subsequent webhooks for an issue now correctly use the already-selected repository instead of re-running routing logic
 - Repository selection now works correctly when multiple repositories are available - fixed Linear client lookup to use workspace ID instead of repository ID
+- Fixed Linear profile URLs in summary subroutines to use correct workspace slug instead of hardcoded "linear" workspace
 
 ## [0.2.0] - 2025-11-07
 

--- a/packages/config-updater/src/handlers/cyrusConfig.ts
+++ b/packages/config-updater/src/handlers/cyrusConfig.ts
@@ -123,6 +123,10 @@ export async function handleCyrusConfig(
 			config.stripeCustomerId = payload.stripeCustomerId;
 		}
 
+		if (payload.linearWorkspaceSlug) {
+			config.linearWorkspaceSlug = payload.linearWorkspaceSlug;
+		}
+
 		if (payload.defaultModel) {
 			config.defaultModel = payload.defaultModel;
 		}

--- a/packages/config-updater/src/types.ts
+++ b/packages/config-updater/src/types.ts
@@ -27,6 +27,7 @@ export interface CyrusConfigPayload {
 	disallowedTools?: string[];
 	ngrokAuthToken?: string;
 	stripeCustomerId?: string;
+	linearWorkspaceSlug?: string;
 	defaultModel?: string;
 	defaultFallbackModel?: string;
 	global_setup_script?: string;

--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -108,6 +108,9 @@ export interface EdgeWorkerConfig {
 	serverHost?: string; // Server host address ('localhost' or '0.0.0.0', default: 'localhost')
 	ngrokAuthToken?: string; // Ngrok auth token for tunnel creation
 
+	// Linear configuration (global)
+	linearWorkspaceSlug?: string; // Linear workspace URL slug (e.g., "ceedar" from "https://linear.app/ceedar/...")
+
 	// Claude config (shared across all repos)
 	defaultAllowedTools?: string[];
 	defaultDisallowedTools?: string[]; // Tools to explicitly disallow across all repositories (no defaults)
@@ -193,6 +196,7 @@ export interface EdgeConfig {
 	repositories: RepositoryConfig[];
 	ngrokAuthToken?: string;
 	stripeCustomerId?: string;
+	linearWorkspaceSlug?: string; // Linear workspace URL slug (e.g., "ceedar" from "https://linear.app/ceedar/...")
 	defaultModel?: string; // Default Claude model to use across all repositories
 	defaultFallbackModel?: string; // Default fallback model if primary model is unavailable
 	global_setup_script?: string; // Optional path to global setup script that runs for all repositories

--- a/packages/edge-worker/test/prompt-assembly-utils.ts
+++ b/packages/edge-worker/test/prompt-assembly-utils.ts
@@ -14,6 +14,7 @@ import type { EdgeWorkerConfig } from "../src/types.js";
  */
 export function createTestWorker(
 	repositories: RepositoryConfig[] = [],
+	linearWorkspaceSlug?: string,
 ): EdgeWorker {
 	// Create mock LinearClients for each repository
 	const linearClients = new Map();
@@ -32,6 +33,7 @@ export function createTestWorker(
 	const config: EdgeWorkerConfig = {
 		cyrusHome: "/tmp/test-cyrus-home",
 		defaultModel: "sonnet",
+		linearWorkspaceSlug,
 		repositories,
 		linearClients,
 		mcpServers: {},

--- a/packages/edge-worker/test/prompt-assembly.subroutines.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.subroutines.test.ts
@@ -10,7 +10,7 @@ import { createTestWorker, scenario } from "./prompt-assembly-utils.js";
 
 describe("Prompt Assembly - Subroutines", () => {
 	it("should include coding-activity subroutine prompt in full-development procedure", async () => {
-		const worker = createTestWorker();
+		const worker = createTestWorker([], "ceedar");
 
 		// Session with full-development procedure at coding-activity subroutine
 		const session = {
@@ -29,6 +29,7 @@ describe("Prompt Assembly - Subroutines", () => {
 			identifier: "CEE-3000",
 			title: "Implement payment processing",
 			description: "Add Stripe integration for payments",
+			url: "https://linear.app/ceedar/issue/CEE-3000",
 		};
 
 		const repository = {
@@ -76,7 +77,7 @@ Add Stripe integration for payments
   </description>
   <state>Unknown</state>
   <priority>None</priority>
-  <url></url>
+  <url>https://linear.app/ceedar/issue/CEE-3000</url>
 </linear_issue>
 
 <linear_comments>
@@ -97,7 +98,7 @@ Complete with: \`Implementation complete - [what was done].\``)
 	});
 
 	it("should include question-investigation subroutine prompt in simple-question procedure", async () => {
-		const worker = createTestWorker();
+		const worker = createTestWorker([], "ceedar");
 
 		// Session with simple-question procedure at investigation phase
 		const session = {
@@ -116,6 +117,7 @@ Complete with: \`Implementation complete - [what was done].\``)
 			identifier: "CEE-4000",
 			title: "How does authentication work?",
 			description: "Can you explain the authentication flow?",
+			url: "https://linear.app/ceedar/issue/CEE-4000",
 		};
 
 		const repository = {
@@ -163,7 +165,7 @@ Can you explain the authentication flow?
   </description>
   <state>Unknown</state>
   <priority>None</priority>
-  <url></url>
+  <url>https://linear.app/ceedar/issue/CEE-4000</url>
 </linear_issue>
 
 <linear_comments>
@@ -182,7 +184,7 @@ Complete with: \`Investigation complete - gathered information from [sources].\`
 	});
 
 	it("should include question-answer subroutine prompt in simple-question procedure", async () => {
-		const worker = createTestWorker();
+		const worker = createTestWorker([], "ceedar");
 
 		// Session with simple-question procedure at answer phase
 		const session = {
@@ -201,6 +203,7 @@ Complete with: \`Investigation complete - gathered information from [sources].\`
 			identifier: "CEE-5000",
 			title: "How does caching work?",
 			description: "Explain the caching implementation",
+			url: "https://linear.app/ceedar/issue/CEE-5000",
 		};
 
 		const repository = {
@@ -248,7 +251,7 @@ Explain the caching implementation
   </description>
   <state>Unknown</state>
   <priority>None</priority>
-  <url></url>
+  <url>https://linear.app/ceedar/issue/CEE-5000</url>
 </linear_issue>
 
 <linear_comments>
@@ -258,7 +261,7 @@ No comments yet.
 # Answer Question
 
 Provide a clear, direct answer using investigation findings:
-- Present in Linear-compatible markdown (supports \`+++collapsible+++\`, @mentions via \`https://linear.app/linear/profiles/username\`)
+- Present in Linear-compatible markdown (supports \`+++collapsible+++\`, @mentions via \`https://linear.app/ceedar/profiles/username\`)
 - Include code references with line numbers
 - Be complete but concise
 


### PR DESCRIPTION
## Summary

Fixes incorrect workspace slug in Linear profile URLs used in summary sub-routines. Previously, URLs were hardcoded to use `https://linear.app/linear/profiles/{username}` instead of the actual workspace.

## Changes Made

- **Made linearWorkspaceSlug a global configuration** instead of repository-specific
- **Removed workspaceSlug from session metadata** to eliminate redundancy
- Added `linearWorkspaceSlug` field to `EdgeWorkerConfig` and `EdgeConfig` interfaces  
- Updated EdgeWorker to use `this.config.linearWorkspaceSlug` directly from global config
- Perform template substitution in subroutine prompts to replace hardcoded "linear" workspace with actual workspace slug
- Updated config-updater to handle linearWorkspaceSlug as a global parameter
- Updated all tests to pass workspace slug to worker constructor

## Implementation Details

**Modified Files:**
- `packages/core/src/config-types.ts` - Added linearWorkspaceSlug to EdgeWorkerConfig and EdgeConfig as global setting
- `packages/core/src/CyrusAgentSession.ts` - Removed workspaceSlug from session metadata
- `packages/edge-worker/src/EdgeWorker.ts` - Use `this.config.linearWorkspaceSlug` from global config, removed session metadata storage, perform template substitution in loadSubroutinePrompt()
- `packages/config-updater/src/handlers/cyrusConfig.ts` - Handle linearWorkspaceSlug as global config parameter
- `packages/config-updater/src/types.ts` - Added linearWorkspaceSlug to CyrusConfigPayload
- `packages/edge-worker/test/prompt-assembly-utils.ts` - Updated createTestWorker to accept linearWorkspaceSlug parameter
- `packages/edge-worker/test/prompt-assembly.subroutines.test.ts` - Pass workspace slug to worker instead of repository

**Key Technical Changes:**
- Uses `linearWorkspaceSlug` from global EdgeWorkerConfig (set via config.json)
- Template substitution replaces `/linear/profiles/` with `/{workspaceSlug}/profiles/` in subroutine prompts
- Workspace slug is workspace-wide setting (not per-repository) since it's a global Linear workspace identifier
- Removed redundant storage in session metadata for cleaner architecture

## Testing

All 254 tests passing, linting clean (1 pre-existing warning), TypeScript types valid.

## Related Issue

Fixes CYPACK-336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>