### PR TITLE
Update Anthropic AI SDKs to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Improved Linear agent-session tool formatting with custom formatters for better readability: Bash tool descriptions now appear in the action field with round brackets, Edit tool results display as unified diffs, and specialized parameter/result formatters for common tools (Read, Write, Grep, Glob, etc.) extract meaningful information instead of showing raw JSON (CYPACK-395, https://github.com/ceedaragents/cyrus/pull/512)
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.42 to v0.1.47 - adds error field to messages, Azure AI Foundry support, and structured outputs - see [@anthropic-ai/claude-agent-sdk v0.1.47 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0147) (CYPACK-413)
+- Updated @anthropic-ai/sdk from v0.69.0 to v0.70.0 - adds Foundry SDK - see [@anthropic-ai/sdk v0.70.0 changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0700-2025-11-18) (CYPACK-413)
 
 ## [0.2.1] - 2025-11-15
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
-		"@anthropic-ai/sdk": "^0.69.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.47",
+		"@anthropic-ai/sdk": "^0.70.0",
 		"@linear/sdk": "^64.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.47",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,11 +95,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.47
+        version: 0.1.47(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.69.0
-        version: 0.69.0(zod@3.25.76)
+        specifier: ^0.70.0
+        version: 0.70.0(zod@3.25.76)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -263,8 +263,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.47
+        version: 0.1.47(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -285,14 +285,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42':
-    resolution: {integrity: sha512-snz2CTHKxkk4rqgvi2D4oMgITXpgmghWC4XvFXcuYjSxgLCBmvDW9TjBk6MTv0apC5fwW4kLE4ydamkBs+BdPg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.47':
+    resolution: {integrity: sha512-0LAXuqp2AsvJcvrpVrJKANbmkqp3ZMpEfm03vRL6DrLc8JIQ5n25aCagIBDMwIVJscDwjd9cn4uAHvdI2PMLvw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.69.0':
-    resolution: {integrity: sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==}
+  '@anthropic-ai/sdk@0.70.0':
+    resolution: {integrity: sha512-FYIuhF/lSCa+pgtaMGgsTF14aOIiWtBnu3azXITDOELv6yxsDNJwcjjt+Zr7vwyuTUjZJE/YL7s9m5r1jXkoeQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2398,7 +2398,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.47(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2409,7 +2409,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.69.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.70.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` and `@anthropic-ai/sdk` to their latest versions.

## Changes

- **@anthropic-ai/claude-agent-sdk**: v0.1.42 → v0.1.47
  - Adds error field to messages
  - Azure AI Foundry support
  - Structured outputs support
  - [See full changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0147)

- **@anthropic-ai/sdk**: v0.69.0 → v0.70.0
  - Adds Foundry SDK
  - [See full changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0700-2025-11-18)

## Testing

- All 290 package tests passing
- Linting clean (1 pre-existing warning)
- TypeScript type checking passes
- No breaking changes detected

## Related

Closes CYPACK-413

🤖 Generated with [Claude Code](https://claude.com/claude-code)