### PR TITLE
Fix biome formatting in initTestRepo.ts

### DIFF
--- a/apps/f1/src/commands/initTestRepo.ts
+++ b/apps/f1/src/commands/initTestRepo.ts
@@ -83,8 +83,6 @@ export function createInitTestRepoCommand(): Command {
 				);
 				console.log(success("Created initial commit"));
 
-
-
 				console.log(`\n${success("Test repository created successfully!")}\n`);
 				console.log("Next steps:");
 				console.log(`  cd ${targetPath}`);


### PR DESCRIPTION
Remove extra blank lines that were causing biome CI to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)