### PR TITLE
[CYPACK-526] Implement Config.toml Generator for Codex

### DIFF
--- a/packages/codex-runner/src/configGenerator.ts
+++ b/packages/codex-runner/src/configGenerator.ts
@@ -1,1 +1,367 @@
-// Config generator implementation
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import toml from "@iarna/toml";
+import type { McpServerConfig } from "cyrus-core";
+import type { CodexMcpServerConfig } from "./types.js";
+
+const CODEX_DIR = join(homedir(), ".codex");
+const CONFIG_PATH = join(CODEX_DIR, "config.toml");
+const BACKUP_PATH = join(CODEX_DIR, "config.toml.backup");
+
+/**
+ * Codex config.toml structure
+ */
+interface CodexConfig {
+	mcp_servers?: Record<string, CodexMcpServerConfig>;
+}
+
+/**
+ * Options for generating Codex configuration
+ */
+export interface CodexConfigOptions {
+	mcpServers?: Record<string, CodexMcpServerConfig>;
+}
+
+/**
+ * Convert McpServerConfig (cyrus-core format) to CodexMcpServerConfig (Codex TOML format)
+ *
+ * Codex CLI supports two transport types:
+ * - stdio: command-based (spawns subprocess)
+ * - streamable_http: URL-based with optional bearer token
+ *
+ * @param serverName - Name of the MCP server (for logging)
+ * @param config - McpServerConfig from cyrus-core
+ * @returns CodexMcpServerConfig or null if conversion not possible
+ */
+export function convertToCodexMcpConfig(
+	serverName: string,
+	config: McpServerConfig,
+): CodexMcpServerConfig | null {
+	const configAny = config as Record<string, unknown>;
+
+	// Detect SDK MCP server instances (in-process servers)
+	// These have methods like listTools, callTool, etc. and are not convertible
+	// to Codex CLI's transport-based configuration format
+	if (
+		typeof configAny.listTools === "function" ||
+		typeof configAny.callTool === "function" ||
+		typeof configAny.name === "string"
+	) {
+		console.warn(
+			`[CodexRunner] MCP server "${serverName}" is an SDK server instance (in-process). ` +
+				`Codex CLI only supports external MCP servers with transport configurations. Skipping.`,
+		);
+		return null;
+	}
+
+	// Determine transport type and configure accordingly
+	if (configAny.command) {
+		// Command-based -> stdio transport
+		const codexConfig: CodexMcpServerConfig = {
+			transport: "stdio",
+			command: configAny.command as string,
+		};
+
+		// Map stdio-specific fields
+		if (configAny.args && Array.isArray(configAny.args)) {
+			codexConfig.args = configAny.args as string[];
+		}
+
+		if (configAny.cwd && typeof configAny.cwd === "string") {
+			codexConfig.cwd = configAny.cwd;
+		}
+
+		// Map common fields
+		if (
+			configAny.env &&
+			typeof configAny.env === "object" &&
+			!Array.isArray(configAny.env)
+		) {
+			codexConfig.env = configAny.env as Record<string, string>;
+		}
+
+		// Map timeout configurations
+		if (configAny.timeout && typeof configAny.timeout === "number") {
+			// Convert milliseconds to seconds for Codex
+			const timeoutSecs = Math.ceil(configAny.timeout / 1000);
+			codexConfig.tool_timeout = { secs: timeoutSecs };
+		}
+
+		// Map tool filtering
+		if (configAny.includeTools && Array.isArray(configAny.includeTools)) {
+			codexConfig.enabled_tools = configAny.includeTools as string[];
+		}
+
+		if (configAny.excludeTools && Array.isArray(configAny.excludeTools)) {
+			codexConfig.disabled_tools = configAny.excludeTools as string[];
+		}
+
+		// Enable by default
+		codexConfig.enabled = true;
+
+		console.log(
+			`[CodexRunner] MCP server "${serverName}" configured with stdio transport: ${codexConfig.command}`,
+		);
+
+		return codexConfig;
+	}
+
+	if (configAny.url) {
+		// URL-based -> streamable_http transport
+		const codexConfig: CodexMcpServerConfig = {
+			transport: "streamable_http",
+			url: configAny.url as string,
+		};
+
+		// Map HTTP-specific fields
+		if (
+			configAny.headers &&
+			typeof configAny.headers === "object" &&
+			!Array.isArray(configAny.headers)
+		) {
+			codexConfig.headers = configAny.headers as Record<string, string>;
+		}
+
+		// Check for bearer token configuration
+		// Look for Authorization header with Bearer token
+		const headers = configAny.headers as Record<string, string> | undefined;
+		if (headers?.Authorization?.startsWith("Bearer ")) {
+			// Extract env var name if it looks like ${ENV_VAR_NAME}
+			const authHeader = headers.Authorization;
+			const envVarMatch = authHeader.match(/\$\{([^}]+)\}/);
+			if (envVarMatch) {
+				codexConfig.bearer_env_var = envVarMatch[1];
+				// Remove Authorization header since we're using bearer_env_var
+				const { Authorization: _, ...restHeaders } = headers;
+				if (Object.keys(restHeaders).length > 0) {
+					codexConfig.headers = restHeaders;
+				} else {
+					delete codexConfig.headers;
+				}
+			}
+		}
+
+		// Map common fields
+		if (
+			configAny.env &&
+			typeof configAny.env === "object" &&
+			!Array.isArray(configAny.env)
+		) {
+			codexConfig.env = configAny.env as Record<string, string>;
+		}
+
+		// Map timeout configurations
+		if (configAny.timeout && typeof configAny.timeout === "number") {
+			// Convert milliseconds to seconds for Codex
+			const timeoutSecs = Math.ceil(configAny.timeout / 1000);
+			codexConfig.tool_timeout = { secs: timeoutSecs };
+		}
+
+		// Map tool filtering
+		if (configAny.includeTools && Array.isArray(configAny.includeTools)) {
+			codexConfig.enabled_tools = configAny.includeTools as string[];
+		}
+
+		if (configAny.excludeTools && Array.isArray(configAny.excludeTools)) {
+			codexConfig.disabled_tools = configAny.excludeTools as string[];
+		}
+
+		// Enable by default
+		codexConfig.enabled = true;
+
+		console.log(
+			`[CodexRunner] MCP server "${serverName}" configured with streamable_http transport: ${codexConfig.url}`,
+		);
+
+		return codexConfig;
+	}
+
+	// No valid transport configuration
+	console.warn(
+		`[CodexRunner] MCP server "${serverName}" has no valid transport configuration (need command or url). Skipping.`,
+	);
+	return null;
+}
+
+/**
+ * Load MCP configuration from file paths
+ *
+ * @param configPaths - Single path or array of paths to MCP config files
+ * @returns Merged MCP server configurations
+ */
+export function loadMcpConfigFromPaths(
+	configPaths: string | string[] | undefined,
+): Record<string, McpServerConfig> {
+	if (!configPaths) {
+		return {};
+	}
+
+	const paths = Array.isArray(configPaths) ? configPaths : [configPaths];
+	let mcpServers: Record<string, McpServerConfig> = {};
+
+	for (const configPath of paths) {
+		try {
+			const mcpConfigContent = readFileSync(configPath, "utf8");
+			const mcpConfig = JSON.parse(mcpConfigContent);
+			const servers = mcpConfig.mcpServers || {};
+			mcpServers = { ...mcpServers, ...servers };
+			console.log(
+				`[CodexRunner] Loaded MCP config from ${configPath}: ${Object.keys(servers).join(", ")}`,
+			);
+		} catch (error) {
+			console.error(
+				`[CodexRunner] Failed to load MCP config from ${configPath}:`,
+				error,
+			);
+		}
+	}
+
+	return mcpServers;
+}
+
+/**
+ * Auto-detect .mcp.json in working directory
+ *
+ * @param workingDirectory - Working directory to check
+ * @returns Path to .mcp.json if valid, undefined otherwise
+ */
+export function autoDetectMcpConfig(
+	workingDirectory?: string,
+): string | undefined {
+	if (!workingDirectory) {
+		return undefined;
+	}
+
+	const mcpJsonPath = join(workingDirectory, ".mcp.json");
+	if (existsSync(mcpJsonPath)) {
+		try {
+			// Validate it's valid JSON
+			const content = readFileSync(mcpJsonPath, "utf8");
+			JSON.parse(content);
+			console.log(`[CodexRunner] Auto-detected .mcp.json at ${mcpJsonPath}`);
+			return mcpJsonPath;
+		} catch {
+			console.warn(
+				`[CodexRunner] Found .mcp.json at ${mcpJsonPath} but it's not valid JSON, skipping`,
+			);
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Generates config.toml structure with MCP servers
+ */
+function generateConfig(options: CodexConfigOptions): CodexConfig {
+	const config: CodexConfig = {};
+
+	// Add MCP servers if provided
+	if (options.mcpServers && Object.keys(options.mcpServers).length > 0) {
+		config.mcp_servers = options.mcpServers;
+		console.log(
+			`[CodexRunner] Including ${Object.keys(options.mcpServers).length} MCP server(s) in config.toml: ${Object.keys(options.mcpServers).join(", ")}`,
+		);
+	}
+
+	return config;
+}
+
+/**
+ * Backup existing config.toml if it exists
+ * Returns true if backup was created, false if no file to backup
+ */
+export function backupCodexConfig(): boolean {
+	if (!existsSync(CONFIG_PATH)) {
+		return false;
+	}
+
+	// Create backup
+	copyFileSync(CONFIG_PATH, BACKUP_PATH);
+	console.log(`[CodexRunner] Backed up config.toml to ${BACKUP_PATH}`);
+	return true;
+}
+
+/**
+ * Restore config.toml from backup
+ * Returns true if restored, false if no backup exists
+ */
+export function restoreCodexConfig(): boolean {
+	if (!existsSync(BACKUP_PATH)) {
+		return false;
+	}
+
+	// Restore from backup
+	copyFileSync(BACKUP_PATH, CONFIG_PATH);
+	unlinkSync(BACKUP_PATH);
+	console.log(`[CodexRunner] Restored config.toml from backup`);
+	return true;
+}
+
+/**
+ * Delete config.toml (used when no backup existed)
+ */
+export function deleteCodexConfig(): void {
+	if (existsSync(CONFIG_PATH)) {
+		unlinkSync(CONFIG_PATH);
+		console.log(`[CodexRunner] Deleted temporary config.toml`);
+	}
+}
+
+/**
+ * Write config.toml with specified options
+ * Creates ~/.codex directory if it doesn't exist
+ *
+ * @param options - Configuration options including mcpServers
+ */
+export function writeCodexConfig(options: CodexConfigOptions): void {
+	// Create ~/.codex directory if it doesn't exist
+	if (!existsSync(CODEX_DIR)) {
+		mkdirSync(CODEX_DIR, { recursive: true });
+	}
+
+	// Generate and write config
+	const config = generateConfig(options);
+	const tomlString = toml.stringify(config as toml.JsonMap);
+	writeFileSync(CONFIG_PATH, tomlString, "utf-8");
+
+	const parts: string[] = [];
+	if (options.mcpServers && Object.keys(options.mcpServers).length > 0) {
+		parts.push(`mcpServers=[${Object.keys(options.mcpServers).join(", ")}]`);
+	}
+	console.log(
+		`[CodexRunner] Wrote config.toml${parts.length > 0 ? ` with ${parts.join(", ")}` : ""}`,
+	);
+}
+
+/**
+ * Setup Codex configuration for a session
+ * Returns cleanup function to call when session ends
+ *
+ * @param mcpServers - MCP server configurations to write to config.toml
+ * @returns Cleanup function to restore/delete config.toml
+ */
+export function setupCodexConfig(
+	mcpServers: Record<string, CodexMcpServerConfig>,
+): () => void {
+	const hadBackup = backupCodexConfig();
+
+	// Write config
+	writeCodexConfig({ mcpServers });
+
+	// Return cleanup function
+	return () => {
+		if (hadBackup) {
+			restoreCodexConfig();
+		} else {
+			deleteCodexConfig();
+		}
+	};
+}

--- a/packages/codex-runner/src/types.ts
+++ b/packages/codex-runner/src/types.ts
@@ -1,1 +1,158 @@
-// Types implementation
+/**
+ * Type definitions for Codex Runner
+ *
+ * Event types are derived from Zod schemas in schemas.ts for runtime validation.
+ * Configuration and session types remain as interfaces.
+ */
+
+import type {
+	AgentRunnerConfig,
+	AgentSessionInfo,
+	McpServerConfig,
+	SDKMessage,
+} from "cyrus-core";
+
+/**
+ * Codex CLI MCP server configuration (TOML format)
+ *
+ * Codex supports two transport types:
+ * - stdio: Spawns a subprocess and communicates via stdin/stdout (command-based)
+ * - streamable_http: Uses HTTP streaming for communication (url-based)
+ *
+ * Reference: Codex config.toml MCP server format from specification
+ */
+export interface CodexMcpServerConfig {
+	/** Transport type: "stdio" or "streamable_http" */
+	transport: "stdio" | "streamable_http";
+
+	// Transport: stdio (command-based)
+	/** The command to execute to start the MCP server (stdio transport) */
+	command?: string;
+	/** Arguments to pass to the command (stdio transport) */
+	args?: string[];
+	/** The working directory in which to start the server (stdio transport) */
+	cwd?: string;
+
+	// Transport: streamable_http (HTTP streaming)
+	/** HTTP streaming endpoint URL (streamable_http transport) */
+	url?: string;
+	/** Environment variable name containing bearer token (streamable_http transport) */
+	bearer_env_var?: string;
+	/** Custom HTTP headers when using streamable_http */
+	headers?: Record<string, string>;
+
+	// Common options
+	/** Environment variables for the server process */
+	env?: Record<string, string>;
+	/** Startup timeout in seconds (default: 10s) */
+	startup_timeout?: { secs: number };
+	/** Tool execution timeout in seconds (default: 60s) */
+	tool_timeout?: { secs: number };
+	/** List of tool names to enable from this MCP server (whitelist) */
+	enabled_tools?: string[];
+	/** List of tool names to disable from this MCP server (blacklist) */
+	disabled_tools?: string[];
+	/** Whether this server is enabled (default: true) */
+	enabled?: boolean;
+}
+
+// Re-export McpServerConfig from cyrus-core for convenience
+export type { McpServerConfig };
+
+// Re-export event types from schemas (derived from Zod schemas)
+export type {
+	// Item types
+	AgentMessageItem,
+	CommandExecutionItem,
+	ErrorItem,
+	FileChangeItem,
+	ItemCompletedEvent,
+	ItemStartedEvent,
+	ItemUpdatedEvent,
+	McpToolCallItem,
+	ReasoningItem,
+	ThreadErrorEvent,
+	// Combined event type
+	ThreadEvent,
+	ThreadItem,
+	ThreadStartedEvent,
+	TodoListItem,
+	TurnCompletedEvent,
+	TurnFailedEvent,
+	TurnStartedEvent,
+	WebSearchItem,
+} from "./schemas.js";
+
+// Re-export schemas for runtime validation
+export {
+	// Item schemas
+	AgentMessageItemSchema,
+	CommandExecutionItemSchema,
+	ErrorItemSchema,
+	FileChangeItemSchema,
+	ItemCompletedEventSchema,
+	ItemStartedEventSchema,
+	ItemUpdatedEventSchema,
+	// Type guards
+	isAgentMessageItem,
+	isCommandExecutionItem,
+	isErrorItem,
+	isFileChangeItem,
+	isItemCompletedEvent,
+	isItemStartedEvent,
+	isItemUpdatedEvent,
+	isMcpToolCallItem,
+	isReasoningItem,
+	isThreadErrorEvent,
+	isThreadStartedEvent,
+	isTodoListItem,
+	isTurnCompletedEvent,
+	isTurnFailedEvent,
+	isTurnStartedEvent,
+	isWebSearchItem,
+	McpToolCallItemSchema,
+	// Parsing utilities
+	parseCodexEvent,
+	ReasoningItemSchema,
+	safeParseCodexEvent,
+	// Event schemas
+	ThreadErrorEventSchema,
+	ThreadItemSchema,
+	ThreadStartedEventSchema,
+	TodoListItemSchema,
+	TurnCompletedEventSchema,
+	TurnFailedEventSchema,
+	TurnStartedEventSchema,
+	WebSearchItemSchema,
+} from "./schemas.js";
+
+/**
+ * Configuration for CodexRunner
+ * Extends the base AgentRunnerConfig with Codex-specific options
+ */
+export interface CodexRunnerConfig extends AgentRunnerConfig {
+	/** Path to codex CLI binary (defaults to 'codex' in PATH) */
+	codexPath?: string;
+	/** Additional directories to include in workspace context */
+	includeDirectories?: string[];
+	/** Enable single-turn mode */
+	singleTurn?: boolean;
+}
+
+/**
+ * Session information for Codex runner
+ */
+export interface CodexSessionInfo extends AgentSessionInfo {
+	/** Codex-specific session ID (thread ID) */
+	sessionId: string | null;
+}
+
+/**
+ * Event emitter interface for CodexRunner
+ */
+export interface CodexRunnerEvents {
+	message: (message: SDKMessage) => void;
+	error: (error: Error) => void;
+	complete: (messages: SDKMessage[]) => void;
+	event: (event: import("./schemas.js").ThreadEvent) => void;
+}

--- a/packages/codex-runner/test/configGenerator.test.ts
+++ b/packages/codex-runner/test/configGenerator.test.ts
@@ -1,0 +1,630 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import toml from "@iarna/toml";
+import type { McpServerConfig } from "cyrus-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	autoDetectMcpConfig,
+	backupCodexConfig,
+	type CodexConfigOptions,
+	convertToCodexMcpConfig,
+	deleteCodexConfig,
+	loadMcpConfigFromPaths,
+	restoreCodexConfig,
+	setupCodexConfig,
+	writeCodexConfig,
+} from "../src/configGenerator.js";
+import type { CodexMcpServerConfig } from "../src/types.js";
+
+const TEST_DIR = join(homedir(), ".codex-test");
+
+// Mock the homedir to use our test directory
+vi.mock("node:os", () => ({
+	homedir: vi.fn(() => "/tmp"),
+}));
+
+// Mock the CODEX_DIR path
+const mockCodexDir = join("/tmp", ".codex");
+const mockConfigPath = join(mockCodexDir, "config.toml");
+const mockBackupPath = join(mockCodexDir, "config.toml.backup");
+
+describe("configGenerator", () => {
+	beforeEach(() => {
+		// Clean up test directory before each test
+		if (existsSync(mockCodexDir)) {
+			rmSync(mockCodexDir, { recursive: true, force: true });
+		}
+	});
+
+	afterEach(() => {
+		// Clean up test directory after each test
+		if (existsSync(mockCodexDir)) {
+			rmSync(mockCodexDir, { recursive: true, force: true });
+		}
+	});
+
+	describe("convertToCodexMcpConfig", () => {
+		it("should convert stdio transport config", () => {
+			const config: McpServerConfig = {
+				command: "npx",
+				args: ["-y", "@anthropic-ai/mcp-linear"],
+				env: {
+					LINEAR_API_TOKEN: "test-token",
+				},
+			};
+
+			const result = convertToCodexMcpConfig("linear", config);
+
+			expect(result).toEqual({
+				transport: "stdio",
+				command: "npx",
+				args: ["-y", "@anthropic-ai/mcp-linear"],
+				env: {
+					LINEAR_API_TOKEN: "test-token",
+				},
+				enabled: true,
+			});
+		});
+
+		it("should convert stdio transport with cwd", () => {
+			const config: McpServerConfig = {
+				command: "node",
+				args: ["server.js"],
+				cwd: "/path/to/server",
+			};
+
+			const result = convertToCodexMcpConfig("custom", config);
+
+			expect(result).toEqual({
+				transport: "stdio",
+				command: "node",
+				args: ["server.js"],
+				cwd: "/path/to/server",
+				enabled: true,
+			});
+		});
+
+		it("should convert stdio transport with timeout", () => {
+			const config: McpServerConfig = {
+				command: "npx",
+				args: ["-y", "mcp-server"],
+				timeout: 30000, // 30 seconds in milliseconds
+			};
+
+			const result = convertToCodexMcpConfig("test", config);
+
+			expect(result).toEqual({
+				transport: "stdio",
+				command: "npx",
+				args: ["-y", "mcp-server"],
+				tool_timeout: { secs: 30 },
+				enabled: true,
+			});
+		});
+
+		it("should convert stdio transport with tool filtering", () => {
+			const config: McpServerConfig = {
+				command: "npx",
+				args: ["-y", "mcp-server"],
+				includeTools: ["tool1", "tool2"],
+				excludeTools: ["tool3"],
+			};
+
+			const result = convertToCodexMcpConfig("test", config);
+
+			expect(result).toEqual({
+				transport: "stdio",
+				command: "npx",
+				args: ["-y", "mcp-server"],
+				enabled_tools: ["tool1", "tool2"],
+				disabled_tools: ["tool3"],
+				enabled: true,
+			});
+		});
+
+		it("should convert streamable_http transport config", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				enabled: true,
+			});
+		});
+
+		it("should convert streamable_http with headers", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+				headers: {
+					"X-Custom-Header": "value",
+					"Content-Type": "application/json",
+				},
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				headers: {
+					"X-Custom-Header": "value",
+					"Content-Type": "application/json",
+				},
+				enabled: true,
+			});
+		});
+
+		it("should extract bearer token to bearer_env_var", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+				headers: {
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: Testing template variable extraction
+					Authorization: "Bearer ${API_TOKEN}",
+					"X-Custom": "value",
+				},
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				bearer_env_var: "API_TOKEN",
+				headers: {
+					"X-Custom": "value",
+				},
+				enabled: true,
+			});
+		});
+
+		it("should remove headers object if only Authorization existed", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+				headers: {
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: Testing template variable extraction
+					Authorization: "Bearer ${API_TOKEN}",
+				},
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				bearer_env_var: "API_TOKEN",
+				enabled: true,
+			});
+			expect(result?.headers).toBeUndefined();
+		});
+
+		it("should convert streamable_http with timeout", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+				timeout: 45000, // 45 seconds
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				tool_timeout: { secs: 45 },
+				enabled: true,
+			});
+		});
+
+		it("should convert streamable_http with tool filtering", () => {
+			const config: McpServerConfig = {
+				url: "https://api.example.com/mcp",
+				includeTools: ["search", "fetch"],
+			};
+
+			const result = convertToCodexMcpConfig("http-server", config);
+
+			expect(result).toEqual({
+				transport: "streamable_http",
+				url: "https://api.example.com/mcp",
+				enabled_tools: ["search", "fetch"],
+				enabled: true,
+			});
+		});
+
+		it("should return null for SDK instance (has listTools method)", () => {
+			const config = {
+				name: "sdk-server",
+				listTools: () => Promise.resolve([]),
+				callTool: () => Promise.resolve({}),
+			} as unknown as McpServerConfig;
+
+			const result = convertToCodexMcpConfig("sdk-server", config);
+
+			expect(result).toBeNull();
+		});
+
+		it("should return null for config with no valid transport", () => {
+			const config = {
+				env: { KEY: "value" },
+			} as McpServerConfig;
+
+			const result = convertToCodexMcpConfig("invalid", config);
+
+			expect(result).toBeNull();
+		});
+
+		it("should round up milliseconds to seconds for timeout", () => {
+			const config: McpServerConfig = {
+				command: "test",
+				timeout: 1500, // 1.5 seconds -> should round up to 2
+			};
+
+			const result = convertToCodexMcpConfig("test", config);
+
+			expect(result?.tool_timeout).toEqual({ secs: 2 });
+		});
+	});
+
+	describe("loadMcpConfigFromPaths", () => {
+		it("should return empty object for undefined path", () => {
+			const result = loadMcpConfigFromPaths(undefined);
+			expect(result).toEqual({});
+		});
+
+		it("should return empty object for empty array", () => {
+			const result = loadMcpConfigFromPaths([]);
+			expect(result).toEqual({});
+		});
+
+		it("should load MCP config from single file path", () => {
+			// Create test config file
+			const testConfigPath = join(TEST_DIR, "test-mcp.json");
+			mkdirSync(TEST_DIR, { recursive: true });
+			const testConfig = {
+				mcpServers: {
+					linear: {
+						command: "npx",
+						args: ["-y", "@anthropic-ai/mcp-linear"],
+					},
+				},
+			};
+			writeFileSync(testConfigPath, JSON.stringify(testConfig));
+
+			const result = loadMcpConfigFromPaths(testConfigPath);
+
+			expect(result).toEqual(testConfig.mcpServers);
+
+			// Cleanup
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		});
+
+		it("should merge configs from multiple paths", () => {
+			// Create test config files
+			mkdirSync(TEST_DIR, { recursive: true });
+
+			const config1Path = join(TEST_DIR, "config1.json");
+			const config1 = {
+				mcpServers: {
+					linear: { command: "npx", args: ["-y", "linear"] },
+				},
+			};
+			writeFileSync(config1Path, JSON.stringify(config1));
+
+			const config2Path = join(TEST_DIR, "config2.json");
+			const config2 = {
+				mcpServers: {
+					github: { command: "npx", args: ["-y", "github"] },
+				},
+			};
+			writeFileSync(config2Path, JSON.stringify(config2));
+
+			const result = loadMcpConfigFromPaths([config1Path, config2Path]);
+
+			expect(result).toEqual({
+				linear: { command: "npx", args: ["-y", "linear"] },
+				github: { command: "npx", args: ["-y", "github"] },
+			});
+
+			// Cleanup
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		});
+
+		it("should handle invalid JSON gracefully", () => {
+			// Create invalid JSON file
+			const testConfigPath = join(TEST_DIR, "invalid.json");
+			mkdirSync(TEST_DIR, { recursive: true });
+			writeFileSync(testConfigPath, "{ invalid json }");
+
+			const result = loadMcpConfigFromPaths(testConfigPath);
+
+			expect(result).toEqual({});
+
+			// Cleanup
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		});
+	});
+
+	describe("autoDetectMcpConfig", () => {
+		it("should return undefined for no working directory", () => {
+			const result = autoDetectMcpConfig(undefined);
+			expect(result).toBeUndefined();
+		});
+
+		it("should return undefined when .mcp.json doesn't exist", () => {
+			const result = autoDetectMcpConfig(TEST_DIR);
+			expect(result).toBeUndefined();
+		});
+
+		it("should return path when valid .mcp.json exists", () => {
+			// Create valid .mcp.json
+			mkdirSync(TEST_DIR, { recursive: true });
+			const mcpPath = join(TEST_DIR, ".mcp.json");
+			writeFileSync(mcpPath, JSON.stringify({ mcpServers: {} }));
+
+			const result = autoDetectMcpConfig(TEST_DIR);
+
+			expect(result).toBe(mcpPath);
+
+			// Cleanup
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		});
+
+		it("should return undefined for invalid JSON", () => {
+			// Create invalid .mcp.json
+			mkdirSync(TEST_DIR, { recursive: true });
+			const mcpPath = join(TEST_DIR, ".mcp.json");
+			writeFileSync(mcpPath, "{ invalid }");
+
+			const result = autoDetectMcpConfig(TEST_DIR);
+
+			expect(result).toBeUndefined();
+
+			// Cleanup
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		});
+	});
+
+	describe("backup and restore operations", () => {
+		it("should return false when backing up non-existent config", () => {
+			const result = backupCodexConfig();
+			expect(result).toBe(false);
+		});
+
+		it("should create backup of existing config", () => {
+			// Create config file
+			mkdirSync(mockCodexDir, { recursive: true });
+			writeFileSync(mockConfigPath, "[mcp_servers]\n");
+
+			const result = backupCodexConfig();
+
+			expect(result).toBe(true);
+			expect(existsSync(mockBackupPath)).toBe(true);
+		});
+
+		it("should return false when restoring non-existent backup", () => {
+			const result = restoreCodexConfig();
+			expect(result).toBe(false);
+		});
+
+		it("should restore config from backup", () => {
+			// Create config and backup
+			mkdirSync(mockCodexDir, { recursive: true });
+			const originalContent = "[mcp_servers]\ntest = true\n";
+			writeFileSync(mockConfigPath, "modified content");
+			writeFileSync(mockBackupPath, originalContent);
+
+			const result = restoreCodexConfig();
+
+			expect(result).toBe(true);
+			expect(readFileSync(mockConfigPath, "utf-8")).toBe(originalContent);
+			expect(existsSync(mockBackupPath)).toBe(false);
+		});
+
+		it("should delete config when it exists", () => {
+			mkdirSync(mockCodexDir, { recursive: true });
+			writeFileSync(mockConfigPath, "test");
+
+			deleteCodexConfig();
+
+			expect(existsSync(mockConfigPath)).toBe(false);
+		});
+
+		it("should not throw when deleting non-existent config", () => {
+			expect(() => deleteCodexConfig()).not.toThrow();
+		});
+	});
+
+	describe("writeCodexConfig", () => {
+		it("should create directory if it doesn't exist", () => {
+			const options: CodexConfigOptions = {
+				mcpServers: {},
+			};
+
+			writeCodexConfig(options);
+
+			expect(existsSync(mockCodexDir)).toBe(true);
+		});
+
+		it("should write valid TOML config", () => {
+			const options: CodexConfigOptions = {
+				mcpServers: {
+					linear: {
+						transport: "stdio",
+						command: "npx",
+						args: ["-y", "@anthropic-ai/mcp-linear"],
+						env: {
+							LINEAR_API_TOKEN: "test-token",
+						},
+						enabled: true,
+					},
+				},
+			};
+
+			writeCodexConfig(options);
+
+			const content = readFileSync(mockConfigPath, "utf-8");
+			const parsed = toml.parse(content);
+
+			expect(parsed).toHaveProperty("mcp_servers");
+			expect(parsed.mcp_servers).toHaveProperty("linear");
+			const linear = (parsed.mcp_servers as any).linear;
+			expect(linear.transport).toBe("stdio");
+			expect(linear.command).toBe("npx");
+			expect(linear.enabled).toBe(true);
+		});
+
+		it("should write config with multiple servers", () => {
+			const options: CodexConfigOptions = {
+				mcpServers: {
+					linear: {
+						transport: "stdio",
+						command: "npx",
+						args: ["-y", "linear"],
+						enabled: true,
+					},
+					github: {
+						transport: "streamable_http",
+						url: "https://api.github.com/mcp",
+						enabled: true,
+					},
+				},
+			};
+
+			writeCodexConfig(options);
+
+			const content = readFileSync(mockConfigPath, "utf-8");
+			const parsed = toml.parse(content);
+
+			expect(parsed.mcp_servers).toHaveProperty("linear");
+			expect(parsed.mcp_servers).toHaveProperty("github");
+		});
+	});
+
+	describe("setupCodexConfig", () => {
+		it("should setup config and return cleanup function", () => {
+			const servers: Record<string, CodexMcpServerConfig> = {
+				linear: {
+					transport: "stdio",
+					command: "npx",
+					enabled: true,
+				},
+			};
+
+			const cleanup = setupCodexConfig(servers);
+
+			// Config should be written
+			expect(existsSync(mockConfigPath)).toBe(true);
+
+			// Cleanup should delete the config
+			cleanup();
+			expect(existsSync(mockConfigPath)).toBe(false);
+		});
+
+		it("should restore original config on cleanup when backup exists", () => {
+			// Create original config
+			mkdirSync(mockCodexDir, { recursive: true });
+			const originalContent = '[mcp_servers.original]\ntransport = "stdio"\n';
+			writeFileSync(mockConfigPath, originalContent);
+
+			const servers: Record<string, CodexMcpServerConfig> = {
+				new: {
+					transport: "stdio",
+					command: "test",
+					enabled: true,
+				},
+			};
+
+			const cleanup = setupCodexConfig(servers);
+
+			// New config should be different
+			const newContent = readFileSync(mockConfigPath, "utf-8");
+			expect(newContent).not.toBe(originalContent);
+
+			// Cleanup should restore original
+			cleanup();
+			const restoredContent = readFileSync(mockConfigPath, "utf-8");
+			expect(restoredContent).toBe(originalContent);
+		});
+
+		it("should delete config on cleanup when no backup existed", () => {
+			const servers: Record<string, CodexMcpServerConfig> = {
+				test: {
+					transport: "stdio",
+					command: "test",
+					enabled: true,
+				},
+			};
+
+			const cleanup = setupCodexConfig(servers);
+
+			expect(existsSync(mockConfigPath)).toBe(true);
+
+			cleanup();
+
+			expect(existsSync(mockConfigPath)).toBe(false);
+		});
+	});
+
+	describe("integration: full conversion workflow", () => {
+		it("should convert and write complete config", () => {
+			const mcpConfig: Record<string, McpServerConfig> = {
+				linear: {
+					command: "npx",
+					args: ["-y", "@anthropic-ai/mcp-linear"],
+					env: { LINEAR_API_TOKEN: "token" },
+					timeout: 60000,
+					includeTools: ["create_issue", "list_issues"],
+				},
+				http_server: {
+					url: "https://api.example.com/mcp",
+					headers: {
+						// biome-ignore lint/suspicious/noTemplateCurlyInString: Testing template variable extraction
+						Authorization: "Bearer ${API_KEY}",
+					},
+					excludeTools: ["dangerous_tool"],
+				},
+			};
+
+			// Convert all servers
+			const codexServers: Record<string, CodexMcpServerConfig> = {};
+			for (const [name, config] of Object.entries(mcpConfig)) {
+				const converted = convertToCodexMcpConfig(name, config);
+				if (converted) {
+					codexServers[name] = converted;
+				}
+			}
+
+			// Setup config
+			const cleanup = setupCodexConfig(codexServers);
+
+			// Verify TOML was written correctly
+			const content = readFileSync(mockConfigPath, "utf-8");
+			const parsed = toml.parse(content);
+
+			expect(parsed.mcp_servers).toHaveProperty("linear");
+			expect(parsed.mcp_servers).toHaveProperty("http_server");
+
+			const linear = (parsed.mcp_servers as any).linear;
+			expect(linear.transport).toBe("stdio");
+			expect(linear.command).toBe("npx");
+			expect(linear.enabled_tools).toEqual(["create_issue", "list_issues"]);
+
+			const httpServer = (parsed.mcp_servers as any).http_server;
+			expect(httpServer.transport).toBe("streamable_http");
+			expect(httpServer.bearer_env_var).toBe("API_KEY");
+			expect(httpServer.disabled_tools).toEqual(["dangerous_tool"]);
+
+			// Cleanup
+			cleanup();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements configuration management for Codex's `~/.codex/config.toml` file, including MCP server conversion from `.mcp.json` format.

**Stack Position**: 5 of 7 in Graphite stack  
**Previous**: CYPACK-525  
**Linear Issue**: https://linear.app/ceedar/issue/CYPACK-526

## Implementation

### Core Components

- **`src/configGenerator.ts`**: Complete configuration generator with TOML serialization
  - `setupCodexConfig(mcpServers)` - Main setup returning cleanup callback
  - `backupCodexConfig()` - Backs up existing config.toml
  - `restoreCodexConfig()` - Restores from backup
  - `deleteCodexConfig()` - Deletes temporary config
  - `convertToCodexMcpConfig()` - Converts SDK format to TOML format
  - `loadMcpConfigFromPaths()` - Loads/merges .mcp.json files
  - `autoDetectMcpConfig()` - Auto-detects .mcp.json in working directory

- **`src/types.ts`**: Added `CodexMcpServerConfig` interface
  - `stdio` transport: command, args, cwd, env
  - `streamable_http` transport: url, headers, bearer_env_var
  - Tool filtering: enabled_tools, disabled_tools
  - Timeout configuration: startup_timeout, tool_timeout

### MCP Server Format Conversion

**stdio transport**:
```typescript
{
  transport: "stdio",
  command: "npx",
  args: ["-y", "@anthropic-ai/mcp-linear"],
  env: { LINEAR_API_TOKEN: "..." },
  enabled: true
}
```

**streamable_http transport**:
```typescript
{
  transport: "streamable_http",
  url: "https://api.example.com/mcp",
  bearer_env_var: "API_TOKEN", // Extracted from Authorization header
  enabled: true
}
```

### Features

✅ SDK instance detection (skips in-process servers)  
✅ Timeout conversion (milliseconds → seconds)  
✅ Bearer token extraction from `Authorization: Bearer ${VAR}` headers  
✅ Tool filtering (includeTools → enabled_tools, excludeTools → disabled_tools)  
✅ Directory creation (~/.codex)  
✅ Cleanup with state tracking (restore if existed, delete if new)

## Testing

- **35 comprehensive unit tests** covering all functions
- Tests for stdio and streamable_http conversion
- Tests for backup/restore operations
- Tests for config file operations
- Integration test for full workflow
- **All 170 tests passing** (35 for configGenerator)

## Verification

```bash
cd packages/codex-runner
pnpm test:run    # 170 tests passing
pnpm typecheck   # Types valid
pnpm build       # Build successful
npx biome check  # Linting clean
```

## Dependencies

- Requires types from CYPACK-522
- Uses `@iarna/toml` for TOML serialization
- Follows gemini-runner patterns exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)