### PR TITLE
Create ISimpleAgentRunner interface abstraction in core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
 		"@linear/sdk": "^64.0.0",
-		"cyrus-claude-runner": "workspace:*"
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-simple-agent-runner": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,18 @@ export type {
 	SerializedCyrusAgentSessionEntry,
 } from "./PersistenceManager.js";
 export { PersistenceManager } from "./PersistenceManager.js";
+// Simple Agent Runner types
+export type {
+	AgentProgressEvent,
+	IAgentProgressEvent,
+	ISimpleAgentQueryOptions,
+	ISimpleAgentResult,
+	ISimpleAgentRunner,
+	ISimpleAgentRunnerConfig,
+	SimpleAgentQueryOptions,
+	SimpleAgentResult,
+	SimpleAgentRunnerConfig,
+} from "./simple-agent-runner-types.js";
 // Platform-agnostic webhook type aliases - exported from issue-tracker
 // These are now defined in issue-tracker/types.ts as aliases to Linear SDK webhook types
 // EdgeWorker and other high-level code should use these generic names via issue-tracker exports

--- a/packages/core/src/simple-agent-runner-types.ts
+++ b/packages/core/src/simple-agent-runner-types.ts
@@ -1,0 +1,207 @@
+import type {
+	AgentProgressEvent as SimpleAgentProgressEvent,
+	SimpleAgentQueryOptions as SimpleAgentQueryOptionsBase,
+	SimpleAgentResult as SimpleAgentResultBase,
+	SimpleAgentRunnerConfig as SimpleAgentRunnerConfigBase,
+} from "cyrus-simple-agent-runner";
+
+/**
+ * Simple Agent Runner Interface
+ *
+ * This interface provides a provider-agnostic abstraction for simple agent runners
+ * that return enumerated responses. It follows the same pattern as IAgentRunner,
+ * where type aliases point to provider-specific SDK types (currently Claude SDK).
+ *
+ * Simple agent runners are specialized agents that:
+ * - Accept a constrained set of valid responses (enumerated type T)
+ * - Run until they produce one of the valid responses
+ * - Validate the response before returning
+ * - Provide progress events during execution
+ *
+ * ## Architecture Pattern
+ *
+ * This abstraction uses type aliasing to external SDK types rather than creating
+ * new types. This approach:
+ * - Maintains compatibility with existing simple-agent-runner code
+ * - Allows gradual migration to provider-agnostic code
+ * - Enables adapter pattern implementations for other providers
+ * - Preserves type safety and IDE autocomplete
+ *
+ * ## Usage Example
+ *
+ * ```typescript
+ * type IssueAction = "fix" | "skip" | "clarify";
+ *
+ * const config: ISimpleAgentRunnerConfig<IssueAction> = {
+ *   validResponses: ["fix", "skip", "clarify"] as const,
+ *   systemPrompt: "You analyze issues and decide what to do",
+ *   cyrusHome: "/home/user/.cyrus",
+ *   onProgress: (event) => {
+ *     if (event.type === "response-detected") {
+ *       console.log(`Agent wants to: ${event.candidateResponse}`);
+ *     }
+ *   }
+ * };
+ *
+ * const runner = new SimpleAgentRunner(config);
+ * const result = await runner.query("What should I do with this bug?");
+ * console.log(`Decision: ${result.response}`); // "fix" | "skip" | "clarify"
+ * ```
+ *
+ * @see {@link ISimpleAgentRunnerConfig} for configuration options
+ * @see {@link ISimpleAgentResult} for result structure
+ * @see {@link IAgentProgressEvent} for progress event types
+ */
+export interface ISimpleAgentRunner<T extends string> {
+	/**
+	 * Query the agent and get an enumerated response
+	 *
+	 * This method runs a complete agent session and returns one of the
+	 * predefined valid responses. The agent will continue running until
+	 * it produces a valid response or times out.
+	 *
+	 * @param question - The question or prompt to send to the agent
+	 * @param options - Optional configuration for this specific query
+	 * @returns A result containing the validated response and session metadata
+	 * @throws Error if the agent times out or fails to produce a valid response
+	 *
+	 * @example
+	 * ```typescript
+	 * const result = await runner.query(
+	 *   "Should we merge this PR?",
+	 *   { context: "CI passed, 2 approvals", allowFileReading: true }
+	 * );
+	 * console.log(`Decision: ${result.response}`); // "approve" | "reject" | "request-changes"
+	 * console.log(`Cost: $${result.costUSD}`);
+	 * console.log(`Duration: ${result.durationMs}ms`);
+	 * ```
+	 */
+	query(
+		question: string,
+		options?: ISimpleAgentQueryOptions,
+	): Promise<ISimpleAgentResult<T>>;
+}
+
+/**
+ * Configuration for Simple Agent Runner
+ *
+ * Defines how the simple agent runner should behave, including valid responses,
+ * prompts, timeouts, and progress callbacks.
+ *
+ * @template T - The enumerated string type for valid responses
+ *
+ * @example
+ * ```typescript
+ * type Priority = "low" | "medium" | "high" | "critical";
+ *
+ * const config: ISimpleAgentRunnerConfig<Priority> = {
+ *   validResponses: ["low", "medium", "high", "critical"] as const,
+ *   systemPrompt: "Analyze the issue and determine priority level",
+ *   maxTurns: 10,
+ *   timeoutMs: 60000,
+ *   model: "sonnet",
+ *   cyrusHome: "/home/user/.cyrus",
+ *   onProgress: (event) => {
+ *     console.log(`Agent progress: ${event.type}`);
+ *   }
+ * };
+ * ```
+ */
+export type ISimpleAgentRunnerConfig<T extends string> =
+	SimpleAgentRunnerConfigBase<T>;
+
+/**
+ * Result from a Simple Agent Runner query
+ *
+ * Contains the validated response along with session metadata including
+ * messages, duration, cost, and session ID.
+ *
+ * @template T - The enumerated string type for valid responses
+ *
+ * @example
+ * ```typescript
+ * const result: ISimpleAgentResult<"approve" | "reject"> = {
+ *   response: "approve",
+ *   messages: [...],  // All SDK messages from the session
+ *   sessionId: "claude-session-123",
+ *   durationMs: 5432,
+ *   costUSD: 0.0234
+ * };
+ * ```
+ */
+export type ISimpleAgentResult<T extends string> = SimpleAgentResultBase<T>;
+
+/**
+ * Progress events emitted during agent execution
+ *
+ * These events allow monitoring the agent's progress as it works toward
+ * producing a valid response. Useful for logging, UI updates, or debugging.
+ *
+ * Event types:
+ * - `started`: Session has begun (includes sessionId)
+ * - `thinking`: Agent is processing (includes reasoning text)
+ * - `tool-use`: Agent is using a tool (includes tool name and input)
+ * - `response-detected`: Agent produced a candidate response (may be invalid)
+ * - `validating`: Checking if response is valid
+ *
+ * @example
+ * ```typescript
+ * const config: ISimpleAgentRunnerConfig<"yes" | "no"> = {
+ *   validResponses: ["yes", "no"] as const,
+ *   cyrusHome: "/home/user/.cyrus",
+ *   onProgress: (event: IAgentProgressEvent) => {
+ *     switch (event.type) {
+ *       case "started":
+ *         console.log(`Session started: ${event.sessionId}`);
+ *         break;
+ *       case "thinking":
+ *         console.log(`Agent thinking: ${event.text}`);
+ *         break;
+ *       case "tool-use":
+ *         console.log(`Using tool: ${event.toolName}`);
+ *         break;
+ *       case "response-detected":
+ *         console.log(`Candidate response: ${event.candidateResponse}`);
+ *         break;
+ *       case "validating":
+ *         console.log(`Validating: ${event.response}`);
+ *         break;
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export type IAgentProgressEvent = SimpleAgentProgressEvent;
+
+/**
+ * Options for a Simple Agent Runner query
+ *
+ * Provides additional configuration that can be specified per-query
+ * to customize behavior beyond the runner's base configuration.
+ *
+ * @example
+ * ```typescript
+ * const options: ISimpleAgentQueryOptions = {
+ *   context: "User has premium subscription, last login was 2 days ago",
+ *   allowFileReading: true,
+ *   allowedDirectories: ["/home/user/project/src"]
+ * };
+ *
+ * const result = await runner.query("Should we send a reminder email?", options);
+ * ```
+ */
+export type ISimpleAgentQueryOptions = SimpleAgentQueryOptionsBase;
+
+/**
+ * Re-export simple-agent-runner types for convenience
+ *
+ * These re-exports allow consumers to import all necessary types
+ * from a single location (packages/core) without knowing the
+ * underlying provider SDK.
+ */
+export type {
+	AgentProgressEvent,
+	SimpleAgentQueryOptions,
+	SimpleAgentResult,
+	SimpleAgentRunnerConfig,
+} from "cyrus-simple-agent-runner";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
+      cyrus-simple-agent-runner:
+        specifier: workspace:*
+        version: link:../simple-agent-runner
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
Add provider-agnostic interface for simple agent runners that return
enumerated responses. This follows the same pattern as IAgentRunner,
using type aliases to the cyrus-simple-agent-runner package.

Changes:
- Created packages/core/src/simple-agent-runner-types.ts with:
  - ISimpleAgentRunner<T> interface with query() method
  - Type aliases: ISimpleAgentRunnerConfig<T>, ISimpleAgentResult<T>,
    IAgentProgressEvent, ISimpleAgentQueryOptions
  - Comprehensive JSDoc documentation with usage examples
  - Re-exports of original types for convenience
- Updated packages/core/src/index.ts to export all new types
- Added cyrus-simple-agent-runner as workspace dependency

Fixes CYPACK-406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>