### PR TITLE
fix(opencode-runner): Pass working directory to OpenCode SDK session (CYPACK-647)

### DIFF
--- a/packages/opencode-runner/package.json
+++ b/packages/opencode-runner/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@opencode-ai/sdk": "1.0.167",
 		"cyrus-core": "workspace:*",
+		"dotenv": "^16.4.5",
 		"zod": "^3.23.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       cyrus-core:
         specifier: workspace:*
         version: link:../core
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
       zod:
         specifier: ^3.23.0
         version: 3.25.76


### PR DESCRIPTION
## Summary

Adds working directory support to OpenCodeRunner to match ClaudeRunner's behavior:

- **Directory creation**: Creates working directory before session start with `mkdirSync`
- **.env loading**: Loads environment variables from repository `.env` file using dotenv
- **MCP auto-detection**: Auto-detects `.mcp.json` in working directory for MCP server configuration
- **New dependency**: Added `dotenv` package

## Problem

OpenCodeRunner did not pass the working directory (`cwd`) to the OpenCode SDK in the same way ClaudeRunner does, which could cause issues if OpenCode is expected to work within a specific repository directory.

| Aspect | ClaudeRunner | OpenCodeRunner (Before) | OpenCodeRunner (After) |
| -- | -- | -- | -- |
| Passes cwd to SDK | ✅ Yes | ✅ Yes (session.create) | ✅ Yes |
| Creates directory | ✅ Yes | ❌ No | ✅ Yes |
| Loads .env | ✅ Yes | ❌ No | ✅ Yes |
| MCP auto-detection | ✅ Yes | ❌ No | ✅ Yes |

## Changes

### `packages/opencode-runner/src/OpenCodeRunner.ts`
- Added imports for `existsSync`, `mkdirSync` and `dotenv`
- Added directory creation before session start
- Added `loadRepositoryEnv()` method for .env loading
- Added logging for working directory configuration

### `packages/opencode-runner/src/configBuilder.ts`
- Added MCP auto-detection from `.mcp.json` in working directory
- Auto-detected MCP servers are loaded as base config, with inline `mcpConfig` overriding for same server names

### `packages/opencode-runner/package.json`
- Added `dotenv` dependency (`^16.4.5`)

## Test plan

- [x] All 265 tests passing across all packages
- [x] TypeScript type checking passes
- [x] Linting passes (only pre-existing warning in unrelated package)
- [x] Build succeeds

Closes CYPACK-647

🤖 Generated with [Claude Code](https://claude.com/claude-code)