### PR TITLE
Add CLI platform type to EdgeWorkerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added CLI platform mode support to enable in-memory issue tracking for testing and development ([CYPACK-509](https://linear.app/ceedar/issue/CYPACK-509))
+
 ## [0.2.5] - 2025-12-03
 
 ### Fixed

--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -109,7 +109,12 @@ export interface EdgeWorkerConfig {
 	ngrokAuthToken?: string; // Ngrok auth token for tunnel creation
 
 	// Issue tracker platform configuration
-	platform?: "linear"; // Issue tracker platform type (default: "linear")
+	/**
+	 * Issue tracker platform type (default: "linear")
+	 * - "linear": Uses Linear as the issue tracker (default production mode)
+	 * - "cli": Uses an in-memory issue tracker for CLI-based testing and development
+	 */
+	platform?: "linear" | "cli";
 
 	// Linear configuration (global)
 	linearWorkspaceSlug?: string; // Linear workspace URL slug (e.g., "ceedar" from "https://linear.app/ceedar/...")


### PR DESCRIPTION
This foundational change extends EdgeWorkerConfig to support platform: "cli"
alongside the existing "linear" option, enabling in-memory issue tracking for
the F1 testing framework.

Changes:
- Updated platform type from "linear" to "linear" | "cli" in config-types.ts
- Added comprehensive TSDoc explaining both platform modes
- Zero breaking changes to existing Linear platform usage
- Updated CHANGELOG.md

Stack Position: 1 of 6 in Graphite stack (CYPACK-509)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>