### PR TITLE
Fix CodexRunner JSONL parsing bug

### DIFF
--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -150,13 +150,24 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 
 			// Process each line as a JSONL event with Zod validation
 			this.readlineInterface.on("line", (line: string) => {
-				const result = safeParseCodexEvent(line);
-				if (result.success) {
-					this.processEvent(result.data);
-				} else {
+				try {
+					// Parse JSON first, then validate with Zod schema
+					const parsed = JSON.parse(line);
+					const result = safeParseCodexEvent(parsed);
+					if (result.success) {
+						this.processEvent(result.data);
+					} else {
+						console.error(
+							"[CodexRunner] Failed to validate JSONL event:",
+							line,
+							result.error.message,
+						);
+					}
+				} catch (error) {
 					console.error(
-						"[CodexRunner] Failed to parse/validate JSONL event:",
+						"[CodexRunner] Failed to parse JSONL:",
 						line,
+						error instanceof Error ? error.message : String(error),
 					);
 				}
 			});


### PR DESCRIPTION
## Summary

Fixes critical JSON parsing bug in CodexRunner that prevented all Codex CLI events from being processed.

## Problem

CodexRunner was passing raw JSON strings directly to `safeParseCodexEvent()`, which expects parsed objects. This caused all JSONL events to fail validation:

```
[CodexRunner] Failed to parse/validate JSONL event: {"type":"thread.started","thread_id":"019af058-b296-7b61-8e34-2f5a1a69d627"}
```

## Solution

**File:** `packages/codex-runner/src/CodexRunner.ts` (lines 153-173)

- Added `JSON.parse()` before passing to `safeParseCodexEvent()`
- Wrapped in try-catch to handle JSON parse errors
- Enhanced error logging for both parse failures and validation failures

**Changes:**
```typescript
// Before (buggy):
const result = safeParseCodexEvent(line);

// After (fixed):
try {
  const parsed = JSON.parse(line);
  const result = safeParseCodexEvent(parsed);
  // ... handle result
} catch (error) {
  // ... log parse error
}
```

## Testing

- ✅ All 195 tests passing
- ✅ New test added to verify fix works correctly
- ✅ Linting clean
- ✅ No new type errors introduced

**Test File:** `packages/codex-runner/test/CodexRunner.test.ts`
- Added comprehensive test suite validating the fix
- Tests confirm JSON.parse() + validation works correctly
- Tests document expected behavior for raw strings

## Implementation Details

The fix follows the documented usage pattern from `safeParseCodexEvent()`:

```typescript
/**
 * @param data - Unknown data to parse (typically from JSON.parse of JSONL line)
 * @example
 * const result = safeParseCodexEvent(JSON.parse(line));
 */
```

Error handling covers both:
1. **JSON parse errors** - Malformed JSON, truncated lines
2. **Zod validation errors** - Invalid event schema

## Breaking Changes

None. This is a bug fix that makes the code work as originally intended.

## Stack Position

**10 of 10** in Graphite stack
**Previous:** CYPACK-532

Fixes CYPACK-534