### PR TITLE
Consolidate AgentSessionManager to single instance (CYPACK-625)

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -84,7 +84,8 @@ export declare interface AgentSessionManager {
  * Transforms Claude streaming messages into Agent Session format
  * Handles session lifecycle: create → active → complete/error
  *
- * CURRENTLY BEING HANDLED 'per repository'
+ * Shared across all repositories. Each session stores its repository context
+ * via the `repositoryContext` field in CyrusAgentSession.
  */
 export class AgentSessionManager extends EventEmitter {
 	private issueTracker: IIssueTrackerService;
@@ -131,6 +132,17 @@ export class AgentSessionManager extends EventEmitter {
 		issueId: string,
 		issueMinimal: IssueMinimal,
 		workspace: Workspace,
+		repositoryContext?: {
+			repositoryId: string;
+			repositoryPath: string;
+			workspaceBaseDir: string;
+			allowedTools?: string[];
+			disallowedTools?: string[];
+			mcpConfigPath?: string;
+			promptTemplatePath?: string;
+			model?: string;
+			fallbackModel?: string;
+		},
 	): CyrusAgentSession {
 		console.log(
 			`[AgentSessionManager] Tracking Linear session ${linearAgentActivitySessionId} for issue ${issueId}`,
@@ -146,6 +158,7 @@ export class AgentSessionManager extends EventEmitter {
 			issueId,
 			issue: issueMinimal,
 			workspace: workspace,
+			repositoryContext,
 		};
 
 		// Store locally

--- a/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
@@ -98,6 +98,11 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 				claudeSessionId: "child-claude-session-456",
 				workspace: { path: "/test/workspaces/CHILD-456" },
 				claudeRunner: mockClaudeRunner,
+				repositoryContext: {
+					repositoryId: "test-repo",
+					repositoryPath: "/test/repo",
+					workspaceBaseDir: "/test/workspaces",
+				},
 			}),
 			getAgentRunner: vi.fn().mockReturnValue(mockClaudeRunner),
 			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
@@ -176,11 +181,8 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 			"parent-session-123",
 		);
 
-		// Setup repository managers
-		(edgeWorker as any).agentSessionManagers.set(
-			"test-repo",
-			mockChildAgentSessionManager,
-		);
+		// Setup single shared agent session manager (replaces per-repository managers)
+		(edgeWorker as any).agentSessionManager = mockChildAgentSessionManager;
 		(edgeWorker as any).repositories.set("test-repo", mockRepository);
 	});
 

--- a/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
@@ -141,11 +141,8 @@ describe("EdgeWorker - Status Endpoint", () => {
 				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner]),
 			};
 
-			// Set the mock session manager
-			(edgeWorker as any).agentSessionManagers.set(
-				"test-repo",
-				mockSessionManager,
-			);
+			// Set the single shared agent session manager
+			(edgeWorker as any).agentSessionManager = mockSessionManager;
 
 			const status = (edgeWorker as any).computeStatus();
 
@@ -166,11 +163,8 @@ describe("EdgeWorker - Status Endpoint", () => {
 				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner]),
 			};
 
-			// Set the mock session manager
-			(edgeWorker as any).agentSessionManagers.set(
-				"test-repo",
-				mockSessionManager,
-			);
+			// Set the single shared agent session manager
+			(edgeWorker as any).agentSessionManager = mockSessionManager;
 
 			const status = (edgeWorker as any).computeStatus();
 
@@ -193,11 +187,8 @@ describe("EdgeWorker - Status Endpoint", () => {
 				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner1, mockRunner2]),
 			};
 
-			// Set the mock session manager
-			(edgeWorker as any).agentSessionManagers.set(
-				"test-repo",
-				mockSessionManager,
-			);
+			// Set the single shared agent session manager
+			(edgeWorker as any).agentSessionManager = mockSessionManager;
 
 			const status = (edgeWorker as any).computeStatus();
 
@@ -215,28 +206,18 @@ describe("EdgeWorker - Status Endpoint", () => {
 				isRunning: vi.fn().mockReturnValue(true),
 			};
 
-			const mockSessionManager1 = {
-				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner1]),
-			};
-			const mockSessionManager2 = {
-				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner2]),
+			// Single shared manager now contains runners from all repositories
+			const combinedManager = {
+				getAllAgentRunners: vi.fn().mockReturnValue([mockRunner1, mockRunner2]),
 			};
 
-			// Set multiple session managers
-			(edgeWorker as any).agentSessionManagers.set(
-				"repo-1",
-				mockSessionManager1,
-			);
-			(edgeWorker as any).agentSessionManagers.set(
-				"repo-2",
-				mockSessionManager2,
-			);
+			// Set the single shared agent session manager
+			(edgeWorker as any).agentSessionManager = combinedManager;
 
 			const status = (edgeWorker as any).computeStatus();
 
 			expect(status).toBe("busy");
-			expect(mockSessionManager1.getAllAgentRunners).toHaveBeenCalled();
-			expect(mockSessionManager2.getAllAgentRunners).toHaveBeenCalled();
+			expect(combinedManager.getAllAgentRunners).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Consolidates AgentSessionManager from a Map of per-repository instances to a single shared instance in EdgeWorker. This is part 4 of 6 in the Graphite stack for unified session management.

## Implementation Approach

### Core Changes

**EdgeWorker.ts**:
- Changed `agentSessionManagers: Map<string, AgentSessionManager>` to `agentSessionManager: AgentSessionManager`
- Created single AgentSessionManager instance in constructor with callbacks that extract repository from session's `repositoryContext`
- Updated all references from `this.agentSessionManagers.get(repo.id)` to `this.agentSessionManager`
- Modified feedback delivery, subroutine transitions, and status computation to use the single manager
- Updated state serialization/deserialization to maintain backwards compatibility by grouping sessions by `repositoryContext.repositoryId`

**AgentSessionManager.ts**:
- Updated `createLinearAgentSession()` to accept and populate `repositoryContext` parameter
- Each session now stores repository-specific configuration via the `repositoryContext` field

**Test Updates**:
- Updated test files to use single manager instance instead of Map
- Added `repositoryContext` to mock session objects
- Fixed assertions to use `getSession` instead of `hasAgentRunner`
- Removed unused mock variables

### Backwards Compatibility

State serialization continues to group sessions by repository ID for backwards compatibility with persisted state, even though internally we now use a single shared manager.

## Testing Performed

- ✅ All 222 tests passing (27 test files)
- ✅ TypeScript compilation: No errors
- ✅ Linting: Clean (1 unrelated warning)
- ✅ Verified backwards-compatible state serialization/deserialization
- ✅ Tested session creation with repositoryContext population
- ✅ Verified subroutine transitions extract repo from session context
- ✅ Confirmed feedback delivery uses single manager correctly

## Breaking Changes

None. The change is internal to EdgeWorker and maintains backwards compatibility with persisted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>