### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.42 to v0.1.44 - see [@anthropic-ai/claude-agent-sdk v0.1.44 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0144) (CYPACK-394)
+
 ## [0.2.1] - 2025-11-15
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.44",
 		"@anthropic-ai/sdk": "^0.69.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.44",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.44
+        version: 0.1.44(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.69.0
         version: 0.69.0(zod@3.25.76)
@@ -257,8 +257,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.44
+        version: 0.1.44(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -279,8 +279,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42':
-    resolution: {integrity: sha512-snz2CTHKxkk4rqgvi2D4oMgITXpgmghWC4XvFXcuYjSxgLCBmvDW9TjBk6MTv0apC5fwW4kLE4ydamkBs+BdPg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.44':
+    resolution: {integrity: sha512-+hyNZZbN6nmruVueCYim+qBDYzhopj8aUXp5mCWhfSmsP80w7QoXwxVQbWqwUvD447qep4xSLMBGALAlb7uYSg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2392,7 +2392,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.44(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.42 to v0.1.44 in both packages that depend on it.

## Changes

- **packages/claude-runner/package.json**: Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.42` to `^0.1.44`
- **packages/simple-agent-runner/package.json**: Updated `@anthropic-ai/claude-agent-sdk` from `^0.1.42` to `^0.1.44`
- **pnpm-lock.yaml**: Updated with new version references
- **CHANGELOG.md**: Added entry in Unreleased section with link to [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0144)

## What's New

The updates bring parity with Claude Code versions:
- **v0.1.43**: Updated to parity with Claude Code v2.0.43
- **v0.1.44**: Updated to parity with Claude Code v2.0.44

See [claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0144) for details.

## Testing

✅ All 224 package tests passing
✅ TypeScript type checking passed across all packages
✅ Build successful
✅ Linting clean (1 pre-existing warning unrelated to this change)

## Notes

- `@anthropic-ai/sdk` was already on latest version (0.69.0), so no update was needed
- No breaking changes in these patch versions

Closes CYPACK-394