### PR TITLE
[CYPACK-588] Add RepositoryContext interface to CyrusAgentSession

### DIFF
--- a/packages/core/src/CyrusAgentSession.ts
+++ b/packages/core/src/CyrusAgentSession.ts
@@ -23,6 +23,18 @@ export interface Workspace {
 	historyPath?: string;
 }
 
+export interface RepositoryContext {
+	repositoryId: string;
+	repositoryPath: string;
+	workspaceBaseDir: string;
+	allowedTools?: string[];
+	disallowedTools?: string[];
+	mcpConfigPath?: string;
+	promptTemplatePath?: string;
+	model?: string;
+	fallbackModel?: string;
+}
+
 export interface CyrusAgentSession {
 	linearAgentActivitySessionId: string;
 	type: AgentSessionType.CommentThread;
@@ -33,6 +45,7 @@ export interface CyrusAgentSession {
 	issueId: string;
 	issue: IssueMinimal;
 	workspace: Workspace;
+	repositoryContext?: RepositoryContext;
 	// NOTE: Only one of these will be populated
 	claudeSessionId?: string; // Claude-specific session ID (assigned once it initializes)
 	geminiSessionId?: string; // Gemini-specific session ID (assigned once it initializes)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
 	CyrusAgentSession,
 	CyrusAgentSessionEntry,
 	IssueMinimal,
+	RepositoryContext,
 	Workspace,
 } from "./CyrusAgentSession.js";
 


### PR DESCRIPTION
## Summary

This PR adds the `RepositoryContext` interface to the core package and includes it as an optional field in `CyrusAgentSession`.

## Changes

- Added `RepositoryContext` interface with fields for repository configuration:
  - `repositoryId`: Repository identifier
  - `repositoryPath`: Path to the repository
  - `workspaceBaseDir`: Base directory for workspaces
  - `allowedTools`: Optional list of allowed tools
  - `disallowedTools`: Optional list of disallowed tools
  - `mcpConfigPath`: Optional MCP configuration path
  - `promptTemplatePath`: Optional prompt template path
  - `model`: Optional model specification
  - `fallbackModel`: Optional fallback model

- Added optional `repositoryContext` field to `CyrusAgentSession` interface
- Exported `RepositoryContext` type from `packages/core/src/index.ts`

## Testing

- All core package tests pass (5/5)
- TypeScript compilation successful
- Linting clean
- No breaking changes - field is optional and all existing code continues to work

## Stack Position

This is the first PR in a stack of 5. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)