### PR TITLE
[Improvement] Consolidate IssueTrackerService to single instance

### DIFF
--- a/packages/edge-worker/test/EdgeWorker.attachments.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.attachments.test.ts
@@ -81,11 +81,11 @@ describe("EdgeWorker - Native Attachments", () => {
 				} as AttachmentConnection),
 			} as unknown as LinearIssue;
 
-			// Mock IssueTrackerService
+			// Mock IssueTrackerService - replace the shared instance
 			const mockIssueTracker = {
 				getComments: vi.fn().mockResolvedValue([]),
 			};
-			(edgeWorker as any).issueTrackers.set("test-repo", mockIssueTracker);
+			(edgeWorker as any).issueTracker = mockIssueTracker;
 
 			// Call the method
 			const result = await (edgeWorker as any).downloadIssueAttachments(
@@ -123,7 +123,7 @@ describe("EdgeWorker - Native Attachments", () => {
 			const mockIssueTracker = {
 				getComments: vi.fn().mockResolvedValue([]),
 			};
-			(edgeWorker as any).issueTrackers.set("test-repo", mockIssueTracker);
+			(edgeWorker as any).issueTracker = mockIssueTracker;
 
 			const result = await (edgeWorker as any).downloadIssueAttachments(
 				mockIssue,
@@ -150,7 +150,7 @@ describe("EdgeWorker - Native Attachments", () => {
 			const mockIssueTracker = {
 				getComments: vi.fn().mockResolvedValue([]),
 			};
-			(edgeWorker as any).issueTrackers.set("test-repo", mockIssueTracker);
+			(edgeWorker as any).issueTracker = mockIssueTracker;
 
 			// Should not throw, but handle gracefully
 			const result = await (edgeWorker as any).downloadIssueAttachments(

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -214,14 +214,14 @@ Issue: {{issue_identifier}}`;
 
 		edgeWorker = new EdgeWorker(mockConfig);
 
-		// Inject mock issue tracker for the test repository
+		// Inject mock issue tracker - replace the shared instance created by EdgeWorker
 		const mockIssueTracker = {
 			fetchIssue: vi.fn().mockImplementation(async (issueId: string) => {
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([{ name: "bug" }]),
 		};
-		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
+		(edgeWorker as any).issueTracker = mockIssueTracker;
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -192,9 +192,7 @@ Base Branch: {{base_branch}}`;
 
 		edgeWorker = new EdgeWorker(mockConfig);
 
-		// Inject mock issue tracker for the test repository
-		// The EdgeWorker constructor creates real LinearIssueTrackerService instances,
-		// but we need to replace them with mocks for testing
+		// Inject mock issue tracker - replace the shared instance created by EdgeWorker
 		const mockIssueTracker = {
 			fetchIssue: vi.fn().mockImplementation(async (issueId: string) => {
 				// Return the same mock data as mockLinearClient.issue()
@@ -202,7 +200,7 @@ Base Branch: {{base_branch}}`;
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([]),
 		};
-		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
+		(edgeWorker as any).issueTracker = mockIssueTracker;
 
 		// Mock branchExists to always return true so parent branches are used
 		vi.spyOn((edgeWorker as any).gitService, "branchExists").mockResolvedValue(

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -213,14 +213,14 @@ Issue: {{issue_identifier}}`;
 
 		edgeWorker = new EdgeWorker(mockConfig);
 
-		// Inject mock issue tracker
+		// Inject mock issue tracker - replace the shared instance created by EdgeWorker
 		const mockIssueTracker = {
 			fetchIssue: vi.fn().mockImplementation(async (issueId: string) => {
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn(),
 		};
-		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
+		(edgeWorker as any).issueTracker = mockIssueTracker;
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -200,14 +200,14 @@ Issue: {{issue_identifier}}`;
 
 		edgeWorker = new EdgeWorker(mockConfig);
 
-		// Inject mock issue tracker for the test repository
+		// Inject mock issue tracker - replace the shared instance created by EdgeWorker
 		const mockIssueTracker = {
 			fetchIssue: vi.fn().mockImplementation(async (issueId: string) => {
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([{ name: "bug" }]),
 		};
-		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
+		(edgeWorker as any).issueTracker = mockIssueTracker;
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/prompt-assembly.system-prompt-behavior.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.system-prompt-behavior.test.ts
@@ -127,7 +127,7 @@ No comments yet.
 
 <workspace_context>
 <teams>
-
+- Default Team (DEF): team-default - Default team for F1 CLI testing
 </teams>
 <labels>
 


### PR DESCRIPTION
## Summary

Consolidates the `issueTrackers: Map<string, IIssueTrackerService>` into a single shared `issueTracker: IIssueTrackerService` instance in EdgeWorker, as we only support a single Linear workspace.

## Changes

### Core Implementation
- **Replaced Map with single instance** (`EdgeWorker.ts:111`): Changed from `Map<string, IIssueTrackerService>` to single `IIssueTrackerService`
- **Workspace-level initialization** (`EdgeWorker.ts:144-159`): Creates single IssueTrackerService using workspace-level `linearToken` (from CYPACK-623) with fallback to first repository's token
- **Updated all references**: Replaced 20+ `this.issueTrackers.get(repo.id)` calls with `this.issueTracker` throughout the file
- **Simplified getIssueTrackerForWorkspace()** (`EdgeWorker.ts:1214-1224`): Now returns the shared instance after verifying workspace ID

### Repository Management
- **Removed per-repository creation** (`EdgeWorker.ts:900-914`): Removed IssueTrackerService creation in `addNewRepositories()`
- **Removed token change handling** (`EdgeWorker.ts:980-996`): Removed per-repository token change detection and recreation
- **Updated removal logic** (`EdgeWorker.ts:1062-1063`): Repository removal no longer deletes the shared tracker

### Test Updates
- **Updated test utilities** (`test/prompt-assembly-utils.ts`): Modified `createTestWorker()` to use CLI platform which creates single CLIIssueTrackerService
- **Fixed integration tests** (5 test files): Replaced shared `issueTracker` with mocks after EdgeWorker construction
- **Updated workspace context expectation** (`test/prompt-assembly.system-prompt-behavior.test.ts`): Adjusted to include CLI default team data

## Testing

- ✅ All 222 tests passing (27 test files)
- ✅ TypeScript compiles without errors
- ✅ Build succeeds
- ✅ Linting clean (1 minor warning)

## Verification Commands

```bash
pnpm typecheck
pnpm test:packages:run
```

## Stack Position

**3 of 6** in Graphite stack

**Previous**: CYPACK-623 (Add workspace-level linearToken)

## Related Issues

Closes CYPACK-624

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)