### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.56 - includes experimental v2 session APIs for streamlined multi-turn conversation handling, bug fixes, and alignment with Claude Code v2.0.56. See [@anthropic-ai/claude-agent-sdk v0.1.56 changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0156) ([CYPACK-470](https://linear.app/ceedar/issue/CYPACK-470))
+
 ## [0.2.4] - 2025-11-25
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.56",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.56",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.56",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.56
+        version: 0.1.56(zod@4.1.12)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.0(zod@4.1.12)
@@ -173,8 +173,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.56
+        version: 0.1.56(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -312,8 +312,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.56
+        version: 0.1.56(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -337,8 +337,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54':
-    resolution: {integrity: sha512-NVdtI63qu+ukIVHvB2Gx4weSlZS8R4l7PiogKg59TlpmzhBI9oZr1hy9MTKf1ujtKwM0m8cqT0odvPVyGuf/+Q==}
+  '@anthropic-ai/claude-agent-sdk@0.1.56':
+    resolution: {integrity: sha512-r4IAJ3Wht2iTyS3qoDYbCEbkTNXM2W33DEt9q5tkDDD9UR0dU5U7qLPwA8TTTX4wyHkZic5a0jLDuD7xU3ZrZg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3566,7 +3566,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.56(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.56 across all packages in the monorepo.

## Changes

### Package Updates
- **packages/claude-runner**: Updated `@anthropic-ai/claude-agent-sdk` to ^0.1.56
- **packages/core**: Updated `@anthropic-ai/claude-agent-sdk` to ^0.1.56
- **packages/simple-agent-runner**: Updated `@anthropic-ai/claude-agent-sdk` to ^0.1.56
- **@anthropic-ai/sdk**: Already at latest version (v0.71.0) - no update needed

### What's New in v0.1.56

From the [official changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0156):

- **v0.1.56**: Alignment with Claude Code v2.0.56
- **v0.1.55**: Alignment with Claude Code v2.0.55
- **v0.1.54**: 
  - Added experimental v2 session APIs (`unstable_v2_createSession`, `unstable_v2_resumeSession`, `unstable_v2_prompt`) for streamlined multi-turn conversation handling
  - Fixed bug where ExitPlanMode tool input was coming through empty
- **v0.1.53**: Alignment with Claude Code v2.0.53

## Testing Performed

✅ All package tests passing (493 tests total):
- config-updater: 5 tests passing
- claude-runner: 66 tests passing
- simple-agent-runner: 24 tests passing
- gemini-runner: 189 tests passing (1 skipped)
- edge-worker: 209 tests passing

✅ Linting passed (biome check)
✅ TypeScript type checking passed across all packages
✅ Build successful for all packages

## Documentation

- Updated CHANGELOG.md with SDK version changes
- Linked to upstream changelog for reference

## Related

Fixes CYPACK-470