### PR TITLE
Release v0.2.8 (CYPACK-671)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.8] - 2025-12-28
+
+(No internal changes in this release)
 
 ## [0.2.7] - 2025-12-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,43 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.8] - 2025-12-28
+
 ### Added
 - **Release procedure** - Added a new `release` procedure with two subroutines for executing software releases. When an issue is classified as a release request, Cyrus will: (1) check for a release skill in the project, (2) check CLAUDE.md or README.md for release instructions, or (3) ask the user via AskUserQuestion how to perform the release. This enables Cyrus to handle release workflows for any project type. ([CYPACK-668](https://linear.app/ceedar/issue/CYPACK-668), [#706](https://github.com/ceedaragents/cyrus/pull/706))
 - **Self-hosting OAuth commands** - New CLI commands for self-hosted deployments: `cyrus self-auth` performs direct Linear OAuth authorization without a proxy, and `cyrus self-add-repo` clones repositories and adds them to config with inherited workspace credentials. Both commands support the `--cyrus-home` flag for custom configuration directories. See the [Self-Hosting Guide](./docs/SELF_HOSTING.md) for setup instructions. Based on the [original OAuth implementation](https://github.com/grandmore/cyrus-self-hosting/pull/1) contributed by Stuart and the Grandmore team. ([CYPACK-669](https://linear.app/ceedar/issue/CYPACK-669), [#707](https://github.com/ceedaragents/cyrus/pull/707))
 
 ### Changed
 - **Documentation restructured** - Moved self-hosting documentation from `selfhosting/` folder to `docs/` with separate files: `SELF_HOSTING.md` (main guide), `CONFIG_FILE.md` (configuration reference), and `CLOUDFLARE_TUNNEL.md` (optional tunnel setup). Main README now links to these docs. ([CYPACK-669](https://linear.app/ceedar/issue/CYPACK-669), [#707](https://github.com/ceedaragents/cyrus/pull/707))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.8
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.8
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.8
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.8
+
+#### cyrus-core
+- cyrus-core@0.2.8
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.8
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.8
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.8
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.8
 
 ## [0.2.7] - 2025-12-28
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary

This PR contains the release v0.2.8 of Cyrus, which includes:

- **Release procedure** - Added a new `release` procedure with two subroutines for executing software releases
- **Self-hosting OAuth commands** - New CLI commands `cyrus self-auth` and `cyrus self-add-repo` for self-hosted deployments
- **Documentation restructured** - Moved self-hosting documentation from `selfhosting/` folder to `docs/`

## Changes

- Updated CHANGELOG.md and CHANGELOG.internal.md with v0.2.8 release notes
- Bumped all package versions from 0.2.7 to 0.2.8
- Published all 9 packages to npm
- Created git tag v0.2.8
- Created GitHub release v0.2.8
- Updated Linear issues CYPACK-668 and CYPACK-669 to ReleasedMonitoring status

## Published Packages

All packages published at v0.2.8:
- cyrus-cloudflare-tunnel-client
- cyrus-claude-runner  
- cyrus-core
- cyrus-simple-agent-runner
- cyrus-linear-event-transport
- cyrus-config-updater
- cyrus-gemini-runner
- cyrus-edge-worker
- cyrus-ai (CLI)

## Test plan

- [x] All 176 package tests passing
- [x] TypeScript type checking passes
- [x] All packages verified on npm registry
- [x] Git tag v0.2.8 exists
- [x] GitHub release v0.2.8 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)