### PR TITLE
Update Anthropic AI SDKs to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.42 to v0.1.49 - brings improvements including Azure AI Foundry support, structured outputs, and synchronization with Claude Code v2.0.49 - see [@anthropic-ai/claude-agent-sdk v0.1.49 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0149) (CYPACK-417)
+- Updated @anthropic-ai/sdk from v0.69.0 to v0.70.1 - adds Azure Foundry SDK and fixes structured outputs beta header - see [@anthropic-ai/sdk v0.70.1 changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0701-2025-11-20) (CYPACK-417)
 - Improved Linear agent-session tool formatting with custom formatters for better readability: Bash tool descriptions now appear in the action field with round brackets, Edit tool results display as unified diffs, and specialized parameter/result formatters for common tools (Read, Write, Grep, Glob, etc.) extract meaningful information instead of showing raw JSON (CYPACK-395, https://github.com/ceedaragents/cyrus/pull/512)
 
 ## [0.2.1] - 2025-11-15

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
-		"@anthropic-ai/sdk": "^0.69.0",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.49",
+		"@anthropic-ai/sdk": "^0.70.1",
 		"@linear/sdk": "^64.0.0",
 		"dotenv": "^16.6.1",
 		"fs-extra": "^11.3.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.42",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.49",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,11 +95,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.49
+        version: 0.1.49(zod@3.25.76)
       '@anthropic-ai/sdk':
-        specifier: ^0.69.0
-        version: 0.69.0(zod@3.25.76)
+        specifier: ^0.70.1
+        version: 0.70.1(zod@3.25.76)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -263,8 +263,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.42
-        version: 0.1.42(zod@3.25.76)
+        specifier: ^0.1.49
+        version: 0.1.49(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -285,14 +285,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42':
-    resolution: {integrity: sha512-snz2CTHKxkk4rqgvi2D4oMgITXpgmghWC4XvFXcuYjSxgLCBmvDW9TjBk6MTv0apC5fwW4kLE4ydamkBs+BdPg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.49':
+    resolution: {integrity: sha512-IncluOweBpv+sgHir3n3KVuz/gh2/AsAe132v+OXOVPSxdIDkNvPpaj/TFDF0c10ix21rPr3qkCgTYmNjeIOow==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
 
-  '@anthropic-ai/sdk@0.69.0':
-    resolution: {integrity: sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==}
+  '@anthropic-ai/sdk@0.70.1':
+    resolution: {integrity: sha512-AGEhifuvE22VxfQ5ROxViTgM8NuVQzEvqcN8bttR4AP24ythmNE/cL/SrOz79xiv7/osrsmCyErjsistJi7Z8A==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2398,7 +2398,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.42(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.49(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -2409,7 +2409,7 @@ snapshots:
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.69.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.70.1(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates both Anthropic AI SDK packages to their latest versions, bringing new features including Azure AI Foundry support and structured outputs.

## Changes

### SDK Updates
- **@anthropic-ai/claude-agent-sdk**: v0.1.42 → v0.1.49 (7 patch versions)
  - Added Azure AI Foundry support
  - Implemented structured outputs for validated JSON responses
  - Synchronized with Claude Code v2.0.49
  - [View changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0149)

- **@anthropic-ai/sdk**: v0.69.0 → v0.70.1 (minor + patch update)
  - Added Azure Foundry SDK
  - Fixed structured outputs beta header
  - [View changelog](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#0701-2025-11-20)

### Files Modified
- `packages/claude-runner/package.json` - Updated both dependencies
- `packages/simple-agent-runner/package.json` - Updated claude-agent-sdk
- `CHANGELOG.md` - Added changelog entries with links to upstream changelogs
- `pnpm-lock.yaml` - Updated lockfile

## Testing

- ✅ All package tests pass (290 tests)
- ✅ TypeScript type checking passes
- ✅ Linting clean (biome check)
- ✅ Built successfully

## Breaking Changes

None - these are compatible SDK updates.

Closes CYPACK-417

🤖 Generated with [Claude Code](https://claude.com/claude-code)