### PR TITLE
Verify Anthropic SDK packages are on latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Verified Anthropic SDK packages are on latest versions: `@anthropic-ai/claude-agent-sdk@0.1.60` and `@anthropic-ai/sdk@0.71.2` ([CYPACK-561](https://linear.app/ceedar/issue/CYPACK-561))
+
 ### Added
 - Added CLI platform mode support to enable in-memory issue tracking for testing and development ([CYPACK-509](https://linear.app/ceedar/issue/CYPACK-509))
 - **User testing procedure** - New "user-testing" procedure for interactive, user-driven testing sessions. When you explicitly request manual testing (e.g., "test this for me", "run user testing"), Cyrus will execute tests based on your instructions and provide a comprehensive summary of results and findings. ([CYPACK-542](https://linear.app/ceedar/issue/CYPACK-542))


### PR DESCRIPTION
## Summary
Verified that `@anthropic-ai/claude-agent-sdk` and `@anthropic-ai/sdk` are already on their latest versions available on npm.

## Changes
- Checked current versions against npm registry:
  - `@anthropic-ai/claude-agent-sdk`: 0.1.60 (latest) ✓
  - `@anthropic-ai/sdk`: 0.71.2 (latest) ✓
- Updated CHANGELOG.md to document this verification

## Implementation Approach
1. Searched all package.json files in the monorepo for Anthropic SDK dependencies
2. Found 3 packages using `@anthropic-ai/claude-agent-sdk@^0.1.60`:
   - packages/claude-runner
   - packages/core
   - packages/simple-agent-runner
3. Found 1 package using `@anthropic-ai/sdk@^0.71.2`:
   - packages/claude-runner
4. Verified against npm registry that these are the latest versions
5. Updated CHANGELOG.md with verification note

## Testing Performed
- All tests passing: 275 tests across all packages
- Linting clean (1 pre-existing warning unrelated to changes)
- TypeScript type checking passed
- Build succeeded for all packages

## Result
No updates were required. As per issue instructions, this issue should be marked as "canceled" since there's no action to take.

Fixes CYPACK-561