### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.58 to support new features including experimental v2 session APIs, configurable built-in tools, and 1M token context beta. See [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details ([CYPACK-516](https://linear.app/ceedar/issue/CYPACK-516))
+
 ## [0.2.5] - 2025-12-03
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.58",
 		"@anthropic-ai/sdk": "^0.71.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.58",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.52",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.58",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@3.25.76)
+        specifier: ^0.1.58
+        version: 0.1.58(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.0(zod@3.25.76)
@@ -173,8 +173,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.58
+        version: 0.1.58(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -312,8 +312,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.52
-        version: 0.1.54(zod@4.1.12)
+        specifier: ^0.1.58
+        version: 0.1.58(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -337,8 +337,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54':
-    resolution: {integrity: sha512-NVdtI63qu+ukIVHvB2Gx4weSlZS8R4l7PiogKg59TlpmzhBI9oZr1hy9MTKf1ujtKwM0m8cqT0odvPVyGuf/+Q==}
+  '@anthropic-ai/claude-agent-sdk@0.1.58':
+    resolution: {integrity: sha512-Gc8YjY734D7qUT4I7eTF/vvu7m2umCKm03OGEZs3fGnqwSzVi0SWfGIkTZn4qLtvEbfojm/qXTRd/9OM2vhi3Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3566,7 +3566,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.58(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3579,7 +3579,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.54(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.58(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.52 to v0.1.58 across three packages:
- `cyrus-claude-runner`
- `cyrus-core`
- `cyrus-simple-agent-runner`

## Changes

### New Features Available (v0.1.53 → v0.1.58)
- **v0.1.58**: Introduced `betas` option to enable experimental features, including `'context-1m-2025-08-07'` for expanded 1M token context support on Sonnet 4/4.5 models
- **v0.1.57**: Added `tools` option allowing developers to specify which built-in tools are available to the agent (allowlists, complete disabling, or preset configurations like `'claude_code'`)
- **v0.1.54**: Introduced experimental v2 session APIs (`unstable_v2_createSession`, `unstable_v2_resumeSession`, `unstable_v2_prompt`) for streamlined multi-turn conversations

See [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for complete details.

## Testing

✅ **All verifications passed:**
- 498 tests passing across 39 test files
- Linting clean (biome check)
- TypeScript type checking passed
- Build successful for all packages

## Notes

`@anthropic-ai/sdk` was already at the latest version (v0.71.0) and did not require updating.

Closes [CYPACK-516](https://linear.app/ceedar/issue/CYPACK-516)