### PR TITLE
Refactor SimpleAgentRunner to implement ISimpleAgentRunner interface

### DIFF
--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -17,7 +17,8 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
-		"cyrus-claude-runner": "workspace:*"
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-core": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/packages/simple-agent-runner/src/SimpleAgentRunner.ts
+++ b/packages/simple-agent-runner/src/SimpleAgentRunner.ts
@@ -1,4 +1,5 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { ISimpleAgentRunner } from "cyrus-core";
 import {
 	InvalidResponseError,
 	SimpleAgentError,
@@ -17,7 +18,9 @@ import type {
  * This class provides the core validation and flow control logic, while
  * concrete implementations provide the actual agent execution.
  */
-export abstract class SimpleAgentRunner<T extends string> {
+export abstract class SimpleAgentRunner<T extends string>
+	implements ISimpleAgentRunner<T>
+{
 	protected readonly config: SimpleAgentRunnerConfig<T>;
 	protected readonly validResponseSet: Set<T>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
+      cyrus-core:
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
## Summary

Refactored the SimpleAgentRunner abstract class in `packages/simple-agent-runner` to implement the new ISimpleAgentRunner interface from the core package. This completes the abstraction layer for simple agent runners as part of CYPACK-404 Stage 1.

## Changes

- **Updated SimpleAgentRunner class** (packages/simple-agent-runner/src/SimpleAgentRunner.ts:2,21-22):
  - Imported `ISimpleAgentRunner` interface using `import type` for type-only import
  - Updated class declaration to implement the interface

- **Updated package.json** (packages/simple-agent-runner/package.json:21):
  - Added `cyrus-core` as a workspace dependency to access the interface

- **Updated pnpm-lock.yaml**:
  - Reflects the new dependency on cyrus-core

## Implementation Approach

- Used `import type` to avoid circular runtime dependencies (only type-level circular dependency)
- No changes to method signatures or behavior - purely an interface compliance refactoring
- SimpleClaudeRunner (concrete implementation) continues to work without modification

## Testing Performed

✅ **TypeCheck**: `pnpm typecheck` passes without errors  
✅ **Tests**: All 24 tests pass (2 test files)  
✅ **Build**: Compilation succeeds, generating correct type definitions  
✅ **Linting**: Clean (1 pre-existing warning unrelated to changes)  
✅ **No Breaking Changes**: SimpleClaudeRunner continues to work as expected

## Verification

To verify these changes:

```bash
cd packages/simple-agent-runner

# Run typecheck
pnpm typecheck

# Run tests
pnpm test:run

# Build and verify interface implementation
rm -rf dist && pnpm build
cat dist/SimpleAgentRunner.d.ts | grep "implements ISimpleAgentRunner"
```

## Related Issues

- Depends on: CYPACK-406 (ISimpleAgentRunner interface)
- Part of: CYPACK-404 (Stage 1 - Create abstraction interfaces)

Resolves CYPACK-408