### PR TITLE
Change routing message to 'Analyzing your request...'

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -23,7 +23,7 @@ import {
 	type SerializedCyrusAgentSessionEntry,
 	type Workspace,
 } from "cyrus-core";
-import type { ProcedureRouter } from "./procedures/ProcedureRouter.js";
+import type { ProcedureAnalyzer } from "./procedures/ProcedureAnalyzer.js";
 import type { SharedApplicationServer } from "./SharedApplicationServer.js";
 
 /**
@@ -65,7 +65,7 @@ export class AgentSessionManager extends EventEmitter {
 	private toolCallsByToolUseId: Map<string, { name: string; input: any }> =
 		new Map(); // Track tool calls by their tool_use_id
 	private activeStatusActivitiesBySession: Map<string, string> = new Map(); // Maps session ID to active compacting status activity ID
-	private procedureRouter?: ProcedureRouter;
+	private procedureAnalyzer?: ProcedureAnalyzer;
 	private sharedApplicationServer?: SharedApplicationServer;
 	private getParentSessionId?: (childSessionId: string) => string | undefined;
 	private resumeParentSession?: (
@@ -82,14 +82,14 @@ export class AgentSessionManager extends EventEmitter {
 			prompt: string,
 			childSessionId: string,
 		) => Promise<void>,
-		procedureRouter?: ProcedureRouter,
+		procedureAnalyzer?: ProcedureAnalyzer,
 		sharedApplicationServer?: SharedApplicationServer,
 	) {
 		super();
 		this.issueTracker = issueTracker;
 		this.getParentSessionId = getParentSessionId;
 		this.resumeParentSession = resumeParentSession;
-		this.procedureRouter = procedureRouter;
+		this.procedureAnalyzer = procedureAnalyzer;
 		this.sharedApplicationServer = sharedApplicationServer;
 	}
 
@@ -261,8 +261,8 @@ export class AgentSessionManager extends EventEmitter {
 		linearAgentActivitySessionId: string,
 		resultMessage: SDKResultMessage,
 	): Promise<void> {
-		if (!this.procedureRouter) {
-			throw new Error("ProcedureRouter not available");
+		if (!this.procedureAnalyzer) {
+			throw new Error("ProcedureAnalyzer not available");
 		}
 
 		// Check if error occurred
@@ -283,12 +283,12 @@ export class AgentSessionManager extends EventEmitter {
 		}
 
 		// Check if there's a next subroutine
-		const nextSubroutine = this.procedureRouter.getNextSubroutine(session);
+		const nextSubroutine = this.procedureAnalyzer.getNextSubroutine(session);
 
 		if (nextSubroutine) {
 			// More subroutines to run - check if current subroutine requires approval
 			const currentSubroutine =
-				this.procedureRouter.getCurrentSubroutine(session);
+				this.procedureAnalyzer.getCurrentSubroutine(session);
 
 			if (currentSubroutine?.requiresApproval) {
 				console.log(
@@ -399,7 +399,7 @@ export class AgentSessionManager extends EventEmitter {
 			console.log(
 				`[AgentSessionManager] Subroutine completed, advancing to next: ${nextSubroutine.name}`,
 			);
-			this.procedureRouter.advanceToNextSubroutine(session, sessionId);
+			this.procedureAnalyzer.advanceToNextSubroutine(session, sessionId);
 
 			// Emit event for EdgeWorker to handle subroutine transition
 			// This replaces the callback pattern and allows EdgeWorker to subscribe
@@ -980,7 +980,7 @@ export class AgentSessionManager extends EventEmitter {
 			// Check if current subroutine has suppressThoughtPosting enabled
 			// If so, suppress thoughts and actions (but still post responses and results)
 			const currentSubroutine =
-				this.procedureRouter?.getCurrentSubroutine(session);
+				this.procedureAnalyzer?.getCurrentSubroutine(session);
 			if (currentSubroutine?.suppressThoughtPosting) {
 				// Only suppress thoughts and actions, not responses or results
 				if (content.type === "thought" || content.type === "action") {
@@ -1505,7 +1505,7 @@ export class AgentSessionManager extends EventEmitter {
 	/**
 	 * Post an ephemeral "Analyzing your request..." thought and return the activity ID
 	 */
-	async postRoutingThought(
+	async postAnalyzingThought(
 		linearAgentActivitySessionId: string,
 	): Promise<string | null> {
 		try {
@@ -1521,19 +1521,19 @@ export class AgentSessionManager extends EventEmitter {
 			if (result.success && result.agentActivity) {
 				const activity = await result.agentActivity;
 				console.log(
-					`[AgentSessionManager] Posted routing thought for session ${linearAgentActivitySessionId}`,
+					`[AgentSessionManager] Posted analyzing thought for session ${linearAgentActivitySessionId}`,
 				);
 				return activity.id;
 			} else {
 				console.error(
-					`[AgentSessionManager] Failed to post routing thought:`,
+					`[AgentSessionManager] Failed to post analyzing thought:`,
 					result,
 				);
 				return null;
 			}
 		} catch (error) {
 			console.error(
-				`[AgentSessionManager] Error posting routing thought:`,
+				`[AgentSessionManager] Error posting analyzing thought:`,
 				error,
 			);
 			return null;

--- a/packages/edge-worker/src/procedures/index.ts
+++ b/packages/edge-worker/src/procedures/index.ts
@@ -1,7 +1,7 @@
 /**
- * Procedure routing system for intelligent workflow selection
+ * Procedure analysis system for intelligent workflow selection
  */
 
-export * from "./ProcedureRouter.js";
+export * from "./ProcedureAnalyzer.js";
 export * from "./registry.js";
 export * from "./types.js";

--- a/packages/edge-worker/src/procedures/registry.ts
+++ b/packages/edge-worker/src/procedures/registry.ts
@@ -1,5 +1,5 @@
 /**
- * Registry of predefined procedures and routing rules
+ * Registry of predefined procedures and analysis rules
  */
 
 import type { ProcedureDefinition, RequestClassification } from "./types.js";

--- a/packages/edge-worker/src/procedures/types.ts
+++ b/packages/edge-worker/src/procedures/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for the procedure routing system
+ * Type definitions for the procedure analysis system
  */
 
 /**
@@ -65,7 +65,7 @@ export interface ProcedureMetadata {
 }
 
 /**
- * Request classification types for routing decisions
+ * Request classification types for analysis decisions
  */
 export type RequestClassification =
 	| "question"
@@ -78,9 +78,9 @@ export type RequestClassification =
 	| "user-testing";
 
 /**
- * Result of procedure routing decision
+ * Result of procedure analysis decision
  */
-export interface RoutingDecision {
+export interface ProcedureAnalysisDecision {
 	/** Classification of the request */
 	classification: RequestClassification;
 

--- a/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
@@ -98,7 +98,7 @@ describe("EdgeWorker - Feedback Delivery", () => {
 				claudeRunner: mockClaudeRunner,
 			}),
 			getAgentRunner: vi.fn().mockReturnValue(mockClaudeRunner),
-			postRoutingThought: vi.fn().mockResolvedValue(undefined),
+			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};

--- a/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
@@ -100,7 +100,7 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 				claudeRunner: mockClaudeRunner,
 			}),
 			getAgentRunner: vi.fn().mockReturnValue(mockClaudeRunner),
-			postRoutingThought: vi.fn().mockResolvedValue(undefined),
+			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -138,7 +138,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			getAllAgentRunners: vi.fn().mockReturnValue([]),
 			serializeState: vi.fn().mockReturnValue({ sessions: {}, entries: {} }),
 			restoreState: vi.fn(),
-			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postAnalyzingThought: vi.fn().mockResolvedValue(null),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};

--- a/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
@@ -68,7 +68,7 @@ describe("EdgeWorker - Orchestrator Label Rerouting", () => {
 
 		// Mock AgentSessionManager
 		mockAgentSessionManager = {
-			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postAnalyzingThought: vi.fn().mockResolvedValue(null),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -132,7 +132,7 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			getAllClaudeRunners: vi.fn().mockReturnValue([]),
 			serializeState: vi.fn().mockReturnValue({ sessions: {}, entries: {} }),
 			restoreState: vi.fn(),
-			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postAnalyzingThought: vi.fn().mockResolvedValue(null),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};

--- a/packages/edge-worker/test/EdgeWorker.procedure-routing.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.procedure-routing.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ProcedureRouter } from "../src/procedures/ProcedureRouter";
+import { ProcedureAnalyzer } from "../src/procedures/ProcedureAnalyzer";
 import { PROCEDURES, SUBROUTINES } from "../src/procedures/registry";
 
 describe("EdgeWorker - Procedure Routing", () => {
-	let procedureRouter: ProcedureRouter;
+	let procedureAnalyzer: ProcedureAnalyzer;
 
 	beforeEach(async () => {
 		vi.clearAllMocks();
 
-		// Create a standalone ProcedureRouter for testing
-		procedureRouter = new ProcedureRouter({
+		// Create a standalone ProcedureAnalyzer for testing
+		procedureAnalyzer = new ProcedureAnalyzer({
 			cyrusHome: "/test/.cyrus",
 		});
 	});
@@ -22,26 +22,26 @@ describe("EdgeWorker - Procedure Routing", () => {
 			};
 
 			// Initialize procedure metadata
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
 
 			// Verify initial state
 			expect(session.metadata.procedure.procedureName).toBe("full-development");
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(0);
 
 			// Simulate completing primary subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(false); // Not complete yet
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(false); // Not complete yet
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(1);
 
 			// Simulate completing verifications subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(false);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(false);
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(2);
 
 			// Simulate completing git-gh subroutine - advances to last subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(3);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
 		});
 
 		it("should execute all subroutines in sequence for documentation-edit procedure", async () => {
@@ -49,7 +49,7 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const session = { metadata: {} } as any;
 
 			// Initialize procedure metadata
-			procedureRouter.initializeProcedureMetadata(session, docEditProcedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, docEditProcedure);
 
 			// Verify initial state
 			expect(session.metadata.procedure.procedureName).toBe(
@@ -58,14 +58,14 @@ describe("EdgeWorker - Procedure Routing", () => {
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(0);
 
 			// Complete primary
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(false);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(false);
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(1);
 
 			// Complete git-gh - advances to last subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(2);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
 		});
 
 		it("should execute all subroutines in sequence for simple-question procedure", async () => {
@@ -73,7 +73,7 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const session = { metadata: {} } as any;
 
 			// Initialize procedure metadata
-			procedureRouter.initializeProcedureMetadata(
+			procedureAnalyzer.initializeProcedureMetadata(
 				session,
 				simpleQuestionProcedure,
 			);
@@ -83,39 +83,39 @@ describe("EdgeWorker - Procedure Routing", () => {
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(0);
 
 			// Complete primary - advances to last subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 			expect(session.metadata.procedure.currentSubroutineIndex).toBe(1);
-			expect(procedureRouter.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
+			expect(procedureAnalyzer.isProcedureComplete(session)).toBe(true); // At last subroutine, no next
 		});
 
 		it("should get current subroutine correctly at each step", async () => {
 			const fullDevProcedure = PROCEDURES["full-development"];
 			const session = { metadata: {} } as any;
 
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
 
 			// Check each subroutine
-			expect(procedureRouter.getCurrentSubroutine(session)?.name).toBe(
+			expect(procedureAnalyzer.getCurrentSubroutine(session)?.name).toBe(
 				"coding-activity",
 			);
 
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.getCurrentSubroutine(session)?.name).toBe(
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.getCurrentSubroutine(session)?.name).toBe(
 				"verifications",
 			);
 
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.getCurrentSubroutine(session)?.name).toBe(
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.getCurrentSubroutine(session)?.name).toBe(
 				"git-gh",
 			);
 
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.getCurrentSubroutine(session)?.name).toBe(
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.getCurrentSubroutine(session)?.name).toBe(
 				"concise-summary",
 			);
 
-			procedureRouter.advanceToNextSubroutine(session, null);
-			expect(procedureRouter.getCurrentSubroutine(session)).toBeNull();
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			expect(procedureAnalyzer.getCurrentSubroutine(session)).toBeNull();
 		});
 	});
 
@@ -145,16 +145,16 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const simpleQuestionProcedure = PROCEDURES["simple-question"];
 
 			// Initialize with simple-question procedure (ends with question-answer)
-			procedureRouter.initializeProcedureMetadata(
+			procedureAnalyzer.initializeProcedureMetadata(
 				session,
 				simpleQuestionProcedure,
 			);
 
 			// Advance to question-answer subroutine
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 
 			// Get current subroutine
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 
 			expect(currentSubroutine?.name).toBe("question-answer");
 			expect(currentSubroutine?.suppressThoughtPosting).toBe(true);
@@ -165,15 +165,15 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const fullDevProcedure = PROCEDURES["full-development"];
 
 			// Initialize with full-development procedure (ends with concise-summary)
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
 
 			// Advance to concise-summary subroutine (skip 3 subroutines)
-			procedureRouter.advanceToNextSubroutine(session, null); // coding-activity -> verifications
-			procedureRouter.advanceToNextSubroutine(session, null); // verifications -> git-gh
-			procedureRouter.advanceToNextSubroutine(session, null); // git-gh -> concise-summary
+			procedureAnalyzer.advanceToNextSubroutine(session, null); // coding-activity -> verifications
+			procedureAnalyzer.advanceToNextSubroutine(session, null); // verifications -> git-gh
+			procedureAnalyzer.advanceToNextSubroutine(session, null); // git-gh -> concise-summary
 
 			// Get current subroutine
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 
 			expect(currentSubroutine?.name).toBe("concise-summary");
 			expect(currentSubroutine?.suppressThoughtPosting).toBe(true);
@@ -183,9 +183,9 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const session = { metadata: {} } as any;
 			const fullDevProcedure = PROCEDURES["full-development"];
 
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 
 			expect(currentSubroutine?.name).toBe("coding-activity");
 			expect(currentSubroutine?.suppressThoughtPosting).toBeUndefined();
@@ -195,10 +195,10 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const session = { metadata: {} } as any;
 			const fullDevProcedure = PROCEDURES["full-development"];
 
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 
 			expect(currentSubroutine?.name).toBe("verifications");
 			expect(currentSubroutine?.suppressThoughtPosting).toBeUndefined();
@@ -208,11 +208,11 @@ describe("EdgeWorker - Procedure Routing", () => {
 			const session = { metadata: {} } as any;
 			const fullDevProcedure = PROCEDURES["full-development"];
 
-			procedureRouter.initializeProcedureMetadata(session, fullDevProcedure);
-			procedureRouter.advanceToNextSubroutine(session, null);
-			procedureRouter.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.initializeProcedureMetadata(session, fullDevProcedure);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
+			procedureAnalyzer.advanceToNextSubroutine(session, null);
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 
 			expect(currentSubroutine?.name).toBe("git-gh");
 			expect(currentSubroutine?.suppressThoughtPosting).toBeUndefined();

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -154,7 +154,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			getAllAgentRunners: vi.fn().mockReturnValue([]),
 			serializeState: vi.fn().mockReturnValue({ sessions: {}, entries: {} }),
 			restoreState: vi.fn(),
-			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postAnalyzingThought: vi.fn().mockResolvedValue(null),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};
@@ -256,7 +256,7 @@ Issue: {{issue_identifier}}`;
 			// Assert
 			expect(capturedRunnerType).toBe("gemini");
 			expect(GeminiRunner).toHaveBeenCalled();
-			// ClaudeRunner is called once for the classifier (ProcedureRouter uses Claude by default)
+			// ClaudeRunner is called once for the classifier (ProcedureAnalyzer uses Claude by default)
 			expect(ClaudeRunner).toHaveBeenCalledTimes(1);
 		});
 
@@ -288,7 +288,7 @@ Issue: {{issue_identifier}}`;
 			// Assert
 			expect(capturedRunnerType).toBe("gemini");
 			expect(GeminiRunner).toHaveBeenCalled();
-			// ClaudeRunner is called once for the classifier (ProcedureRouter uses Claude by default)
+			// ClaudeRunner is called once for the classifier (ProcedureAnalyzer uses Claude by default)
 			expect(ClaudeRunner).toHaveBeenCalledTimes(1);
 			expect(capturedRunnerConfig.model).toBe("gemini-2.5-pro");
 		});

--- a/packages/edge-worker/test/EdgeWorker.subroutine-disallowed-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.subroutine-disallowed-tools.test.ts
@@ -8,14 +8,14 @@
 
 import type { CyrusAgentSession } from "cyrus-core";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ProcedureRouter } from "../src/procedures/ProcedureRouter";
+import { ProcedureAnalyzer } from "../src/procedures/ProcedureAnalyzer";
 import { PROCEDURES, SUBROUTINES } from "../src/procedures/registry";
 
 describe("EdgeWorker - Subroutine DisallowedTools", () => {
-	let procedureRouter: ProcedureRouter;
+	let procedureAnalyzer: ProcedureAnalyzer;
 
 	beforeEach(() => {
-		procedureRouter = new ProcedureRouter({
+		procedureAnalyzer = new ProcedureAnalyzer({
 			cyrusHome: "/test/.cyrus",
 		});
 	});
@@ -93,15 +93,15 @@ describe("EdgeWorker - Subroutine DisallowedTools", () => {
 				metadata: {},
 			};
 
-			procedureRouter.initializeProcedureMetadata(session, procedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, procedure);
 
 			// Advance to concise-summary (last subroutine)
 			// full-development: coding-activity → verifications → git-gh → concise-summary
-			procedureRouter.advanceToNextSubroutine(session, "claude-123"); // Move to verifications
-			procedureRouter.advanceToNextSubroutine(session, "claude-123"); // Move to git-gh
-			procedureRouter.advanceToNextSubroutine(session, "claude-123"); // Move to concise-summary
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-123"); // Move to verifications
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-123"); // Move to git-gh
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-123"); // Move to concise-summary
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("concise-summary");
 			expect(currentSubroutine?.disallowedTools).toBeDefined();
 			expect(currentSubroutine?.disallowedTools).toContain(
@@ -136,13 +136,13 @@ describe("EdgeWorker - Subroutine DisallowedTools", () => {
 			};
 
 			// Manually register a procedure with verbose-summary
-			procedureRouter.registerProcedure({
+			procedureAnalyzer.registerProcedure({
 				name: "test-verbose",
 				description: "Test procedure with verbose summary",
 				subroutines: [SUBROUTINES.verboseSummary],
 			});
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("verbose-summary");
 			expect(currentSubroutine?.disallowedTools).toBeDefined();
 			expect(currentSubroutine?.disallowedTools).toContain(
@@ -170,12 +170,12 @@ describe("EdgeWorker - Subroutine DisallowedTools", () => {
 				metadata: {},
 			};
 
-			procedureRouter.initializeProcedureMetadata(session, procedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, procedure);
 
 			// simple-question: question-investigation → question-answer
-			procedureRouter.advanceToNextSubroutine(session, "claude-789"); // Move to question-answer
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-789"); // Move to question-answer
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("question-answer");
 			expect(currentSubroutine?.disallowedTools).toBeDefined();
 			expect(currentSubroutine?.disallowedTools).toContain(
@@ -203,12 +203,12 @@ describe("EdgeWorker - Subroutine DisallowedTools", () => {
 				metadata: {},
 			};
 
-			procedureRouter.initializeProcedureMetadata(session, procedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, procedure);
 
 			// plan-mode: preparation → plan-summary
-			procedureRouter.advanceToNextSubroutine(session, "claude-101"); // Move to plan-summary
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-101"); // Move to plan-summary
 
-			const currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			const currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("plan-summary");
 			expect(currentSubroutine?.disallowedTools).toBeDefined();
 			expect(currentSubroutine?.disallowedTools).toContain(
@@ -236,22 +236,22 @@ describe("EdgeWorker - Subroutine DisallowedTools", () => {
 				metadata: {},
 			};
 
-			procedureRouter.initializeProcedureMetadata(session, procedure);
+			procedureAnalyzer.initializeProcedureMetadata(session, procedure);
 
 			// Check coding-activity (first subroutine)
-			let currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			let currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("coding-activity");
 			expect(currentSubroutine?.disallowedTools).toBeUndefined();
 
 			// Advance to verifications
-			procedureRouter.advanceToNextSubroutine(session, "claude-202");
-			currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-202");
+			currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("verifications");
 			expect(currentSubroutine?.disallowedTools).toBeUndefined();
 
 			// Advance to git-gh
-			procedureRouter.advanceToNextSubroutine(session, "claude-202");
-			currentSubroutine = procedureRouter.getCurrentSubroutine(session);
+			procedureAnalyzer.advanceToNextSubroutine(session, "claude-202");
+			currentSubroutine = procedureAnalyzer.getCurrentSubroutine(session);
 			expect(currentSubroutine?.name).toBe("git-gh");
 			expect(currentSubroutine?.disallowedTools).toBeUndefined();
 		});

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -134,7 +134,7 @@ describe("EdgeWorker - System Prompt Resume", () => {
 			getAllClaudeRunners: vi.fn().mockReturnValue([]),
 			serializeState: vi.fn().mockReturnValue({ sessions: {}, entries: {} }),
 			restoreState: vi.fn(),
-			postRoutingThought: vi.fn().mockResolvedValue(null),
+			postAnalyzingThought: vi.fn().mockResolvedValue(null),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			on: vi.fn(), // EventEmitter method
 		};


### PR DESCRIPTION
## Summary

Updates terminology from "routing" to "analyzing" throughout the codebase to eliminate confusion and better reflect the actual purpose of the system components.

+++Changes Made - Part 1 (Message Update)
- Updated ephemeral thought message from "Routing your request…" to "Analyzing your request…"
- Updated JSDoc comment in `AgentSessionManager.postAnalyzingThought()` method
+++

+++Changes Made - Part 2 (Code Refactoring)
- Renamed `ProcedureRouter` class → `ProcedureAnalyzer`
- Renamed `ProcedureRouterConfig` → `ProcedureAnalyzerConfig`
- Renamed `RoutingDecision` → `ProcedureAnalysisDecision`
- Renamed all `procedureRouter` instances → `procedureAnalyzer`
- Renamed `postRoutingThought()` → `postAnalyzingThought()`
- Renamed `routingRunner` → `analysisRunner`
- Renamed `buildRoutingSystemPrompt()` → `buildAnalysisSystemPrompt()`
- Updated all comments and console logs to use "analysis" terminology
- Renamed file from `ProcedureRouter.ts` → `ProcedureAnalyzer.ts`
- Updated all test mocks and imports across 10 test files
+++

+++Files Modified
- `packages/edge-worker/src/AgentSessionManager.ts`
- `packages/edge-worker/src/EdgeWorker.ts`
- `packages/edge-worker/src/procedures/ProcedureAnalyzer.ts` (renamed from ProcedureRouter.ts)
- `packages/edge-worker/src/procedures/index.ts`
- `packages/edge-worker/src/procedures/registry.ts`
- `packages/edge-worker/src/procedures/types.ts`
- 10 test files in `packages/edge-worker/test/`
+++

## Testing

- Linting passes with no new issues (1 pre-existing warning in unrelated file)
- All terminology consistently updated throughout codebase
- File rename preserved git history

Fixes CYPACK-543

🤖 Generated with [Claude Code](https://claude.com/claude-code)