### PR TITLE
Fix Read tool first line indentation by preserving horizontal whitespace

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -430,8 +430,10 @@ export class AgentSessionManager {
 							"",
 						);
 
-						// Trim any extra whitespace
-						cleanedResult = cleanedResult.trim();
+						// Trim only blank lines (not horizontal whitespace) to preserve indentation
+						cleanedResult = cleanedResult
+							.replace(/^\n+/, "")
+							.replace(/\n+$/, "");
 
 						// Try to detect language from file extension
 						let lang = "";


### PR DESCRIPTION
## Summary

Fixes CYPACK-401 - Read tool output was stripping indentation from the first line when displaying file content in Linear comments.

## Problem

The `AgentSessionManager.formatToolResult()` method was using `.trim()` to clean up Read tool output after removing line numbers and system-reminder blocks. This caused the first line's indentation to be stripped because `.trim()` removes ALL leading whitespace, including spaces and tabs that are part of the code's indentation.

**Before:**
```python
coordinate["x"] -= 1        # ← No indentation!
    elif direction == "up":
        coordinate["y"] += 1
```

**After:**
```python
    coordinate["x"] -= 1    # ← Indentation preserved!
    elif direction == "up":
        coordinate["y"] += 1
```

## Implementation

Changed the whitespace trimming logic to only remove vertical whitespace (newlines) while preserving horizontal whitespace (spaces/tabs):

**Before:**
```typescript
cleanedResult = cleanedResult.trim();
```

**After:**
```typescript
// Trim only blank lines (not horizontal whitespace) to preserve indentation
cleanedResult = cleanedResult
    .replace(/^\n+/, "")   // Remove leading newlines
    .replace(/\n+$/, "");  // Remove trailing newlines
```

## Testing

- ✅ Added new test: `formatToolResult - Read tool preserves first line indentation`
- ✅ All existing tests pass (195 tests across 25 test files)
- ✅ No regressions in line number removal or system-reminder block removal
- ✅ Linting clean
- ✅ TypeScript type checking passes

## Changes

- `packages/edge-worker/src/AgentSessionManager.ts`: Updated whitespace trimming logic
- `packages/edge-worker/test/AgentSessionManager.tool-formatting.test.ts`: Added regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)