### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated @anthropic-ai/claude-agent-sdk** - Upgraded from v0.1.60 to [v0.1.67](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0167). Updates include fixes for project MCP servers from `.mcp.json` (v0.1.66), stdin closure issues affecting MCP servers/hooks (v0.1.64), and support for the Opus 4.5 model (v0.1.61). ([CYPACK-607](https://linear.app/ceedar/issue/CYPACK-607))
+
 ### Added
 - **Process status endpoint** - Added `GET /status` endpoint that returns `{"status": "idle"}` or `{"status": "busy"}` to safely determine when Cyrus can be restarted without interrupting active work. ([CYPACK-576](https://linear.app/ceedar/issue/CYPACK-576), [#632](https://github.com/ceedaragents/cyrus/pull/632))
 - **Version logging on startup** - Cyrus now displays the running version when the edge worker starts, making it easier to verify which version is deployed. ([CYPACK-585](https://linear.app/ceedar/issue/CYPACK-585))

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.67",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.67",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.67",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@3.25.76)
+        specifier: ^0.1.67
+        version: 0.1.67(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@3.25.76)
@@ -198,8 +198,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.67
+        version: 0.1.67(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -337,8 +337,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.67
+        version: 0.1.67(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -362,8 +362,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60':
-    resolution: {integrity: sha512-Kl7zo4yNiUs3fRc9CQ5kcRuihdPEzH26boC5E8szO9WMNwPFBfJExLfYZDAcYmFaE3+M6mLpuYzmTGLxSoXrhg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.67':
+    resolution: {integrity: sha512-SPeMOfBeQ4Q6BcTRGRyMzaSEzKja3w8giZn6xboab02rPly5KQmgDK0wNerUntPe+xyw7c01xdu5K/pjZXq0dw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3591,7 +3591,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.67(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3604,7 +3604,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.67(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary
Updated `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.67 across all packages that use it.

## Changes
- Updated dependency in `packages/core/package.json`
- Updated dependency in `packages/claude-runner/package.json`
- Updated dependency in `packages/simple-agent-runner/package.json`
- Updated `pnpm-lock.yaml` with new versions
- Added changelog entry documenting the upgrade

## What's New in v0.1.67
From the [upstream changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md):
- **v0.1.66**: Fixed issue where project MCP servers from `.mcp.json` weren't available when `settingSources` included the "project" option
- **v0.1.65**: Updated to match Claude Code v2.0.66 functionality
- **v0.1.64**: Resolved problems where SDK MCP servers, hooks, or tool-check callbacks could fail when stdin closed prematurely after the initial result
- **v0.1.63**: Aligned with Claude Code v2.0.63 updates
- **v0.1.61**: Support for the newly released Opus 4.5 model

## Testing Performed
- ✅ All 516 package tests passing
- ✅ TypeScript compilation successful
- ✅ Linting clean
- ✅ Build successful

## Note
`@anthropic-ai/sdk` was already at the latest version (v0.71.2) and did not require updating.

Fixes [CYPACK-607](https://linear.app/ceedar/issue/CYPACK-607)