### PR TITLE
[CYPACK-405] Create IAgentRunner interface abstraction in core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
 		"@linear/sdk": "^60.0.0",
 		"cyrus-claude-runner": "workspace:*"
 	},

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -1,0 +1,300 @@
+import type {
+	HookCallbackMatcher,
+	HookEvent,
+	McpServerConfig,
+	SDKMessage,
+	SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Agent Runner Interface
+ *
+ * This interface provides a provider-agnostic abstraction for AI agent runners.
+ * It follows the same pattern as IIssueTrackerService, where type aliases point
+ * to provider-specific SDK types (currently Claude SDK).
+ *
+ * The interface is designed to support multiple AI providers (Claude, Gemini, etc.)
+ * through adapter implementations, while maintaining a consistent API surface.
+ *
+ * ## Architecture Pattern
+ *
+ * This abstraction uses type aliasing to external SDK types rather than creating
+ * new types. This approach:
+ * - Maintains compatibility with existing Claude SDK code
+ * - Allows gradual migration to provider-agnostic code
+ * - Enables adapter pattern implementations for other providers
+ * - Preserves type safety and IDE autocomplete
+ *
+ * ## Usage Example
+ *
+ * ```typescript
+ * class ClaudeRunnerAdapter implements IAgentRunner {
+ *   async start(prompt: string): Promise<AgentSessionInfo> {
+ *     // Implementation using Claude SDK
+ *   }
+ *
+ *   async startStreaming(initialPrompt?: string): Promise<AgentSessionInfo> {
+ *     // Implementation using Claude SDK streaming
+ *   }
+ *
+ *   // ... other methods
+ * }
+ *
+ * class GeminiRunnerAdapter implements IAgentRunner {
+ *   async start(prompt: string): Promise<AgentSessionInfo> {
+ *     // Implementation using Gemini SDK
+ *   }
+ *
+ *   // ... other methods
+ * }
+ * ```
+ *
+ * @see {@link AgentRunnerConfig} for configuration options
+ * @see {@link AgentSessionInfo} for session information structure
+ */
+export interface IAgentRunner {
+	/**
+	 * Start a new agent session with a string prompt (legacy/simple mode)
+	 *
+	 * This method initiates a complete agent session with a single prompt string.
+	 * The session runs until completion or until stopped.
+	 *
+	 * @param prompt - The initial prompt to send to the agent
+	 * @returns Session information including session ID and status
+	 *
+	 * @example
+	 * ```typescript
+	 * const runner = new ClaudeRunnerAdapter(config);
+	 * const session = await runner.start("Please analyze this codebase");
+	 * console.log(`Session started: ${session.sessionId}`);
+	 * ```
+	 */
+	start(prompt: string): Promise<AgentSessionInfo>;
+
+	/**
+	 * Start a new agent session with streaming input support
+	 *
+	 * This method enables adding messages to the session dynamically after it has started.
+	 * Use this for interactive sessions where prompts arrive over time (e.g., from webhooks).
+	 *
+	 * @param initialPrompt - Optional initial prompt to send immediately
+	 * @returns Session information including session ID and status
+	 *
+	 * @example
+	 * ```typescript
+	 * const runner = new ClaudeRunnerAdapter(config);
+	 * const session = await runner.startStreaming("Initial task");
+	 *
+	 * // Later, add more messages
+	 * runner.addStreamMessage("Additional context");
+	 * runner.addStreamMessage("Final instruction");
+	 * runner.completeStream();
+	 * ```
+	 */
+	startStreaming(initialPrompt?: string): Promise<AgentSessionInfo>;
+
+	/**
+	 * Add a message to the streaming prompt
+	 *
+	 * Only works when the session was started with `startStreaming()`.
+	 * Messages are queued and sent to the agent as it processes them.
+	 *
+	 * @param content - The message content to add to the stream
+	 * @throws Error if not in streaming mode or if stream is already completed
+	 *
+	 * @example
+	 * ```typescript
+	 * runner.addStreamMessage("New comment from user: Fix the bug in auth.ts");
+	 * ```
+	 */
+	addStreamMessage(content: string): void;
+
+	/**
+	 * Complete the streaming prompt (no more messages will be added)
+	 *
+	 * This signals to the agent that no more messages will be added to the stream.
+	 * The agent will complete processing and finish the session.
+	 *
+	 * @example
+	 * ```typescript
+	 * runner.addStreamMessage("Final message");
+	 * runner.completeStream(); // Agent will finish processing
+	 * ```
+	 */
+	completeStream(): void;
+
+	/**
+	 * Stop the current agent session
+	 *
+	 * Gracefully terminates the running session. Any in-progress operations
+	 * will be aborted, and the session will transition to stopped state.
+	 *
+	 * @example
+	 * ```typescript
+	 * // User unassigned from issue - stop the agent
+	 * if (runner.isRunning()) {
+	 *   runner.stop();
+	 * }
+	 * ```
+	 */
+	stop(): void;
+
+	/**
+	 * Check if the session is currently running
+	 *
+	 * @returns True if the session is active and processing, false otherwise
+	 *
+	 * @example
+	 * ```typescript
+	 * if (runner.isRunning()) {
+	 *   console.log("Session still active");
+	 * } else {
+	 *   console.log("Session completed or not started");
+	 * }
+	 * ```
+	 */
+	isRunning(): boolean;
+
+	/**
+	 * Get all messages from the current session
+	 *
+	 * Returns a copy of all messages exchanged in the session, including
+	 * user prompts, assistant responses, system messages, and tool results.
+	 *
+	 * @returns Array of all session messages (copy, not reference)
+	 *
+	 * @example
+	 * ```typescript
+	 * const messages = runner.getMessages();
+	 * console.log(`Session has ${messages.length} messages`);
+	 *
+	 * // Analyze assistant responses
+	 * const assistantMessages = messages.filter(m => m.type === 'assistant');
+	 * ```
+	 */
+	getMessages(): AgentMessage[];
+}
+
+/**
+ * Configuration for agent runner
+ *
+ * This type aliases to the Claude SDK configuration structure. When implementing
+ * adapters for other providers (e.g., Gemini), they should map their config to
+ * this structure or extend it with provider-specific options.
+ *
+ * @example
+ * ```typescript
+ * const config: AgentRunnerConfig = {
+ *   workingDirectory: '/path/to/repo',
+ *   allowedDirectories: ['/path/to/repo'],
+ *   mcpConfig: {
+ *     'linear': { command: 'npx', args: ['-y', '@linear/mcp-server'] }
+ *   },
+ *   cyrusHome: '/home/user/.cyrus'
+ * };
+ * ```
+ */
+export interface AgentRunnerConfig {
+	/** Working directory for the agent session */
+	workingDirectory?: string;
+	/** List of allowed tool patterns (e.g., ["Read(**)", "Edit(**)"]) */
+	allowedTools?: string[];
+	/** List of disallowed tool patterns */
+	disallowedTools?: string[];
+	/** Directories the agent can read from */
+	allowedDirectories?: string[];
+	/** Session ID to resume from a previous session */
+	resumeSessionId?: string;
+	/** Workspace name for logging and organization */
+	workspaceName?: string;
+	/** Custom system prompt (overrides default) */
+	systemPrompt?: string;
+	/** Additional text to append to default system prompt */
+	appendSystemPrompt?: string;
+	/** Path(s) to MCP configuration file(s) */
+	mcpConfigPath?: string | string[];
+	/** MCP server configurations (inline) */
+	mcpConfig?: Record<string, McpServerConfig>;
+	/** AI model to use (e.g., "opus", "sonnet", "haiku") */
+	model?: string;
+	/** Fallback model if primary is unavailable */
+	fallbackModel?: string;
+	/** Maximum number of turns before completing session */
+	maxTurns?: number;
+	/** Cyrus home directory (required) */
+	cyrusHome: string;
+	/** Prompt template version information */
+	promptVersions?: {
+		userPromptVersion?: string;
+		systemPromptVersion?: string;
+	};
+	/** Event hooks for customizing agent behavior */
+	hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>;
+	/** Callback for each message received */
+	onMessage?: (message: AgentMessage) => void | Promise<void>;
+	/** Callback for errors */
+	onError?: (error: Error) => void | Promise<void>;
+	/** Callback when session completes */
+	onComplete?: (messages: AgentMessage[]) => void | Promise<void>;
+}
+
+/**
+ * Information about an agent session
+ *
+ * Tracks the lifecycle and status of an agent session.
+ * The sessionId is initially null and gets assigned by the provider
+ * when the first message is processed.
+ *
+ * @example
+ * ```typescript
+ * const info: AgentSessionInfo = {
+ *   sessionId: 'claude-session-abc123',
+ *   startedAt: new Date(),
+ *   isRunning: true
+ * };
+ * ```
+ */
+export interface AgentSessionInfo {
+	/** Unique session identifier (null until first message) */
+	sessionId: string | null;
+	/** When the session started */
+	startedAt: Date;
+	/** Whether the session is currently active */
+	isRunning: boolean;
+}
+
+/**
+ * Type alias for agent messages
+ *
+ * Maps to Claude SDK's SDKMessage type, which is a union of:
+ * - SDKUserMessage (user inputs)
+ * - SDKAssistantMessage (agent responses)
+ * - SDKSystemMessage (system prompts)
+ * - SDKResultMessage (completion/error results)
+ *
+ * Other provider adapters should map their message types to this structure.
+ */
+export type AgentMessage = SDKMessage;
+
+/**
+ * Type alias for user messages
+ *
+ * Maps to Claude SDK's SDKUserMessage type.
+ * Used for prompts and user inputs to the agent.
+ */
+export type AgentUserMessage = SDKUserMessage;
+
+/**
+ * Re-export SDK types for convenience
+ *
+ * These re-exports allow consumers to import all necessary types
+ * from a single location (packages/core) without knowing the
+ * underlying provider SDK.
+ */
+export type {
+	HookCallbackMatcher,
+	HookEvent,
+	McpServerConfig,
+	SDKMessage,
+	SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,19 @@
 // export type { SessionOptions, , NarrativeItem } from './Session.js'
 // export { ClaudeSessionManager as SessionManager } from './ClaudeSessionManager.js'
 
+// Agent Runner types
+export type {
+	AgentMessage,
+	AgentRunnerConfig,
+	AgentSessionInfo,
+	AgentUserMessage,
+	HookCallbackMatcher,
+	HookEvent,
+	IAgentRunner,
+	McpServerConfig,
+	SDKMessage,
+	SDKUserMessage,
+} from "./agent-runner-types.js";
 export type {
 	CyrusAgentSession,
 	CyrusAgentSessionEntry,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.42
+        version: 0.1.42(zod@3.25.76)
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0


### PR DESCRIPTION
## Summary

This PR implements the IAgentRunner interface abstraction in the `packages/core` package, creating a provider-agnostic interface for agent runners. This is Stage 1 of [CYPACK-404](https://linear.app/ceedar/issue/CYPACK-404/add-gemini-cli-with-gemini-3-support), establishing the foundation for supporting multiple AI providers (Claude, Gemini) through adapter implementations.

## Changes

### Core Package (`packages/core`)

- **Created `src/agent-runner-types.ts`**:
  - `IAgentRunner` interface with core methods: `start()`, `startStreaming()`, `addStreamMessage()`, `completeStream()`, `stop()`, `isRunning()`, `getMessages()`
  - `AgentRunnerConfig` interface that aliases to Claude SDK configuration structure
  - `AgentSessionInfo` interface for session lifecycle tracking
  - Type aliases: `AgentMessage` (→ `SDKMessage`), `AgentUserMessage` (→ `SDKUserMessage`)
  - Comprehensive JSDoc documentation explaining the abstraction pattern and usage examples
  - Re-exports of SDK types for convenience

- **Updated `src/index.ts`**:
  - Exported all new interfaces and types from `agent-runner-types.ts`
  - Organized with clear comments following existing patterns

- **Updated `package.json`**:
  - Added `@anthropic-ai/claude-agent-sdk` (^0.1.42) as a dependency

## Implementation Approach

Followed the same pattern as `IIssueTrackerService`, using type aliases to point to provider-specific SDK types (currently Claude SDK). This approach:

- Maintains compatibility with existing Claude SDK code
- Allows gradual migration to provider-agnostic code
- Enables adapter pattern implementations for other providers (e.g., Gemini)
- Preserves type safety and IDE autocomplete

The interface is designed to be implemented by provider-specific adapters:
- `ClaudeRunnerAdapter` - wraps existing ClaudeRunner
- `GeminiRunnerAdapter` - future implementation for Gemini support

## Testing Performed

✅ All package tests passing (62 tests)  
✅ TypeScript compilation successful across all packages  
✅ Linting clean (auto-fixed import organization)  
✅ No breaking changes to existing functionality  
✅ Generated type definitions verified

### Verification Commands
```bash
pnpm typecheck          # All packages pass
pnpm build              # All packages build successfully
pnpm test:packages:run  # 62 tests passing
pnpm lint --write       # Linting clean
```

## Breaking Changes

None. This is a purely additive change that introduces new types without modifying existing code.

## Migration Notes

This PR only creates the interface abstraction. Future PRs will:
1. Create `ClaudeRunnerAdapter` that implements `IAgentRunner`
2. Update consumers to use the interface instead of `ClaudeRunner` directly
3. Implement `GeminiRunnerAdapter` for Gemini support

## Related Issues

- Implements: [CYPACK-405](https://linear.app/ceedar/issue/CYPACK-405/feature-create-iagentrunner-interface-abstraction-in-core-package)
- Part of: [CYPACK-404](https://linear.app/ceedar/issue/CYPACK-404/add-gemini-cli-with-gemini-3-support) (Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>