### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.54 - includes parity with Claude Code v2.0.54, experimental v2 session APIs for simpler multi-turn conversations, and ExitPlanMode bug fix. See [@anthropic-ai/claude-agent-sdk v0.1.54 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0154) ([CYPACK-459](https://linear.app/ceedar/issue/CYPACK-459))
+
 ## [0.2.4] - 2025-11-25
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.54",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.54",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.54",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
+        specifier: ^0.1.54
         version: 0.1.54(zod@4.1.12)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
@@ -173,7 +173,7 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
+        specifier: ^0.1.54
         version: 0.1.54(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
@@ -312,7 +312,7 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
+        specifier: ^0.1.54
         version: 0.1.54(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.54 across three packages in the monorepo.

## Changes

**Packages Updated:**
- `packages/claude-runner/package.json`
- `packages/core/package.json`
- `packages/simple-agent-runner/package.json`

**What's New in v0.1.54:**
- Parity with Claude Code v2.0.54
- Experimental v2 session APIs for simpler multi-turn conversations (`unstable_v2_createSession`, `unstable_v2_resumeSession`, `unstable_v2_prompt`)
- Bug fix for ExitPlanMode tool input returning empty

**SDK Status:**
- ✅ `@anthropic-ai/claude-agent-sdk`: 0.1.52 → 0.1.54
- ℹ️ `@anthropic-ai/sdk`: Already at latest (0.71.0)

## Testing

- ✅ All 493 package tests passing (66 claude-runner, 5 config-updater, 24 simple-agent-runner, 189 gemini-runner, 209 edge-worker)
- ✅ TypeScript type checking passes across all packages
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Dependencies installed successfully

## Documentation

- Updated `CHANGELOG.md` with details about the upgrade
- Included link to [claude-agent-sdk v0.1.54 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0154)
- Referenced Linear issue CYPACK-459

## References

- Linear Issue: https://linear.app/ceedar/issue/CYPACK-459
- Upstream Changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0154

🤖 Generated with [Claude Code](https://claude.com/claude-code)