### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.70 (CYPACK-616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Default model upgraded to Opus** - Cyrus now uses Claude Opus as the default model with Sonnet as fallback (previously Sonnet with Haiku fallback). This provides higher quality responses for all tasks. ([CYPACK-613](https://linear.app/ceedar/issue/CYPACK-613))
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.69 to v0.1.70. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-616](https://linear.app/ceedar/issue/CYPACK-616))
 - Updated `@anthropic-ai/claude-agent-sdk` from v0.1.60 to v0.1.69 to maintain parity with Claude Code v2.0.69. This update includes fixes for disallowed MCP tools visibility, project MCP server access issues, and improved handling when stdin is closed. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0169) for full details. ([CYPACK-611](https://linear.app/ceedar/issue/CYPACK-611))
 
 ### Added

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.70",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.70",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.69",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.70",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.69
-        version: 0.1.69(zod@3.25.76)
+        specifier: ^0.1.70
+        version: 0.1.70(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@3.25.76)
@@ -197,8 +197,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.69
-        version: 0.1.69(zod@4.1.12)
+        specifier: ^0.1.70
+        version: 0.1.70(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -336,8 +336,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.69
-        version: 0.1.69(zod@4.1.12)
+        specifier: ^0.1.70
+        version: 0.1.70(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -361,8 +361,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.69':
-    resolution: {integrity: sha512-T6mb8xKGYIH0g3drS0VRxDHemj8kmWD37nuB+ENoD9sZfi/lomnugWLWBjq9Cjw10WBewE5hjv+i8swM34nkAA==}
+  '@anthropic-ai/claude-agent-sdk@0.1.70':
+    resolution: {integrity: sha512-4jpFPDX8asys6skO1r3Pzh0Fe9nbND2ASYTWuyFB5iN9bWEL6WScTFyGokjql3M2TkEp9ZGuB2YYpTCdaqT9Sw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1
@@ -3734,7 +3734,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.69(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.70(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3747,7 +3747,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.69(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.70(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from v0.1.69 to v0.1.70 across three packages:
- `packages/claude-runner`
- `packages/core`
- `packages/simple-agent-runner`

Verified that `@anthropic-ai/sdk` is already on the latest version (0.71.2), so no update was needed.

## Implementation

- Updated version in `package.json` for the three affected packages
- Ran `pnpm install` to update `pnpm-lock.yaml`
- Updated `CHANGELOG.md` with the change and linked to the upstream SDK changelog
- Verified all changes with comprehensive testing

## Testing

- ✅ All package tests passing (517 tests across 42 test files)
- ✅ Type checking passed for all packages
- ✅ Linting clean (only 1 pre-existing warning unrelated to changes)
- ✅ Build successful for all packages

## Changes

- 3 `package.json` files updated with new SDK version
- `pnpm-lock.yaml` updated with resolved dependencies
- `CHANGELOG.md` updated with entry in Unreleased section

## Links

- Linear Issue: [CYPACK-616](https://linear.app/ceedar/issue/CYPACK-616)
- SDK Changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)