### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.57 and fix peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated @anthropic-ai/claude-agent-sdk from v0.1.52 to v0.1.57 - includes latest agent capabilities and experimental v2 session APIs for streamlined multi-turn conversations. See [@anthropic-ai/claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for versions [0.1.53](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0153), [0.1.54](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0154), [0.1.55](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0155), [0.1.56](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0156), and [0.1.57](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0157) ([CYPACK-481](https://linear.app/ceedar/issue/CYPACK-481))
+
+### Fixed
+- Fixed peer dependency warnings by adding zod ^3.24.1 to cyrus-core and cyrus-simple-agent-runner packages to satisfy @anthropic-ai/claude-agent-sdk requirements ([CYPACK-481](https://linear.app/ceedar/issue/CYPACK-481))
+
 ## [0.2.4] - 2025-11-25
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.57",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,8 +16,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
-		"@linear/sdk": "^64.0.0"
+		"@anthropic-ai/claude-agent-sdk": "^0.1.57",
+		"@linear/sdk": "^64.0.0",
+		"zod": "^3.24.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,9 +16,10 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.57",
 		"cyrus-claude-runner": "workspace:*",
-		"cyrus-core": "workspace:*"
+		"cyrus-core": "workspace:*",
+		"zod": "^3.24.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@3.25.76)
+        specifier: ^0.1.57
+        version: 0.1.57(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.0(zod@3.25.76)
@@ -173,11 +173,14 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.57
+        version: 0.1.57(zod@3.25.76)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -312,14 +315,17 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.57
+        version: 0.1.57(zod@3.25.76)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
       cyrus-core:
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -337,8 +343,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54':
-    resolution: {integrity: sha512-NVdtI63qu+ukIVHvB2Gx4weSlZS8R4l7PiogKg59TlpmzhBI9oZr1hy9MTKf1ujtKwM0m8cqT0odvPVyGuf/+Q==}
+  '@anthropic-ai/claude-agent-sdk@0.1.57':
+    resolution: {integrity: sha512-8M1Csigqw33ndK9/oMQJN1cw9jizOOXGRUuo5ykqIuvj26vLHPl1qMdsoyqin9Ww71nod9ihzdmNS382pRrcAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3556,9 +3562,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
-
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -3566,22 +3569,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.57(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@4.1.12)':
-    dependencies:
-      zod: 4.1.12
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -6956,5 +6946,3 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.1.12: {}


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.57 across all packages that use it. This brings in the latest agent capabilities including experimental v2 session APIs for streamlined multi-turn conversations.

Also fixed peer dependency warnings by adding `zod ^3.24.1` to `cyrus-core` and `cyrus-simple-agent-runner` packages.

## Changes

### Package Updates
- **@anthropic-ai/claude-agent-sdk**: `^0.1.52` → `^0.1.57` in:
  - `packages/claude-runner/package.json`
  - `packages/core/package.json`
  - `packages/simple-agent-runner/package.json`

### Dependency Fixes
- Added `zod ^3.24.1` to `packages/core/package.json`
- Added `zod ^3.24.1` to `packages/simple-agent-runner/package.json`

## What's New in claude-agent-sdk 0.1.53-0.1.57

- **v0.1.57, 0.1.56, 0.1.55, 0.1.53**: Parity updates with Claude Code releases
- **v0.1.54**: 
  - Introduced experimental v2 session APIs (`unstable_v2_createSession`, `unstable_v2_resumeSession`, `unstable_v2_prompt`)
  - Fixed ExitPlanMode tool input parameter bug

See [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details.

## Testing Performed

- ✅ All 498 tests pass (71 in claude-runner, 24 in simple-agent-runner, 209 in edge-worker, 189 in gemini-runner, 5 in config-updater)
- ✅ TypeScript compilation successful across all packages
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ No peer dependency warnings after zod additions

## Breaking Changes

None - all changes are backward compatible.

---

Closes CYPACK-481

🤖 Generated with [Claude Code](https://claude.com/claude-code)