### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - **Graphite workflow support** - Cyrus now integrates with Graphite CLI for stacked PR workflows. Apply a "graphite" label to any issue to enable Graphite-aware behavior: sub-issues automatically branch from their blocking issue's branch (based on Linear's "blocked by" relationships) instead of main, and PRs are created using `gt submit`. For orchestrating complex multi-part features, apply both "graphite" and "orchestrator" labels - the orchestrator will create dependent sub-issues with proper blocking relationships that automatically stack in Graphite's dashboard. ([CYPACK-466](https://linear.app/ceedar/issue/CYPACK-466), [#577](https://github.com/ceedaragents/cyrus/pull/577))
 - **Linear agent sessions MCP tools** - Added `linear_get_agent_sessions` and `linear_get_agent_session` tools to cyrus-tools MCP server for retrieving agent session information from Linear. The tools support pagination, filtering, and provide comprehensive session details including timestamps, associated issues, and related entities. ([CYPACK-549](https://linear.app/ceedar/issue/CYPACK-549), [#625](https://github.com/ceedaragents/cyrus/pull/625))
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.61 for parity with Claude Code v2.0.61 ([changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0161---2025-11-07)) ([CYPACK-575](https://linear.app/ceedar/issue/CYPACK-575))
+
 ## [0.2.5] - 2025-12-03
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.61",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.61",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.61",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@3.25.76)
+        specifier: ^0.1.61
+        version: 0.1.61(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@3.25.76)
@@ -198,8 +198,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.61
+        version: 0.1.61(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -337,8 +337,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.61
+        version: 0.1.61(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -362,8 +362,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60':
-    resolution: {integrity: sha512-Kl7zo4yNiUs3fRc9CQ5kcRuihdPEzH26boC5E8szO9WMNwPFBfJExLfYZDAcYmFaE3+M6mLpuYzmTGLxSoXrhg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.61':
+    resolution: {integrity: sha512-V0WlOMp56OetCeNoYMtvXSh6LmRYvoA69K16iaF7mXg8XYPZcrO2tuC8k8S8LWDUjoVjgg7EJYP1v/p0Ax2UPA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3591,7 +3591,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.61(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3604,7 +3604,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.61(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.61 for parity with Claude Code v2.0.61.

## Changes

- Updated `@anthropic-ai/claude-agent-sdk` to v0.1.61 in:
  - `packages/claude-runner/package.json`
  - `packages/core/package.json`
  - `packages/simple-agent-runner/package.json`
- Verified `@anthropic-ai/sdk` is already at latest version (v0.71.2)
- Updated `CHANGELOG.md` with version change details and [SDK changelog link](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0161---2025-11-07)
- Updated `pnpm-lock.yaml`

## SDK Changes (v0.1.61)

The update brings parity with Claude Code v2.0.61 as documented in the [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0161---2025-11-07).

## Testing

- ✅ All 243 package tests passing
- ✅ TypeScript type checking passing
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Build successful

## Linear Issue

Resolves [CYPACK-575](https://linear.app/ceedar/issue/CYPACK-575)

🤖 Generated with [Claude Code](https://claude.com/claude-code)