### PR TITLE
[CYPACK-527] Implement Core CodexRunner Class

### DIFF
--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1,1 +1,495 @@
-// CodexRunner implementation
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import type { IAgentRunner, IMessageFormatter, SDKMessage } from "cyrus-core";
+import { codexEventToSDKMessage } from "./adapters.js";
+import {
+	autoDetectMcpConfig,
+	convertToCodexMcpConfig,
+	loadMcpConfigFromPaths,
+	setupCodexConfig,
+} from "./configGenerator.js";
+import { CodexMessageFormatter } from "./formatter.js";
+import { safeParseCodexEvent, type ThreadEvent } from "./schemas.js";
+import type {
+	CodexMcpServerConfig,
+	CodexRunnerConfig,
+	CodexRunnerEvents,
+	CodexSessionInfo,
+} from "./types.js";
+
+export declare interface CodexRunner {
+	on<K extends keyof CodexRunnerEvents>(
+		event: K,
+		listener: CodexRunnerEvents[K],
+	): this;
+	emit<K extends keyof CodexRunnerEvents>(
+		event: K,
+		...args: Parameters<CodexRunnerEvents[K]>
+	): boolean;
+}
+
+/**
+ * Manages Codex CLI sessions and communication
+ *
+ * CodexRunner implements the IAgentRunner interface to provide a provider-agnostic
+ * wrapper around the Codex CLI. It spawns the Codex CLI process and translates
+ * between the CLI's JSONL format and Claude SDK message types.
+ *
+ * @example
+ * ```typescript
+ * const runner = new CodexRunner({
+ *   cyrusHome: '/home/user/.cyrus',
+ *   workingDirectory: '/path/to/repo',
+ *   model: 'gpt-4o',
+ *   autoApprove: true
+ * });
+ *
+ * await runner.start("Implement a new feature");
+ * const messages = runner.getMessages();
+ * ```
+ */
+export class CodexRunner extends EventEmitter implements IAgentRunner {
+	/**
+	 * CodexRunner does not support streaming input.
+	 * The session starts with a single prompt and runs to completion.
+	 */
+	readonly supportsStreamingInput = false;
+
+	private config: CodexRunnerConfig;
+	private process: ChildProcess | null = null;
+	private sessionInfo: CodexSessionInfo | null = null;
+	private logStream: WriteStream | null = null;
+	private readableLogStream: WriteStream | null = null;
+	private messages: SDKMessage[] = [];
+	private cyrusHome: string;
+	private configCleanup: (() => void) | null = null;
+	private formatter: IMessageFormatter;
+	private readlineInterface: ReturnType<typeof createInterface> | null = null;
+
+	constructor(config: CodexRunnerConfig) {
+		super();
+		this.config = config;
+		this.cyrusHome = config.cyrusHome;
+		this.formatter = new CodexMessageFormatter();
+
+		// Forward config callbacks to events
+		if (config.onMessage) this.on("message", config.onMessage);
+		if (config.onError) this.on("error", config.onError);
+		if (config.onComplete) this.on("complete", config.onComplete);
+	}
+
+	/**
+	 * Start a new Codex session with the given prompt
+	 */
+	async start(prompt: string): Promise<CodexSessionInfo> {
+		if (this.isRunning()) {
+			throw new Error("Codex session already running");
+		}
+
+		// Initialize session info without session ID (will be set from thread.started event)
+		this.sessionInfo = {
+			sessionId: null,
+			startedAt: new Date(),
+			isRunning: true,
+		};
+
+		console.log(
+			`[CodexRunner] Starting new session (thread ID will be assigned by Codex)`,
+		);
+		console.log(
+			"[CodexRunner] Working directory:",
+			this.config.workingDirectory,
+		);
+
+		// Ensure working directory exists
+		if (this.config.workingDirectory) {
+			try {
+				mkdirSync(this.config.workingDirectory, { recursive: true });
+				console.log("[CodexRunner] Created working directory");
+			} catch (err) {
+				console.error("[CodexRunner] Failed to create working directory:", err);
+			}
+		}
+
+		// Set up logging
+		this.setupLogging();
+
+		// Reset messages array
+		this.messages = [];
+
+		// Build MCP servers configuration
+		const mcpServers = this.buildMcpServers();
+
+		// Setup Codex config.toml with MCP servers
+		// Only setup config if we have something to configure
+		if (Object.keys(mcpServers).length > 0) {
+			this.configCleanup = setupCodexConfig(mcpServers);
+		}
+
+		try {
+			// Build Codex CLI command
+			const args = this.buildArgs(prompt);
+
+			// Spawn Codex CLI process
+			const codexPath = this.config.codexPath || "codex";
+			console.log(`[CodexRunner] Spawning: ${codexPath} ${args.join(" ")}`);
+			this.process = spawn(codexPath, args, {
+				cwd: this.config.workingDirectory,
+				stdio: ["ignore", "pipe", "pipe"],
+				env: process.env,
+			});
+
+			// Set up stdout line reader for JSONL events
+			this.readlineInterface = createInterface({
+				input: this.process.stdout!,
+				crlfDelay: Infinity,
+			});
+
+			// Process each line as a JSONL event with Zod validation
+			this.readlineInterface.on("line", (line: string) => {
+				const result = safeParseCodexEvent(line);
+				if (result.success) {
+					this.processEvent(result.data);
+				} else {
+					console.error(
+						"[CodexRunner] Failed to parse/validate JSONL event:",
+						line,
+					);
+				}
+			});
+
+			// Handle stderr
+			this.process.stderr?.on("data", (data: Buffer) => {
+				const stderrText = data.toString();
+				console.error("[CodexRunner] stderr:", stderrText);
+			});
+
+			// Wait for process to complete
+			await new Promise<void>((resolve, reject) => {
+				if (!this.process) {
+					reject(new Error("Process not started"));
+					return;
+				}
+
+				this.process.on("close", (code: number | null) => {
+					// Close readline interface first to prevent hang
+					if (this.readlineInterface) {
+						this.readlineInterface.close();
+						this.readlineInterface = null;
+					}
+
+					console.log(`[CodexRunner] Process exited with code ${code}`);
+					if (this.sessionInfo) {
+						this.sessionInfo.isRunning = false;
+					}
+
+					// Emit complete event
+					this.emit("complete", this.messages);
+
+					// Close log streams
+					if (this.logStream) {
+						this.logStream.end();
+						this.logStream = null;
+					}
+					if (this.readableLogStream) {
+						this.readableLogStream.end();
+						this.readableLogStream = null;
+					}
+
+					// Cleanup config
+					if (this.configCleanup) {
+						this.configCleanup();
+						this.configCleanup = null;
+					}
+
+					if (code !== 0 && code !== null) {
+						reject(new Error(`Codex process exited with code ${code}`));
+					} else {
+						resolve();
+					}
+				});
+
+				this.process.on("error", (error: Error) => {
+					console.error("[CodexRunner] Process error:", error);
+					this.emit("error", error);
+					reject(error);
+				});
+			});
+
+			return this.sessionInfo;
+		} catch (error) {
+			console.error("[CodexRunner] Failed to start session:", error);
+			if (this.sessionInfo) {
+				this.sessionInfo.isRunning = false;
+			}
+
+			// Cleanup config on error
+			if (this.configCleanup) {
+				this.configCleanup();
+				this.configCleanup = null;
+			}
+
+			throw error;
+		}
+	}
+
+	/**
+	 * Stop the running Codex session
+	 */
+	stop(): void {
+		if (this.process) {
+			console.log("[CodexRunner] Stopping process");
+			// Close readline before killing to prevent hang
+			if (this.readlineInterface) {
+				this.readlineInterface.close();
+				this.readlineInterface = null;
+			}
+			this.process.kill();
+			this.process = null;
+		}
+		if (this.sessionInfo) {
+			this.sessionInfo.isRunning = false;
+		}
+
+		// Cleanup config
+		if (this.configCleanup) {
+			this.configCleanup();
+			this.configCleanup = null;
+		}
+	}
+
+	/**
+	 * Check if a session is currently running
+	 */
+	isRunning(): boolean {
+		return this.sessionInfo?.isRunning ?? false;
+	}
+
+	/**
+	 * Get all messages from the current session
+	 */
+	getMessages(): SDKMessage[] {
+		return [...this.messages];
+	}
+
+	/**
+	 * Get the message formatter for this runner
+	 */
+	getFormatter(): IMessageFormatter {
+		return this.formatter;
+	}
+
+	/**
+	 * Build CLI arguments for Codex
+	 */
+	private buildArgs(prompt: string): string[] {
+		const args: string[] = ["exec", "--json"];
+
+		// Add auto-approve flag (bypasses approvals and sandbox)
+		if (this.config.autoApprove) {
+			args.push("--dangerously-bypass-approvals-and-sandbox");
+		}
+
+		// Add full-auto flag
+		if (this.config.fullAuto) {
+			args.push("--full-auto");
+		}
+
+		// Add working directory
+		if (this.config.workingDirectory) {
+			args.push("--cd", this.config.workingDirectory);
+		}
+
+		// Add skip git repo check
+		if (this.config.skipGitRepoCheck) {
+			args.push("--skip-git-repo-check");
+		}
+
+		// Add web search
+		if (this.config.webSearchEnabled) {
+			args.push("--search");
+		}
+
+		// Add model
+		if (this.config.model) {
+			args.push("--model", this.config.model);
+		}
+
+		// Add additional directories
+		if (
+			this.config.additionalDirectories &&
+			this.config.additionalDirectories.length > 0
+		) {
+			for (const dir of this.config.additionalDirectories) {
+				args.push("--add-dir", dir);
+			}
+		}
+
+		// Add the prompt as the last argument
+		args.push(prompt);
+
+		return args;
+	}
+
+	/**
+	 * Build MCP servers configuration from various sources
+	 */
+	private buildMcpServers(): Record<string, CodexMcpServerConfig> {
+		const mcpServers: Record<string, CodexMcpServerConfig> = {};
+
+		// 1. Load from auto-detected .mcp.json in working directory
+		const autoDetectedPath = autoDetectMcpConfig(this.config.workingDirectory);
+		if (autoDetectedPath) {
+			console.log(
+				`[CodexRunner] Auto-detected MCP config: ${autoDetectedPath}`,
+			);
+			const autoServers = loadMcpConfigFromPaths([autoDetectedPath]);
+			for (const [name, config] of Object.entries(autoServers)) {
+				const codexConfig = convertToCodexMcpConfig(name, config);
+				if (codexConfig) {
+					mcpServers[name] = codexConfig;
+				}
+			}
+		}
+
+		// 2. Load from explicitly configured mcpConfigPath
+		if (this.config.mcpConfigPath) {
+			const paths = Array.isArray(this.config.mcpConfigPath)
+				? this.config.mcpConfigPath
+				: [this.config.mcpConfigPath];
+			const explicitServers = loadMcpConfigFromPaths(paths);
+			for (const [name, config] of Object.entries(explicitServers)) {
+				const codexConfig = convertToCodexMcpConfig(name, config);
+				if (codexConfig) {
+					mcpServers[name] = codexConfig;
+				}
+			}
+		}
+
+		// 3. Add inline mcpConfig servers (highest priority, can override)
+		if (this.config.mcpConfig) {
+			for (const [name, config] of Object.entries(this.config.mcpConfig)) {
+				const codexConfig = convertToCodexMcpConfig(name, config);
+				if (codexConfig) {
+					mcpServers[name] = codexConfig;
+				}
+			}
+		}
+
+		// Filter by allowMCPServers/excludeMCPServers
+		let filteredServers = mcpServers;
+		if (this.config.allowMCPServers) {
+			filteredServers = Object.fromEntries(
+				Object.entries(filteredServers).filter(([name]) =>
+					this.config.allowMCPServers?.includes(name),
+				),
+			);
+		}
+		if (this.config.excludeMCPServers) {
+			filteredServers = Object.fromEntries(
+				Object.entries(filteredServers).filter(
+					([name]) => !this.config.excludeMCPServers?.includes(name),
+				),
+			);
+		}
+
+		return filteredServers;
+	}
+
+	/**
+	 * Process a single Codex event
+	 */
+	private processEvent(event: ThreadEvent): void {
+		console.log(`[CodexRunner] Processing event: ${event.type}`);
+
+		// Extract thread_id from thread.started event
+		if (event.type === "thread.started") {
+			const threadId = event.thread_id;
+			if (this.sessionInfo) {
+				this.sessionInfo.sessionId = threadId;
+			}
+			console.log(`[CodexRunner] Thread started with ID: ${threadId}`);
+			// Re-setup logging with session ID
+			this.setupLogging();
+		}
+
+		// Emit raw event for debugging
+		this.emit("event", event);
+
+		// Convert to SDK message
+		const sessionId = this.sessionInfo?.sessionId || "unknown";
+		const sdkMessage = codexEventToSDKMessage(event, sessionId);
+
+		if (sdkMessage) {
+			// Add to messages array and emit
+			this.emitMessage(sdkMessage);
+		}
+	}
+
+	/**
+	 * Emit a message and add it to the messages array
+	 */
+	private emitMessage(message: SDKMessage): void {
+		this.messages.push(message);
+
+		// Write to logs
+		if (this.logStream) {
+			this.logStream.write(`${JSON.stringify(message)}\n`);
+		}
+		if (this.readableLogStream) {
+			this.readableLogStream.write(
+				`[${message.type}] ${JSON.stringify(message, null, 2)}\n\n`,
+			);
+		}
+
+		// Emit message event
+		this.emit("message", message);
+	}
+
+	/**
+	 * Set up logging streams
+	 */
+	private setupLogging(): void {
+		const workspaceName = this.config.workspaceName || "default";
+		const sessionId = this.sessionInfo?.sessionId || "pending";
+		const logsDir = join(this.cyrusHome, "logs", workspaceName);
+
+		// Create logs directory
+		mkdirSync(logsDir, { recursive: true });
+
+		// Close existing log streams if re-setting up
+		if (this.logStream) {
+			this.logStream.end();
+		}
+		if (this.readableLogStream) {
+			this.readableLogStream.end();
+		}
+
+		// Create log streams
+		this.logStream = createWriteStream(join(logsDir, `${sessionId}.ndjson`), {
+			flags: "a",
+		});
+		this.readableLogStream = createWriteStream(
+			join(logsDir, `${sessionId}.log`),
+			{ flags: "a" },
+		);
+
+		// Write session start entry
+		const startEntry = {
+			type: "session_start",
+			sessionId,
+			workingDirectory: this.config.workingDirectory,
+			model: this.config.model,
+			timestamp: new Date().toISOString(),
+		};
+		this.logStream.write(`${JSON.stringify(startEntry)}\n`);
+		this.readableLogStream.write(
+			`=== Session Start ===\n${JSON.stringify(startEntry, null, 2)}\n\n`,
+		);
+
+		console.log(`[CodexRunner] Logging to: ${join(logsDir, sessionId)}.*`);
+	}
+}

--- a/packages/codex-runner/src/index.ts
+++ b/packages/codex-runner/src/index.ts
@@ -1,4 +1,18 @@
 // Main exports
 
 export type { IMessageFormatter } from "cyrus-core";
+export { codexEventToSDKMessage } from "./adapters.js";
+export { CodexRunner } from "./CodexRunner.js";
+export {
+	autoDetectMcpConfig,
+	convertToCodexMcpConfig,
+	loadMcpConfigFromPaths,
+	setupCodexConfig,
+} from "./configGenerator.js";
 export { CodexMessageFormatter, type CodexToolInput } from "./formatter.js";
+export type {
+	CodexMcpServerConfig,
+	CodexRunnerConfig,
+	CodexRunnerEvents,
+	CodexSessionInfo,
+} from "./types.js";

--- a/packages/codex-runner/src/types.ts
+++ b/packages/codex-runner/src/types.ts
@@ -7,7 +7,6 @@
 
 import type {
 	AgentRunnerConfig,
-	AgentSessionInfo,
 	McpServerConfig,
 	SDKMessage,
 } from "cyrus-core";
@@ -133,18 +132,36 @@ export {
 export interface CodexRunnerConfig extends AgentRunnerConfig {
 	/** Path to codex CLI binary (defaults to 'codex' in PATH) */
 	codexPath?: string;
+	/** Sandbox mode: "read-only", "workspace-write", or "danger-full-access" */
+	sandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
+	/** Approval policy: "untrusted", "on-failure", "on-request", or "never" */
+	approvalPolicy?: "untrusted" | "on-failure" | "on-request" | "never";
+	/** Automatically approve all tool calls (bypasses approvals and sandbox) */
+	autoApprove?: boolean;
+	/** Enable full auto mode (no human intervention) */
+	fullAuto?: boolean;
+	/** Enable web search functionality */
+	webSearchEnabled?: boolean;
 	/** Additional directories to include in workspace context */
-	includeDirectories?: string[];
-	/** Enable single-turn mode */
-	singleTurn?: boolean;
+	additionalDirectories?: string[];
+	/** Skip git repository check before starting */
+	skipGitRepoCheck?: boolean;
+	/** List of MCP server names to allow (whitelist) */
+	allowMCPServers?: string[];
+	/** List of MCP server names to exclude (blacklist) */
+	excludeMCPServers?: string[];
 }
 
 /**
  * Session information for Codex runner
  */
-export interface CodexSessionInfo extends AgentSessionInfo {
+export interface CodexSessionInfo {
 	/** Codex-specific session ID (thread ID) */
 	sessionId: string | null;
+	/** When the session started */
+	startedAt: Date;
+	/** Whether the session is currently active */
+	isRunning: boolean;
 }
 
 /**

--- a/packages/codex-runner/test/CodexRunner.test.ts
+++ b/packages/codex-runner/test/CodexRunner.test.ts
@@ -1,5 +1,339 @@
-import { describe, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexRunner } from "../src/CodexRunner.js";
+import type { CodexRunnerConfig } from "../src/types.js";
+
+/**
+ * Integration tests for CodexRunner
+ *
+ * These tests verify the core functionality of CodexRunner:
+ * - Configuration handling
+ * - CLI argument building
+ * - Event emission
+ * - Message tracking
+ * - Session management
+ */
 
 describe("CodexRunner", () => {
-	it.todo("should be implemented");
+	let config: CodexRunnerConfig;
+
+	beforeEach(() => {
+		config = {
+			cyrusHome: "/tmp/test-cyrus-home",
+			workingDirectory: "/tmp/test-workspace",
+			model: "gpt-4o",
+			autoApprove: true,
+		};
+	});
+
+	describe("Constructor", () => {
+		it("should create a CodexRunner instance", () => {
+			const runner = new CodexRunner(config);
+			expect(runner).toBeInstanceOf(CodexRunner);
+			expect(runner).toBeInstanceOf(EventEmitter);
+		});
+
+		it("should set supportsStreamingInput to false", () => {
+			const runner = new CodexRunner(config);
+			expect(runner.supportsStreamingInput).toBe(false);
+		});
+
+		it("should forward config callbacks to events", () => {
+			const onMessage = vi.fn();
+			const onError = vi.fn();
+			const onComplete = vi.fn();
+
+			const runner = new CodexRunner({
+				...config,
+				onMessage,
+				onError,
+				onComplete,
+			});
+
+			// Emit test events
+			runner.emit("message", {
+				type: "user",
+				message: { role: "user", content: "test" },
+				parent_tool_use_id: null,
+				session_id: "test",
+			});
+			runner.emit("error", new Error("test error"));
+			runner.emit("complete", []);
+
+			expect(onMessage).toHaveBeenCalledOnce();
+			expect(onError).toHaveBeenCalledOnce();
+			expect(onComplete).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe("Session Management", () => {
+		it("should initially not be running", () => {
+			const runner = new CodexRunner(config);
+			expect(runner.isRunning()).toBe(false);
+		});
+
+		it("should return empty messages array initially", () => {
+			const runner = new CodexRunner(config);
+			expect(runner.getMessages()).toEqual([]);
+		});
+
+		it("should return a copy of messages array", () => {
+			const runner = new CodexRunner(config);
+			const messages1 = runner.getMessages();
+			const messages2 = runner.getMessages();
+			expect(messages1).not.toBe(messages2);
+		});
+	});
+
+	describe("Formatter", () => {
+		it("should return a CodexMessageFormatter instance", () => {
+			const runner = new CodexRunner(config);
+			const formatter = runner.getFormatter();
+			expect(formatter).toBeDefined();
+			expect(formatter.formatToolParameter).toBeInstanceOf(Function);
+			expect(formatter.formatToolActionName).toBeInstanceOf(Function);
+			expect(formatter.formatToolResult).toBeInstanceOf(Function);
+		});
+	});
+
+	describe("CLI Argument Building", () => {
+		it("should build basic args with exec --json", () => {
+			const runner = new CodexRunner(config);
+			// Access private method through type assertion for testing
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test prompt");
+
+			expect(args).toContain("exec");
+			expect(args).toContain("--json");
+			expect(args[args.length - 1]).toBe("test prompt");
+		});
+
+		it("should add --dangerously-bypass-approvals-and-sandbox when autoApprove is true", () => {
+			const runner = new CodexRunner({ ...config, autoApprove: true });
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
+		});
+
+		it("should add --full-auto when fullAuto is true", () => {
+			const runner = new CodexRunner({ ...config, fullAuto: true });
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--full-auto");
+		});
+
+		it("should add --cd with working directory", () => {
+			const runner = new CodexRunner(config);
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--cd");
+			expect(args).toContain("/tmp/test-workspace");
+		});
+
+		it("should add --skip-git-repo-check when skipGitRepoCheck is true", () => {
+			const runner = new CodexRunner({ ...config, skipGitRepoCheck: true });
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--skip-git-repo-check");
+		});
+
+		it("should add --search when webSearchEnabled is true", () => {
+			const runner = new CodexRunner({ ...config, webSearchEnabled: true });
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--search");
+		});
+
+		it("should add --model with specified model", () => {
+			const runner = new CodexRunner({ ...config, model: "gpt-5.1-codex-max" });
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--model");
+			expect(args).toContain("gpt-5.1-codex-max");
+		});
+
+		it("should add --add-dir for each additional directory", () => {
+			const runner = new CodexRunner({
+				...config,
+				additionalDirectories: ["/path/to/dir1", "/path/to/dir2"],
+			});
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "test");
+
+			expect(args).toContain("--add-dir");
+			expect(args).toContain("/path/to/dir1");
+			expect(args).toContain("/path/to/dir2");
+		});
+
+		it("should put prompt as the last argument", () => {
+			const runner = new CodexRunner(config);
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "my test prompt");
+
+			expect(args[args.length - 1]).toBe("my test prompt");
+		});
+
+		it("should build complex args with all options", () => {
+			const runner = new CodexRunner({
+				...config,
+				autoApprove: true,
+				fullAuto: true,
+				skipGitRepoCheck: true,
+				webSearchEnabled: true,
+				model: "gpt-4o",
+				additionalDirectories: ["/dir1", "/dir2"],
+			});
+			const buildArgs = (
+				runner as unknown as { buildArgs: (prompt: string) => string[] }
+			).buildArgs;
+			const args = buildArgs.call(runner, "complex prompt");
+
+			expect(args).toEqual([
+				"exec",
+				"--json",
+				"--dangerously-bypass-approvals-and-sandbox",
+				"--full-auto",
+				"--cd",
+				"/tmp/test-workspace",
+				"--skip-git-repo-check",
+				"--search",
+				"--model",
+				"gpt-4o",
+				"--add-dir",
+				"/dir1",
+				"--add-dir",
+				"/dir2",
+				"complex prompt",
+			]);
+		});
+	});
+
+	describe("Stop Method", () => {
+		it("should not throw when called on non-running session", () => {
+			const runner = new CodexRunner(config);
+			expect(() => runner.stop()).not.toThrow();
+		});
+
+		it("should set isRunning to false", () => {
+			const runner = new CodexRunner(config);
+			// Manually set sessionInfo to simulate running state
+			(
+				runner as unknown as { sessionInfo: { isRunning: boolean } }
+			).sessionInfo = {
+				isRunning: true,
+			};
+
+			runner.stop();
+			expect(runner.isRunning()).toBe(false);
+		});
+	});
+
+	describe("MCP Server Building", () => {
+		it("should build MCP servers from config", () => {
+			const runner = new CodexRunner({
+				...config,
+				mcpConfig: {
+					linear: {
+						command: "npx",
+						args: ["-y", "@linear/mcp-server"],
+						env: { LINEAR_API_KEY: "test-key" },
+					},
+				},
+			});
+
+			const buildMcpServers = (
+				runner as unknown as { buildMcpServers: () => Record<string, unknown> }
+			).buildMcpServers;
+			const servers = buildMcpServers.call(runner);
+
+			expect(servers).toHaveProperty("linear");
+		});
+
+		it("should filter servers by allowMCPServers", () => {
+			const runner = new CodexRunner({
+				...config,
+				mcpConfig: {
+					linear: { command: "linear-server" },
+					github: { command: "github-server" },
+				},
+				allowMCPServers: ["linear"],
+			});
+
+			const buildMcpServers = (
+				runner as unknown as { buildMcpServers: () => Record<string, unknown> }
+			).buildMcpServers;
+			const servers = buildMcpServers.call(runner);
+
+			expect(servers).toHaveProperty("linear");
+			expect(servers).not.toHaveProperty("github");
+		});
+
+		it("should filter servers by excludeMCPServers", () => {
+			const runner = new CodexRunner({
+				...config,
+				mcpConfig: {
+					linear: { command: "linear-server" },
+					github: { command: "github-server" },
+				},
+				excludeMCPServers: ["github"],
+			});
+
+			const buildMcpServers = (
+				runner as unknown as { buildMcpServers: () => Record<string, unknown> }
+			).buildMcpServers;
+			const servers = buildMcpServers.call(runner);
+
+			expect(servers).toHaveProperty("linear");
+			expect(servers).not.toHaveProperty("github");
+		});
+	});
+
+	describe("Configuration Options", () => {
+		it("should accept all config options from acceptance criteria", () => {
+			const fullConfig: CodexRunnerConfig = {
+				cyrusHome: "/home/user/.cyrus",
+				workingDirectory: "/path/to/repo",
+				model: "gpt-4o",
+				codexPath: "/custom/path/to/codex",
+				sandboxMode: "workspace-write",
+				approvalPolicy: "on-request",
+				autoApprove: true,
+				fullAuto: false,
+				webSearchEnabled: true,
+				additionalDirectories: ["/dir1", "/dir2"],
+				skipGitRepoCheck: true,
+				mcpConfig: {},
+				mcpConfigPaths: ["/path/to/.mcp.json"],
+				allowMCPServers: ["linear"],
+				excludeMCPServers: ["github"],
+			};
+
+			const runner = new CodexRunner(fullConfig);
+			expect(runner).toBeInstanceOf(CodexRunner);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Implements the core `CodexRunner` class that spawns the Codex CLI, parses JSONL output, and implements the `IAgentRunner` interface. This is the final piece (6 of 7) in the Codex integration stack.

## Implementation

### CodexRunner Class (`src/CodexRunner.ts`)
- Extends `EventEmitter` and implements `IAgentRunner` interface
- Sets `supportsStreamingInput = false` (Codex doesn't support streaming input)
- Implements all required methods: `start()`, `stop()`, `isRunning()`, `getMessages()`, `getFormatter()`

### CLI Argument Building
Implements `buildArgs()` method with support for:
- `exec --json` base command
- `--dangerously-bypass-approvals-and-sandbox` (when autoApprove)
- `--full-auto` (when fullAuto)
- `--cd <workingDirectory>`
- `--skip-git-repo-check` (when configured)
- `--search` (when webSearchEnabled)
- `--model <model>`
- `--add-dir <dir>` (for additionalDirectories)

### JSONL Parsing
- Uses `readline.createInterface` for line-by-line processing
- Validates events with Zod schemas via `safeParseCodexEvent`
- Proper error handling for invalid events

### Config Management
- Integrates `setupCodexConfig()` for MCP server configuration
- Automatic cleanup on session stop/completion
- Supports multiple config sources (auto-detect, explicit paths, inline)

### Event Emission
- Emits `message` events for each SDK message
- Emits `complete` event when process exits
- Emits `error` events for failures
- Emits `event` for raw Codex events (debugging)

### Session Management
- Tracks thread ID from `thread.started` events
- Maintains session state (running, stopped)
- Creates log streams (NDJSON and human-readable)

### Configuration (`src/types.ts`)
Updated `CodexRunnerConfig` with all acceptance criteria fields:
- `codexPath`, `sandboxMode`, `approvalPolicy`
- `autoApprove`, `fullAuto`, `webSearchEnabled`
- `additionalDirectories`, `skipGitRepoCheck`
- `allowMCPServers`, `excludeMCPServers`

## Testing

Added comprehensive integration tests (`test/CodexRunner.test.ts`):
- Constructor and configuration handling (3 tests)
- Session management (3 tests)
- Formatter integration (1 test)
- CLI argument building (10 tests covering all scenarios)
- Stop method (2 tests)
- MCP server building and filtering (3 tests)
- Configuration options validation (1 test)

**Total: 193 tests passing** (23 new CodexRunner tests + 170 existing)

## Verification

✅ All tests pass: `pnpm --filter=cyrus-codex-runner test:run`
✅ Build succeeds: `pnpm --filter=cyrus-codex-runner build`
✅ Type checking clean: `pnpm --filter=cyrus-codex-runner typecheck`

## Stack Position

**6 of 7 in Graphite stack**

Previous: CYPACK-526 (Config.toml generator)
Next: CYPACK-528 (Final integration)

## Links

- Linear Issue: [CYPACK-527](https://linear.app/ceedar/issue/CYPACK-527)
- Stack: cypack-522 → cypack-523 → cypack-524 → cypack-525 → cypack-526 → **cypack-527** → cypack-528

🤖 Generated with [Claude Code](https://claude.com/claude-code)