### PR TITLE
[CYPACK-407] Refactor ClaudeRunner to implement IAgentRunner interface

### DIFF
--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -3,7 +3,15 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
+		"moduleResolution": "NodeNext",
+		"baseUrl": "../../",
+		"paths": {
+			"cyrus-core": ["packages/core/src"],
+			"cyrus-claude-runner": ["packages/claude-runner/src"],
+			"cyrus-simple-agent-runner": ["packages/simple-agent-runner/src"],
+			"cyrus-config-updater": ["packages/config-updater/src"],
+			"cyrus-edge-worker": ["packages/edge-worker/src"]
+		}
 	},
 	"include": ["*.ts", "src/**/*.ts"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -19,6 +19,7 @@
 		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
 		"@anthropic-ai/sdk": "^0.69.0",
 		"@linear/sdk": "^60.0.0",
+		"cyrus-core": "workspace:*",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",
 		"openai": "^6.3.0",

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -13,6 +13,7 @@ import {
 	type SDKMessage,
 	type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
+import type { IAgentRunner } from "cyrus-core";
 import dotenv from "dotenv";
 
 // AbortError is no longer exported in v1.0.95, so we define it locally
@@ -146,7 +147,7 @@ export declare interface ClaudeRunner {
 /**
  * Manages Claude SDK sessions and communication
  */
-export class ClaudeRunner extends EventEmitter {
+export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	private config: ClaudeRunnerConfig;
 	private abortController: AbortController | null = null;
 	private sessionInfo: ClaudeSessionInfo | null = null;

--- a/packages/claude-runner/tsconfig.json
+++ b/packages/claude-runner/tsconfig.json
@@ -3,7 +3,13 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
+		"moduleResolution": "NodeNext",
+		"baseUrl": "../../",
+		"paths": {
+			"cyrus-core": ["packages/core/src"],
+			"cyrus-claude-runner": ["packages/claude-runner/src"],
+			"cyrus-simple-agent-runner": ["packages/simple-agent-runner/src"]
+		}
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,13 @@
 		"rootDir": "src",
 		"outDir": "dist",
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
+		"moduleResolution": "NodeNext",
+		"baseUrl": "../../",
+		"paths": {
+			"cyrus-core": ["packages/core/src"],
+			"cyrus-claude-runner": ["packages/claude-runner/src"],
+			"cyrus-simple-agent-runner": ["packages/simple-agent-runner/src"]
+		}
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/packages/edge-worker/tsconfig.json
+++ b/packages/edge-worker/tsconfig.json
@@ -3,7 +3,14 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"module": "NodeNext",
-		"moduleResolution": "NodeNext"
+		"moduleResolution": "NodeNext",
+		"baseUrl": "../../",
+		"paths": {
+			"cyrus-core": ["packages/core/src"],
+			"cyrus-claude-runner": ["packages/claude-runner/src"],
+			"cyrus-simple-agent-runner": ["packages/simple-agent-runner/src"],
+			"cyrus-config-updater": ["packages/config-updater/src"]
+		}
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@linear/sdk':
         specifier: ^60.0.0
         version: 60.0.0
+      cyrus-core:
+        specifier: workspace:*
+        version: link:../core
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1


### PR DESCRIPTION
## Summary

This PR refactors the ClaudeRunner class to implement the new IAgentRunner interface from the cyrus-core package, establishing it as a concrete implementation rather than a standalone class. This is Stage 1 of CYPACK-404, setting the pattern for future runner implementations like GeminiRunner.

## Changes

### Core Implementation
- ✅ Added `cyrus-core` as workspace dependency in `packages/claude-runner/package.json`
- ✅ Imported and implemented `IAgentRunner` interface in ClaudeRunner class
- ✅ ClaudeRunner now declares: `export class ClaudeRunner extends EventEmitter implements IAgentRunner`

### TypeScript Configuration
- ✅ Added TypeScript path mappings to resolve circular dependencies in monorepo
- ✅ Updated tsconfig.json files in:
  - `packages/claude-runner`
  - `packages/core`
  - `packages/edge-worker`
  - `apps/cli`
- ✅ Path mappings enable TypeScript to find module declarations during development without requiring pre-built dist directories

## Testing

- ✅ All 66 existing tests pass
- ✅ TypeScript type checking passes across all packages
- ✅ Linting clean (1 pre-existing warning in unrelated package)
- ✅ Build succeeds

## Breaking Changes

None. This is an internal refactoring that maintains full backward compatibility. All existing method signatures match the IAgentRunner interface exactly.

## Implementation Approach

The existing ClaudeRunner methods already matched the IAgentRunner interface signature, so this was primarily a declaration change. The main technical challenge was resolving circular dependencies in the monorepo build process, which was solved by adding TypeScript path mappings to all affected packages.

Closes CYPACK-407