### PR TITLE
Fix session status tracking and add /status endpoint (CYPACK-531)

### DIFF
--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -319,6 +319,40 @@ export class SharedApplicationServer {
 	}
 
 	/**
+	 * Register a status endpoint handler
+	 * Allows EdgeWorker to provide real-time status information
+	 */
+	registerStatusEndpoint(
+		getStatusFn: () => {
+			status: "idle" | "busy";
+			activeSessions: number;
+			totalSessions: number;
+			sessions: Array<{
+				id: string;
+				issueId: string;
+				issueIdentifier: string;
+				status: string;
+				isRunning: boolean;
+				startedAt: number;
+				repositoryId?: string;
+			}>;
+		},
+	): void {
+		this.initializeFastify();
+
+		this.app!.get("/status", async (_request, reply) => {
+			const status = getStatusFn();
+			return reply.send({
+				...status,
+				uptime: process.uptime(),
+				timestamp: new Date().toISOString(),
+			});
+		});
+
+		console.log(`🔗 Registered /status endpoint`);
+	}
+
+	/**
 	 * Register an approval request and get approval URL
 	 */
 	registerApprovalRequest(sessionId: string): {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in agent session status tracking and adds a `/status` endpoint for monitoring Cyrus process state.

### Problem

When a stop signal was sent to terminate an agent session, the session's `status` remained `Active` even though the runner was stopped (`isRunning() = false`). This created "zombie" sessions that appeared busy to status checks but weren't actually running.

### Solution

1. **Fixed stop signal handling** - Now updates session status to `Complete` after stopping the runner
2. **Added robust busy detection** - New `isBusy()` method checks BOTH `status === Active` AND `runner.isRunning() === true`
3. **Added `/status` endpoint** - Returns real-time process status (`idle`/`busy`), session counts, and detailed session info

## Changes

| File | Changes |
|------|---------|
| `EdgeWorker.ts` | Added `AgentSessionStatus` import, status update in `handleStopSignal`, `/status` registration, `getAggregatedStatus()` method |
| `AgentSessionManager.ts` | Made `updateSessionStatus` public, added transition logging, added `isSessionBusy()`, `isBusy()`, `getStatus()` methods |
| `SharedApplicationServer.ts` | Added `registerStatusEndpoint()` method |

## `/status` Response Format

```json
{
    "status": "idle",
    "activeSessions": 0,
    "totalSessions": 2,
    "uptime": 3600,
    "timestamp": "2025-12-05T22:55:00Z",
    "sessions": [
        {
            "id": "session-abc",
            "issueId": "uuid-123",
            "issueIdentifier": "CYPACK-100",
            "status": "complete",
            "isRunning": false,
            "startedAt": 1733432400000,
            "repositoryId": "repo-1"
        }
    ]
}
```

## Test plan

- [x] Build passes
- [x] All 209 edge-worker tests pass
- [x] All 71 claude-runner tests pass
- [x] TypeScript type check passes
- [x] Lint passes on changed files

Fixes CYPACK-531

🤖 Generated with [Claude Code](https://claude.com/claude-code)