### PR TITLE
Release v0.1.61-og

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.61-og] - 2025-11-27
+
 ### Added
 - Claude Opus 4.5 model support via the "opus" label on Linear issues - [CYPACK-460](https://linear.app/ceedar/issue/CYPACK-460)
 
@@ -11,6 +13,26 @@ All notable changes to this project will be documented in this file.
 - Updated @anthropic-ai/claude-agent-sdk to v0.1.54 (from v0.1.31) - [CYPACK-460](https://linear.app/ceedar/issue/CYPACK-460)
 - Updated @anthropic-ai/sdk to v0.71.0 (from v0.68.0) - [CYPACK-460](https://linear.app/ceedar/issue/CYPACK-460)
 - Improved Linear activity formatting with smart tool parameter, action name, and result formatting - tool inputs and outputs now display with proper markdown, syntax highlighting, and human-readable summaries - [CYPACK-460](https://linear.app/ceedar/issue/CYPACK-460)
+
+### Packages
+
+#### cyrus-ndjson-client
+- cyrus-ndjson-client@0.0.26-og
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.0.33-og
+
+#### cyrus-core
+- cyrus-core@0.0.22-og
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.0.5-og
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.0.42-og
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.1.61-og
 
 ## [0.1.60] - 2025-11-03
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.1.60",
+	"version": "0.1.61-og",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/app.js",
 	"types": "dist/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.0.32",
+	"version": "0.0.33-og",
 	"description": "Claude process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.0.21",
+	"version": "0.0.22-og",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.0.41",
+	"version": "0.0.42-og",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/ndjson-client/package.json
+++ b/packages/ndjson-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ndjson-client",
-	"version": "0.0.25",
+	"version": "0.0.26-og",
 	"description": "NDJSON streaming client for proxy communication",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.0.4",
+	"version": "0.0.5-og",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.1.61-og for the legacy-pro (0.1.x) release channel.

This PR contains the version bumps and changelog updates for the release.

## Published Packages

All packages published with the `-og` tag to avoid conflicting with main release channel:

- `cyrus-ndjson-client@0.0.26-og`
- `cyrus-claude-runner@0.0.33-og`
- `cyrus-core@0.0.22-og`
- `cyrus-simple-agent-runner@0.0.5-og`
- `cyrus-edge-worker@0.0.42-og`
- `cyrus-ai@0.1.61-og`

## Installation

```bash
npm install cyrus-ai@og
# or
npm install cyrus-ai@0.1.61-og
```

## Related Issue

Closes [CYPACK-460](https://linear.app/ceedar/issue/CYPACK-460)

🤖 Generated with [Claude Code](https://claude.com/claude-code)