### PR TITLE
feat(packages): Update @anthropic-ai/claude-agent-sdk to v0.1.76 (CYPACK-661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.72 to v0.1.76 to maintain parity with the latest Claude Code updates. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details. ([CYPACK-661](https://linear.app/ceedar/issue/CYPACK-661))
+
 ### Fixed
 - **AskUserQuestion UI cleanup** - The AskUserQuestion tool no longer appears as raw JSON in Linear's activity stream. Since the tool is custom-handled via Linear's select signal elicitation, the tool call and result are now suppressed from the activity UI for a cleaner experience. ([CYPACK-654](https://linear.app/ceedar/issue/CYPACK-654), [#698](https://github.com/ceedaragents/cyrus/pull/698))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.72(zod@3.25.76)
+        specifier: ^0.1.76
+        version: 0.1.76(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@3.25.76)
@@ -197,8 +197,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.72(zod@4.1.12)
+        specifier: ^0.1.76
+        version: 0.1.76(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -342,8 +342,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.72(zod@4.1.12)
+        specifier: ^0.1.76
+        version: 0.1.76(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -367,8 +367,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.72':
-    resolution: {integrity: sha512-fS/aTDfpafNA49K3Kn2QCQYpFiz6RckIxDFeBO0xw9ciudkao2M3uqjaa7K4eHMOhrXePfypCij4uTt8D4tyHQ==}
+  '@anthropic-ai/claude-agent-sdk@0.1.76':
+    resolution: {integrity: sha512-s7RvpXoFaLXLG7A1cJBAPD8ilwOhhc/12fb5mJXRuD561o4FmPtQ+WRfuy9akMmrFRfLsKv8Ornw3ClGAPL2fw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.1 || ^4.0.0
@@ -3756,7 +3756,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.72(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
     optionalDependencies:
@@ -3769,7 +3769,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.72(zod@4.1.12)':
+  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@4.1.12)':
     dependencies:
       zod: 4.1.12
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` from v0.1.72 to v0.1.76 across three packages:
- `cyrus-core`
- `cyrus-claude-runner`
- `cyrus-simple-agent-runner`

## Changes

### SDK Updates (v0.1.72 → v0.1.76)

**v0.1.76**:
- Updated to parity with Claude Code v2.0.76

**v0.1.75**:
- Updated to parity with Claude Code v2.0.75

**v0.1.74**:
- Updated to parity with Claude Code v2.0.74

**v0.1.73**:
- Fixed a bug where Stop hooks would not consistently run due to "Stream closed" error
- Updated to parity with Claude Code v2.0.73

See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for complete details.

## Testing

✅ **All verifications passed:**
- 280 tests passing in edge-worker package
- 189 tests passing in gemini-runner package
- 72 tests passing in claude-runner package
- 6 tests passing in core package
- 5 tests passing in config-updater package
- TypeScript type checking passed
- Linting clean (1 pre-existing warning in ConfigApiClient.ts)
- Build successful for all packages

## Notes

- `@anthropic-ai/sdk` was already at the latest version (v0.71.2) and did not require updating
- Updated CHANGELOG.md with the SDK update details and link to upstream changelog

## Related PRs

This PR supersedes:
- #697 (CYPACK-660) - Update to v0.1.76 (closed and Linear issue canceled)

Closes [CYPACK-661](https://linear.app/ceedar/issue/CYPACK-661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)