### PR TITLE
Update Anthropic SDK packages to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.42 to v0.1.46 - adds Azure AI Foundry support and structured outputs - see [@anthropic-ai/claude-agent-sdk v0.1.46 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0146) ([CYPACK-399](https://linear.app/ceedar/issue/CYPACK-399))
+- Updated @anthropic-ai/sdk from v0.69.0 to v0.70.0 - adds Foundry SDK integration - see [@anthropic-ai/sdk v0.70.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0700-2025-11-18) ([CYPACK-399](https://linear.app/ceedar/issue/CYPACK-399))
+
 ## [0.2.1] - 2025-11-15
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
-		"@anthropic-ai/sdk": "^0.69.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.46",
+		"@anthropic-ai/sdk": "^0.70.0",
 		"@linear/sdk": "^60.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.46",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,11 +95,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.46
+        version: 0.1.46(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.69.0
-        version: 0.69.0(zod@3.25.76)
+        specifier: ^0.70.0
+        version: 0.70.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
@@ -257,8 +257,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.46
+        version: 0.1.46(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -279,14 +279,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42':
-    resolution: {integrity: sha512-snz2CTHKxkk4rqgvi2D4oMgITXpgmghWC4XvFXcuYjSxgLCBmvDW9TjBk6MTv0apC5fwW4kLE4ydamkBs+BdPg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.46':
+    resolution: {integrity: sha512-2Jf8ODvZ8rAciQyal2s/ky2E83BRlWmIs66/aAzgb37OzP04uI47HWMuHj+GYlk19QakJRqN74L3+JT2bIj5Gg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.69.0':
-    resolution: {integrity: sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==}
+  '@anthropic-ai/sdk@0.70.0':
+    resolution: {integrity: sha512-FYIuhF/lSCa+pgtaMGgsTF14aOIiWtBnu3azXITDOELv6yxsDNJwcjjt+Zr7vwyuTUjZJE/YL7s9m5r1jXkoeQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2392,7 +2392,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.46(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2403,7 +2403,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.69.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.70.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updates @anthropic-ai/claude-agent-sdk and @anthropic-ai/sdk to their latest versions as requested in CYPACK-399.

## Changes
- **@anthropic-ai/claude-agent-sdk**: `0.1.42` → `0.1.46`
  - Adds Azure AI Foundry integration support
  - Implements structured outputs functionality
  - Updated to parity with Claude Code v2.0.46
  - See [changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0146)

- **@anthropic-ai/sdk**: `0.69.0` → `0.70.0`
  - Adds Foundry SDK integration
  - See [changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0700-2025-11-18)

## Files Modified
- `packages/claude-runner/package.json` - Updated both SDK versions
- `packages/simple-agent-runner/package.json` - Updated claude-agent-sdk version
- `CHANGELOG.md` - Added entries with links to SDK changelogs
- `pnpm-lock.yaml` - Updated lockfile

## Testing
- ✅ All 336 package tests passing
- ✅ TypeScript type checking clean
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Successfully built all packages

## Linear Issue
Fixes [CYPACK-399](https://linear.app/ceedar/issue/CYPACK-399)

🤖 Generated with [Claude Code](https://claude.com/claude-code)