### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.55 - includes parity updates with Claude Code v2.0.55, experimental v2 session APIs for streamlined multi-turn conversations, and bug fix for empty ExitPlanMode tool input. See [@anthropic-ai/claude-agent-sdk v0.1.55 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0155) (CYPACK-464)
+
 ## [0.2.4] - 2025-11-25
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.55",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.55",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.55",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.55
+        version: 0.1.55(zod@4.1.12)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.0(zod@4.1.12)
@@ -173,8 +173,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.55
+        version: 0.1.55(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -312,8 +312,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.55
+        version: 0.1.55(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -337,8 +337,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54':
-    resolution: {integrity: sha512-NVdtI63qu+ukIVHvB2Gx4weSlZS8R4l7PiogKg59TlpmzhBI9oZr1hy9MTKf1ujtKwM0m8cqT0odvPVyGuf/+Q==}
+  '@anthropic-ai/claude-agent-sdk@0.1.55':
+    resolution: {integrity: sha512-nwlxPjn/gc7I+iOGYY7AGtM2xcjzJFCxF9Bnr0xH1JNaNx+QXLM3h/wmzSvuEOKeJgPymf1GMBs4DZ3jyd/Z7Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3566,7 +3566,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.55(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.55 across three packages in the monorepo.

## Changes

**Updated packages:**
- `packages/claude-runner/package.json`
- `packages/core/package.json`
- `packages/simple-agent-runner/package.json`

**Version changes:**
- `@anthropic-ai/claude-agent-sdk`: `^0.1.52` → `^0.1.55`
- `@anthropic-ai/sdk`: `^0.71.0` (already latest, no change needed)

**What's new in v0.1.55:**
- v0.1.53: Parity updates with Claude Code v2.0.53
- v0.1.54: Experimental v2 session APIs (`unstable_v2_createSession`, `unstable_v2_resumeSession`, `unstable_v2_prompt`) for streamlined multi-turn conversations, and bug fix for empty ExitPlanMode tool input
- v0.1.55: Parity updates with Claude Code v2.0.55

See [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0155) for full details.

## Testing Performed

✅ All package tests passing (446 tests)
✅ TypeScript type checking clean across all packages
✅ Linting clean (1 pre-existing warning unrelated to changes)
✅ Full build successful
✅ Dependencies installed and lockfile updated

## Breaking Changes

None - this is a patch update with backward-compatible changes.

Closes CYPACK-464

🤖 Generated with [Claude Code](https://claude.com/claude-code)