### PR TITLE
[CYPACK-524] Implement Codex Event to SDK Message Adapters

### DIFF
--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -17,6 +17,7 @@
 	},
 	"dependencies": {
 		"@iarna/toml": "^3.0.0",
+		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*",
 		"zod": "^3.23.0"
 	},

--- a/packages/codex-runner/src/adapters.ts
+++ b/packages/codex-runner/src/adapters.ts
@@ -1,1 +1,435 @@
-// Adapters implementation
+import crypto from "node:crypto";
+import { cwd } from "node:process";
+import type { SDKSystemMessage } from "cyrus-claude-runner";
+import type {
+	SDKAssistantMessage,
+	SDKMessage,
+	SDKResultMessage,
+	SDKUserMessage,
+} from "cyrus-core";
+import type { ThreadEvent, ThreadItem, Usage } from "./schemas.js";
+import {
+	isAgentMessageItem,
+	isCommandExecutionItem,
+	isErrorItem,
+	isFileChangeItem,
+	isItemCompletedEvent,
+	isMcpToolCallItem,
+	isReasoningItem,
+	isThreadErrorEvent,
+	isThreadStartedEvent,
+	isTurnCompletedEvent,
+	isTurnFailedEvent,
+} from "./schemas.js";
+
+/**
+ * Create a minimal BetaMessage for assistant responses
+ *
+ * Since we're adapting from Codex CLI to Claude SDK format, we create
+ * a minimal valid BetaMessage structure with placeholder values for fields
+ * that Codex doesn't provide (model, usage, etc.).
+ */
+function createBetaMessage(
+	content: string | Array<Record<string, unknown>>,
+	messageId: string = crypto.randomUUID(),
+): SDKAssistantMessage["message"] {
+	// Type assertion needed because we're constructing content blocks from Codex format
+	// which has the same structure but TypeScript can't verify the runtime types
+	const contentBlocks = (typeof content === "string"
+		? [{ type: "text", text: content }]
+		: content) as unknown as SDKAssistantMessage["message"]["content"];
+
+	return {
+		id: messageId,
+		type: "message" as const,
+		role: "assistant" as const,
+		content: contentBlocks,
+		model: "codex" as const,
+		stop_reason: null,
+		stop_sequence: null,
+		usage: {
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation: null,
+			server_tool_use: null,
+			service_tier: null,
+		},
+		container: null,
+		context_management: null,
+	};
+}
+
+/**
+ * Generate a unique tool ID for tool_use blocks
+ *
+ * Codex items have IDs but we need to create tool IDs that follow
+ * Claude's conventions for tool_use/tool_result correlation.
+ *
+ * @param itemId - The Codex item ID (e.g., "item_1")
+ * @returns A tool ID (e.g., "toolu_01abc123...")
+ */
+function generateToolId(itemId: string): string {
+	// Create a deterministic tool ID based on the item ID
+	// This ensures we can correlate tool_use and tool_result events
+	const hash = crypto.createHash("sha256").update(itemId).digest("hex");
+	return `toolu_${hash.substring(0, 22)}`;
+}
+
+/**
+ * Convert a Codex thread item to SDK message content
+ *
+ * Maps different item types to appropriate content blocks for SDK messages.
+ * Tool-related items (command_execution, file_change, mcp_tool_call) are
+ * converted to tool_use content blocks.
+ *
+ * @param item - Codex thread item from item.completed event
+ * @param sessionId - Current session ID
+ * @returns SDKAssistantMessage or null if item type doesn't map to a message
+ */
+export function convertItemToMessage(
+	item: ThreadItem,
+	sessionId: string,
+): SDKAssistantMessage | null {
+	// Agent message - final response text
+	if (isAgentMessageItem(item)) {
+		return {
+			type: "assistant",
+			message: createBetaMessage(item.text, crypto.randomUUID()),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// Reasoning - thinking/reasoning summaries
+	if (isReasoningItem(item)) {
+		return {
+			type: "assistant",
+			message: createBetaMessage(item.text, crypto.randomUUID()),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// Command execution - map to tool_use block
+	if (isCommandExecutionItem(item)) {
+		const toolId = generateToolId(item.id);
+		return {
+			type: "assistant",
+			message: createBetaMessage(
+				[
+					{
+						type: "tool_use",
+						id: toolId,
+						name: "command_execution",
+						input: {
+							command: item.command,
+							output: item.aggregated_output,
+							exit_code: item.exit_code,
+							status: item.status,
+						},
+					},
+				],
+				crypto.randomUUID(),
+			),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// File change - map to tool_use block
+	if (isFileChangeItem(item)) {
+		const toolId = generateToolId(item.id);
+		return {
+			type: "assistant",
+			message: createBetaMessage(
+				[
+					{
+						type: "tool_use",
+						id: toolId,
+						name: "file_change",
+						input: {
+							file_path: item.file_path,
+							change_type: item.change_type,
+							content: item.content,
+							status: item.status,
+						},
+					},
+				],
+				crypto.randomUUID(),
+			),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// MCP tool call - map to tool_use block
+	if (isMcpToolCallItem(item)) {
+		const toolId = generateToolId(item.id);
+		return {
+			type: "assistant",
+			message: createBetaMessage(
+				[
+					{
+						type: "tool_use",
+						id: toolId,
+						name: item.tool_name,
+						input: item.parameters,
+					},
+				],
+				crypto.randomUUID(),
+			),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// Error item - convert to text message
+	if (isErrorItem(item)) {
+		return {
+			type: "assistant",
+			message: createBetaMessage(`Error: ${item.message}`, crypto.randomUUID()),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId,
+		};
+	}
+
+	// Web search and todo list items don't map to SDK messages
+	// Return null for these types
+	return null;
+}
+
+/**
+ * Create a system message for thread.started events
+ *
+ * @param threadId - The thread ID from thread.started event
+ * @returns SDKSystemMessage with thread initialization info
+ */
+export function createSystemMessage(threadId: string): SDKSystemMessage {
+	return {
+		type: "system",
+		subtype: "init",
+		agents: undefined,
+		apiKeySource: "user",
+		claude_code_version: "codex-adapter",
+		cwd: cwd(),
+		tools: [],
+		mcp_servers: [],
+		model: "codex",
+		permissionMode: "default",
+		slash_commands: [],
+		output_style: "default",
+		skills: [],
+		plugins: [],
+		uuid: crypto.randomUUID(),
+		session_id: threadId,
+	};
+}
+
+/**
+ * Create a result message for turn.completed events
+ *
+ * Extracts content from the last assistant message to include in the result.
+ * This ensures the result contains the actual final output, not just metadata.
+ *
+ * @param usage - Usage statistics from turn.completed event
+ * @param lastAgentMessage - Last assistant message for result coercion
+ * @returns SDKResultMessage with success status and usage stats
+ */
+export function createResultMessage(
+	usage: Usage,
+	lastAgentMessage?: SDKAssistantMessage | null,
+): SDKResultMessage {
+	// Extract result content from last assistant message if available
+	let resultContent = "Session completed successfully";
+	if (lastAgentMessage?.message?.content) {
+		const content = lastAgentMessage.message.content;
+		if (Array.isArray(content) && content.length > 0) {
+			const textBlock = content.find((block) => block.type === "text");
+			if (textBlock && "text" in textBlock) {
+				resultContent = textBlock.text;
+			}
+		}
+	}
+
+	return {
+		type: "result",
+		subtype: "success",
+		duration_ms: 0, // Codex doesn't provide duration
+		duration_api_ms: 0,
+		is_error: false,
+		num_turns: 1, // Codex has single turn per completion
+		result: resultContent,
+		total_cost_usd: 0,
+		usage: {
+			input_tokens: usage.input_tokens,
+			output_tokens: usage.output_tokens,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: usage.cached_input_tokens || 0,
+			cache_creation: {
+				ephemeral_1h_input_tokens: 0,
+				ephemeral_5m_input_tokens: 0,
+			},
+			server_tool_use: {
+				web_fetch_requests: 0,
+				web_search_requests: 0,
+			},
+			service_tier: "standard" as const,
+		},
+		modelUsage: {},
+		permission_denials: [],
+		uuid: crypto.randomUUID(),
+		session_id: "pending", // Will be set by caller
+	};
+}
+
+/**
+ * Create an error result message for turn.failed or error events
+ *
+ * @param error - Error message or object with message property
+ * @returns SDKResultMessage with error status
+ */
+export function createErrorResultMessage(
+	error: string | { message: string },
+): SDKResultMessage {
+	const errorMessage = typeof error === "string" ? error : error.message;
+
+	return {
+		type: "result",
+		subtype: "error_during_execution",
+		duration_ms: 0,
+		duration_api_ms: 0,
+		is_error: true,
+		num_turns: 0,
+		errors: [errorMessage],
+		total_cost_usd: 0,
+		usage: {
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation: {
+				ephemeral_1h_input_tokens: 0,
+				ephemeral_5m_input_tokens: 0,
+			},
+			server_tool_use: {
+				web_fetch_requests: 0,
+				web_search_requests: 0,
+			},
+			service_tier: "standard" as const,
+		},
+		modelUsage: {},
+		permission_denials: [],
+		uuid: crypto.randomUUID(),
+		session_id: "pending", // Will be set by caller
+	};
+}
+
+/**
+ * Convert a Codex JSONL event to cyrus-core SDKMessage format
+ *
+ * This adapter maps Codex CLI's JSONL events to the cyrus-core SDKMessage
+ * format, allowing CodexRunner to implement the IAgentRunner interface.
+ *
+ * Event Mapping:
+ * - thread.started → SDKSystemMessage (init)
+ * - turn.started → null (no SDK message)
+ * - turn.completed → SDKResultMessage (success with usage)
+ * - turn.failed → SDKResultMessage (error)
+ * - item.started → null (wait for item.completed)
+ * - item.updated → null (wait for item.completed)
+ * - item.completed → SDKAssistantMessage (via convertItemToMessage)
+ * - error → SDKResultMessage (error)
+ *
+ * @param event - Codex CLI JSONL event
+ * @param sessionId - Current session ID (may be null initially)
+ * @param lastAssistantMessage - Last assistant message for result coercion (optional)
+ * @returns SDKMessage or null if event type doesn't map to a message
+ */
+export function codexEventToSDKMessage(
+	event: ThreadEvent,
+	sessionId: string | null,
+	lastAssistantMessage?: SDKAssistantMessage | null,
+): SDKMessage | null {
+	// thread.started - initialize session with system message
+	if (isThreadStartedEvent(event)) {
+		return createSystemMessage(event.thread_id);
+	}
+
+	// turn.completed - create success result message
+	if (isTurnCompletedEvent(event)) {
+		const resultMessage = createResultMessage(
+			event.usage,
+			lastAssistantMessage,
+		);
+		resultMessage.session_id = sessionId || "pending";
+		return resultMessage;
+	}
+
+	// turn.failed - create error result message
+	if (isTurnFailedEvent(event)) {
+		const errorMessage = createErrorResultMessage(event.error);
+		errorMessage.session_id = sessionId || "pending";
+		return errorMessage;
+	}
+
+	// item.completed - convert item to appropriate message type
+	if (isItemCompletedEvent(event)) {
+		return convertItemToMessage(event.item, sessionId || "pending");
+	}
+
+	// error - thread-level error
+	if (isThreadErrorEvent(event)) {
+		const errorMessage = createErrorResultMessage(event.message);
+		errorMessage.session_id = sessionId || "pending";
+		return errorMessage;
+	}
+
+	// turn.started, item.started, item.updated don't map to SDK messages
+	return null;
+}
+
+/**
+ * Create a Cyrus Core SDK UserMessage from a plain string prompt
+ *
+ * Helper function to create properly formatted SDKUserMessage objects
+ * for the Codex CLI input.
+ *
+ * @param content - The prompt text
+ * @param sessionId - Current session ID (may be null for initial message)
+ * @returns Formatted SDKUserMessage
+ */
+export function createUserMessage(
+	content: string,
+	sessionId: string | null,
+): SDKUserMessage {
+	return {
+		type: "user",
+		message: {
+			role: "user",
+			content: content,
+		},
+		parent_tool_use_id: null,
+		session_id: sessionId || "pending",
+	};
+}
+
+/**
+ * Extract session ID from Codex thread.started event
+ *
+ * @param event - Codex thread event
+ * @returns Session ID (thread_id) if event is thread.started type, null otherwise
+ */
+export function extractSessionId(event: ThreadEvent): string | null {
+	if (isThreadStartedEvent(event)) {
+		return event.thread_id;
+	}
+	return null;
+}

--- a/packages/codex-runner/test/adapters.test.ts
+++ b/packages/codex-runner/test/adapters.test.ts
@@ -1,5 +1,636 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import {
+	codexEventToSDKMessage,
+	convertItemToMessage,
+	createErrorResultMessage,
+	createResultMessage,
+	createSystemMessage,
+	createUserMessage,
+	extractSessionId,
+} from "../src/adapters.js";
+import type {
+	AgentMessageItem,
+	CommandExecutionItem,
+	ErrorItem,
+	FileChangeItem,
+	ItemCompletedEvent,
+	McpToolCallItem,
+	ReasoningItem,
+	ThreadErrorEvent,
+	ThreadStartedEvent,
+	TurnCompletedEvent,
+	TurnFailedEvent,
+	TurnStartedEvent,
+	Usage,
+} from "../src/schemas.js";
 
 describe("Adapters", () => {
-	it.todo("should be implemented");
+	const TEST_SESSION_ID = "test-session-123";
+	const TEST_THREAD_ID = "thread-abc-456";
+
+	describe("createSystemMessage", () => {
+		it("should create a valid SDKSystemMessage from thread_id", () => {
+			const message = createSystemMessage(TEST_THREAD_ID);
+
+			expect(message.type).toBe("system");
+			expect(message.subtype).toBe("init");
+			expect(message.session_id).toBe(TEST_THREAD_ID);
+			expect(message.model).toBe("codex");
+			expect(message.claude_code_version).toBe("codex-adapter");
+			expect(message.tools).toEqual([]);
+			expect(message.mcp_servers).toEqual([]);
+			expect(message.uuid).toBeDefined();
+		});
+	});
+
+	describe("createUserMessage", () => {
+		it("should create a valid SDKUserMessage with session ID", () => {
+			const content = "Test prompt";
+			const message = createUserMessage(content, TEST_SESSION_ID);
+
+			expect(message.type).toBe("user");
+			expect(message.message.role).toBe("user");
+			expect(message.message.content).toBe(content);
+			expect(message.session_id).toBe(TEST_SESSION_ID);
+			expect(message.parent_tool_use_id).toBeNull();
+		});
+
+		it("should use 'pending' session ID when null is provided", () => {
+			const message = createUserMessage("Test", null);
+			expect(message.session_id).toBe("pending");
+		});
+	});
+
+	describe("createResultMessage", () => {
+		const usage: Usage = {
+			input_tokens: 1000,
+			output_tokens: 500,
+			cached_input_tokens: 200,
+		};
+
+		it("should create success result with usage statistics", () => {
+			const result = createResultMessage(usage);
+
+			expect(result.type).toBe("result");
+			expect(result.subtype).toBe("success");
+			expect(result.is_error).toBe(false);
+			expect(result.usage.input_tokens).toBe(1000);
+			expect(result.usage.output_tokens).toBe(500);
+			expect(result.usage.cache_read_input_tokens).toBe(200);
+			expect(result.result).toBe("Session completed successfully");
+		});
+
+		it("should extract result content from last assistant message", () => {
+			const lastMessage = {
+				type: "assistant" as const,
+				message: {
+					id: "msg-123",
+					type: "message" as const,
+					role: "assistant" as const,
+					content: [{ type: "text" as const, text: "Final output text" }],
+					model: "codex" as const,
+					stop_reason: null,
+					stop_sequence: null,
+					usage: {
+						input_tokens: 0,
+						output_tokens: 0,
+						cache_creation_input_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation: null,
+						server_tool_use: null,
+						service_tier: null,
+					},
+					container: null,
+					context_management: null,
+				},
+				parent_tool_use_id: null,
+				uuid: "uuid-123",
+				session_id: TEST_SESSION_ID,
+			};
+
+			const result = createResultMessage(usage, lastMessage);
+			expect(result.result).toBe("Final output text");
+		});
+
+		it("should handle missing cached_input_tokens", () => {
+			const usageWithoutCache: Usage = {
+				input_tokens: 1000,
+				output_tokens: 500,
+			};
+			const result = createResultMessage(usageWithoutCache);
+			expect(result.usage.cache_read_input_tokens).toBe(0);
+		});
+	});
+
+	describe("createErrorResultMessage", () => {
+		it("should create error result from string message", () => {
+			const errorMsg = "Connection timeout";
+			const result = createErrorResultMessage(errorMsg);
+
+			expect(result.type).toBe("result");
+			expect(result.subtype).toBe("error_during_execution");
+			expect(result.is_error).toBe(true);
+			expect(result.errors).toEqual([errorMsg]);
+		});
+
+		it("should create error result from error object", () => {
+			const error = { message: "Rate limit exceeded" };
+			const result = createErrorResultMessage(error);
+
+			expect(result.is_error).toBe(true);
+			expect(result.errors).toEqual(["Rate limit exceeded"]);
+		});
+	});
+
+	describe("convertItemToMessage", () => {
+		it("should convert agent_message item to text message", () => {
+			const item: AgentMessageItem = {
+				id: "item_1",
+				type: "agent_message",
+				text: "Hello, world!",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			expect(message?.session_id).toBe(TEST_SESSION_ID);
+			expect(message?.message.content).toHaveLength(1);
+			expect(message?.message.content[0]).toMatchObject({
+				type: "text",
+				text: "Hello, world!",
+			});
+		});
+
+		it("should convert reasoning item to text message", () => {
+			const item: ReasoningItem = {
+				id: "item_2",
+				type: "reasoning",
+				text: "Thinking about the problem...",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			expect(message?.message.content[0]).toMatchObject({
+				type: "text",
+				text: "Thinking about the problem...",
+			});
+		});
+
+		it("should convert command_execution item to tool_use message", () => {
+			const item: CommandExecutionItem = {
+				id: "item_3",
+				type: "command_execution",
+				command: "ls -la",
+				aggregated_output: "file1.txt\nfile2.txt\n",
+				exit_code: 0,
+				status: "completed",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			expect(message?.message.content[0]).toMatchObject({
+				type: "tool_use",
+				name: "command_execution",
+			});
+			const toolUse = message?.message.content[0] as {
+				type: string;
+				id: string;
+				name: string;
+				input: unknown;
+			};
+			expect(toolUse.id).toMatch(/^toolu_/);
+			expect(toolUse.input).toMatchObject({
+				command: "ls -la",
+				output: "file1.txt\nfile2.txt\n",
+				exit_code: 0,
+				status: "completed",
+			});
+		});
+
+		it("should convert file_change item to tool_use message", () => {
+			const item: FileChangeItem = {
+				id: "item_4",
+				type: "file_change",
+				file_path: "src/index.ts",
+				change_type: "update",
+				content: "export const x = 1;",
+				status: "completed",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			const toolUse = message?.message.content[0] as {
+				type: string;
+				name: string;
+				input: unknown;
+			};
+			expect(toolUse.name).toBe("file_change");
+			expect(toolUse.input).toMatchObject({
+				file_path: "src/index.ts",
+				change_type: "update",
+				content: "export const x = 1;",
+				status: "completed",
+			});
+		});
+
+		it("should convert mcp_tool_call item to tool_use message", () => {
+			const item: McpToolCallItem = {
+				id: "item_5",
+				type: "mcp_tool_call",
+				tool_name: "linear_create_issue",
+				parameters: { title: "Test Issue" },
+				result: { success: true },
+				status: "completed",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			const toolUse = message?.message.content[0] as {
+				type: string;
+				name: string;
+				input: unknown;
+			};
+			expect(toolUse.name).toBe("linear_create_issue");
+			expect(toolUse.input).toEqual({ title: "Test Issue" });
+		});
+
+		it("should convert error item to text message", () => {
+			const item: ErrorItem = {
+				id: "item_6",
+				type: "error",
+				message: "Command failed",
+			};
+
+			const message = convertItemToMessage(item, TEST_SESSION_ID);
+
+			expect(message).not.toBeNull();
+			expect(message?.type).toBe("assistant");
+			expect(message?.message.content[0]).toMatchObject({
+				type: "text",
+				text: "Error: Command failed",
+			});
+		});
+
+		it("should generate consistent tool IDs for same item ID", () => {
+			const item: CommandExecutionItem = {
+				id: "item_consistent",
+				type: "command_execution",
+				command: "echo test",
+				aggregated_output: "test\n",
+				exit_code: 0,
+				status: "completed",
+			};
+
+			const message1 = convertItemToMessage(item, TEST_SESSION_ID);
+			const message2 = convertItemToMessage(item, TEST_SESSION_ID);
+
+			const toolUse1 = message1?.message.content[0] as { id: string };
+			const toolUse2 = message2?.message.content[0] as { id: string };
+
+			expect(toolUse1.id).toBe(toolUse2.id);
+		});
+	});
+
+	describe("extractSessionId", () => {
+		it("should extract thread_id from thread.started event", () => {
+			const event: ThreadStartedEvent = {
+				type: "thread.started",
+				thread_id: "thread-xyz-789",
+			};
+
+			const sessionId = extractSessionId(event);
+			expect(sessionId).toBe("thread-xyz-789");
+		});
+
+		it("should return null for non-thread.started events", () => {
+			const event: TurnStartedEvent = {
+				type: "turn.started",
+			};
+
+			const sessionId = extractSessionId(event);
+			expect(sessionId).toBeNull();
+		});
+	});
+
+	describe("codexEventToSDKMessage", () => {
+		describe("thread.started event", () => {
+			it("should convert to SDKSystemMessage", () => {
+				const event: ThreadStartedEvent = {
+					type: "thread.started",
+					thread_id: TEST_THREAD_ID,
+				};
+
+				const message = codexEventToSDKMessage(event, null);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("system");
+				if (message?.type === "system") {
+					expect(message.subtype).toBe("init");
+					expect(message.session_id).toBe(TEST_THREAD_ID);
+				}
+			});
+		});
+
+		describe("turn.started event", () => {
+			it("should return null (no SDK message needed)", () => {
+				const event: TurnStartedEvent = {
+					type: "turn.started",
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+				expect(message).toBeNull();
+			});
+		});
+
+		describe("turn.completed event", () => {
+			it("should convert to success SDKResultMessage", () => {
+				const event: TurnCompletedEvent = {
+					type: "turn.completed",
+					usage: {
+						input_tokens: 1500,
+						output_tokens: 750,
+						cached_input_tokens: 300,
+					},
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("result");
+				if (message?.type === "result") {
+					expect(message.subtype).toBe("success");
+					expect(message.is_error).toBe(false);
+					expect(message.session_id).toBe(TEST_SESSION_ID);
+					expect(message.usage.input_tokens).toBe(1500);
+					expect(message.usage.output_tokens).toBe(750);
+				}
+			});
+
+			it("should include last assistant message content in result", () => {
+				const event: TurnCompletedEvent = {
+					type: "turn.completed",
+					usage: {
+						input_tokens: 100,
+						output_tokens: 50,
+					},
+				};
+
+				const lastMessage = {
+					type: "assistant" as const,
+					message: {
+						id: "msg-123",
+						type: "message" as const,
+						role: "assistant" as const,
+						content: [{ type: "text" as const, text: "Task completed!" }],
+						model: "codex" as const,
+						stop_reason: null,
+						stop_sequence: null,
+						usage: {
+							input_tokens: 0,
+							output_tokens: 0,
+							cache_creation_input_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation: null,
+							server_tool_use: null,
+							service_tier: null,
+						},
+						container: null,
+						context_management: null,
+					},
+					parent_tool_use_id: null,
+					uuid: "uuid-123",
+					session_id: TEST_SESSION_ID,
+				};
+
+				const message = codexEventToSDKMessage(
+					event,
+					TEST_SESSION_ID,
+					lastMessage,
+				);
+
+				if (message?.type === "result") {
+					expect(message.result).toBe("Task completed!");
+				}
+			});
+		});
+
+		describe("turn.failed event", () => {
+			it("should convert to error SDKResultMessage", () => {
+				const event: TurnFailedEvent = {
+					type: "turn.failed",
+					error: {
+						message: "API rate limit exceeded",
+					},
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("result");
+				if (message?.type === "result") {
+					expect(message.subtype).toBe("error_during_execution");
+					expect(message.is_error).toBe(true);
+					expect(message.session_id).toBe(TEST_SESSION_ID);
+					expect(message.errors).toEqual(["API rate limit exceeded"]);
+				}
+			});
+		});
+
+		describe("item.completed event", () => {
+			it("should convert agent_message item to assistant message", () => {
+				const event: ItemCompletedEvent = {
+					type: "item.completed",
+					item: {
+						id: "item_1",
+						type: "agent_message",
+						text: "Response text",
+					},
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("assistant");
+				if (message?.type === "assistant") {
+					expect(message.session_id).toBe(TEST_SESSION_ID);
+					expect(message.message.content[0]).toMatchObject({
+						type: "text",
+						text: "Response text",
+					});
+				}
+			});
+
+			it("should convert command_execution item to tool_use message", () => {
+				const event: ItemCompletedEvent = {
+					type: "item.completed",
+					item: {
+						id: "item_2",
+						type: "command_execution",
+						command: "npm test",
+						aggregated_output: "All tests passed\n",
+						exit_code: 0,
+						status: "completed",
+					},
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("assistant");
+				if (message?.type === "assistant") {
+					const toolUse = message.message.content[0] as {
+						type: string;
+						name: string;
+					};
+					expect(toolUse.type).toBe("tool_use");
+					expect(toolUse.name).toBe("command_execution");
+				}
+			});
+
+			it("should handle null session ID by using 'pending'", () => {
+				const event: ItemCompletedEvent = {
+					type: "item.completed",
+					item: {
+						id: "item_1",
+						type: "agent_message",
+						text: "Test",
+					},
+				};
+
+				const message = codexEventToSDKMessage(event, null);
+
+				expect(message).not.toBeNull();
+				if (message?.type === "assistant") {
+					expect(message.session_id).toBe("pending");
+				}
+			});
+		});
+
+		describe("error event", () => {
+			it("should convert to error SDKResultMessage", () => {
+				const event: ThreadErrorEvent = {
+					type: "error",
+					message: "Thread execution failed",
+				};
+
+				const message = codexEventToSDKMessage(event, TEST_SESSION_ID);
+
+				expect(message).not.toBeNull();
+				expect(message?.type).toBe("result");
+				if (message?.type === "result") {
+					expect(message.subtype).toBe("error_during_execution");
+					expect(message.is_error).toBe(true);
+					expect(message.errors).toEqual(["Thread execution failed"]);
+				}
+			});
+		});
+	});
+
+	describe("Real-world event sequence", () => {
+		it("should process a complete thread lifecycle", () => {
+			const messages: Array<
+				NonNullable<ReturnType<typeof codexEventToSDKMessage>>
+			> = [];
+
+			// 1. Thread starts
+			const threadStart: ThreadStartedEvent = {
+				type: "thread.started",
+				thread_id: "thread-real-001",
+			};
+			const msg1 = codexEventToSDKMessage(threadStart, null);
+			if (msg1) messages.push(msg1);
+
+			// Extract session ID
+			const sessionId = extractSessionId(threadStart);
+			expect(sessionId).toBe("thread-real-001");
+
+			// 2. Turn starts (no message)
+			const turnStart: TurnStartedEvent = {
+				type: "turn.started",
+			};
+			const msg2 = codexEventToSDKMessage(turnStart, sessionId);
+			expect(msg2).toBeNull();
+
+			// 3. Reasoning item completes
+			const reasoningComplete: ItemCompletedEvent = {
+				type: "item.completed",
+				item: {
+					id: "item_0",
+					type: "reasoning",
+					text: "Analyzing the request...",
+				},
+			};
+			const msg3 = codexEventToSDKMessage(reasoningComplete, sessionId);
+			if (msg3) messages.push(msg3);
+
+			// 4. Command execution completes
+			const cmdComplete: ItemCompletedEvent = {
+				type: "item.completed",
+				item: {
+					id: "item_1",
+					type: "command_execution",
+					command: "ls -la",
+					aggregated_output: "file1.txt\n",
+					exit_code: 0,
+					status: "completed",
+				},
+			};
+			const msg4 = codexEventToSDKMessage(cmdComplete, sessionId);
+			if (msg4) messages.push(msg4);
+
+			// 5. Agent message completes
+			const agentComplete: ItemCompletedEvent = {
+				type: "item.completed",
+				item: {
+					id: "item_2",
+					type: "agent_message",
+					text: "Listed files successfully",
+				},
+			};
+			const msg5 = codexEventToSDKMessage(agentComplete, sessionId);
+			if (msg5) messages.push(msg5);
+
+			// Track last assistant message
+			const lastAssistantMessage =
+				msg5?.type === "assistant" ? msg5 : undefined;
+
+			// 6. Turn completes
+			const turnComplete: TurnCompletedEvent = {
+				type: "turn.completed",
+				usage: {
+					input_tokens: 2000,
+					output_tokens: 100,
+					cached_input_tokens: 500,
+				},
+			};
+			const msg6 = codexEventToSDKMessage(
+				turnComplete,
+				sessionId,
+				lastAssistantMessage,
+			);
+			if (msg6) messages.push(msg6);
+
+			// Verify sequence
+			expect(messages).toHaveLength(5);
+			expect(messages[0].type).toBe("system");
+			expect(messages[1].type).toBe("assistant"); // reasoning
+			expect(messages[2].type).toBe("assistant"); // command
+			expect(messages[3].type).toBe("assistant"); // agent message
+			expect(messages[4].type).toBe("result"); // turn complete
+
+			// Verify result includes final message
+			if (messages[4].type === "result") {
+				expect(messages[4].result).toBe("Listed files successfully");
+			}
+		});
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@iarna/toml':
         specifier: ^3.0.0
         version: 3.0.0
+      cyrus-claude-runner:
+        specifier: workspace:*
+        version: link:../claude-runner
       cyrus-core:
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

Implements adapter functions that convert Codex JSONL events to Claude SDK message types, enabling the CodexRunner to integrate with the Cyrus infrastructure.

## Changes

### Core Adapter (`src/adapters.ts`)
- **`codexEventToSDKMessage()`** - Main adapter routing all 8 Codex event types to SDK messages
- **Event mappings:**
  - `thread.started` → `SDKSystemMessage` (init)
  - `turn.completed` → `SDKResultMessage` (success with usage stats)
  - `turn.failed` → `SDKResultMessage` (error)
  - `item.completed` → `SDKAssistantMessage` (via item conversion)
  - `error` → `SDKResultMessage` (thread error)

### Helper Functions
- `createSystemMessage(threadId)` - System initialization messages
- `convertItemToMessage(item, sessionId)` - Item-to-message conversion
- `createResultMessage(usage, lastAgentMessage)` - Success results with result coercion
- `createErrorResultMessage(error)` - Error result messages
- `createUserMessage(content, sessionId)` - User prompt messages
- `extractSessionId(event)` - Session ID extraction
- `generateToolId(itemId)` - Deterministic SHA-256 based tool IDs

### Item Type Conversions
- ✅ `agent_message` → text content
- ✅ `reasoning` → text content
- ✅ `command_execution` → tool_use block
- ✅ `file_change` → tool_use block
- ✅ `mcp_tool_call` → tool_use block
- ✅ `error` → error text

### Testing (`test/adapters.test.ts`)
- 27 comprehensive adapter tests
- Tests for each helper function
- Tests for all event/item type conversions
- Tool ID generation consistency tests
- Real-world event sequence simulation
- **100/100 tests passing** (27 adapter + 73 schema)

### Package Configuration
- Added `cyrus-claude-runner` dependency for `SDKSystemMessage` type
- TypeScript compilation clean
- Linting clean

## Stack Position

**3 of 7** in Graphite stack

**Previous:** CYPACK-523 (Codex JSONL schemas)
**Next:** CYPACK-525 (TBD)

## Verification

```bash
cd packages/codex-runner
pnpm test:run    # 100 tests passing
pnpm typecheck   # Clean
pnpm build       # Clean
```

## Technical Notes

- Follows gemini-runner adapter patterns for consistency
- Implements result message coercion (extracts final output from last assistant message)
- Uses deterministic tool ID generation for tool_use/tool_result correlation
- Handles null session IDs gracefully with "pending" placeholder

Resolves CYPACK-524

🤖 Generated with [Claude Code](https://claude.com/claude-code)