### PR TITLE
[Feature] Implement Codex JSONL Event Schemas

### DIFF
--- a/packages/codex-runner/src/schemas.ts
+++ b/packages/codex-runner/src/schemas.ts
@@ -1,1 +1,538 @@
-// Schemas implementation
+/**
+ * Zod Schemas for Codex CLI JSONL Events
+ *
+ * These schemas provide runtime validation for the OpenAI Codex CLI's JSONL output format.
+ * TypeScript types are derived from these schemas using z.infer<> for type safety.
+ *
+ * The Codex CLI outputs events in JSONL format documenting thread lifecycle, turn processing,
+ * and item execution. This module provides comprehensive schemas for all event and item types.
+ *
+ * Event Types:
+ * - thread.started - Thread initialization with thread_id
+ * - turn.started - Turn processing begins
+ * - turn.completed - Turn processing completes with usage stats
+ * - turn.failed - Turn processing failed with error
+ * - item.started - Item execution begins
+ * - item.updated - Item execution progress update
+ * - item.completed - Item execution completes
+ * - error - Thread-level error
+ *
+ * Item Types:
+ * - agent_message - Final response text from agent
+ * - reasoning - Agent reasoning/thinking summaries
+ * - command_execution - Shell command execution
+ * - file_change - File modification operations
+ * - mcp_tool_call - MCP tool invocations
+ * - web_search - Web search operations
+ * - todo_list - Todo tracking items
+ * - error - Item-level errors
+ */
+
+import { z } from "zod";
+
+// ============================================================================
+// Base Schemas
+// ============================================================================
+
+/**
+ * Usage statistics for token consumption
+ *
+ * Example:
+ * ```json
+ * {"input_tokens":6651,"cached_input_tokens":6144,"output_tokens":39}
+ * ```
+ */
+export const UsageSchema = z.object({
+	input_tokens: z.number().int().nonnegative(),
+	cached_input_tokens: z.number().int().nonnegative().optional(),
+	output_tokens: z.number().int().nonnegative(),
+});
+
+export type Usage = z.infer<typeof UsageSchema>;
+
+/**
+ * Item status enum - tracks execution state
+ */
+export const ItemStatusSchema = z.enum(["in_progress", "completed", "failed"]);
+
+export type ItemStatus = z.infer<typeof ItemStatusSchema>;
+
+// ============================================================================
+// Thread Item Schemas
+// ============================================================================
+
+/**
+ * Base item schema with common fields
+ */
+const BaseItemSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+});
+
+/**
+ * Agent message item - final response text
+ *
+ * Example:
+ * ```json
+ * {"id":"item_2","type":"agent_message","text":"README.md\n\ndone"}
+ * ```
+ */
+export const AgentMessageItemSchema = BaseItemSchema.extend({
+	type: z.literal("agent_message"),
+	text: z.string(),
+});
+
+export type AgentMessageItem = z.infer<typeof AgentMessageItemSchema>;
+
+/**
+ * Reasoning item - agent thinking/reasoning summary
+ *
+ * Example:
+ * ```json
+ * {"id":"item_0","type":"reasoning","text":"**Listing files**"}
+ * ```
+ */
+export const ReasoningItemSchema = BaseItemSchema.extend({
+	type: z.literal("reasoning"),
+	text: z.string(),
+});
+
+export type ReasoningItem = z.infer<typeof ReasoningItemSchema>;
+
+/**
+ * Command execution item - shell command with output and status
+ *
+ * Example:
+ * ```json
+ * {"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"README.md\n","exit_code":0,"status":"completed"}
+ * ```
+ */
+export const CommandExecutionItemSchema = BaseItemSchema.extend({
+	type: z.literal("command_execution"),
+	command: z.string(),
+	aggregated_output: z.string(),
+	exit_code: z.number().int().nullable(),
+	status: ItemStatusSchema,
+});
+
+export type CommandExecutionItem = z.infer<typeof CommandExecutionItemSchema>;
+
+/**
+ * File change item - file modification operation
+ *
+ * Example:
+ * ```json
+ * {"id":"item_3","type":"file_change","file_path":"src/index.ts","change_type":"create","content":"export const hello = 'world';","status":"completed"}
+ * ```
+ */
+export const FileChangeItemSchema = BaseItemSchema.extend({
+	type: z.literal("file_change"),
+	file_path: z.string(),
+	change_type: z.enum(["create", "update", "delete"]),
+	content: z.string().optional(),
+	status: ItemStatusSchema,
+});
+
+export type FileChangeItem = z.infer<typeof FileChangeItemSchema>;
+
+/**
+ * MCP tool call item - Model Context Protocol tool invocation
+ *
+ * Example:
+ * ```json
+ * {"id":"item_4","type":"mcp_tool_call","tool_name":"linear_create_issue","parameters":{"title":"Test"},"result":{"success":true},"status":"completed"}
+ * ```
+ */
+export const McpToolCallItemSchema = BaseItemSchema.extend({
+	type: z.literal("mcp_tool_call"),
+	tool_name: z.string(),
+	parameters: z.record(z.unknown()),
+	result: z.unknown().optional(),
+	status: ItemStatusSchema,
+});
+
+export type McpToolCallItem = z.infer<typeof McpToolCallItemSchema>;
+
+/**
+ * Web search item - web search operation
+ *
+ * Example:
+ * ```json
+ * {"id":"item_5","type":"web_search","query":"TypeScript best practices","results":[{"title":"...","url":"..."}],"status":"completed"}
+ * ```
+ */
+export const WebSearchItemSchema = BaseItemSchema.extend({
+	type: z.literal("web_search"),
+	query: z.string(),
+	results: z.array(z.record(z.unknown())).optional(),
+	status: ItemStatusSchema,
+});
+
+export type WebSearchItem = z.infer<typeof WebSearchItemSchema>;
+
+/**
+ * Todo list item - todo tracking
+ *
+ * Example:
+ * ```json
+ * {"id":"item_6","type":"todo_list","todos":[{"description":"Implement feature","status":"pending"}],"status":"completed"}
+ * ```
+ */
+export const TodoItemSchema = z.object({
+	description: z.string(),
+	status: z.enum(["pending", "in_progress", "completed"]),
+});
+
+export const TodoListItemSchema = BaseItemSchema.extend({
+	type: z.literal("todo_list"),
+	todos: z.array(TodoItemSchema),
+	status: ItemStatusSchema,
+});
+
+export type TodoItem = z.infer<typeof TodoItemSchema>;
+export type TodoListItem = z.infer<typeof TodoListItemSchema>;
+
+/**
+ * Error item - item-level error
+ *
+ * Example:
+ * ```json
+ * {"id":"item_7","type":"error","message":"Command failed with exit code 1"}
+ * ```
+ */
+export const ErrorItemSchema = BaseItemSchema.extend({
+	type: z.literal("error"),
+	message: z.string(),
+});
+
+export type ErrorItem = z.infer<typeof ErrorItemSchema>;
+
+/**
+ * Union type for all thread items
+ */
+export const ThreadItemSchema = z.discriminatedUnion("type", [
+	AgentMessageItemSchema,
+	ReasoningItemSchema,
+	CommandExecutionItemSchema,
+	FileChangeItemSchema,
+	McpToolCallItemSchema,
+	WebSearchItemSchema,
+	TodoListItemSchema,
+	ErrorItemSchema,
+]);
+
+export type ThreadItem = z.infer<typeof ThreadItemSchema>;
+
+// ============================================================================
+// Thread Event Schemas
+// ============================================================================
+
+/**
+ * Thread started event - emitted when thread begins
+ *
+ * Example:
+ * ```json
+ * {"type":"thread.started","thread_id":"019ae047-d040-7891-8d68-5dd42b18474e"}
+ * ```
+ */
+export const ThreadStartedEventSchema = z.object({
+	type: z.literal("thread.started"),
+	thread_id: z.string(),
+});
+
+export type ThreadStartedEvent = z.infer<typeof ThreadStartedEventSchema>;
+
+/**
+ * Turn started event - emitted when turn processing begins
+ *
+ * Example:
+ * ```json
+ * {"type":"turn.started"}
+ * ```
+ */
+export const TurnStartedEventSchema = z.object({
+	type: z.literal("turn.started"),
+});
+
+export type TurnStartedEvent = z.infer<typeof TurnStartedEventSchema>;
+
+/**
+ * Turn completed event - emitted when turn processing completes with usage stats
+ *
+ * Example:
+ * ```json
+ * {"type":"turn.completed","usage":{"input_tokens":6651,"cached_input_tokens":6144,"output_tokens":39}}
+ * ```
+ */
+export const TurnCompletedEventSchema = z.object({
+	type: z.literal("turn.completed"),
+	usage: UsageSchema,
+});
+
+export type TurnCompletedEvent = z.infer<typeof TurnCompletedEventSchema>;
+
+/**
+ * Turn failed event - emitted when turn processing fails
+ *
+ * Example:
+ * ```json
+ * {"type":"turn.failed","error":{"message":"Rate limit exceeded"}}
+ * ```
+ */
+export const TurnFailedEventSchema = z.object({
+	type: z.literal("turn.failed"),
+	error: z.object({
+		message: z.string(),
+	}),
+});
+
+export type TurnFailedEvent = z.infer<typeof TurnFailedEventSchema>;
+
+/**
+ * Item started event - emitted when item execution begins
+ *
+ * Example:
+ * ```json
+ * {"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+ * ```
+ */
+export const ItemStartedEventSchema = z.object({
+	type: z.literal("item.started"),
+	item: ThreadItemSchema,
+});
+
+export type ItemStartedEvent = z.infer<typeof ItemStartedEventSchema>;
+
+/**
+ * Item updated event - emitted when item execution progresses
+ *
+ * Example:
+ * ```json
+ * {"type":"item.updated","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"README.md","exit_code":null,"status":"in_progress"}}
+ * ```
+ */
+export const ItemUpdatedEventSchema = z.object({
+	type: z.literal("item.updated"),
+	item: ThreadItemSchema,
+});
+
+export type ItemUpdatedEvent = z.infer<typeof ItemUpdatedEventSchema>;
+
+/**
+ * Item completed event - emitted when item execution completes
+ *
+ * Example:
+ * ```json
+ * {"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"README.md\n","exit_code":0,"status":"completed"}}
+ * ```
+ */
+export const ItemCompletedEventSchema = z.object({
+	type: z.literal("item.completed"),
+	item: ThreadItemSchema,
+});
+
+export type ItemCompletedEvent = z.infer<typeof ItemCompletedEventSchema>;
+
+/**
+ * Thread error event - emitted when a thread-level error occurs
+ *
+ * Example:
+ * ```json
+ * {"type":"error","message":"Thread execution failed"}
+ * ```
+ */
+export const ThreadErrorEventSchema = z.object({
+	type: z.literal("error"),
+	message: z.string(),
+});
+
+export type ThreadErrorEvent = z.infer<typeof ThreadErrorEventSchema>;
+
+/**
+ * Union type for all thread events
+ */
+export const ThreadEventSchema = z.discriminatedUnion("type", [
+	ThreadStartedEventSchema,
+	TurnStartedEventSchema,
+	TurnCompletedEventSchema,
+	TurnFailedEventSchema,
+	ItemStartedEventSchema,
+	ItemUpdatedEventSchema,
+	ItemCompletedEventSchema,
+	ThreadErrorEventSchema,
+]);
+
+export type ThreadEvent = z.infer<typeof ThreadEventSchema>;
+
+// ============================================================================
+// Parsing Utilities
+// ============================================================================
+
+/**
+ * Safely parse a Codex JSONL event with runtime validation
+ *
+ * @param data - Unknown data to parse (typically from JSON.parse of JSONL line)
+ * @returns Zod safe parse result with parsed event or error details
+ *
+ * @example
+ * ```typescript
+ * const result = safeParseCodexEvent(JSON.parse(line));
+ * if (result.success) {
+ *   console.log('Event type:', result.data.type);
+ * } else {
+ *   console.error('Validation failed:', result.error);
+ * }
+ * ```
+ */
+export function safeParseCodexEvent(data: unknown) {
+	return ThreadEventSchema.safeParse(data);
+}
+
+/**
+ * Parse a Codex JSONL event, throwing on validation failure
+ *
+ * @param data - Unknown data to parse
+ * @returns Parsed and validated ThreadEvent
+ * @throws ZodError if validation fails
+ */
+export function parseCodexEvent(data: unknown): ThreadEvent {
+	return ThreadEventSchema.parse(data);
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+/**
+ * Type guard for thread.started events
+ */
+export function isThreadStartedEvent(
+	event: ThreadEvent,
+): event is ThreadStartedEvent {
+	return event.type === "thread.started";
+}
+
+/**
+ * Type guard for turn.started events
+ */
+export function isTurnStartedEvent(
+	event: ThreadEvent,
+): event is TurnStartedEvent {
+	return event.type === "turn.started";
+}
+
+/**
+ * Type guard for turn.completed events
+ */
+export function isTurnCompletedEvent(
+	event: ThreadEvent,
+): event is TurnCompletedEvent {
+	return event.type === "turn.completed";
+}
+
+/**
+ * Type guard for turn.failed events
+ */
+export function isTurnFailedEvent(
+	event: ThreadEvent,
+): event is TurnFailedEvent {
+	return event.type === "turn.failed";
+}
+
+/**
+ * Type guard for item.started events
+ */
+export function isItemStartedEvent(
+	event: ThreadEvent,
+): event is ItemStartedEvent {
+	return event.type === "item.started";
+}
+
+/**
+ * Type guard for item.updated events
+ */
+export function isItemUpdatedEvent(
+	event: ThreadEvent,
+): event is ItemUpdatedEvent {
+	return event.type === "item.updated";
+}
+
+/**
+ * Type guard for item.completed events
+ */
+export function isItemCompletedEvent(
+	event: ThreadEvent,
+): event is ItemCompletedEvent {
+	return event.type === "item.completed";
+}
+
+/**
+ * Type guard for error events
+ */
+export function isThreadErrorEvent(
+	event: ThreadEvent,
+): event is ThreadErrorEvent {
+	return event.type === "error";
+}
+
+// ============================================================================
+// Item Type Guards
+// ============================================================================
+
+/**
+ * Type guard for agent_message items
+ */
+export function isAgentMessageItem(item: ThreadItem): item is AgentMessageItem {
+	return item.type === "agent_message";
+}
+
+/**
+ * Type guard for reasoning items
+ */
+export function isReasoningItem(item: ThreadItem): item is ReasoningItem {
+	return item.type === "reasoning";
+}
+
+/**
+ * Type guard for command_execution items
+ */
+export function isCommandExecutionItem(
+	item: ThreadItem,
+): item is CommandExecutionItem {
+	return item.type === "command_execution";
+}
+
+/**
+ * Type guard for file_change items
+ */
+export function isFileChangeItem(item: ThreadItem): item is FileChangeItem {
+	return item.type === "file_change";
+}
+
+/**
+ * Type guard for mcp_tool_call items
+ */
+export function isMcpToolCallItem(item: ThreadItem): item is McpToolCallItem {
+	return item.type === "mcp_tool_call";
+}
+
+/**
+ * Type guard for web_search items
+ */
+export function isWebSearchItem(item: ThreadItem): item is WebSearchItem {
+	return item.type === "web_search";
+}
+
+/**
+ * Type guard for todo_list items
+ */
+export function isTodoListItem(item: ThreadItem): item is TodoListItem {
+	return item.type === "todo_list";
+}
+
+/**
+ * Type guard for error items
+ */
+export function isErrorItem(item: ThreadItem): item is ErrorItem {
+	return item.type === "error";
+}

--- a/packages/codex-runner/test/schemas.test.ts
+++ b/packages/codex-runner/test/schemas.test.ts
@@ -1,5 +1,1058 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import {
+	AgentMessageItemSchema,
+	CommandExecutionItemSchema,
+	ErrorItemSchema,
+	FileChangeItemSchema,
+	ItemCompletedEventSchema,
+	ItemStartedEventSchema,
+	ItemStatusSchema,
+	ItemUpdatedEventSchema,
+	// Item type guards
+	isAgentMessageItem,
+	isCommandExecutionItem,
+	isErrorItem,
+	isFileChangeItem,
+	isItemCompletedEvent,
+	isItemStartedEvent,
+	isItemUpdatedEvent,
+	isMcpToolCallItem,
+	isReasoningItem,
+	isThreadErrorEvent,
+	// Event type guards
+	isThreadStartedEvent,
+	isTodoListItem,
+	isTurnCompletedEvent,
+	isTurnFailedEvent,
+	isTurnStartedEvent,
+	isWebSearchItem,
+	McpToolCallItemSchema,
+	parseCodexEvent,
+	ReasoningItemSchema,
+	// Parsing utilities
+	safeParseCodexEvent,
+	ThreadErrorEventSchema,
+	ThreadEventSchema,
+	ThreadItemSchema,
+	ThreadStartedEventSchema,
+	TodoListItemSchema,
+	TurnCompletedEventSchema,
+	TurnFailedEventSchema,
+	TurnStartedEventSchema,
+	// Schemas
+	UsageSchema,
+	WebSearchItemSchema,
+} from "../src/schemas.js";
 
-describe("Schemas", () => {
-	it.todo("should be implemented");
+describe("Codex Event Schemas", () => {
+	describe("UsageSchema", () => {
+		it("should validate valid usage with all fields", () => {
+			const usage = {
+				input_tokens: 6651,
+				cached_input_tokens: 6144,
+				output_tokens: 39,
+			};
+
+			const result = UsageSchema.parse(usage);
+			expect(result.input_tokens).toBe(6651);
+			expect(result.cached_input_tokens).toBe(6144);
+			expect(result.output_tokens).toBe(39);
+		});
+
+		it("should validate usage without cached_input_tokens", () => {
+			const usage = {
+				input_tokens: 1000,
+				output_tokens: 50,
+			};
+
+			const result = UsageSchema.parse(usage);
+			expect(result.input_tokens).toBe(1000);
+			expect(result.output_tokens).toBe(50);
+			expect(result.cached_input_tokens).toBeUndefined();
+		});
+
+		it("should reject negative token counts", () => {
+			const usage = {
+				input_tokens: -100,
+				output_tokens: 50,
+			};
+
+			expect(() => UsageSchema.parse(usage)).toThrow(ZodError);
+		});
+
+		it("should reject non-integer token counts", () => {
+			const usage = {
+				input_tokens: 100.5,
+				output_tokens: 50,
+			};
+
+			expect(() => UsageSchema.parse(usage)).toThrow(ZodError);
+		});
+	});
+
+	describe("ItemStatusSchema", () => {
+		it("should validate all status values", () => {
+			expect(ItemStatusSchema.parse("in_progress")).toBe("in_progress");
+			expect(ItemStatusSchema.parse("completed")).toBe("completed");
+			expect(ItemStatusSchema.parse("failed")).toBe("failed");
+		});
+
+		it("should reject invalid status", () => {
+			expect(() => ItemStatusSchema.parse("invalid")).toThrow(ZodError);
+		});
+	});
+
+	describe("ThreadStartedEventSchema", () => {
+		it("should validate valid thread.started event", () => {
+			const event = {
+				type: "thread.started",
+				thread_id: "019ae047-d040-7891-8d68-5dd42b18474e",
+			};
+
+			const result = ThreadStartedEventSchema.parse(event);
+			expect(result.type).toBe("thread.started");
+			expect(result.thread_id).toBe("019ae047-d040-7891-8d68-5dd42b18474e");
+		});
+
+		it("should reject missing thread_id", () => {
+			const event = {
+				type: "thread.started",
+			};
+
+			expect(() => ThreadStartedEventSchema.parse(event)).toThrow(ZodError);
+		});
+
+		it("should reject wrong type", () => {
+			const event = {
+				type: "thread.stopped",
+				thread_id: "019ae047-d040-7891-8d68-5dd42b18474e",
+			};
+
+			expect(() => ThreadStartedEventSchema.parse(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("TurnStartedEventSchema", () => {
+		it("should validate valid turn.started event", () => {
+			const event = {
+				type: "turn.started",
+			};
+
+			const result = TurnStartedEventSchema.parse(event);
+			expect(result.type).toBe("turn.started");
+		});
+
+		it("should reject wrong type", () => {
+			const event = {
+				type: "turn.completed",
+			};
+
+			expect(() => TurnStartedEventSchema.parse(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("TurnCompletedEventSchema", () => {
+		it("should validate valid turn.completed event", () => {
+			const event = {
+				type: "turn.completed",
+				usage: {
+					input_tokens: 6651,
+					cached_input_tokens: 6144,
+					output_tokens: 39,
+				},
+			};
+
+			const result = TurnCompletedEventSchema.parse(event);
+			expect(result.type).toBe("turn.completed");
+			expect(result.usage.input_tokens).toBe(6651);
+			expect(result.usage.output_tokens).toBe(39);
+		});
+
+		it("should reject missing usage", () => {
+			const event = {
+				type: "turn.completed",
+			};
+
+			expect(() => TurnCompletedEventSchema.parse(event)).toThrow(ZodError);
+		});
+
+		it("should reject invalid usage", () => {
+			const event = {
+				type: "turn.completed",
+				usage: {
+					input_tokens: "invalid",
+					output_tokens: 39,
+				},
+			};
+
+			expect(() => TurnCompletedEventSchema.parse(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("TurnFailedEventSchema", () => {
+		it("should validate valid turn.failed event", () => {
+			const event = {
+				type: "turn.failed",
+				error: {
+					message: "Rate limit exceeded",
+				},
+			};
+
+			const result = TurnFailedEventSchema.parse(event);
+			expect(result.type).toBe("turn.failed");
+			expect(result.error.message).toBe("Rate limit exceeded");
+		});
+
+		it("should reject missing error", () => {
+			const event = {
+				type: "turn.failed",
+			};
+
+			expect(() => TurnFailedEventSchema.parse(event)).toThrow(ZodError);
+		});
+
+		it("should reject error without message", () => {
+			const event = {
+				type: "turn.failed",
+				error: {},
+			};
+
+			expect(() => TurnFailedEventSchema.parse(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("AgentMessageItemSchema", () => {
+		it("should validate valid agent_message item", () => {
+			const item = {
+				id: "item_2",
+				type: "agent_message",
+				text: "README.md\n\ndone",
+			};
+
+			const result = AgentMessageItemSchema.parse(item);
+			expect(result.type).toBe("agent_message");
+			expect(result.text).toBe("README.md\n\ndone");
+		});
+
+		it("should reject missing text", () => {
+			const item = {
+				id: "item_2",
+				type: "agent_message",
+			};
+
+			expect(() => AgentMessageItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("ReasoningItemSchema", () => {
+		it("should validate valid reasoning item", () => {
+			const item = {
+				id: "item_0",
+				type: "reasoning",
+				text: "**Listing files**",
+			};
+
+			const result = ReasoningItemSchema.parse(item);
+			expect(result.type).toBe("reasoning");
+			expect(result.text).toBe("**Listing files**");
+		});
+	});
+
+	describe("CommandExecutionItemSchema", () => {
+		it("should validate valid command_execution item in progress", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "/bin/zsh -lc ls",
+				aggregated_output: "",
+				exit_code: null,
+				status: "in_progress",
+			};
+
+			const result = CommandExecutionItemSchema.parse(item);
+			expect(result.type).toBe("command_execution");
+			expect(result.command).toBe("/bin/zsh -lc ls");
+			expect(result.exit_code).toBeNull();
+			expect(result.status).toBe("in_progress");
+		});
+
+		it("should validate valid command_execution item completed", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "/bin/zsh -lc ls",
+				aggregated_output: "README.md\n",
+				exit_code: 0,
+				status: "completed",
+			};
+
+			const result = CommandExecutionItemSchema.parse(item);
+			expect(result.exit_code).toBe(0);
+			expect(result.status).toBe("completed");
+			expect(result.aggregated_output).toBe("README.md\n");
+		});
+
+		it("should validate command with non-zero exit code", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "/bin/zsh -lc 'exit 1'",
+				aggregated_output: "Error message\n",
+				exit_code: 1,
+				status: "failed",
+			};
+
+			const result = CommandExecutionItemSchema.parse(item);
+			expect(result.exit_code).toBe(1);
+			expect(result.status).toBe("failed");
+		});
+
+		it("should reject missing required fields", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "/bin/zsh -lc ls",
+			};
+
+			expect(() => CommandExecutionItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("FileChangeItemSchema", () => {
+		it("should validate create file change", () => {
+			const item = {
+				id: "item_3",
+				type: "file_change",
+				file_path: "src/index.ts",
+				change_type: "create",
+				content: "export const hello = 'world';",
+				status: "completed",
+			};
+
+			const result = FileChangeItemSchema.parse(item);
+			expect(result.change_type).toBe("create");
+			expect(result.file_path).toBe("src/index.ts");
+			expect(result.content).toBe("export const hello = 'world';");
+		});
+
+		it("should validate update file change", () => {
+			const item = {
+				id: "item_4",
+				type: "file_change",
+				file_path: "src/index.ts",
+				change_type: "update",
+				content: "export const hello = 'updated';",
+				status: "completed",
+			};
+
+			const result = FileChangeItemSchema.parse(item);
+			expect(result.change_type).toBe("update");
+		});
+
+		it("should validate delete file change without content", () => {
+			const item = {
+				id: "item_5",
+				type: "file_change",
+				file_path: "src/old.ts",
+				change_type: "delete",
+				status: "completed",
+			};
+
+			const result = FileChangeItemSchema.parse(item);
+			expect(result.change_type).toBe("delete");
+			expect(result.content).toBeUndefined();
+		});
+
+		it("should reject invalid change_type", () => {
+			const item = {
+				id: "item_3",
+				type: "file_change",
+				file_path: "src/index.ts",
+				change_type: "modify",
+				status: "completed",
+			};
+
+			expect(() => FileChangeItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("McpToolCallItemSchema", () => {
+		it("should validate valid mcp_tool_call item", () => {
+			const item = {
+				id: "item_4",
+				type: "mcp_tool_call",
+				tool_name: "linear_create_issue",
+				parameters: { title: "Test Issue", description: "Test" },
+				result: { success: true, issue_id: "ABC-123" },
+				status: "completed",
+			};
+
+			const result = McpToolCallItemSchema.parse(item);
+			expect(result.tool_name).toBe("linear_create_issue");
+			expect(result.parameters).toEqual({
+				title: "Test Issue",
+				description: "Test",
+			});
+			expect(result.result).toEqual({ success: true, issue_id: "ABC-123" });
+		});
+
+		it("should validate mcp_tool_call without result", () => {
+			const item = {
+				id: "item_4",
+				type: "mcp_tool_call",
+				tool_name: "linear_create_issue",
+				parameters: { title: "Test" },
+				status: "in_progress",
+			};
+
+			const result = McpToolCallItemSchema.parse(item);
+			expect(result.result).toBeUndefined();
+		});
+
+		it("should reject empty parameters", () => {
+			const item = {
+				id: "item_4",
+				type: "mcp_tool_call",
+				tool_name: "linear_create_issue",
+				status: "completed",
+			};
+
+			expect(() => McpToolCallItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("WebSearchItemSchema", () => {
+		it("should validate valid web_search item with results", () => {
+			const item = {
+				id: "item_5",
+				type: "web_search",
+				query: "TypeScript best practices",
+				results: [
+					{ title: "TS Handbook", url: "https://example.com/handbook" },
+					{ title: "TS Guide", url: "https://example.com/guide" },
+				],
+				status: "completed",
+			};
+
+			const result = WebSearchItemSchema.parse(item);
+			expect(result.query).toBe("TypeScript best practices");
+			expect(result.results).toHaveLength(2);
+		});
+
+		it("should validate web_search without results", () => {
+			const item = {
+				id: "item_5",
+				type: "web_search",
+				query: "TypeScript best practices",
+				status: "in_progress",
+			};
+
+			const result = WebSearchItemSchema.parse(item);
+			expect(result.results).toBeUndefined();
+		});
+	});
+
+	describe("TodoListItemSchema", () => {
+		it("should validate valid todo_list item", () => {
+			const item = {
+				id: "item_6",
+				type: "todo_list",
+				todos: [
+					{ description: "Implement feature", status: "pending" },
+					{ description: "Write tests", status: "in_progress" },
+					{ description: "Deploy", status: "completed" },
+				],
+				status: "completed",
+			};
+
+			const result = TodoListItemSchema.parse(item);
+			expect(result.todos).toHaveLength(3);
+			expect(result.todos[0].description).toBe("Implement feature");
+			expect(result.todos[1].status).toBe("in_progress");
+		});
+
+		it("should reject invalid todo status", () => {
+			const item = {
+				id: "item_6",
+				type: "todo_list",
+				todos: [{ description: "Task", status: "invalid" }],
+				status: "completed",
+			};
+
+			expect(() => TodoListItemSchema.parse(item)).toThrow(ZodError);
+		});
+
+		it("should reject empty todos array", () => {
+			const item = {
+				id: "item_6",
+				type: "todo_list",
+				status: "completed",
+			};
+
+			expect(() => TodoListItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("ErrorItemSchema", () => {
+		it("should validate valid error item", () => {
+			const item = {
+				id: "item_7",
+				type: "error",
+				message: "Command failed with exit code 1",
+			};
+
+			const result = ErrorItemSchema.parse(item);
+			expect(result.type).toBe("error");
+			expect(result.message).toBe("Command failed with exit code 1");
+		});
+	});
+
+	describe("ThreadItemSchema (discriminated union)", () => {
+		it("should parse all item types correctly", () => {
+			const items = [
+				{
+					id: "item_1",
+					type: "agent_message",
+					text: "Done",
+				},
+				{
+					id: "item_2",
+					type: "reasoning",
+					text: "Thinking...",
+				},
+				{
+					id: "item_3",
+					type: "command_execution",
+					command: "ls",
+					aggregated_output: "",
+					exit_code: null,
+					status: "in_progress",
+				},
+				{
+					id: "item_4",
+					type: "file_change",
+					file_path: "test.ts",
+					change_type: "create",
+					status: "completed",
+				},
+				{
+					id: "item_5",
+					type: "mcp_tool_call",
+					tool_name: "test",
+					parameters: {},
+					status: "completed",
+				},
+				{
+					id: "item_6",
+					type: "web_search",
+					query: "test",
+					status: "completed",
+				},
+				{
+					id: "item_7",
+					type: "todo_list",
+					todos: [{ description: "test", status: "pending" }],
+					status: "completed",
+				},
+				{
+					id: "item_8",
+					type: "error",
+					message: "Failed",
+				},
+			];
+
+			for (const item of items) {
+				const result = ThreadItemSchema.parse(item);
+				expect(result.type).toBe(item.type);
+			}
+		});
+
+		it("should reject unknown item type", () => {
+			const item = {
+				id: "item_1",
+				type: "unknown_type",
+			};
+
+			expect(() => ThreadItemSchema.parse(item)).toThrow(ZodError);
+		});
+	});
+
+	describe("ItemStartedEventSchema", () => {
+		it("should validate valid item.started event", () => {
+			const event = {
+				type: "item.started",
+				item: {
+					id: "item_1",
+					type: "command_execution",
+					command: "/bin/zsh -lc ls",
+					aggregated_output: "",
+					exit_code: null,
+					status: "in_progress",
+				},
+			};
+
+			const result = ItemStartedEventSchema.parse(event);
+			expect(result.type).toBe("item.started");
+			expect(result.item.type).toBe("command_execution");
+		});
+	});
+
+	describe("ItemUpdatedEventSchema", () => {
+		it("should validate valid item.updated event", () => {
+			const event = {
+				type: "item.updated",
+				item: {
+					id: "item_1",
+					type: "command_execution",
+					command: "/bin/zsh -lc ls",
+					aggregated_output: "README.md",
+					exit_code: null,
+					status: "in_progress",
+				},
+			};
+
+			const result = ItemUpdatedEventSchema.parse(event);
+			expect(result.type).toBe("item.updated");
+			expect(result.item.type).toBe("command_execution");
+		});
+	});
+
+	describe("ItemCompletedEventSchema", () => {
+		it("should validate valid item.completed event", () => {
+			const event = {
+				type: "item.completed",
+				item: {
+					id: "item_0",
+					type: "reasoning",
+					text: "**Listing files**",
+				},
+			};
+
+			const result = ItemCompletedEventSchema.parse(event);
+			expect(result.type).toBe("item.completed");
+			expect(result.item.type).toBe("reasoning");
+		});
+	});
+
+	describe("ThreadErrorEventSchema", () => {
+		it("should validate valid error event", () => {
+			const event = {
+				type: "error",
+				message: "Thread execution failed",
+			};
+
+			const result = ThreadErrorEventSchema.parse(event);
+			expect(result.type).toBe("error");
+			expect(result.message).toBe("Thread execution failed");
+		});
+	});
+
+	describe("ThreadEventSchema (discriminated union)", () => {
+		it("should parse all event types correctly", () => {
+			const events = [
+				{
+					type: "thread.started",
+					thread_id: "019ae047-d040-7891-8d68-5dd42b18474e",
+				},
+				{
+					type: "turn.started",
+				},
+				{
+					type: "turn.completed",
+					usage: {
+						input_tokens: 6651,
+						cached_input_tokens: 6144,
+						output_tokens: 39,
+					},
+				},
+				{
+					type: "turn.failed",
+					error: { message: "Failed" },
+				},
+				{
+					type: "item.started",
+					item: {
+						id: "item_0",
+						type: "reasoning",
+						text: "Thinking",
+					},
+				},
+				{
+					type: "item.updated",
+					item: {
+						id: "item_0",
+						type: "reasoning",
+						text: "Still thinking",
+					},
+				},
+				{
+					type: "item.completed",
+					item: {
+						id: "item_0",
+						type: "reasoning",
+						text: "Done thinking",
+					},
+				},
+				{
+					type: "error",
+					message: "Error occurred",
+				},
+			];
+
+			for (const event of events) {
+				const result = ThreadEventSchema.parse(event);
+				expect(result.type).toBe(event.type);
+			}
+		});
+
+		it("should reject unknown event type", () => {
+			const event = {
+				type: "unknown.event",
+			};
+
+			expect(() => ThreadEventSchema.parse(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("safeParseCodexEvent", () => {
+		it("should return success for valid event", () => {
+			const event = {
+				type: "thread.started",
+				thread_id: "019ae047-d040-7891-8d68-5dd42b18474e",
+			};
+
+			const result = safeParseCodexEvent(event);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.type).toBe("thread.started");
+			}
+		});
+
+		it("should return error for invalid event", () => {
+			const event = {
+				type: "invalid.event",
+			};
+
+			const result = safeParseCodexEvent(event);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error).toBeInstanceOf(ZodError);
+			}
+		});
+
+		it("should handle null and undefined", () => {
+			expect(safeParseCodexEvent(null).success).toBe(false);
+			expect(safeParseCodexEvent(undefined).success).toBe(false);
+		});
+	});
+
+	describe("parseCodexEvent", () => {
+		it("should parse valid event", () => {
+			const event = {
+				type: "turn.started",
+			};
+
+			const result = parseCodexEvent(event);
+			expect(result.type).toBe("turn.started");
+		});
+
+		it("should throw for invalid event", () => {
+			const event = {
+				type: "invalid",
+			};
+
+			expect(() => parseCodexEvent(event)).toThrow(ZodError);
+		});
+	});
+
+	describe("Event Type Guards", () => {
+		const threadStartedEvent = {
+			type: "thread.started" as const,
+			thread_id: "test-id",
+		};
+		const turnStartedEvent = { type: "turn.started" as const };
+		const turnCompletedEvent = {
+			type: "turn.completed" as const,
+			usage: { input_tokens: 100, output_tokens: 50 },
+		};
+		const turnFailedEvent = {
+			type: "turn.failed" as const,
+			error: { message: "Failed" },
+		};
+		const itemStartedEvent = {
+			type: "item.started" as const,
+			item: { id: "item_1", type: "reasoning" as const, text: "Test" },
+		};
+		const itemUpdatedEvent = {
+			type: "item.updated" as const,
+			item: { id: "item_1", type: "reasoning" as const, text: "Test" },
+		};
+		const itemCompletedEvent = {
+			type: "item.completed" as const,
+			item: { id: "item_1", type: "reasoning" as const, text: "Test" },
+		};
+		const errorEvent = { type: "error" as const, message: "Error" };
+
+		it("isThreadStartedEvent should identify thread.started events", () => {
+			expect(isThreadStartedEvent(threadStartedEvent)).toBe(true);
+			expect(isThreadStartedEvent(turnStartedEvent)).toBe(false);
+		});
+
+		it("isTurnStartedEvent should identify turn.started events", () => {
+			expect(isTurnStartedEvent(turnStartedEvent)).toBe(true);
+			expect(isTurnStartedEvent(turnCompletedEvent)).toBe(false);
+		});
+
+		it("isTurnCompletedEvent should identify turn.completed events", () => {
+			expect(isTurnCompletedEvent(turnCompletedEvent)).toBe(true);
+			expect(isTurnCompletedEvent(turnFailedEvent)).toBe(false);
+		});
+
+		it("isTurnFailedEvent should identify turn.failed events", () => {
+			expect(isTurnFailedEvent(turnFailedEvent)).toBe(true);
+			expect(isTurnFailedEvent(turnCompletedEvent)).toBe(false);
+		});
+
+		it("isItemStartedEvent should identify item.started events", () => {
+			expect(isItemStartedEvent(itemStartedEvent)).toBe(true);
+			expect(isItemStartedEvent(itemUpdatedEvent)).toBe(false);
+		});
+
+		it("isItemUpdatedEvent should identify item.updated events", () => {
+			expect(isItemUpdatedEvent(itemUpdatedEvent)).toBe(true);
+			expect(isItemUpdatedEvent(itemCompletedEvent)).toBe(false);
+		});
+
+		it("isItemCompletedEvent should identify item.completed events", () => {
+			expect(isItemCompletedEvent(itemCompletedEvent)).toBe(true);
+			expect(isItemCompletedEvent(itemStartedEvent)).toBe(false);
+		});
+
+		it("isThreadErrorEvent should identify error events", () => {
+			expect(isThreadErrorEvent(errorEvent)).toBe(true);
+			expect(isThreadErrorEvent(threadStartedEvent)).toBe(false);
+		});
+	});
+
+	describe("Item Type Guards", () => {
+		const agentMessageItem = {
+			id: "item_1",
+			type: "agent_message" as const,
+			text: "Done",
+		};
+		const reasoningItem = {
+			id: "item_2",
+			type: "reasoning" as const,
+			text: "Thinking",
+		};
+		const commandExecutionItem = {
+			id: "item_3",
+			type: "command_execution" as const,
+			command: "ls",
+			aggregated_output: "",
+			exit_code: null,
+			status: "in_progress" as const,
+		};
+		const fileChangeItem = {
+			id: "item_4",
+			type: "file_change" as const,
+			file_path: "test.ts",
+			change_type: "create" as const,
+			status: "completed" as const,
+		};
+		const mcpToolCallItem = {
+			id: "item_5",
+			type: "mcp_tool_call" as const,
+			tool_name: "test",
+			parameters: {},
+			status: "completed" as const,
+		};
+		const webSearchItem = {
+			id: "item_6",
+			type: "web_search" as const,
+			query: "test",
+			status: "completed" as const,
+		};
+		const todoListItem = {
+			id: "item_7",
+			type: "todo_list" as const,
+			todos: [{ description: "test", status: "pending" as const }],
+			status: "completed" as const,
+		};
+		const errorItem = {
+			id: "item_8",
+			type: "error" as const,
+			message: "Failed",
+		};
+
+		it("isAgentMessageItem should identify agent_message items", () => {
+			expect(isAgentMessageItem(agentMessageItem)).toBe(true);
+			expect(isAgentMessageItem(reasoningItem)).toBe(false);
+		});
+
+		it("isReasoningItem should identify reasoning items", () => {
+			expect(isReasoningItem(reasoningItem)).toBe(true);
+			expect(isReasoningItem(agentMessageItem)).toBe(false);
+		});
+
+		it("isCommandExecutionItem should identify command_execution items", () => {
+			expect(isCommandExecutionItem(commandExecutionItem)).toBe(true);
+			expect(isCommandExecutionItem(fileChangeItem)).toBe(false);
+		});
+
+		it("isFileChangeItem should identify file_change items", () => {
+			expect(isFileChangeItem(fileChangeItem)).toBe(true);
+			expect(isFileChangeItem(commandExecutionItem)).toBe(false);
+		});
+
+		it("isMcpToolCallItem should identify mcp_tool_call items", () => {
+			expect(isMcpToolCallItem(mcpToolCallItem)).toBe(true);
+			expect(isMcpToolCallItem(webSearchItem)).toBe(false);
+		});
+
+		it("isWebSearchItem should identify web_search items", () => {
+			expect(isWebSearchItem(webSearchItem)).toBe(true);
+			expect(isWebSearchItem(mcpToolCallItem)).toBe(false);
+		});
+
+		it("isTodoListItem should identify todo_list items", () => {
+			expect(isTodoListItem(todoListItem)).toBe(true);
+			expect(isTodoListItem(errorItem)).toBe(false);
+		});
+
+		it("isErrorItem should identify error items", () => {
+			expect(isErrorItem(errorItem)).toBe(true);
+			expect(isErrorItem(todoListItem)).toBe(false);
+		});
+	});
+
+	describe("Real-world JSONL sequence", () => {
+		it("should parse complete JSONL sequence from example", () => {
+			const lines = [
+				'{"type":"thread.started","thread_id":"019ae047-d040-7891-8d68-5dd42b18474e"}',
+				'{"type":"turn.started"}',
+				'{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"**Listing files**"}}',
+				'{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"","exit_code":null,"status":"in_progress"}}',
+				'{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"README.md\\n","exit_code":0,"status":"completed"}}',
+				'{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"README.md\\n\\ndone"}}',
+				'{"type":"turn.completed","usage":{"input_tokens":6651,"cached_input_tokens":6144,"output_tokens":39}}',
+			];
+
+			const events = lines.map((line) => JSON.parse(line));
+			const results = events.map((event) => safeParseCodexEvent(event));
+
+			// All should parse successfully
+			expect(results.every((r) => r.success)).toBe(true);
+
+			// Verify specific events
+			const parsedEvents = results.map((r) => (r.success ? r.data : null));
+
+			expect(parsedEvents[0]?.type).toBe("thread.started");
+			expect(parsedEvents[1]?.type).toBe("turn.started");
+			expect(parsedEvents[2]?.type).toBe("item.completed");
+			expect(parsedEvents[3]?.type).toBe("item.started");
+			expect(parsedEvents[4]?.type).toBe("item.completed");
+			expect(parsedEvents[5]?.type).toBe("item.completed");
+			expect(parsedEvents[6]?.type).toBe("turn.completed");
+
+			// Verify thread_id
+			if (parsedEvents[0] && isThreadStartedEvent(parsedEvents[0])) {
+				expect(parsedEvents[0].thread_id).toBe(
+					"019ae047-d040-7891-8d68-5dd42b18474e",
+				);
+			}
+
+			// Verify usage stats
+			if (parsedEvents[6] && isTurnCompletedEvent(parsedEvents[6])) {
+				expect(parsedEvents[6].usage.input_tokens).toBe(6651);
+				expect(parsedEvents[6].usage.cached_input_tokens).toBe(6144);
+				expect(parsedEvents[6].usage.output_tokens).toBe(39);
+			}
+		});
+	});
+
+	describe("Edge cases", () => {
+		it("should handle empty strings in text fields", () => {
+			const item = {
+				id: "item_1",
+				type: "agent_message",
+				text: "",
+			};
+
+			const result = AgentMessageItemSchema.parse(item);
+			expect(result.text).toBe("");
+		});
+
+		it("should handle zero token counts", () => {
+			const usage = {
+				input_tokens: 0,
+				output_tokens: 0,
+			};
+
+			const result = UsageSchema.parse(usage);
+			expect(result.input_tokens).toBe(0);
+			expect(result.output_tokens).toBe(0);
+		});
+
+		it("should handle empty command output", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "true",
+				aggregated_output: "",
+				exit_code: 0,
+				status: "completed",
+			};
+
+			const result = CommandExecutionItemSchema.parse(item);
+			expect(result.aggregated_output).toBe("");
+		});
+
+		it("should handle special characters in strings", () => {
+			const item = {
+				id: "item_1",
+				type: "reasoning",
+				text: "**Special chars**: \n\t\\r\\n 🎉 <>&",
+			};
+
+			const result = ReasoningItemSchema.parse(item);
+			expect(result.text).toContain("🎉");
+		});
+
+		it("should handle large exit codes", () => {
+			const item = {
+				id: "item_1",
+				type: "command_execution",
+				command: "test",
+				aggregated_output: "",
+				exit_code: 255,
+				status: "failed",
+			};
+
+			const result = CommandExecutionItemSchema.parse(item);
+			expect(result.exit_code).toBe(255);
+		});
+
+		it("should handle complex nested MCP parameters", () => {
+			const item = {
+				id: "item_1",
+				type: "mcp_tool_call",
+				tool_name: "complex_tool",
+				parameters: {
+					nested: {
+						deeply: {
+							nested: "value",
+						},
+					},
+					array: [1, 2, 3],
+					mixed: { a: 1, b: "test" },
+				},
+				status: "completed",
+			};
+
+			const result = McpToolCallItemSchema.parse(item);
+			expect(result.parameters).toHaveProperty("nested");
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Implements comprehensive Zod validation schemas for all Codex CLI JSONL event types as specified in CYPACK-523.

## Changes

### Schemas Implemented (src/schemas.ts)
- **Event Schemas (8 types)**: ThreadStartedEvent, TurnStartedEvent, TurnCompletedEvent, TurnFailedEvent, ItemStartedEvent, ItemUpdatedEvent, ItemCompletedEvent, ThreadErrorEvent
- **Item Schemas (8 types)**: AgentMessageItem, ReasoningItem, CommandExecutionItem, FileChangeItem, McpToolCallItem, WebSearchItem, TodoListItem, ErrorItem
- **Base Schemas**: UsageSchema for token consumption tracking, ItemStatusSchema for execution states
- **Union Types**: ThreadEvent (discriminated union of all events), ThreadItem (discriminated union of all items)
- **Validation Functions**: safeParseCodexEvent() for safe parsing, parseCodexEvent() for strict parsing
- **Type Guards**: Complete set of type guards for all event and item types

### Test Coverage (test/schemas.test.ts)
- **73 passing tests** covering:
  - Valid event/item parsing for all types
  - Invalid data rejection
  - Edge cases (empty strings, zero values, special characters, large numbers)
  - Real-world JSONL sequence validation (from issue example)
  - All type guard functions
  - Union type discrimination
  - Error handling with null/undefined

## Implementation Approach

- Followed the same patterns as gemini-runner/src/schemas.ts for consistency
- Used Zod discriminated unions for type-safe event/item parsing
- Comprehensive JSDoc documentation with JSON examples for each schema
- Followed the JSONL event format from the issue description

## Testing Performed

```bash
pnpm test:run   # 73/73 tests passing
pnpm typecheck  # No TypeScript errors
pnpm lint       # Clean (only pre-existing warnings in other packages)
pnpm build      # Successful
```

## Stack Position

This is **PR 2 of 7** in the Graphite stack for the Codex Runner implementation:
- Previous: CYPACK-522 (Package scaffolding)
- Current: CYPACK-523 (Event schemas)
- Next: CYPACK-524 (Stream adapters)

Resolves CYPACK-523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>