### PR TITLE
Verify CLI accepts auth keys with 'cysk' prefix

### DIFF
--- a/VERIFICATION_REPORT.md
+++ b/VERIFICATION_REPORT.md
@@ -1,0 +1,201 @@
+# Auth Key Format Verification Report
+
+## Summary
+
+✅ **VERIFIED**: The Cyrus CLI successfully accepts auth keys with the 'cysk' prefix.
+
+**No code changes required** - the existing implementation works perfectly with the new auth key format.
+
+## New Auth Key Format
+
+- **Prefix**: `cysk` (4 characters)
+- **Random part**: ~43 characters of URL-safe base64
+- **Total length**: ~47 characters
+- **Example**: `cyskjG4p1hsV_CDHcGYCg9tNI7P1ARsPXaWxflVsfA7Xz0c`
+
+## Why This Format Works
+
+### 1. Commander.js Configuration
+
+The auth command is defined as a **positional argument**, not an option:
+
+```typescript
+program
+  .command("auth <auth-key>")
+  .description("Authenticate with Cyrus using auth key")
+  .action(async (authKey: string) => {
+    // authKey is captured as a positional argument
+  });
+```
+
+**Key Points:**
+- `<auth-key>` syntax means it's a required positional argument
+- Positional arguments are NOT parsed as options/flags
+- Only strings starting with `-` or `--` are treated as options, and only when they appear in positions where options are expected
+- Since 'cysk' doesn't start with `-`, it's completely safe
+
+### 2. Auth Command Validation
+
+The AuthCommand.execute() method performs simple validation:
+
+```typescript
+if (!authKey || typeof authKey !== "string" || authKey.trim().length === 0) {
+  this.logError("Error: Auth key is required");
+  process.exit(1);
+}
+```
+
+**This validation:**
+- ✅ Accepts any non-empty string
+- ✅ Works with 'cysk' prefix
+- ✅ Works with URL-safe base64 characters (A-Z, a-z, 0-9, -, _)
+
+## Testing Results
+
+### Test 1: Basic Format Validation
+
+Generated 5 test auth keys with 'cysk' prefix:
+
+```
+Test Key 1: cyskbizg89N9JMWExOZuB_pUDj4AJyczJiJ5DuhmKOpxfhs (47 chars) ✓
+Test Key 2: cyskradVqlIvLuDFNcGMYCwUa6rypYA6KuCQUZGokEurwNc (47 chars) ✓
+Test Key 3: cysk-TdDiZYwx1KczIPmq6vx8c0o36BGFekHywRYeS7Iw8Y (47 chars) ✓
+Test Key 4: cyskH6PIxDLj_bqq09Y2v_4gKFdSSv8vScgm7hp3Ui5QdDg (47 chars) ✓
+Test Key 5: cyskmq-hd3W4kZvrfmoOMGnnGYKP493rWlRFlG_iD_J0low (47 chars) ✓
+```
+
+All keys match the expected format: `^cysk[A-Za-z0-9_-]+$`
+
+### Test 2: CLI Argument Parsing
+
+Tested CLI with multiple generated keys:
+
+```bash
+$ cyrus auth cyskbizg89N9JMWExOZuB_pUDj4AJyczJiJ5DuhmKOpxfhs
+🔑 Authenticating with Cyrus...
+Validating auth key...
+❌ Authentication failed (401 Unauthorized - Invalid or expired auth key)
+```
+
+**Result**: ✅ Success
+- The CLI successfully parsed the auth key
+- Passed it to the authentication API
+- Failed with expected 401 error (because it's a test key, not a real one)
+- **No Commander.js parsing errors**
+
+### Test 3: Special Characters
+
+Tested keys containing hyphens and underscores:
+
+```bash
+$ cyrus auth cysk-TdDiZYwx1KczIPmq6vx8c0o36BGFekHywRYeS7Iw8Y
+$ cyrus auth cyskH6PIxDLj_bqq09Y2v_4gKFdSSv8vScgm7hp3Ui5QdDg
+```
+
+**Result**: ✅ Both work perfectly
+- Hyphens (-) are handled correctly
+- Underscores (_) are handled correctly
+- URL-safe base64 characters pose no issues
+
+### Test 4: Unit Tests
+
+All existing CLI tests pass: ✅ 18/18 tests passed
+
+```bash
+$ pnpm test:run
+✓ app.test.ts (18 tests) 6ms
+```
+
+## Why the 'cysk' Prefix Solves the Original Problem
+
+### The Original Issue (from cyrus-hosted PR #288)
+
+Auth keys that started with `-` were problematic:
+- Commander.js could interpret them as option flags
+- Example: `-abc123def` might be parsed as option `-a` with value `bc123def`
+
+### The Solution
+
+All auth keys now start with `cysk`:
+- ✅ Clearly not an option flag (doesn't start with `-`)
+- ✅ Easy to identify as a Cyrus auth key
+- ✅ Consistent branding across all auth keys
+- ✅ No parsing ambiguity
+
+### Comparison
+
+| Old Format | New Format |
+|------------|------------|
+| `-abc123...` (problematic) | `cyskabc123...` ✓ |
+| `+xyz789...` (potential issue) | `cyskxyz789...` ✓ |
+| `abc123...` (works but ambiguous) | `cyskabc123...` ✓ |
+
+## Code Analysis
+
+### No Changes Required
+
+After thorough analysis, **no code changes are required** in the Cyrus CLI package:
+
+1. **apps/cli/src/app.ts:49** - Commander.js command definition is correct
+2. **apps/cli/src/commands/AuthCommand.ts:11-24** - Validation logic works perfectly
+3. All existing tests pass without modification
+
+### Files Analyzed
+
+- ✅ `apps/cli/src/app.ts` - Commander.js configuration
+- ✅ `apps/cli/src/commands/AuthCommand.ts` - Auth command implementation
+- ✅ `apps/cli/app.test.ts` - Existing test suite
+
+## Recommendations
+
+### 1. No Action Required
+
+The CLI is fully compatible with the new auth key format. No code changes needed.
+
+### 2. Optional: Add Tests (Future Enhancement)
+
+Consider adding specific tests for the 'cysk' prefix format to prevent regressions:
+
+```typescript
+describe("Auth Key Format Validation", () => {
+  it("should accept auth keys with cysk prefix", () => {
+    const testKeys = [
+      "cyskbizg89N9JMWExOZuB_pUDj4AJyczJiJ5DuhmKOpxfhs",
+      "cysk-TdDiZYwx1KczIPmq6vx8c0o36BGFekHywRYeS7Iw8Y",
+    ];
+
+    for (const authKey of testKeys) {
+      expect(authKey).toMatch(/^cysk[A-Za-z0-9_-]+$/);
+      expect(authKey.startsWith("cysk")).toBe(true);
+    }
+  });
+});
+```
+
+### 3. Documentation
+
+Update user-facing documentation to reference the new format:
+- Auth keys now start with 'cysk' prefix
+- Total length is ~47 characters
+- Contains URL-safe base64 characters
+
+## Conclusion
+
+✅ **Verification Complete**: The Cyrus CLI fully supports auth keys with the 'cysk' prefix.
+
+The implementation is robust and requires no modifications. The new format enhances security and user experience by:
+1. Preventing Commander.js parsing issues
+2. Making auth keys easily identifiable
+3. Providing consistent branding
+4. Supporting all URL-safe base64 characters
+
+---
+
+**Related Links:**
+- [Cyrus Hosted PR #288](https://github.com/ceedaragents/cyrus-hosted/pull/288)
+- Linear Issue: CYHOST-365
+- Linear Issue: CYPACK-479
+
+**Tested By:** Claude Code
+**Date:** 2025-12-02
+**CLI Version:** 0.2.1

--- a/test-auth-key.mjs
+++ b/test-auth-key.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify Cyrus CLI accepts auth keys with 'cysk' prefix
+ *
+ * This generates test auth keys matching the new format from cyrus-hosted:
+ * - Prefix: 'cysk' (4 characters)
+ * - Random part: ~43 characters of URL-safe base64
+ * - Total length: ~47 characters
+ */
+
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Generate a test auth key with 'cysk' prefix
+ */
+function generateTestAuthKey() {
+  // Generate 32 random bytes (same as the cyrus-hosted implementation)
+  const bytes = randomBytes(32);
+
+  // Convert to URL-safe base64
+  const randomPart = bytes
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+
+  // Add 'cysk' prefix
+  const authKey = `cysk${randomPart}`;
+
+  return authKey;
+}
+
+/**
+ * Generate multiple test keys for verification
+ */
+function generateTestKeys(count = 5) {
+  console.log('🔑 Generating test auth keys with "cysk" prefix\n');
+  console.log('Format: cysk + ~43 chars of URL-safe base64');
+  console.log('Total length: ~47 characters\n');
+  console.log('─'.repeat(60));
+
+  const keys = [];
+  for (let i = 0; i < count; i++) {
+    const key = generateTestAuthKey();
+    keys.push(key);
+
+    console.log(`\nTest Key ${i + 1}:`);
+    console.log(`  Value:  ${key}`);
+    console.log(`  Length: ${key.length} chars`);
+    console.log(`  Prefix: ${key.substring(0, 4)}`);
+    console.log(`  Format: ${/^cysk[A-Za-z0-9_-]+$/.test(key) ? '✓ Valid' : '✗ Invalid'}`);
+  }
+
+  console.log('\n' + '─'.repeat(60));
+  console.log('\n✅ All keys generated successfully!\n');
+  console.log('To test with the CLI, run:');
+  console.log(`  cyrus auth ${keys[0]}\n`);
+  console.log('Note: This will fail authentication (invalid key),');
+  console.log('but it verifies the CLI accepts the format.\n');
+
+  return keys;
+}
+
+// Run the generator
+const keys = generateTestKeys(5);
+
+// Export for testing
+export { generateTestAuthKey, generateTestKeys };


### PR DESCRIPTION
## Summary

Verified that the Cyrus CLI successfully accepts auth keys with the new **'cysk' prefix** format introduced in cyrus-hosted. **No code changes were required** - the existing implementation works perfectly with the new format.

## Context

The Cyrus Hosted service (PR #288) updated all auth keys to use a 'cysk' prefix to prevent Commander.js parsing issues. This PR verifies that the CLI package accepts this new format.

**New Auth Key Format:**
- Prefix: `cysk` (4 characters)
- Random part: ~43 characters of URL-safe base64
- Total length: ~47 characters
- Example: `cyskjG4p1hsV_CDHcGYCg9tNI7P1ARsPXaWxflVsfA7Xz0c`

## Why It Works

### Commander.js Configuration
The auth command defines the key as a **positional argument**, not an option:
```typescript
program
  .command("auth <auth-key>")
```

This means:
- ✅ The key is captured directly, not parsed as a flag
- ✅ The 'cysk' prefix is completely safe (doesn't start with `-`)
- ✅ URL-safe base64 characters (-, _) are handled correctly

### Validation Logic
The AuthCommand validation is simple and permissive:
```typescript
if (!authKey || typeof authKey !== "string" || authKey.trim().length === 0) {
  // reject
}
```

This accepts any non-empty string, including the new format.

## Testing Performed

### 1. Generated Test Keys
Created 5 test auth keys matching the exact format from cyrus-hosted:
```
cyskbizg89N9JMWExOZuB_pUDj4AJyczJiJ5DuhmKOpxfhs ✓
cysk-TdDiZYwx1KczIPmq6vx8c0o36BGFekHywRYeS7Iw8Y ✓ (with hyphens)
cyskH6PIxDLj_bqq09Y2v_4gKFdSSv8vScgm7hp3Ui5QdDg ✓ (with underscores)
```

### 2. CLI Integration Testing
Tested multiple keys with the CLI:
```bash
$ cyrus auth cyskbizg89N9JMWExOZuB_pUDj4AJyczJiJ5DuhmKOpxfhs
🔑 Authenticating with Cyrus...
Validating auth key...
❌ Authentication failed (401 Unauthorized)
```

**Result:** ✅ CLI successfully parsed and processed the key (401 is expected for test keys)

### 3. Unit Tests
All existing tests pass: **18/18 tests passing**

### 4. Quality Checks
- ✅ TypeScript compilation successful
- ✅ Linting clean (1 pre-existing warning unrelated to this issue)
- ✅ All package tests passing

## Files Added

### test-auth-key.mjs
Test script to generate auth keys with 'cysk' prefix for manual testing:
```bash
$ node test-auth-key.mjs
🔑 Generating test auth keys with "cysk" prefix
```

### VERIFICATION_REPORT.md
Comprehensive documentation of:
- Auth key format specification
- Commander.js parsing analysis
- Test results and findings
- Comparison with problematic formats

## Related

- Linear Issue: CYPACK-479
- Cyrus Hosted PR: ceedaragents/cyrus-hosted#288
- Related Issue: CYHOST-365

## Conclusion

✅ The Cyrus CLI is fully compatible with the new 'cysk' prefix format. No code changes are required. The new format enhances security and user experience by preventing CLI parsing ambiguities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)