### PR TITLE
feat(opencode-runner): Add event adapters for SDKMessage conversion (CYPACK-634)

### DIFF
--- a/packages/opencode-runner/src/adapters.ts
+++ b/packages/opencode-runner/src/adapters.ts
@@ -1,0 +1,593 @@
+/**
+ * OpenCode Event Adapters
+ *
+ * Converts OpenCode SSE events to SDKMessage format for compatibility
+ * with the Cyrus infrastructure. Follows the adapter pattern used in gemini-runner.
+ *
+ * @packageDocumentation
+ */
+
+import crypto from "node:crypto";
+import type {
+	AssistantMessage,
+	Event,
+	EventMessagePartUpdated,
+	EventMessageUpdated,
+	EventSessionError,
+	EventSessionIdle,
+	EventSessionStatus,
+	Part,
+	TextPart,
+	ToolPart,
+	ToolStateCompleted,
+	ToolStateError,
+	UserMessage,
+} from "@opencode-ai/sdk";
+import type {
+	SDKAssistantMessage,
+	SDKMessage,
+	SDKResultMessage,
+	SDKUserMessage,
+} from "cyrus-core";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Accumulated message state for building complete messages from parts.
+ */
+export interface AccumulatedMessage {
+	messageId: string;
+	sessionId: string;
+	role: "user" | "assistant";
+	contentBlocks: Array<{
+		type: "text" | "tool_use" | "tool_result";
+		id?: string;
+		text?: string;
+		name?: string;
+		input?: Record<string, unknown>;
+		tool_use_id?: string;
+		content?: string;
+		is_error?: boolean;
+	}>;
+	tokenMetrics?: {
+		inputTokens: number;
+		outputTokens: number;
+	};
+}
+
+/**
+ * OpenCode event that we process - a subset of all Event types.
+ */
+export type ProcessableEvent =
+	| EventMessagePartUpdated
+	| EventMessageUpdated
+	| EventSessionIdle
+	| EventSessionError
+	| EventSessionStatus;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create a minimal BetaMessage for assistant responses.
+ *
+ * Since we're adapting from OpenCode to Claude SDK format, we create
+ * a minimal valid BetaMessage structure with placeholder values for fields
+ * that OpenCode doesn't provide (stop_reason, usage, etc.).
+ */
+function createBetaMessage(
+	content: string | Array<Record<string, unknown>>,
+	messageId: string = crypto.randomUUID(),
+): SDKAssistantMessage["message"] {
+	// Convert string to content blocks, or use array directly
+	const contentBlocks = (typeof content === "string"
+		? [{ type: "text", text: content }]
+		: content) as unknown as SDKAssistantMessage["message"]["content"];
+
+	return {
+		id: messageId,
+		type: "message" as const,
+		role: "assistant" as const,
+		content: contentBlocks,
+		model: "opencode" as const,
+		stop_reason: null,
+		stop_sequence: null,
+		usage: {
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation: null,
+			server_tool_use: null,
+			service_tier: null,
+		},
+		container: null,
+		context_management: null,
+	};
+}
+
+/**
+ * Create token usage object from OpenCode token metrics.
+ */
+function createUsage(tokens?: {
+	input: number;
+	output: number;
+	reasoning?: number;
+	cache?: { read: number; write: number };
+}): SDKResultMessage["usage"] {
+	return {
+		input_tokens: tokens?.input || 0,
+		output_tokens: tokens?.output || 0,
+		cache_creation_input_tokens: tokens?.cache?.write || 0,
+		cache_read_input_tokens: tokens?.cache?.read || 0,
+		cache_creation: {
+			ephemeral_1h_input_tokens: 0,
+			ephemeral_5m_input_tokens: 0,
+		},
+		server_tool_use: {
+			web_fetch_requests: 0,
+			web_search_requests: 0,
+		},
+		service_tier: "standard" as const,
+	};
+}
+
+// ============================================================================
+// Event Type Guards
+// ============================================================================
+
+/**
+ * Check if event is a message part update.
+ */
+export function isMessagePartUpdated(
+	event: Event,
+): event is EventMessagePartUpdated {
+	return event.type === "message.part.updated";
+}
+
+/**
+ * Check if event is a message update.
+ */
+export function isMessageUpdated(event: Event): event is EventMessageUpdated {
+	return event.type === "message.updated";
+}
+
+/**
+ * Check if event is a session idle event.
+ */
+export function isSessionIdle(event: Event): event is EventSessionIdle {
+	return event.type === "session.idle";
+}
+
+/**
+ * Check if event is a session error event.
+ */
+export function isSessionError(event: Event): event is EventSessionError {
+	return event.type === "session.error";
+}
+
+/**
+ * Check if event is a session status event.
+ */
+export function isSessionStatus(event: Event): event is EventSessionStatus {
+	return event.type === "session.status";
+}
+
+/**
+ * Check if a part is a text part.
+ */
+export function isTextPart(part: Part): part is TextPart {
+	return part.type === "text";
+}
+
+/**
+ * Check if a part is a tool part.
+ */
+export function isToolPart(part: Part): part is ToolPart {
+	return part.type === "tool";
+}
+
+/**
+ * Check if tool state is completed.
+ */
+export function isToolStateCompleted(
+	state: ToolPart["state"],
+): state is ToolStateCompleted {
+	return state.status === "completed";
+}
+
+/**
+ * Check if tool state is error.
+ */
+export function isToolStateError(
+	state: ToolPart["state"],
+): state is ToolStateError {
+	return state.status === "error";
+}
+
+// ============================================================================
+// Part Conversion Functions
+// ============================================================================
+
+/**
+ * Convert an OpenCode TextPart to SDK text content block.
+ */
+export function textPartToContentBlock(part: TextPart): {
+	type: "text";
+	text: string;
+} {
+	return {
+		type: "text",
+		text: part.text,
+	};
+}
+
+/**
+ * Convert an OpenCode ToolPart to SDK tool_use content block.
+ *
+ * Note: Only tool parts in "running" or later states have meaningful data.
+ * "pending" state may have incomplete input (raw JSON string).
+ */
+export function toolPartToToolUseBlock(part: ToolPart): {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: Record<string, unknown>;
+} {
+	return {
+		type: "tool_use",
+		id: part.callID,
+		name: part.tool,
+		input: part.state.input || {},
+	};
+}
+
+/**
+ * Convert a completed ToolPart to SDK tool_result content block.
+ *
+ * This is used when we need to emit the tool result as a user message.
+ */
+export function toolPartToToolResultBlock(part: ToolPart): {
+	type: "tool_result";
+	tool_use_id: string;
+	content: string;
+	is_error: boolean;
+} {
+	if (isToolStateCompleted(part.state)) {
+		return {
+			type: "tool_result",
+			tool_use_id: part.callID,
+			content: part.state.output,
+			is_error: false,
+		};
+	} else if (isToolStateError(part.state)) {
+		return {
+			type: "tool_result",
+			tool_use_id: part.callID,
+			content: part.state.error,
+			is_error: true,
+		};
+	}
+	// For pending/running states, return empty result
+	return {
+		type: "tool_result",
+		tool_use_id: part.callID,
+		content: "",
+		is_error: false,
+	};
+}
+
+// ============================================================================
+// Message Conversion Functions
+// ============================================================================
+
+/**
+ * Convert an OpenCode message part update event to SDK message.
+ *
+ * This handles individual part updates as they stream in.
+ * The caller is responsible for accumulating parts into complete messages.
+ *
+ * @param event - The message.part.updated event
+ * @param sessionId - Current session ID
+ * @returns SDKMessage or null if part type doesn't map to a message
+ */
+export function partEventToSDKMessage(
+	event: EventMessagePartUpdated,
+	sessionId: string | null,
+): SDKMessage | null {
+	const part = event.properties.part;
+	const delta = event.properties.delta;
+
+	if (isTextPart(part)) {
+		// Text part - emit as assistant message
+		const text = delta !== undefined ? delta : part.text;
+
+		const assistantMessage: SDKAssistantMessage = {
+			type: "assistant",
+			message: createBetaMessage([{ type: "text", text }], part.messageID),
+			parent_tool_use_id: null,
+			uuid: crypto.randomUUID(),
+			session_id: sessionId || "pending",
+		};
+		return assistantMessage;
+	}
+
+	if (isToolPart(part)) {
+		// Tool part - handle based on state
+		if (part.state.status === "running") {
+			// Tool invocation - emit as assistant message with tool_use
+			const assistantMessage: SDKAssistantMessage = {
+				type: "assistant",
+				message: createBetaMessage(
+					[toolPartToToolUseBlock(part)],
+					part.messageID,
+				),
+				parent_tool_use_id: null,
+				uuid: crypto.randomUUID(),
+				session_id: sessionId || "pending",
+			};
+			return assistantMessage;
+		}
+
+		if (part.state.status === "completed" || part.state.status === "error") {
+			// Tool result - emit as user message with tool_result
+			const toolResultMessage: SDKUserMessage = {
+				type: "user",
+				message: {
+					role: "user",
+					content: [toolPartToToolResultBlock(part)],
+				},
+				parent_tool_use_id: null,
+				session_id: sessionId || "pending",
+			};
+			return toolResultMessage;
+		}
+	}
+
+	// Other part types (file, snapshot, patch, etc.) - not mapped
+	return null;
+}
+
+/**
+ * Convert an OpenCode message update event to SDK message.
+ *
+ * This handles complete message updates (not individual parts).
+ *
+ * @param event - The message.updated event
+ * @param sessionId - Current session ID
+ * @returns SDKMessage or null
+ */
+export function messageEventToSDKMessage(
+	event: EventMessageUpdated,
+	sessionId: string | null,
+): SDKMessage | null {
+	const message = event.properties.info;
+
+	if (message.role === "user") {
+		// User message - rarely needed but included for completeness
+		const userMsg = message as UserMessage;
+		const userMessage: SDKUserMessage = {
+			type: "user",
+			message: {
+				role: "user",
+				content: userMsg.summary?.title || "User message",
+			},
+			parent_tool_use_id: null,
+			session_id: sessionId || "pending",
+		};
+		return userMessage;
+	}
+
+	// Assistant message - this is typically the completion signal
+	// We use this to check for completion state via time.completed
+	return null;
+}
+
+/**
+ * Synthesize an SDKResultMessage from completion state.
+ *
+ * OpenCode doesn't have a dedicated result message - we synthesize from:
+ * - AssistantMessage.finish === "stop"
+ * - AssistantMessage.time.completed set
+ * - session.idle event
+ *
+ * @param sessionId - Current session ID
+ * @param lastAssistantMessage - Last assistant message for content extraction
+ * @param assistantInfo - Optional AssistantMessage info for token metrics
+ * @returns SDKResultMessage
+ */
+export function synthesizeResultMessage(
+	sessionId: string | null,
+	lastAssistantMessage?: SDKAssistantMessage | null,
+	assistantInfo?: AssistantMessage | null,
+): SDKResultMessage {
+	// Extract result content from last assistant message
+	let resultContent = "Session completed successfully";
+	if (lastAssistantMessage?.message?.content) {
+		const content = lastAssistantMessage.message.content;
+		if (Array.isArray(content) && content.length > 0) {
+			const textBlock = content.find((block) => block.type === "text");
+			if (textBlock && "text" in textBlock) {
+				resultContent = textBlock.text;
+			}
+		}
+	}
+
+	// Calculate duration if we have timing info
+	let durationMs = 0;
+	if (assistantInfo?.time?.created && assistantInfo?.time?.completed) {
+		durationMs = assistantInfo.time.completed - assistantInfo.time.created;
+	}
+
+	return {
+		type: "result",
+		subtype: "success",
+		duration_ms: durationMs,
+		duration_api_ms: 0,
+		is_error: false,
+		num_turns: 0, // OpenCode doesn't track this directly
+		result: resultContent,
+		total_cost_usd: assistantInfo?.cost || 0,
+		usage: createUsage(assistantInfo?.tokens),
+		modelUsage: {},
+		permission_denials: [],
+		uuid: crypto.randomUUID(),
+		session_id: sessionId || "pending",
+	};
+}
+
+/**
+ * Convert a session error event to SDKResultMessage.
+ *
+ * @param event - The session.error event
+ * @param sessionId - Current session ID
+ * @returns SDKResultMessage with error info
+ */
+export function errorEventToSDKMessage(
+	event: EventSessionError,
+	sessionId: string | null,
+): SDKResultMessage {
+	const error = event.properties.error;
+
+	// Format error message based on error type
+	let errorMessage = "Unknown error";
+	if (error) {
+		// Extract message from error data if available
+		const errorData = error.data as { message?: string; statusCode?: number };
+		errorMessage = errorData?.message || error.name;
+		if (errorData?.statusCode !== undefined) {
+			errorMessage += ` (status: ${errorData.statusCode})`;
+		}
+	}
+
+	return {
+		type: "result",
+		subtype: "error_during_execution",
+		duration_ms: 0,
+		duration_api_ms: 0,
+		is_error: true,
+		num_turns: 0,
+		errors: [errorMessage],
+		total_cost_usd: 0,
+		usage: createUsage(),
+		modelUsage: {},
+		permission_denials: [],
+		uuid: crypto.randomUUID(),
+		session_id: sessionId || "pending",
+	};
+}
+
+// ============================================================================
+// Main Adapter Function
+// ============================================================================
+
+/**
+ * Convert an OpenCode event to cyrus-core SDKMessage format.
+ *
+ * This adapter maps OpenCode's SSE events to the cyrus-core SDKMessage format,
+ * allowing OpenCodeRunner to implement the IAgentRunner interface.
+ *
+ * NOTE: This adapter is stateless for most events. For complete message
+ * accumulation, the caller (OpenCodeRunner) should track parts and build
+ * complete messages.
+ *
+ * @param event - OpenCode SSE event
+ * @param sessionId - Current session ID (may be null initially)
+ * @param lastAssistantMessage - Last assistant message for result coercion (optional)
+ * @param lastAssistantInfo - Last assistant message info for metrics (optional)
+ * @returns SDKMessage or null if event type doesn't map to a message
+ */
+export function openCodeEventToSDKMessage(
+	event: Event,
+	sessionId: string | null,
+	lastAssistantMessage?: SDKAssistantMessage | null,
+	lastAssistantInfo?: AssistantMessage | null,
+): SDKMessage | null {
+	if (isMessagePartUpdated(event)) {
+		return partEventToSDKMessage(event, sessionId);
+	}
+
+	if (isMessageUpdated(event)) {
+		// Check if this is a completion signal
+		const message = event.properties.info;
+		if (message.role === "assistant") {
+			const assistantMsg = message as AssistantMessage;
+			// If the message has finished, we might want to emit a result
+			// But we defer result emission to session.idle for consistency
+			if (assistantMsg.finish === "stop" && assistantMsg.time?.completed) {
+				// Store this for result synthesis later
+				// Return null here - result will be synthesized on session.idle
+			}
+		}
+		return messageEventToSDKMessage(event, sessionId);
+	}
+
+	if (isSessionIdle(event)) {
+		// Session has completed - synthesize result message
+		return synthesizeResultMessage(
+			sessionId,
+			lastAssistantMessage,
+			lastAssistantInfo,
+		);
+	}
+
+	if (isSessionError(event)) {
+		return errorEventToSDKMessage(event, sessionId);
+	}
+
+	// Other event types (session.status, file.edited, etc.) - not mapped
+	return null;
+}
+
+/**
+ * Extract session ID from an OpenCode event.
+ *
+ * @param event - OpenCode event
+ * @returns Session ID if available, null otherwise
+ */
+export function extractSessionId(event: Event): string | null {
+	if (isMessagePartUpdated(event)) {
+		return event.properties.part.sessionID;
+	}
+	if (isMessageUpdated(event)) {
+		return event.properties.info.sessionID;
+	}
+	if (isSessionIdle(event)) {
+		return event.properties.sessionID;
+	}
+	if (isSessionError(event)) {
+		return event.properties.sessionID || null;
+	}
+	if (isSessionStatus(event)) {
+		return event.properties.sessionID;
+	}
+	return null;
+}
+
+/**
+ * Create a Cyrus Core SDK UserMessage from a plain string prompt.
+ *
+ * Helper function to create properly formatted SDKUserMessage objects
+ * for sending to OpenCode.
+ *
+ * @param content - The prompt text
+ * @param sessionId - Current session ID (may be null for initial message)
+ * @returns Formatted SDKUserMessage
+ */
+export function createUserMessage(
+	content: string,
+	sessionId: string | null,
+): SDKUserMessage {
+	return {
+		type: "user",
+		message: {
+			role: "user",
+			content: content,
+		},
+		parent_tool_use_id: null,
+		session_id: sessionId || "pending",
+	};
+}

--- a/packages/opencode-runner/src/index.ts
+++ b/packages/opencode-runner/src/index.ts
@@ -105,6 +105,39 @@ export {
 } from "./portAllocator.js";
 
 // ============================================================================
+// Event Adapters (CYPACK-634)
+// ============================================================================
+
+// Type exports
+export type { AccumulatedMessage, ProcessableEvent } from "./adapters.js";
+// Main adapter function
+// Part conversion functions
+// Message conversion functions
+// Event type guards
+// Helper functions
+export {
+	createUserMessage,
+	errorEventToSDKMessage,
+	extractSessionId,
+	isMessagePartUpdated,
+	isMessageUpdated,
+	isSessionError,
+	isSessionIdle,
+	isSessionStatus,
+	isTextPart,
+	isToolPart,
+	isToolStateCompleted,
+	isToolStateError,
+	messageEventToSDKMessage,
+	openCodeEventToSDKMessage,
+	partEventToSDKMessage,
+	synthesizeResultMessage,
+	textPartToContentBlock,
+	toolPartToToolResultBlock,
+	toolPartToToolUseBlock,
+} from "./adapters.js";
+
+// ============================================================================
 // Placeholder Exports for Future Implementation
 // ============================================================================
 

--- a/packages/opencode-runner/test/adapters.test.ts
+++ b/packages/opencode-runner/test/adapters.test.ts
@@ -1,0 +1,796 @@
+/**
+ * Unit tests for OpenCode event adapters.
+ *
+ * Tests the conversion of OpenCode SSE events to SDKMessage format.
+ */
+
+import type {
+	AssistantMessage,
+	Event,
+	EventMessagePartUpdated,
+	EventMessageUpdated,
+	EventSessionError,
+	EventSessionIdle,
+	EventSessionStatus,
+	TextPart,
+	ToolPart,
+	ToolStateCompleted,
+	ToolStateError,
+	ToolStatePending,
+	ToolStateRunning,
+} from "@opencode-ai/sdk";
+import type { SDKAssistantMessage, SDKUserMessage } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	createUserMessage,
+	errorEventToSDKMessage,
+	extractSessionId,
+	isMessagePartUpdated,
+	isMessageUpdated,
+	isSessionError,
+	isSessionIdle,
+	isSessionStatus,
+	isTextPart,
+	isToolPart,
+	isToolStateCompleted,
+	isToolStateError,
+	openCodeEventToSDKMessage,
+	partEventToSDKMessage,
+	synthesizeResultMessage,
+	textPartToContentBlock,
+	toolPartToToolResultBlock,
+	toolPartToToolUseBlock,
+} from "../src/adapters.js";
+
+// ============================================================================
+// Mock Event Factories
+// ============================================================================
+
+function createTextPart(
+	text: string,
+	options: Partial<TextPart> = {},
+): TextPart {
+	return {
+		id: "part-123",
+		sessionID: "session-456",
+		messageID: "msg-789",
+		type: "text",
+		text,
+		...options,
+	};
+}
+
+function createToolPart(
+	state: ToolPart["state"],
+	options: Partial<Omit<ToolPart, "state">> = {},
+): ToolPart {
+	return {
+		id: "part-tool-123",
+		sessionID: "session-456",
+		messageID: "msg-789",
+		type: "tool",
+		callID: "call-abc",
+		tool: "bash",
+		state,
+		...options,
+	};
+}
+
+function createMessagePartUpdatedEvent(
+	part: TextPart | ToolPart,
+	delta?: string,
+): EventMessagePartUpdated {
+	return {
+		type: "message.part.updated",
+		properties: {
+			part,
+			delta,
+		},
+	};
+}
+
+function createMessageUpdatedEvent(
+	info: AssistantMessage,
+): EventMessageUpdated {
+	return {
+		type: "message.updated",
+		properties: {
+			info,
+		},
+	};
+}
+
+function createSessionIdleEvent(sessionID: string): EventSessionIdle {
+	return {
+		type: "session.idle",
+		properties: {
+			sessionID,
+		},
+	};
+}
+
+function createSessionErrorEvent(
+	error?: EventSessionError["properties"]["error"],
+	sessionID?: string,
+): EventSessionError {
+	return {
+		type: "session.error",
+		properties: {
+			sessionID,
+			error,
+		},
+	};
+}
+
+function createSessionStatusEvent(
+	sessionID: string,
+	status: EventSessionStatus["properties"]["status"],
+): EventSessionStatus {
+	return {
+		type: "session.status",
+		properties: {
+			sessionID,
+			status,
+		},
+	};
+}
+
+function createAssistantMessageInfo(
+	options: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		id: "msg-123",
+		sessionID: "session-456",
+		role: "assistant",
+		time: {
+			created: Date.now(),
+		},
+		parentID: "parent-123",
+		modelID: "claude-3-sonnet",
+		providerID: "anthropic",
+		mode: "build",
+		path: {
+			cwd: "/workspace",
+			root: "/workspace",
+		},
+		cost: 0.001,
+		tokens: {
+			input: 100,
+			output: 50,
+			reasoning: 0,
+			cache: { read: 0, write: 0 },
+		},
+		...options,
+	};
+}
+
+// ============================================================================
+// Type Guard Tests
+// ============================================================================
+
+describe("Event Type Guards", () => {
+	describe("isMessagePartUpdated", () => {
+		it("returns true for message.part.updated events", () => {
+			const event = createMessagePartUpdatedEvent(createTextPart("Hello"));
+			expect(isMessagePartUpdated(event)).toBe(true);
+		});
+
+		it("returns false for other event types", () => {
+			const event = createSessionIdleEvent("session-123");
+			expect(isMessagePartUpdated(event)).toBe(false);
+		});
+	});
+
+	describe("isMessageUpdated", () => {
+		it("returns true for message.updated events", () => {
+			const event = createMessageUpdatedEvent(createAssistantMessageInfo());
+			expect(isMessageUpdated(event)).toBe(true);
+		});
+
+		it("returns false for other event types", () => {
+			const event = createSessionIdleEvent("session-123");
+			expect(isMessageUpdated(event)).toBe(false);
+		});
+	});
+
+	describe("isSessionIdle", () => {
+		it("returns true for session.idle events", () => {
+			const event = createSessionIdleEvent("session-123");
+			expect(isSessionIdle(event)).toBe(true);
+		});
+
+		it("returns false for other event types", () => {
+			const event = createMessagePartUpdatedEvent(createTextPart("Hello"));
+			expect(isSessionIdle(event)).toBe(false);
+		});
+	});
+
+	describe("isSessionError", () => {
+		it("returns true for session.error events", () => {
+			const event = createSessionErrorEvent(undefined, "session-123");
+			expect(isSessionError(event)).toBe(true);
+		});
+
+		it("returns false for other event types", () => {
+			const event = createSessionIdleEvent("session-123");
+			expect(isSessionError(event)).toBe(false);
+		});
+	});
+
+	describe("isSessionStatus", () => {
+		it("returns true for session.status events", () => {
+			const event = createSessionStatusEvent("session-123", { type: "idle" });
+			expect(isSessionStatus(event)).toBe(true);
+		});
+
+		it("returns false for other event types", () => {
+			const event = createSessionIdleEvent("session-123");
+			expect(isSessionStatus(event)).toBe(false);
+		});
+	});
+});
+
+describe("Part Type Guards", () => {
+	describe("isTextPart", () => {
+		it("returns true for text parts", () => {
+			const part = createTextPart("Hello");
+			expect(isTextPart(part as any)).toBe(true);
+		});
+
+		it("returns false for tool parts", () => {
+			const part = createToolPart({ status: "pending", input: {}, raw: "" });
+			expect(isTextPart(part as any)).toBe(false);
+		});
+	});
+
+	describe("isToolPart", () => {
+		it("returns true for tool parts", () => {
+			const part = createToolPart({ status: "pending", input: {}, raw: "" });
+			expect(isToolPart(part as any)).toBe(true);
+		});
+
+		it("returns false for text parts", () => {
+			const part = createTextPart("Hello");
+			expect(isToolPart(part as any)).toBe(false);
+		});
+	});
+
+	describe("isToolStateCompleted", () => {
+		it("returns true for completed state", () => {
+			const state: ToolStateCompleted = {
+				status: "completed",
+				input: { command: "ls" },
+				output: "file1.txt\nfile2.txt",
+				title: "List files",
+				metadata: {},
+				time: { start: Date.now() - 1000, end: Date.now() },
+			};
+			expect(isToolStateCompleted(state)).toBe(true);
+		});
+
+		it("returns false for running state", () => {
+			const state: ToolStateRunning = {
+				status: "running",
+				input: { command: "ls" },
+				time: { start: Date.now() },
+			};
+			expect(isToolStateCompleted(state)).toBe(false);
+		});
+	});
+
+	describe("isToolStateError", () => {
+		it("returns true for error state", () => {
+			const state: ToolStateError = {
+				status: "error",
+				input: { command: "bad-command" },
+				error: "Command not found",
+				time: { start: Date.now() - 1000, end: Date.now() },
+			};
+			expect(isToolStateError(state)).toBe(true);
+		});
+
+		it("returns false for completed state", () => {
+			const state: ToolStateCompleted = {
+				status: "completed",
+				input: { command: "ls" },
+				output: "file1.txt",
+				title: "List files",
+				metadata: {},
+				time: { start: Date.now() - 1000, end: Date.now() },
+			};
+			expect(isToolStateError(state)).toBe(false);
+		});
+	});
+});
+
+// ============================================================================
+// Part Conversion Tests
+// ============================================================================
+
+describe("Part Conversion Functions", () => {
+	describe("textPartToContentBlock", () => {
+		it("converts text part to SDK text block", () => {
+			const part = createTextPart("Hello, world!");
+			const block = textPartToContentBlock(part);
+
+			expect(block).toEqual({
+				type: "text",
+				text: "Hello, world!",
+			});
+		});
+	});
+
+	describe("toolPartToToolUseBlock", () => {
+		it("converts tool part to SDK tool_use block", () => {
+			const state: ToolStateRunning = {
+				status: "running",
+				input: { command: "ls -la" },
+				time: { start: Date.now() },
+			};
+			const part = createToolPart(state, { tool: "bash", callID: "call-xyz" });
+			const block = toolPartToToolUseBlock(part);
+
+			expect(block).toEqual({
+				type: "tool_use",
+				id: "call-xyz",
+				name: "bash",
+				input: { command: "ls -la" },
+			});
+		});
+	});
+
+	describe("toolPartToToolResultBlock", () => {
+		it("converts completed tool part to SDK tool_result block", () => {
+			const state: ToolStateCompleted = {
+				status: "completed",
+				input: { command: "ls" },
+				output: "file1.txt\nfile2.txt",
+				title: "List files",
+				metadata: {},
+				time: { start: Date.now() - 1000, end: Date.now() },
+			};
+			const part = createToolPart(state, { callID: "call-xyz" });
+			const block = toolPartToToolResultBlock(part);
+
+			expect(block).toEqual({
+				type: "tool_result",
+				tool_use_id: "call-xyz",
+				content: "file1.txt\nfile2.txt",
+				is_error: false,
+			});
+		});
+
+		it("converts error tool part to SDK tool_result block with error", () => {
+			const state: ToolStateError = {
+				status: "error",
+				input: { command: "bad-command" },
+				error: "Command not found",
+				time: { start: Date.now() - 1000, end: Date.now() },
+			};
+			const part = createToolPart(state, { callID: "call-xyz" });
+			const block = toolPartToToolResultBlock(part);
+
+			expect(block).toEqual({
+				type: "tool_result",
+				tool_use_id: "call-xyz",
+				content: "Command not found",
+				is_error: true,
+			});
+		});
+
+		it("returns empty result for pending state", () => {
+			const state: ToolStatePending = {
+				status: "pending",
+				input: {},
+				raw: '{"command": "ls"}',
+			};
+			const part = createToolPart(state, { callID: "call-xyz" });
+			const block = toolPartToToolResultBlock(part);
+
+			expect(block).toEqual({
+				type: "tool_result",
+				tool_use_id: "call-xyz",
+				content: "",
+				is_error: false,
+			});
+		});
+	});
+});
+
+// ============================================================================
+// Message Conversion Tests
+// ============================================================================
+
+describe("partEventToSDKMessage", () => {
+	const sessionId = "session-123";
+
+	it("converts text part event to SDKAssistantMessage", () => {
+		const part = createTextPart("Hello, world!");
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("assistant");
+		const assistantMsg = message as SDKAssistantMessage;
+		expect(assistantMsg.session_id).toBe(sessionId);
+		expect(assistantMsg.message.content).toHaveLength(1);
+		expect(
+			(assistantMsg.message.content[0] as { type: string; text: string }).type,
+		).toBe("text");
+		expect(
+			(assistantMsg.message.content[0] as { type: string; text: string }).text,
+		).toBe("Hello, world!");
+	});
+
+	it("uses delta text when provided", () => {
+		const part = createTextPart("Hello, world!");
+		const event = createMessagePartUpdatedEvent(part, "Hello");
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		const assistantMsg = message as SDKAssistantMessage;
+		expect(
+			(assistantMsg.message.content[0] as { type: string; text: string }).text,
+		).toBe("Hello");
+	});
+
+	it("converts running tool part to SDKAssistantMessage with tool_use", () => {
+		const state: ToolStateRunning = {
+			status: "running",
+			input: { command: "ls -la" },
+			time: { start: Date.now() },
+		};
+		const part = createToolPart(state);
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("assistant");
+		const assistantMsg = message as SDKAssistantMessage;
+		expect(assistantMsg.message.content).toHaveLength(1);
+		expect((assistantMsg.message.content[0] as { type: string }).type).toBe(
+			"tool_use",
+		);
+	});
+
+	it("converts completed tool part to SDKUserMessage with tool_result", () => {
+		const state: ToolStateCompleted = {
+			status: "completed",
+			input: { command: "ls" },
+			output: "file1.txt",
+			title: "List files",
+			metadata: {},
+			time: { start: Date.now() - 1000, end: Date.now() },
+		};
+		const part = createToolPart(state);
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("user");
+		const userMsg = message as SDKUserMessage;
+		expect(Array.isArray(userMsg.message.content)).toBe(true);
+		expect((userMsg.message.content as { type: string }[])[0].type).toBe(
+			"tool_result",
+		);
+	});
+
+	it("converts error tool part to SDKUserMessage with error tool_result", () => {
+		const state: ToolStateError = {
+			status: "error",
+			input: { command: "bad-cmd" },
+			error: "Command failed",
+			time: { start: Date.now() - 1000, end: Date.now() },
+		};
+		const part = createToolPart(state);
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("user");
+		const userMsg = message as SDKUserMessage;
+		const content = (userMsg.message.content as { is_error: boolean }[])[0];
+		expect(content.is_error).toBe(true);
+	});
+
+	it("returns null for pending tool part", () => {
+		const state: ToolStatePending = {
+			status: "pending",
+			input: {},
+			raw: "",
+		};
+		const part = createToolPart(state);
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, sessionId);
+
+		expect(message).toBeNull();
+	});
+
+	it("uses 'pending' as session_id when null", () => {
+		const part = createTextPart("Hello");
+		const event = createMessagePartUpdatedEvent(part);
+		const message = partEventToSDKMessage(event, null);
+
+		expect(message).not.toBeNull();
+		expect((message as SDKAssistantMessage).session_id).toBe("pending");
+	});
+});
+
+// ============================================================================
+// Result Message Tests
+// ============================================================================
+
+describe("synthesizeResultMessage", () => {
+	const sessionId = "session-123";
+
+	it("creates success result message", () => {
+		const result = synthesizeResultMessage(sessionId);
+
+		expect(result.type).toBe("result");
+		expect(result.subtype).toBe("success");
+		expect(result.is_error).toBe(false);
+		expect(result.session_id).toBe(sessionId);
+		expect(result.result).toBe("Session completed successfully");
+	});
+
+	it("extracts content from last assistant message", () => {
+		const lastAssistantMessage: SDKAssistantMessage = {
+			type: "assistant",
+			message: {
+				id: "msg-123",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "Final response text" }] as any,
+				model: "opencode",
+				stop_reason: null,
+				stop_sequence: null,
+				usage: {
+					input_tokens: 0,
+					output_tokens: 0,
+					cache_creation_input_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation: null,
+					server_tool_use: null,
+					service_tier: null,
+				},
+				container: null,
+				context_management: null,
+			},
+			parent_tool_use_id: null,
+			uuid: "uuid-123",
+			session_id: sessionId,
+		};
+
+		const result = synthesizeResultMessage(sessionId, lastAssistantMessage);
+
+		expect(result.result).toBe("Final response text");
+	});
+
+	it("includes token metrics from assistant info", () => {
+		const assistantInfo = createAssistantMessageInfo({
+			tokens: {
+				input: 500,
+				output: 200,
+				reasoning: 100,
+				cache: { read: 50, write: 25 },
+			},
+			cost: 0.005,
+		});
+
+		const result = synthesizeResultMessage(sessionId, null, assistantInfo);
+
+		expect(result.usage.input_tokens).toBe(500);
+		expect(result.usage.output_tokens).toBe(200);
+		expect(result.usage.cache_read_input_tokens).toBe(50);
+		expect(result.usage.cache_creation_input_tokens).toBe(25);
+		expect(result.total_cost_usd).toBe(0.005);
+	});
+
+	it("calculates duration from timing info", () => {
+		const startTime = Date.now() - 5000;
+		const endTime = Date.now();
+		const assistantInfo = createAssistantMessageInfo({
+			time: { created: startTime, completed: endTime },
+		});
+
+		const result = synthesizeResultMessage(sessionId, null, assistantInfo);
+
+		expect(result.duration_ms).toBe(endTime - startTime);
+	});
+
+	it("uses 'pending' as session_id when null", () => {
+		const result = synthesizeResultMessage(null);
+
+		expect(result.session_id).toBe("pending");
+	});
+});
+
+describe("errorEventToSDKMessage", () => {
+	const sessionId = "session-123";
+
+	it("creates error result message", () => {
+		const event = createSessionErrorEvent(
+			{
+				name: "UnknownError",
+				data: { message: "Something went wrong" },
+			},
+			sessionId,
+		);
+
+		const result = errorEventToSDKMessage(event, sessionId);
+
+		expect(result.type).toBe("result");
+		expect(result.subtype).toBe("error_during_execution");
+		expect(result.is_error).toBe(true);
+		expect(result.errors).toContain("Something went wrong");
+	});
+
+	it("includes status code in error message when available", () => {
+		const event = createSessionErrorEvent(
+			{
+				name: "APIError",
+				data: {
+					message: "Rate limit exceeded",
+					statusCode: 429,
+					isRetryable: true,
+				},
+			},
+			sessionId,
+		);
+
+		const result = errorEventToSDKMessage(event, sessionId);
+
+		expect(result.errors?.[0]).toContain("429");
+	});
+
+	it("handles missing error with default message", () => {
+		const event = createSessionErrorEvent(undefined, sessionId);
+
+		const result = errorEventToSDKMessage(event, sessionId);
+
+		expect(result.errors).toContain("Unknown error");
+	});
+
+	it("uses error name when message is not available", () => {
+		const event = createSessionErrorEvent(
+			{
+				name: "MessageOutputLengthError",
+				data: {},
+			},
+			sessionId,
+		);
+
+		const result = errorEventToSDKMessage(event, sessionId);
+
+		expect(result.errors).toContain("MessageOutputLengthError");
+	});
+});
+
+// ============================================================================
+// Main Adapter Function Tests
+// ============================================================================
+
+describe("openCodeEventToSDKMessage", () => {
+	const sessionId = "session-123";
+
+	it("handles message.part.updated events", () => {
+		const part = createTextPart("Hello");
+		const event = createMessagePartUpdatedEvent(part);
+		const message = openCodeEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("assistant");
+	});
+
+	it("handles session.idle events", () => {
+		const event = createSessionIdleEvent(sessionId);
+		const message = openCodeEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("result");
+		expect((message as any).subtype).toBe("success");
+	});
+
+	it("handles session.error events", () => {
+		const event = createSessionErrorEvent(
+			{
+				name: "UnknownError",
+				data: { message: "Test error" },
+			},
+			sessionId,
+		);
+		const message = openCodeEventToSDKMessage(event, sessionId);
+
+		expect(message).not.toBeNull();
+		expect(message?.type).toBe("result");
+		expect((message as any).is_error).toBe(true);
+	});
+
+	it("returns null for unhandled event types", () => {
+		const event: Event = {
+			type: "file.edited",
+			properties: { file: "/path/to/file.ts" },
+		} as any;
+		const message = openCodeEventToSDKMessage(event, sessionId);
+
+		expect(message).toBeNull();
+	});
+});
+
+// ============================================================================
+// Helper Function Tests
+// ============================================================================
+
+describe("extractSessionId", () => {
+	it("extracts session ID from message.part.updated event", () => {
+		const part = createTextPart("Hello", { sessionID: "test-session" });
+		const event = createMessagePartUpdatedEvent(part);
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBe("test-session");
+	});
+
+	it("extracts session ID from message.updated event", () => {
+		const info = createAssistantMessageInfo({ sessionID: "test-session-2" });
+		const event = createMessageUpdatedEvent(info);
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBe("test-session-2");
+	});
+
+	it("extracts session ID from session.idle event", () => {
+		const event = createSessionIdleEvent("test-session-3");
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBe("test-session-3");
+	});
+
+	it("extracts session ID from session.error event", () => {
+		const event = createSessionErrorEvent(undefined, "test-session-4");
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBe("test-session-4");
+	});
+
+	it("extracts session ID from session.status event", () => {
+		const event = createSessionStatusEvent("test-session-5", { type: "busy" });
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBe("test-session-5");
+	});
+
+	it("returns null for events without session ID", () => {
+		const event: Event = {
+			type: "file.edited",
+			properties: { file: "/path/to/file.ts" },
+		} as any;
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBeNull();
+	});
+
+	it("returns null for session.error with no sessionID", () => {
+		const event = createSessionErrorEvent(undefined);
+		const sessionId = extractSessionId(event);
+
+		expect(sessionId).toBeNull();
+	});
+});
+
+describe("createUserMessage", () => {
+	it("creates SDK user message with content", () => {
+		const message = createUserMessage("Hello, Claude!", "session-123");
+
+		expect(message.type).toBe("user");
+		expect(message.message.role).toBe("user");
+		expect(message.message.content).toBe("Hello, Claude!");
+		expect(message.session_id).toBe("session-123");
+		expect(message.parent_tool_use_id).toBeNull();
+	});
+
+	it("uses 'pending' for null session ID", () => {
+		const message = createUserMessage("Test prompt", null);
+
+		expect(message.session_id).toBe("pending");
+	});
+});


### PR DESCRIPTION
## Summary

Implement OpenCode event-to-SDKMessage adapters following the gemini-runner pattern. This adds the adapter layer that converts OpenCode SSE events to Claude SDK message types for compatibility with the existing Cyrus infrastructure.

### Changes
- Add `adapters.ts` with event type guards and conversion functions
- Handle `message.part.updated` events for text and tool parts
- Handle `session.idle` events with result synthesis
- Handle `session.error` events with error result messages
- Export adapter functions from package index
- Add comprehensive unit tests (52 tests)

### Event Mapping

| OpenCode Event | SDKMessage Type |
| -- | -- |
| `message.part.updated` (type: text) | `SDKAssistantMessage` text block |
| `message.part.updated` (type: tool, running) | `SDKAssistantMessage` tool_use block |
| `message.part.updated` (type: tool, completed/error) | `SDKUserMessage` tool_result block |
| `session.idle` | `SDKResultMessage` (success) |
| `session.error` | `SDKResultMessage` (error) |

## Test plan

- [x] Run `pnpm test:run` in `packages/opencode-runner` - 52 tests passing
- [x] Run `pnpm typecheck` - No TypeScript errors
- [x] Run `pnpm lint` - Clean (no new issues)
- [x] Build passes with `pnpm build`

## Stack Position

**Previous in Stack**: CYPACK-633 (Package Setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)