### PR TITLE
Set default model to 'opus' and fallback to 'sonnet' (CYPACK-613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Default model upgraded to Opus** - Cyrus now uses Claude Opus as the default model with Sonnet as fallback (previously Sonnet with Haiku fallback). This provides higher quality responses for all tasks. ([CYPACK-613](https://linear.app/ceedar/issue/CYPACK-613))
 - Updated `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.69 to maintain parity with Claude Code v2.0.69. This update includes fixes for disallowed MCP tools visibility, project MCP server access issues, and improved handling when stdin is closed. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0169) for full details. ([CYPACK-611](https://linear.app/ceedar/issue/CYPACK-611))
 
 ### Added

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -287,8 +287,8 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 			const queryOptions: Parameters<typeof query>[0] = {
 				prompt: promptForQuery,
 				options: {
-					model: this.config.model || "sonnet",
-					fallbackModel: this.config.fallbackModel || "haiku",
+					model: this.config.model || "opus",
+					fallbackModel: this.config.fallbackModel || "sonnet",
 					abortController: this.abortController,
 					// Use Claude Code preset by default to maintain backward compatibility
 					// This can be overridden if systemPrompt is explicitly provided

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -123,8 +123,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "Hello Claude",
 				options: {
-					model: "sonnet",
-					fallbackModel: "haiku",
+					model: "opus",
+					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: { type: "preset", preset: "claude_code" },
@@ -153,8 +153,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "test",
 				options: {
-					model: "sonnet",
-					fallbackModel: "haiku",
+					model: "opus",
+					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: { type: "preset", preset: "claude_code" },
@@ -183,8 +183,8 @@ describe("ClaudeRunner", () => {
 			expect(mockQuery).toHaveBeenCalledWith({
 				prompt: "test",
 				options: {
-					model: "sonnet",
-					fallbackModel: "haiku",
+					model: "opus",
+					fallbackModel: "sonnet",
 					abortController: expect.any(AbortController),
 					cwd: "/tmp/test",
 					systemPrompt: "You are a helpful assistant",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2279,8 +2279,8 @@ export class EdgeWorker extends EventEmitter {
 		if (!labels || labels.length === 0) {
 			return {
 				runnerType: "claude",
-				modelOverride: "sonnet",
-				fallbackModelOverride: "haiku",
+				modelOverride: "opus",
+				fallbackModelOverride: "sonnet",
 			};
 		}
 
@@ -2348,8 +2348,8 @@ export class EdgeWorker extends EventEmitter {
 		// Default to claude if no runner labels found
 		return {
 			runnerType: "claude",
-			modelOverride: "sonnet",
-			fallbackModelOverride: "haiku",
+			modelOverride: "opus",
+			fallbackModelOverride: "sonnet",
 		};
 	}
 


### PR DESCRIPTION
## Summary

Upgraded Cyrus default AI model from Sonnet to Opus, with Sonnet as the fallback (previously Haiku). This provides higher quality responses for all tasks while maintaining cost-effective fallback options.

## Changes

### Model Defaults Updated
- **ClaudeRunner** (`packages/claude-runner/src/ClaudeRunner.ts`): Changed default from `sonnet`/`haiku` to `opus`/`sonnet`
- **EdgeWorker** (`packages/edge-worker/src/EdgeWorker.ts`): Updated default fallbacks in two locations:
  - When no labels are present
  - When no runner-related labels are found

### Test Updates
- **ClaudeRunner tests** (`packages/claude-runner/test/ClaudeRunner.test.ts`): Updated 3 test expectations to reflect new defaults

### Documentation
- **CHANGELOG.md**: Added entry documenting the model upgrade for end users

## Implementation Details

The model selection hierarchy remains unchanged:
1. Label-based override (highest priority - dynamic per issue)
2. Environment variables (`CYRUS_DEFAULT_MODEL`, `CYRUS_DEFAULT_FALLBACK_MODEL`)
3. Repository config (`model`/`fallbackModel` per repository)
4. Global config (`defaultModel`/`defaultFallbackModel`)
5. Hardcoded defaults (now `opus`/`sonnet` - lowest priority)

Users can still override models using:
- Linear issue labels (`opus`, `sonnet`, `haiku`)
- Environment variables
- Repository-specific configuration
- Global configuration files

## Testing

- ✅ All 517 package tests passing
- ✅ TypeScript compilation successful
- ✅ Linting clean (1 pre-existing warning unrelated to changes)
- ✅ Backward compatibility maintained - all override mechanisms still work

## Related

- Linear Issue: [CYPACK-613](https://linear.app/ceedar/issue/CYPACK-613)

🤖 Generated with [Claude Code](https://claude.com/claude-code)