### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.53 - includes latest agent capabilities and improvements. See [@anthropic-ai/claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) ([CYPACK-433](https://linear.app/ceedar/issue/CYPACK-433))
+
 ## [0.2.3] - 2025-11-24
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.53",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"dotenv": "^16.6.1",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.53",
 		"cyrus-claude-runner": "workspace:*"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.52(zod@3.25.76)
+        specifier: ^0.1.53
+        version: 0.1.53(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.0(zod@3.25.76)
@@ -263,8 +263,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.52(zod@3.25.76)
+        specifier: ^0.1.53
+        version: 0.1.53(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -285,8 +285,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.52':
-    resolution: {integrity: sha512-yF8N05+9NRbqYA/h39jQ726HTQFrdXXp7pEfDNKIJ2c4FdWvEjxBA/8ciZIebN6/PyvGDcbEp3yq2Co4rNpg6A==}
+  '@anthropic-ai/claude-agent-sdk@0.1.53':
+    resolution: {integrity: sha512-k8qsWx2Ey3Y1qNdarS9VFFaJk+H+lEmH6AWtBbDRwQkYcdlltjZPZ8IJ71Eo683oNbwQMeepmJ4AAYMmK8EH0g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -2420,7 +2420,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.52(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.53(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.53 to include the latest agent capabilities and improvements.

## Changes
- Updated `@anthropic-ai/claude-agent-sdk` to `^0.1.53` in:
  - `packages/claude-runner/package.json`
  - `packages/simple-agent-runner/package.json`
- Updated `CHANGELOG.md` with reference to upstream changelog
- `@anthropic-ai/sdk` was already on the latest version (v0.71.0), no update needed

## Testing
- ✅ All 290 tests passing across all packages
- ✅ TypeScript type checking clean
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Build successful

## Links
- Linear Issue: [CYPACK-433](https://linear.app/ceedar/issue/CYPACK-433)
- Upstream Changelog: [claude-agent-sdk-typescript](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)