### PR TITLE
Create IAgentRunner interface abstraction in core package

### DIFF
--- a/spec/f1/ORCHESTRATION-PLAN.md
+++ b/spec/f1/ORCHESTRATION-PLAN.md
@@ -36,8 +36,9 @@ The F1 framework consists of three main components:
 
 ## Sub-Issue Decomposition
 
-### Sub-Issue 1: CLI Type System Foundation
+### CYPACK-502: CLI Type System Foundation
 **Stack Position**: 1 of 5 (First in stack)
+**Linear URL**: https://linear.app/ceedar/issue/CYPACK-502
 **Scope**: Define TypeScript types for CLI platform
 
 Creates the foundational type definitions that mirror Linear SDK types but for in-memory CLI usage:
@@ -46,8 +47,9 @@ Creates the foundational type definitions that mirror Linear SDK types but for i
 - Type factories and ID generators
 - Platform configuration types
 
-### Sub-Issue 2: CLIIssueTrackerService Implementation
-**Stack Position**: 2 of 5 (Blocked by: Sub-Issue 1)
+### CYPACK-503: CLIIssueTrackerService Implementation
+**Stack Position**: 2 of 5 (Blocked by: CYPACK-502)
+**Linear URL**: https://linear.app/ceedar/issue/CYPACK-503
 **Scope**: Implement IIssueTrackerService for CLI platform
 
 Full implementation of `IIssueTrackerService` interface:
@@ -56,8 +58,9 @@ Full implementation of `IIssueTrackerService` interface:
 - Event emission for state changes
 - Synchronous property access (no Promises for simple gets)
 
-### Sub-Issue 3: CLIRPCServer and Event Transport
-**Stack Position**: 3 of 5 (Blocked by: Sub-Issue 2)
+### CYPACK-504: CLIRPCServer and Event Transport
+**Stack Position**: 3 of 5 (Blocked by: CYPACK-503)
+**Linear URL**: https://linear.app/ceedar/issue/CYPACK-504
 **Scope**: JSON-RPC server and event transport
 
 Implements the communication layer:
@@ -66,8 +69,9 @@ Implements the communication layer:
 - CLIEventTransport for in-process event delivery
 - Error handling and response formatting
 
-### Sub-Issue 4: EdgeWorker CLI Platform Mode
-**Stack Position**: 4 of 5 (Blocked by: Sub-Issue 3)
+### CYPACK-505: EdgeWorker CLI Platform Mode
+**Stack Position**: 4 of 5 (Blocked by: CYPACK-504)
+**Linear URL**: https://linear.app/ceedar/issue/CYPACK-505
 **Scope**: Add CLI platform support to EdgeWorker
 
 Modifies EdgeWorker to support `platform: "cli"`:
@@ -76,8 +80,9 @@ Modifies EdgeWorker to support `platform: "cli"`:
 - Integration with CLIIssueTrackerService and CLIRPCServer
 - Worktree creation for CLI sessions
 
-### Sub-Issue 5: F1 CLI Application
-**Stack Position**: 5 of 5 (Blocked by: Sub-Issue 4)
+### CYPACK-506: F1 CLI Application
+**Stack Position**: 5 of 5 (Blocked by: CYPACK-505)
+**Linear URL**: https://linear.app/ceedar/issue/CYPACK-506
 **Scope**: Commander.js CLI and server startup
 
 The user-facing F1 CLI:


### PR DESCRIPTION
Create IAgentRunner interface abstraction in core package

Added provider-agnostic interface for agent runners following the same
pattern as IIssueTrackerService, using type aliases to Claude SDK types.

Changes:
- Created packages/core/src/agent-runner-types.ts with IAgentRunner interface
- Added AgentRunnerConfig, AgentSessionInfo, AgentMessage type definitions
- Included comprehensive JSDoc documentation explaining abstraction pattern
- Added @anthropic-ai/claude-agent-sdk dependency to core package
- Exported all new types from packages/core/src/index.ts

The interface includes core methods: start(), startStreaming(),
addStreamMessage(), completeStream(), stop(), isRunning(), getMessages()

This creates the foundation for supporting multiple AI providers (Claude,
Gemini) through adapter implementations while maintaining a consistent API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Release v0.2.2

Update Anthropic AI packages to latest versions

- Update @anthropic-ai/claude-agent-sdk from v0.1.42 to v0.1.52
- Update @anthropic-ai/sdk from v0.69.0 to v0.71.0
- Update CHANGELOG.md with links to release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Move Anthropic package updates to Unreleased section in CHANGELOG

Release v0.2.3

Update CHANGELOG to highlight Claude Opus 4.5 support

[2/8] Create ISimpleAgentRunner interface abstraction (#531)

* Create ISimpleAgentRunner interface abstraction in core package

Add provider-agnostic interface for simple agent runners that return
enumerated responses. This follows the same pattern as IAgentRunner,
using type aliases to the cyrus-simple-agent-runner package.

Changes:
- Created packages/core/src/simple-agent-runner-types.ts with:
  - ISimpleAgentRunner<T> interface with query() method
  - Type aliases: ISimpleAgentRunnerConfig<T>, ISimpleAgentResult<T>,
    IAgentProgressEvent, ISimpleAgentQueryOptions
  - Comprehensive JSDoc documentation with usage examples
  - Re-exports of original types for convenience
- Updated packages/core/src/index.ts to export all new types
- Added cyrus-simple-agent-runner as workspace dependency

Fixes CYPACK-406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* [3/8] Refactor ClaudeRunner to implement IAgentRunner (#532)

* Refactor ClaudeRunner to implement IAgentRunner interface

- Add cyrus-core as workspace dependency in package.json
- Import and implement IAgentRunner interface in ClaudeRunner class
- Add TypeScript path mappings to resolve circular dependencies in monorepo
  - Updated claude-runner, core, edge-worker, and CLI tsconfig.json files
  - Enables TypeScript to find module declarations during development
- All existing tests pass (66 tests)
- No breaking changes to external API

CYPACK-407

* [4/8] Refactor SimpleAgentRunner to implement ISimpleAgentRunner (#533)

* Refactor SimpleAgentRunner to implement ISimpleAgentRunner interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* [5/8] Create gemini-runner package with Gemini CLI integration (#534)

* feat: create gemini-runner package with Gemini CLI integration

Implements CYPACK-409: Create new package `packages/gemini-runner` that wraps
the Gemini CLI, implementing the IAgentRunner interface.

Changes:
- Created GeminiRunner class implementing IAgentRunner interface
- Implemented all 7 required methods: start(), startStreaming(),
  addStreamMessage(), completeStream(), stop(), isRunning(), getMessages()
- Added message adapter functions to translate between Gemini CLI JSON
  stream format and Claude SDK message types
- Implemented StreamingPrompt class for AsyncIterable message queueing
- Added comprehensive type definitions for Gemini-specific types
- Configured package with proper dependencies and TypeScript setup
- Includes dual logging (JSON NDJSON + Markdown)
- Follows same architecture pattern as claude-runner

Technical details:
- Spawns Gemini CLI as child process using node:child_process
- Handles stdio communication via --output-format stream-json
- Supports both string mode and streaming mode for prompts
- Proper session lifecycle management and cleanup
- Event emitter architecture for async communication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: address PR review comments for gemini-runner package

- Change 'Claude SDK' references to 'cyrus-core SDKMessage' in comments
- Refactor type casting to use proper typed variables before casting
- Use tool_id variable name for Gemini CLI tool call IDs
- Consolidate StreamingPrompt by importing from cyrus-claude-runner
- Remove re-exports from index.ts and types.ts
- Add comprehensive tool_id usage examples in type documentation
- Add 'raw event emitting' comment
- Add cyrus-claude-runner as dependency

* fix: align gemini-runner with real Gemini CLI output format

Based on analysis of real Gemini CLI streaming output, fixed critical
discrepancies in type definitions and adapter logic:

**Type Definition Updates:**
- Added `timestamp: string` to all event interfaces
- Added `delta?: boolean` to GeminiMessageEvent for streaming chunks
- Added `tool_id: string` to GeminiToolUseEvent (Gemini-provided)
- Restructured GeminiToolResultEvent with tool_id, status, output, error
- Updated GeminiResultEvent to match real output structure

**Adapter Logic Fixes:**
- Fixed tool_use to use event.tool_id instead of client-side generation
- Rewrote tool_result handler for both success and error cases
- Updated result event handler (stats only, no message content)

**Delta Message Accumulation:**
- Implemented delta message buffering in GeminiRunner
- Added accumulateDeltaMessage() and flushAccumulatedMessage() methods
- Messages with delta: true now correctly combine into single SDK messages

All changes verified with TypeScript compilation and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: address PR comments - remove StreamingPrompt export and add SDK message types

- Remove StreamingPrompt from public exports (internal use only)
- Export SDKAssistantMessage, SDKResultMessage from core package
- Re-export these types from gemini-runner for convenience
- Keep 'as unknown as SDKMessage' casts for format conversion (appropriate since we're mapping between Gemini CLI and Claude SDK formats)
- Logging already uses appropriate levels (console.log for info, console.error for errors)

Addresses PR review comments from https://github.com/ceedaragents/cyrus/pull/524

* fix: implement strict typing for SDK messages in gemini-runner

- Add SDKAssistantMessage import and createBetaMessage helper function
- Create fully-compliant BetaMessage objects with all required fields:
  * id, type, role, content, model, stop_reason, stop_sequence
  * usage with all token tracking fields
  * container, context_management
- Replace all 'as unknown as SDKMessage' casts with 'satisfies' type assertions
- Use strict typing for SDKAssistantMessage and SDKUserMessage
- Add proper JSDoc for createBetaMessage helper

This ensures type safety while adapting between Gemini CLI format and Claude SDK format.
The minimal BetaMessage uses placeholder values (zeros, nulls) for fields that
Gemini doesn't provide (usage stats, model info, etc.).

Addresses PR review comment requesting strict typing on SDKAssistantMessage.message.

* fix: address PR review comments for gemini-runner

Changes based on code review feedback:

**Documentation & Naming**
- Update comments to reference 'cyrus-core SDKMessage' instead of 'Claude SDK'
- Update JSDoc to say 'Cyrus Core SDK UserMessage' for consistency
- Add 'raw event emitting' comment to streamEvent in GeminiRunnerEvents

**Exports & Imports**
- Remove re-exports of core types from gemini-runner/index.ts
- Remove re-exports of core types from gemini-runner/types.ts
- Users should import types directly from cyrus-core if needed

**StreamingPrompt Consolidation**
- Create StreamingPrompt class in cyrus-core to eliminate duplication
- Both GeminiRunner and ClaudeRunner had identical implementations
- Move to packages/core/src/StreamingPrompt.ts for reusability
- Update both runners to import StreamingPrompt from cyrus-core
- Remove StreamingPrompt from public exports of claude-runner

**Type Safety**
- tool_id usage was already correct (verified using event.tool_id)
- core/src/index.ts exports were already correct (only SDKAssistantMessage/SDKResultMessage added)

**Note on Logging**
Logging consolidation comment noted but deferred to separate refactoring PR.
Both runners currently follow consistent logging patterns with [GeminiRunner]
and [ClaudeRunner] prefixes. A shared logging infrastructure would require
broader changes across the codebase.

Addresses PR review comments from https://github.com/ceedaragents/cyrus/pull/534

* style: apply linting fixes

Auto-format imports for consistency:
- Reorganize StreamingPrompt export in core/src/index.ts (moved to end with other exports)
- Format ClaudeRunner import statement to single line

No functional changes, just code style improvements.

* fix: restore core/src/index.ts to match CYPACK-408 base plus SDK exports

The core/src/index.ts file should match the CYPACK-408 base branch (commit d128444)
with only two additions:
1. SDKAssistantMessage and SDKResultMessage exports in agent-runner types
2. StreamingPrompt export after PersistenceManager

Changes:
- Restored issue-tracker exports (AgentActivity, etc.) from base branch
- Restored issue-tracker source files that were incorrectly deleted
- Restored core package.json dependencies (fastify, @linear/sdk@64)
- Removed webhook-types exports that were from different branch work

This ensures the PR only contains gemini-runner changes plus the minimal
core package modifications needed to support it (SDK type exports and
StreamingPrompt consolidation).

Addresses review comment about keeping core/src/index.ts unchanged except
for the two new SDK type exports.

* fix: use intermediate variables with explicit types instead of inline satisfies

Changed all SDK message creation to define intermediate variables with explicit
types (SDKUserMessage, SDKAssistantMessage) before returning, instead of using
inline object literals with 'satisfies'. This provides better type checking and
follows the pattern requested in code review.

Updated locations:
- User messages (line 70-79)
- Assistant messages (line 82-90)
- Tool use messages (line 101-116)
- Tool result messages (line 143-160)

Addresses repeated code review comment about defining intermediate variables
for type safety benefits.

* feat(gemini-runner): add includeDirectories config support

Add support for Gemini CLI's --include-directories flag to allow
specifying additional directories for workspace context.

- Add includeDirectories field to GeminiRunnerConfig
- Pass --include-directories flag to Gemini CLI when directories are configured
- Directories are joined with commas per Gemini CLI requirements

* feat(gemini-runner): map GeminiResultEvent and GeminiErrorEvent to SDKResultMessage

Convert Gemini CLI result and error events to SDK result messages:
- Success results map to SDKResultMessage with subtype 'success'
- Error results map to SDKResultMessage with subtype 'error_during_execution'
- Include token usage stats from Gemini CLI output
- Populate required SDK fields (usage, modelUsage, permission_denials, etc.)
- Use tool_calls count as proxy for num_turns

* feat(gemini-runner): implement session resumption support

Add support for resuming previous Gemini CLI sessions:
- Check for resumeSessionId in config (inherited from AgentRunnerConfig)
- Pass -r flag with session ID to Gemini CLI when resuming
- Log session resumption for debugging
- Enables conversation continuity across multiple webhook events

* [6/8] Create SimpleGeminiRunner for enumerated response use cases (#535)

* feat: create SimpleGeminiRunner for enumerated response use cases

- Implement SimpleGeminiRunner extending SimpleAgentRunner<T>
- Use GeminiRunner internally for agent execution
- Implement executeAgent() and extractResponse() abstract methods
- Support validResponse enumeration pattern matching SimpleClaudeRunner
- Add comprehensive JSDoc documentation
- Export from gemini-runner package index
- Add cyrus-simple-agent-runner dependency
- Create test script and implementation documentation

Resolves CYPACK-410

* [7/8] Add comprehensive unit tests for GeminiRunner and SimpleGeminiRunner (#536)

* feat: add comprehensive unit tests for GeminiRunner and SimpleGeminiRunner

Add test suites for gemini-runner package covering:
- GeminiRunner: 35 passing tests for configuration, message processing,
  event emission, error handling, and state management
- SimpleGeminiRunner: 58 passing tests for enumerated response handling,
  validation, timeout management, and cost extraction

Test implementation includes:
- Mock child_process and readline to avoid external dependencies
- ProcessEmulator helper class for simulating Gemini CLI behavior
- Comprehensive coverage of success and error paths
- Message format conversion testing (Gemini events → SDK messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* [8/8] Add comprehensive documentation and examples for gemini-runner package (#537)

* docs: add comprehensive documentation and examples for gemini-runner package

- Create README.md with overview, installation, API reference, and troubleshooting
- Add basic-usage.ts example demonstrating GeminiRunner with event handling
- Add simple-agent-example.ts with 6 use cases for SimpleGeminiRunner
- Document adapter pattern and message format conversion
- Document differences between Claude and Gemini implementations
- Include Gemini CLI setup instructions
- Add troubleshooting section for common issues

Resolves CYPACK-412

* feat: implement single-turn mode and Gemini result coercion (#546)

* refactor: update EdgeWorker to use IAgentRunner interface

Decoupled EdgeWorker and AgentSessionManager from ClaudeRunner-specific
implementation to support multi-provider agent runners.

Changes:
- Updated CyrusAgentSession to use IAgentRunner instead of ClaudeRunner
- Renamed AgentSessionManager methods for provider-agnostic naming:
  - addClaudeRunner → addAgentRunner
  - getAllClaudeRunners → getAllAgentRunners
  - getClaudeRunnersForIssue → getAgentRunnersForIssue
  - getClaudeRunner → getAgentRunner
  - hasClaudeRunner → hasAgentRunner
- Updated EdgeWorker to use AgentRunnerConfig and IAgentRunner types
- Renamed EdgeWorker methods:
  - initializeClaudeRunner → initializeAgentRunner
  - buildClaudeRunnerConfig → buildAgentRunnerConfig
- Added type assertions for ClaudeRunner-specific methods (isStreaming)
- Updated all variable names from claudeRunner to agentRunner

This refactoring maintains backward compatibility while preparing the
codebase for GeminiRunner integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: remove circular dependency from config-types by importing SDKMessage from Claude SDK directly

* feat: change default runner to GeminiRunner for testing

- Add cyrus-gemini-runner dependency to edge-worker package
- Replace ClaudeRunner instantiations with GeminiRunner
- Keep ClaudeRunner import for type casting streaming methods

* style: organize imports and use type-only imports for better tree-shaking

* fix: add TypeScript path mappings and type annotations to simple-agent-runner

- Add baseUrl and paths to tsconfig for workspace dependencies
- Add rootDir to match other packages
- Add type annotations for message and error event handlers
- Fixes TS2307 and TS7006 errors preventing build

* fix: remove circular dependency between core and simple-agent-runner

- Move simple agent runner type definitions from simple-agent-runner to core
- Update simple-agent-runner to re-export types from core
- Remove core's dependencies on claude-runner and simple-agent-runner from package.json
- Revert tsconfig.json files to match main branch pattern (no path mappings in packages)
- Add type guard for ClaudeRunner.updatePromptVersions in EdgeWorker
- Add missing dependencies (fs-extra, zod, openai) to claude-runner

This fixes the build failure where TypeScript couldn't find 'cyrus-core' or 'cyrus-claude-runner'
modules. The root cause was a circular dependency: core imported from simple-agent-runner,
which imported from core. Now the dependency flows one-way: simple-agent-runner -> core.

Fixes CYPACK-415

* fix: resolve GeminiRunner hanging by writing prompt to stdin immediately

The GeminiRunner was hanging during startup because it spawned the gemini
process with stdin piped but didn't write the prompt to stdin immediately.
The gemini CLI was waiting for input that never came.

The fix ensures that when using streaming mode:
1. Spawn gemini with stdin set to 'pipe' (not 'ignore')
2. Write the initial prompt to stdin IMMEDIATELY after spawn
3. Close stdin immediately so gemini knows input is complete

This allows gemini to process the prompt without hanging.

Fixes CYPACK-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: keep stdin open for streaming to support multiple addStreamMessage() calls

The previous fix closed stdin immediately after writing the initial prompt,
which prevented EdgeWorker from sending additional messages via addStreamMessage().

Root cause analysis from gemini-cli source (packages/cli/src/utils/readStdin.ts):
- Has 500ms timeout that resolves if NO data arrives
- Once data arrives, timeout is canceled and waits for stdin close ('end' event)
- Continues reading chunks as they arrive until stdin closes

The fix:
- Write initial prompt immediately to cancel the 500ms timeout (line 249)
- Keep stdin OPEN to allow addStreamMessage() to write more data (lines 104-106)
- Only close stdin in completeStream() when all messages sent (line 118)

This enables proper streaming behavior where EdgeWorker can:
1. Start session with initial prompt
2. Add user comments via addStreamMessage() as they arrive
3. Close stdin via completeStream() when conversation ends

Fixes CYPACK-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* feat: implement single-turn mode and Gemini result coercion

**Result Message Coercion:**
- GeminiRunner now tracks last assistant message and includes it in result messages
- Gemini result messages now contain actual final response content instead of generic "Session completed successfully"
- Added getLastAssistantMessage() method to expose tracked message

**Single-Turn Mode:**
- Replaced maxTurns integer with singleTurn boolean in SubroutineDefinition for clearer semantics
- EdgeWorker automatically converts singleTurn to maxTurns=1 and appends "-shortone" to Gemini model names
- Summary subroutines (concise-summary, verbose-summary, question-answer, plan-summary) now use singleTurn mode

**Gemini Configuration:**
- Added settingsGenerator.ts to auto-create ~/.gemini/settings.json if missing
- Generates single-turn aliases for all 4 main Gemini models (gemini-3-pro-preview-shortone, gemini-2.5-pro-shortone, etc.)
- Enables preview features in generated settings
- Referenced official Gemini CLI configuration docs in CLAUDE.md

**Testing:**
- Fixed linting errors in stdin test scripts (added type annotations and biome-ignore comments)

Fixes CYPACK-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* test: consolidate and improve gemini-runner tests

- Removed redundant test files (test-stdin-logic.ts, test-multiple-stdin.ts)
- Kept test-stdin-direct.ts as proof of stdin streaming functionality
- Added comprehensive test-result-and-singleturn.ts covering:
  * Result message coercion (actual content vs generic message)
  * Single-turn mode with -shortone aliases
  * Settings.json auto-generation verification
- Created packages/gemini-runner/CLAUDE.md with complete documentation:
  * Architecture overview and key features
  * Test usage instructions and expected outputs
  * Common issues and debugging guidance
  * Integration points with EdgeWorker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* ci: enable GitHub Actions CI for cypack-* branches

Configure CI workflow to run on:
- Push to cypack-* branches
- Pull requests targeting cypack-* branches

This ensures all feature branches get automated testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: resolve GeminiRunner result coercion and consolidate tests

Critical Fixes:
- Fix IIssueTrackerService export as type-only in cyrus-core
- Fix delta message accumulation to use Claude SDK format (array of content blocks)
- Update lastAssistantMessage before emitting in flushAccumulatedMessage()
- Fix stdin streaming test timing (don't await startStreaming until after addStreamMessage)

Test Consolidation:
- Remove test-stdin-direct.ts and test-result-and-singleturn.ts
- Create single comprehensive test: test-gemini-runner.ts
  - Tests settings generation (8 assertions)
  - Tests stdin streaming with multiple writes (3 assertions)
  - Tests result message coercion (3 assertions)
  - Tests single-turn mode for all 4 Gemini models (12 assertions)
  - Tests getLastAssistantMessage() API (2 assertions)
  - Total: 28 assertions, all passing

Documentation:
- Update packages/gemini-runner/CLAUDE.md
  - Add TypeScript coding principles (avoid type assertions)
  - Update test documentation to reflect single comprehensive test
  - Document critical behaviors (delta accumulation format, result coercion timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* feat: emit error result messages instead of only throwing

When Gemini CLI exits with a non-zero code, GeminiRunner now emits an
SDKResultMessage with subtype 'error_during_execution' before emitting
the error event. This maintains consistent message flow and ensures
EdgeWorker receives error information in the expected format.

Changes:
- Import SDKResultMessage type
- Construct error result message in catch block
- Emit error result before emitting error event
- Error result includes: duration, error message in errors array, usage stats

This ensures agents can track all session outcomes uniformly, whether
successful or failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: correct settings.json format for Gemini CLI aliases

Updated settingsGenerator to use the correct Gemini CLI alias format
with modelConfig wrapper. Fixed test assertions to check maxSessionTurns
at the correct path (modelConfig.maxSessionTurns).

Changes:
- Alias format: { modelConfig: { model: "base-model", maxSessionTurns: 1 } }
- Updated test to check alias.modelConfig?.maxSessionTurns
- Verified gemini-3-pro-preview base model exists and works

Note: Gemini CLI currently does not resolve aliases - it passes the alias
name directly to the API. This is a Gemini CLI limitation, not a configuration
issue. Base models work correctly when called directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: implement proper Gemini single-turn mode using settings.json backup/restore

- Replace invalid per-alias maxSessionTurns approach with proper top-level configuration
- GeminiRunner now backs up existing ~/.gemini/settings.json before sessions
- Temporarily writes settings with maxSessionTurns=1 (single-turn) or -1 (multi-turn)
- Restores original settings after session completes or on error
- Add singleTurn boolean flag to GeminiRunnerConfig
- Cleanup runs in finally block and stop() method for all exit paths
- Document uuithub.com proxy tip in CLAUDE.md for GitHub source navigation
- Add comprehensive test script for backup/restore mechanism

Investigation revealed that Gemini CLI's maxSessionTurns is a global top-level
setting under 'model', not a per-alias configuration. Aliases can only configure
generateContentConfig parameters (temperature, topP, etc). Complete findings
documented in GEMINI_CLI_FINDINGS.md.

Ref: CYPACK-415

* feat: add Gemini session ID support for multi-runner session resumption (#548)

* feat: add Gemini session ID support for multi-runner session resumption

Update CyrusAgentSession to track both claudeSessionId and geminiSessionId,
enabling proper session resumption based on the active runner type. The system
now automatically detects which runner (Claude or Gemini) was used for a session
and selects the appropriate runner when resuming.

Changes:
- Add geminiSessionId field to CyrusAgentSession and CyrusAgentSessionEntry types
- Update EdgeWorker resume logic to check both session IDs and select correct runner
- Modify AgentSessionManager to set appropriate session ID based on runner type
- Update ProcedureRouter to track both session IDs in subroutine history
- Import ClaudeRunner class for instantiation in EdgeWorker

Closes CYPACK-418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: ensure runner type consistency and GeminiRunner compatibility

- Made ProcedureRouter runner-agnostic by supporting both Claude and Gemini simple runners via configuration
- Changed default runner to Gemini for both ProcedureRouter and main issue processing
- Fixed GeminiRunner compatibility by replacing Claude-specific isStreaming() calls with common isRunning() method
- Session resumption now correctly selects runner type based on existing session IDs (Claude vs Gemini)

Resolves CYPACK-418

* feat: add detailed logging for GeminiRunner stdin/stdout debugging

- Log initial streaming prompt being written to stdin with character count and preview
- Log addStreamMessage writes to stdin with character count and preview
- Log detailed stream event data (first 200 chars of JSON)
- Add logging for stdin availability checks

This will help diagnose why GeminiRunner completes immediately without processing the full prompt.

* fix: ensure runner type consistency and GeminiRunner compatibility

- Fixed GeminiRunner to use positional arguments instead of deprecated --prompt flag
- Updated ProcedureRouter to use runner-specific model defaults (haiku/sonnet for Claude, gemini-2.5-flash-lite/gemini-2.0-flash-exp for Gemini)
- This resolves the deprecation warning and ensures correct model selection for each runner type

* fix: add system prompt support to GeminiRunner

The Gemini CLI doesn't have a --system-prompt flag like Claude does, so we need to prepend the system prompt to the user prompt manually.

This fixes the SimpleGeminiRunner classification issue where it was responding with conversational text instead of choosing from the enumerated options because it wasn't receiving the system prompt that constrains responses.

Changes:
- Prepend systemPrompt to user prompt in string mode (positional argument)
- Prepend systemPrompt to streaming initial prompt (stdin mode)
- Add logging to show when systemPrompt is being used

* docs: update CHANGELOG with all CYPACK-418 fixes

Added entries for:
- System prompt support in GeminiRunner
- Deprecated --prompt flag fix
- Runner-specific model defaults in ProcedureRouter

* fix: refactor GeminiRunner system prompt to use GEMINI_SYSTEM_MD env var (#549)

* Add Gemini system prompt

* fix: refactor GeminiRunner system prompt to use GEMINI_SYSTEM_MD env var

Refactored GeminiRunner to comply with Gemini CLI's expected system prompt
input format. Instead of prepending system prompts to user prompts, system
prompts are now written to disk and referenced via the GEMINI_SYSTEM_MD
environment variable.

Changes:
- Created SystemPromptManager class to handle writing system prompts to
  ~/.cyrus/gemini-system-prompt.md
- Updated GeminiRunner to use SystemPromptManager and set GEMINI_SYSTEM_MD
  environment variable when spawning Gemini CLI process
- Added support for both systemPrompt and appendSystemPrompt config fields
- Removed old approach of prepending system prompts to user prompts
- Exported SystemPromptManager from package index

This aligns with Gemini CLI documentation requirements for system prompt
handling via file-based configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: make SystemPromptManager workspace-aware for parallel execution

Updated SystemPromptManager to use workspace-specific file paths instead
of a single shared file, enabling parallel execution of multiple issues
with different system prompts without race conditions.

Changes:
- Modified SystemPromptManager constructor to accept workspaceName parameter
- System prompts now written to ~/.cyrus/gemini-system-prompts/<workspace>.md
- Each workspace gets its own system prompt file for isolation
- Updated GeminiRunner to pass workspaceName to SystemPromptManager

This prevents conflicts when multiple Gemini sessions run simultaneously
with different system prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: write system prompt at last moment before spawning Gemini process

Moved system prompt file writing to occur immediately before spawning the
Gemini CLI process, minimizing the window where files could be stale or
overwritten in parallel execution scenarios.

Changes:
- Moved prepareSystemPrompt() call from early initialization to just before
  spawn() call
- System prompt is now written to disk as the last step before process launch
- Ensures freshest possible system prompt content for each session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Fix system prompt creation and handling for gemini-runner.

* Fix SimpleGeminiRunner, so that it uses the 'appendSystemPrompt' instead of 'systemPrompt'. Remove 'systemPrompt' entirely from 'AgentRunnerConfig'.

* Increase timeout for simpleAgentRunner

* Add a bunch of hacks to get Gemini to work

* Enable sandbox mode by default

* Add base repository path to 'allowedDirectories' as it is needed for Gemini sandbox mode

* Add the 'allowedDirectories' to the Gemini runner

* Change default model to gemini-2.5-pro. Cleanup argument passing to gemini runner.

* feat(formatters): move formatTools logic into ClaudeRunner (#553)

- Created IMessageFormatter interface in core package
- Implemented ClaudeMessageFormatter in claude-runner package
- Added getFormatter() method to IAgentRunner interface
- Updated ClaudeRunner and GeminiRunner to provide formatters
- Refactored AgentSessionManager to use runner's formatter
- Updated tests to test formatter directly instead of private methods
- All 25 tool formatting tests passing

Closes CYPACK-423

* feat(gemini-runner): implement GeminiMessageFormatter and Zod schemas for Gemini CLI (#561)

## Summary
- Implements dedicated `GeminiMessageFormatter` class for Gemini CLI tool formatting
- Adds comprehensive Zod schemas for runtime validation of all Gemini stream event types
- Adds detailed Zod schemas for all tool parameters and results
- Installs `@google/gemini-cli-core@0.17.0` as dev dependency for official type reference
- Replaces `any` types with proper `FormatterToolInput` type and type-safe helper functions
- Updates `GeminiRunner` to use the new formatter and Zod validation

## Implementation Details

### GeminiMessageFormatter
- New formatter class implementing `IMessageFormatter` interface
- Handles Gemini-specific tool names: `read_file`, `write_file`, `list_directory`, `search_file_content`, `run_shell_command`, `write_todos`, `replace`
- Type-safe property access using `getString()`, `getNumber()`, `hasProperty()` helpers

### Zod Event Schemas (`schemas.ts`)
- `GeminiInitEventSchema` - session initialization with UUID validation
- `GeminiMessageEventSchema` - user/assistant messages with optional delta streaming
- `GeminiToolUseEventSchema` - tool invocations with parameters
- `GeminiToolResultEventSchema` - tool results with success/error status
- `GeminiErrorEventSchema` - non-fatal error events
- `GeminiResultEventSchema` - session completion with statistics
- Discriminated union schema for type-safe event parsing
- Type guard functions and parsing utilities

### Tool Parameter Schemas
Detailed Zod schemas for all Gemini CLI tool parameters:
- `ReadFileParametersSchema`: `{ file_path: string }`
- `WriteFileParametersSchema`: `{ file_path: string, content: string }`
- `ListDirectoryParametersSchema`: `{ dir_path: string }`
- `SearchFileContentParametersSchema`: `{ pattern: string }`
- `RunShellCommandParametersSchema`: `{ command: string }`
- `WriteTodosParametersSchema`: `{ todos: Array<{ description, status? }> }`
- `ReplaceParametersSchema`: `{ instruction?, file_path?, old_string?, new_string? }`

### Typed Tool Use Events
Schema validation for each specific tool type:
- `ReadFileToolUseEventSchema`, `WriteFileToolUseEventSchema`, etc.
- Each validates both the `tool_name` literal and parameters structure

### Tool Result Schemas
Typed tool results based on `tool_id` prefix:
- `ReadFileToolResultSchema`, `WriteFileToolResultSchema`, etc.
- Type guards: `isReadFileToolResult()`, `isWriteFileToolResult()`, etc.

### FormatterToolInput Type
- Replaces `any` with well-documented `Record<string, unknown>` type
- Helper functions for safe property access: `getString()`, `getNumber()`, `hasProperty()`
- Explicit documentation of known properties from Gemini tools

### Official Type Reference
- Installed `@google/gemini-cli-core@0.17.0` as dev dependency for reference
- Added pinned links (v0.17.0) to official type definitions in schemas.ts
- Documented type reference in CLAUDE.md with verification instructions
- Our Zod schemas provide runtime validation and detailed tool typing that official TS-only types lack

## Test plan
- [x] All 41 formatter tests passing
- [x] All 85 schema tests passing (126 total)
- [x] TypeScript type checking passes
- [x] Linting passes (biome)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

* feat: add label-based runner selection for Linear issues (#555)

* feat: add label-based runner selection for Linear issues

Add functionality to select the runner (Claude vs Gemini) based on Linear issue labels.

- Add determineRunnerFromLabels() method to EdgeWorker
- Support Gemini labels: gemini, gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-3-pro, gemini-3-pro-preview
- Support Claude labels: claude, sonnet, opus
- Default to Claude runner when no runner label is present
- Implement case-insensitive label matching
- Update both resumeAgentSession() and initializeAgentRunner() to use label-based selection
- Integrate model override logic with runner selection
- Add comprehensive test suite with 11 tests covering all scenarios

Closes CYPACK-425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* test: add model override verification to runner selection tests

Add assertions to verify that model overrides are correctly passed to runner configs:
- Verify gemini-2.5-pro label sets model to "gemini-2.5-pro"
- Verify gemini-3-pro label sets model to "gemini-3-pro-preview"
- Verify opus label sets model to "opus"
- Capture runner config in test mocks to enable model verification

This addresses feedback to ensure models are actually being passed through to the runner configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Update the label-based runner matching to be more inclusive (`gemini-3` & `gemini-2.5`)

* refactor: eliminate redundant runner selection calls

Move runner selection logic entirely into buildAgentRunnerConfig() to avoid calling determineRunnerFromLabels() twice. The method now returns both the config and runner type, making it the single source of truth for runner selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* refactor: move fallback model selection into determineRunnerFromLabels

The fallback model logic is directly related to runner selection and should be encapsulated within the determineRunnerFromLabels method. This simplifies buildAgentRunnerConfig and keeps all model selection logic in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: preserve model override from labels when continuing sessions

When continuing an existing session, the code was setting labelsForSelection
to undefined, which caused buildAgentRunnerConfig to lose the model override
from labels. This resulted in sessions switching from label-specified models
(e.g., gemini-3-pro-preview) to default models (e.g., sonnet) on continuation.

Fixed by always passing labels to buildAgentRunnerConfig to preserve model
overrides while still using session IDs to determine runner type continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* docs: update CHANGELOG with PR #555 for CYPACK-425

Replace placeholder XXX with actual PR number 555 for label-based runner selection feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* feat: add validation to prevent cross-runner model overrides

Implements validation in resumeAgentSession to prevent applying model overrides
from labels when the label's runner type doesn't match the session's runner type.

For example, if a Gemini session is running and someone changes the issue label
to 'opus' (Claude model), the system now:
1. Detects the mismatch between label runner type (claude) and actual runner (gemini)
2. Logs a warning about ignoring the cross-runner model override
3. Falls back to repository/default model instead of applying 'opus' to Gemini

Added 3 unit tests to verify the validation logic:
- Detects cross-runner model override scenarios
- Allows same-runner model overrides
- Correctly identifies runner type mismatches

Fixes the edge case identified in senior engineering review where label changes
mid-session could cause incompatible model overrides to be applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: use runner-specific defaults when ignoring cross-runner overrides

Changed the fallback behavior when cross-runner model overrides are detected:
- Claude sessions now fallback to 'sonnet-4.5' instead of repository/global default
- Gemini sessions now fallback to 'gemini-2.5-pro' instead of repository/global default

This ensures consistent behavior aligned with each runner's default model.

Example: If a Gemini session has label changed to 'opus', it now falls back to
'gemini-2.5-pro' instead of potentially using a Claude default model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Remove false CLAUDE.md file

* Use specific model versions for Claude

* Simplify runner and model selection when resuming session

* Update Claude models to use 'sonnet' instead of 'sonnet-4.5' as the latter is not supported. Make the 'ProcedureRunner' use 'haiku' and Claude runner.

* Fix typo

* fix: update test mocks to use AgentRunner interface after CYPACK-419 merge

Merged CYPACK-419 (Gemini system prompt refactoring) into CYPACK-425 and fixed all test failures:

- Updated gemini-runner tests to use new Zod schemas with timestamps and UUIDs
- Changed systemPrompt to appendSystemPrompt in all tests
- Updated result event structure (status instead of response)
- Fixed edge-worker test mocks:
  - Renamed addClaudeRunner → addAgentRunner
  - Renamed hasClaudeRunner → hasAgentRunner
  - Renamed getClaudeRunner → getAgentRunner
  - Renamed resumeClaudeSession → resumeAgentSession
  - Added start() method to runner mocks
  - Updated subroutine checks from maxTurns to singleTurn
- Fixed runner selection tests to account for classifier using Claude
- Updated CHANGELOG.md

All 494 package tests passing, linting clean, types valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* fix: resolve race condition in GeminiRunner error event test

Fixed flaky test that was failing in CI but passing locally. The test had a race condition where it used setImmediate() which didn't provide enough time for the process error handler to be fully set up in CI environments.

Changed from setImmediate() to setTimeout(50ms) to ensure the error handler is registered before emitting the test error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Clean up 'resumeAgentSession' method

* Fix model name typo

* Remove hack where 'SIGTERM' was not being sent to the Gemini runner, as it was previously corrupting the session. However, it appears to be fixed as I am not able to reproduce it.

* fix: properly stop GeminiRunner by closing readline interface

Fixed critical bug where GeminiRunner continued processing events after
stop signal was sent. The readline interface attached to stdout was not
being cleaned up, causing it to continue emitting events from buffered
output even after SIGTERM was sent to the process.

Changes:
- Track readline interface instance in GeminiRunner class
- Close readline interface and remove listeners in stop() method
- Close interface before killing process to prevent race conditions
- Guard against missing close() method for test compatibility

The fix ensures immediate cessation of event processing when stop() is
called, preventing the issue where Linear activity continued to be
posted after the user requested the agent to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Payton Webber <paytonwebber@gmail.com>
Co-authored-by: Claude <noreply@anthropic.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <paytonwebber@gmail.com>

fix(gemini-runner): increase test timeout to fix flaky CI on Node 18.x (#564)

The test "should emit 'error' event on process error" was failing
intermittently in CI on Node 18.x because 50ms wasn't sufficient for
the event loop to register the process error handler before the test
emitted the error.

Increased timeout from 50ms to 150ms to ensure reliable test execution
across all Node versions in CI environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude <noreply@anthropic.com>

Fix race condition in subroutine transitions and refactor to event-based architecture (#565)

* Fix race condition in subroutine transitions and refactor to event-based architecture

- Defer result message emission in ClaudeRunner and GeminiRunner until streaming
  loop completes, preventing subroutine transitions from starting before the
  previous runner has fully cleaned up
- Replace anonymous callback pattern with event-based architecture:
  - AgentSessionManager now extends EventEmitter
  - Emits 'subroutineComplete' event instead of calling resumeNextSubroutine callback
  - EdgeWorker subscribes to events after AgentSessionManager construction
- Add handleSubroutineTransition method to EdgeWorker for cleaner separation
- Update all test mocks to include EventEmitter's on() method

Fixes CYPACK-435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Set isRunning=false before emitting result messages in both runners

Ensures code checking isRunning() during result message processing
sees the correct state (not running) in both ClaudeRunner and GeminiRunner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Add supportsStreamingInput flag to IAgentRunner interface

- Add `supportsStreamingInput` boolean property to IAgentRunner interface
- Make streaming methods optional (startStreaming, addStreamMessage, completeStream)
- ClaudeRunner: supportsStreamingInput = true (supports full streaming)
- GeminiRunner: supportsStreamingInput = false (no streaming input support)
- EdgeWorker: Check supportsStreamingInput before calling addStreamMessage()
- Update all test mocks with appropriate supportsStreamingInput values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Use startStreaming() when runner supports streaming input

- EdgeWorker now calls startStreaming() instead of start() when
  runner.supportsStreamingInput is true
- Removed claudeSessionId check from streaming condition in resumeAgentSession
- Updated parent-branch tests to expect startStreaming() calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Add Gemini write_todos tool support to AgentSessionManager

Extended TodoWrite tool handling to also recognize Gemini's write_todos tool:
- Skip creating activity for write_todos results (same as TodoWrite)
- Format write_todos as thought activity (non-ephemeral)
- Fixed emoji unicode escapes in GeminiMessageFormatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Add MCP support for Gemini runner (#566)

* Add MCP support for Gemini runner

Add MCP (Model Context Protocol) server configuration support to the
GeminiRunner, enabling Linear MCP tools and other MCP servers to be
available when using Gemini CLI.

Key changes:
- Add GeminiMcpServerConfig interface for Gemini CLI's MCP format
- Add convertToGeminiMcpConfig() to convert Claude SDK format to Gemini format
- Add loadMcpConfigFromPaths() and autoDetectMcpConfig() for config loading
- Update GeminiRunnerConfig with allowMCPServers/excludeMCPServers options
- Update setupGeminiSettings() to accept MCP servers in settings.json
- Add buildMcpServers() method to GeminiRunner for layered config loading

HTTP-based MCP servers are filtered out since Gemini CLI only supports
stdio (command-based) MCP servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Fix: Support HTTP and SSE transports for MCP servers in Gemini runner

Gemini CLI supports three transport types:
- stdio: command-based (spawns subprocess)
- sse: Server-Sent Events (url-based)
- http: Streamable HTTP (httpUrl-based)

Updated convertToGeminiMcpConfig() to properly map Claude SDK's HTTP
transport (type: "http" with url) to Gemini CLI's httpUrl format.
This enables Linear MCP server support at https://mcp.linear.app/mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Improve SDK server detection in Gemini MCP config conversion

Add explicit detection of SDK MCP server instances (in-process servers)
in convertToGeminiMcpConfig(). These servers have methods like listTools()
and callTool() and cannot be converted to Gemini CLI's transport-based
configuration format.

Previously, SDK server instances like cyrus-tools would fall through to
the generic "no valid transport configuration" warning, which was confusing.
Now they get a specific warning explaining that Gemini CLI only supports
external MCP servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Update settingsGenerator.ts with documentation link

Add documentation link for Gemini CLI configuration.

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <53197664+PaytonWebber@users.noreply.github.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: Payton Webber <53197664+PaytonWebber@users.noreply.github.com>

Update CHANGELOG.md

Merge remote-tracking branch 'origin/main' into cypack-405

Merge main into cypack-405

- Merged latest changes from main branch including v0.2.3 release
- Updated package dependencies to latest versions
- Includes Claude Opus 4.5 support
- All tests passing, types valid, linting clean

Merge remote cypack-405 changes and resolve conflicts

- Merged remote changes including Gemini runner and subroutine improvements
- Resolved conflicts in CHANGELOG, package.json files, and pnpm-lock.yaml
- Updated core package to use claude-agent-sdk v0.1.52 for compatibility
- Combined v0.2.3 release changes with latest Unreleased features
- Maintained Claude Opus 4.5 support and updated dependencies

Delete GEMINI_CLI_FINDINGS.md

Delete packages/gemini-runner/SIMPLE_GEMINI_RUNNER.md

Update CHANGELOG.md for recent changes

Updated changelog to reflect new features, changes, and fixes.

Update CHANGELOG with end-user summary of Gemini runner support

- Simplified Unreleased section to focus on end-user benefits
- Consolidated technical implementation details into clear feature description
- Emphasized ability to choose AI models via Linear issue labels
- Removed internal/technical details not relevant to users

Release v0.2.4

Update README.md

Fix Zod peer dependency mismatch in claude-runner

Fixes CYPACK-478

## Problem
The `mcp__cyrus-tools__linear_agent_session_create` MCP tools were failing with:
`MCP error -32603: keyValidator._parse is not a function`

## Root Cause
- claude-runner was using Zod v4.1.12
- @anthropic-ai/claude-agent-sdk requires Zod v3.24.1 (peer dependency)
- Zod v4 changed internal APIs, breaking SDK compatibility

## Solution
Downgraded claude-runner's Zod dependency from ^4.1.12 to ^3.24.1 to match the SDK's peer dependency requirement.

## Changes
- Updated packages/claude-runner/package.json: zod ^4.1.12 → ^3.24.1
- Added test documenting the issue and verifying compatibility
- Updated pnpm-lock.yaml with new Zod version

## Testing
- All 473 tests passing (35 claude-runner, 5 config-updater, 189 gemini-runner, 209 edge-worker, 35 simple-agent-runner)
- TypeScript compilation clean
- Linting clean
- No regressions in other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Prepare release v0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Add F1 orchestration plan documentation

Create spec/f1 directory with orchestration plan for F1 testing framework.
Documents architecture, data flow, and sub-issue decomposition.

Update orchestration plan with Linear issue identifiers

Add CYPACK-502 through CYPACK-506 issue IDs and Linear URLs to the
orchestration plan for tracking sub-issue progress.