### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.69 (CYPACK-611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.69 to maintain parity with Claude Code v2.0.69. This update includes fixes for disallowed MCP tools visibility, project MCP server access issues, and improved handling when stdin is closed. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0169) for full details. ([CYPACK-611](https://linear.app/ceedar/issue/CYPACK-611))
+
 ### Added
 - **Process status endpoint** - Added `GET /status` endpoint that returns `{"status": "idle"}` or `{"status": "busy"}` to safely determine when Cyrus can be restarted without interrupting active work. ([CYPACK-576](https://linear.app/ceedar/issue/CYPACK-576), [#632](https://github.com/ceedaragents/cyrus/pull/632))
 - **Version logging on startup** - Cyrus now displays the running version when the edge worker starts, making it easier to verify which version is deployed. ([CYPACK-585](https://linear.app/ceedar/issue/CYPACK-585))

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.60",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@3.25.76)
+        specifier: ^0.1.69
+        version: 0.1.69(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@3.25.76)
@@ -198,8 +198,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.69
+        version: 0.1.69(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -337,8 +337,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.60
-        version: 0.1.60(zod@4.1.12)
+        specifier: ^0.1.69
+        version: 0.1.69(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -362,8 +362,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60':
-    resolution: {integrity: sha512-Kl7zo4yNiUs3fRc9CQ5kcRuihdPEzH26boC5E8szO9WMNwPFBfJExLfYZDAcYmFaE3+M6mLpuYzmTGLxSoXrhg==}
+  '@anthropic-ai/claude-agent-sdk@0.1.69':
+    resolution: {integrity: sha512-T6mb8xKGYIH0g3drS0VRxDHemj8kmWD37nuB+ENoD9sZfi/lomnugWLWBjq9Cjw10WBewE5hjv+i8swM34nkAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3591,7 +3591,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.69(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3604,7 +3604,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.60(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.69(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.69 to maintain parity with Claude Code v2.0.69.

## Changes

Updated the SDK in three packages:
- `packages/claude-runner/package.json`: ^0.1.60 → ^0.1.69
- `packages/core/package.json`: ^0.1.60 → ^0.1.69
- `packages/simple-agent-runner/package.json`: ^0.1.60 → ^0.1.69

`@anthropic-ai/sdk` remains at v0.71.2 (already at latest version).

## Key Improvements in v0.1.61-0.1.69

- **v0.1.68**: Fixed disallowed MCP tools being visible to the model
- **v0.1.66**: Fixed project MCP servers from .mcp.json not being accessible when project settings were specified
- **v0.1.64**: Fixed SDK MCP servers, hooks, or canUseTool callbacks failing when stdin was closed prematurely
- **v0.1.69, v0.1.67, v0.1.65, v0.1.63, v0.1.61**: Updates to maintain parity with corresponding Claude Code versions

See the [official changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0169) for complete details.

## Testing Performed

✅ All package tests passing (516 tests)
✅ Linting clean (1 pre-existing warning)
✅ TypeScript type checking passes
✅ Dependencies installed successfully

## Related

- Linear Issue: [CYPACK-611](https://linear.app/ceedar/issue/CYPACK-611)
- Claude Agent SDK Changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)