### PR TITLE
Add dynamic label support to F1 create-issue command (CYPACK-680)

### DIFF
--- a/apps/f1/src/commands/createIssue.ts
+++ b/apps/f1/src/commands/createIssue.ts
@@ -22,6 +22,7 @@ interface CreateIssueParams {
 	teamId: string;
 	title: string;
 	description?: string;
+	labels?: string[];
 }
 
 export function createCreateIssueCommand(): Command {
@@ -32,11 +33,16 @@ export function createCreateIssueCommand(): Command {
 		.requiredOption("-t, --title <title>", "Issue title")
 		.option("-d, --description <description>", "Issue description")
 		.option("-T, --team-id <teamId>", "Team ID (required)", "team-default")
+		.option(
+			"-l, --labels <labels>",
+			"Comma-separated label names (created if they don't exist)",
+		)
 		.action(
 			async (options: {
 				title: string;
 				description?: string;
 				teamId: string;
+				labels?: string;
 			}) => {
 				printRpcUrl();
 
@@ -47,6 +53,14 @@ export function createCreateIssueCommand(): Command {
 
 				if (options.description) {
 					params.description = options.description;
+				}
+
+				if (options.labels) {
+					// Parse comma-separated label names, trim whitespace
+					params.labels = options.labels
+						.split(",")
+						.map((label) => label.trim())
+						.filter((label) => label.length > 0);
 				}
 
 				try {

--- a/packages/core/test/CLIIssueTrackerService.labels.test.ts
+++ b/packages/core/test/CLIIssueTrackerService.labels.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { CLIIssueTrackerService } from "../src/issue-tracker/adapters/CLIIssueTrackerService";
+
+describe("CLIIssueTrackerService - Label Operations", () => {
+	let service: CLIIssueTrackerService;
+
+	beforeEach(() => {
+		service = new CLIIssueTrackerService();
+		service.seedDefaultData();
+	});
+
+	describe("findOrCreateLabel", () => {
+		it("should create a new label when it doesn't exist", async () => {
+			const labelId = await service.findOrCreateLabel("sonnet");
+
+			expect(labelId).toMatch(/^label-/);
+
+			// Verify the label was created
+			const label = await service.fetchLabel(labelId);
+			expect(label.name).toBe("sonnet");
+			expect(label.color).toBeDefined();
+		});
+
+		it("should return existing label ID when label already exists", async () => {
+			// Create label first time
+			const firstLabelId = await service.findOrCreateLabel("feature");
+
+			// Request same label again
+			const secondLabelId = await service.findOrCreateLabel("feature");
+
+			// Should return same ID
+			expect(secondLabelId).toBe(firstLabelId);
+		});
+
+		it("should handle multiple different labels", async () => {
+			const labelId1 = await service.findOrCreateLabel("sonnet");
+			const labelId2 = await service.findOrCreateLabel("opus");
+			const labelId3 = await service.findOrCreateLabel("haiku");
+
+			// All should be different
+			expect(labelId1).not.toBe(labelId2);
+			expect(labelId2).not.toBe(labelId3);
+			expect(labelId1).not.toBe(labelId3);
+
+			// All should be retrievable
+			const label1 = await service.fetchLabel(labelId1);
+			const label2 = await service.fetchLabel(labelId2);
+			const label3 = await service.fetchLabel(labelId3);
+
+			expect(label1.name).toBe("sonnet");
+			expect(label2.name).toBe("opus");
+			expect(label3.name).toBe("haiku");
+		});
+
+		it("should generate consistent colors for same label name", async () => {
+			const labelId = await service.findOrCreateLabel("test-label");
+			const label = await service.fetchLabel(labelId);
+
+			// Color should be a valid hex color
+			expect(label.color).toMatch(/^#[0-9a-f]{6}$/i);
+		});
+	});
+
+	describe("createIssue with labels", () => {
+		it("should create issue with label IDs after findOrCreateLabel", async () => {
+			// First create labels
+			const labelId1 = await service.findOrCreateLabel("sonnet");
+			const labelId2 = await service.findOrCreateLabel("feature");
+
+			// Create issue with those label IDs
+			const issue = await service.createIssue({
+				teamId: "team-default",
+				title: "Test Issue with Labels",
+				labelIds: [labelId1, labelId2],
+			});
+
+			// Verify labels are attached
+			expect(issue.labelIds).toContain(labelId1);
+			expect(issue.labelIds).toContain(labelId2);
+
+			// Verify labels() method returns the labels
+			const labels = await issue.labels();
+			expect(labels.nodes).toHaveLength(2);
+			expect(labels.nodes.map((l) => l.name).sort()).toEqual([
+				"feature",
+				"sonnet",
+			]);
+		});
+
+		it("should persist labels across multiple issues", async () => {
+			// Create a label
+			const labelId = await service.findOrCreateLabel("shared-label");
+
+			// Create first issue with label
+			const issue1 = await service.createIssue({
+				teamId: "team-default",
+				title: "Issue 1",
+				labelIds: [labelId],
+			});
+
+			// Create second issue with same label
+			const issue2 = await service.createIssue({
+				teamId: "team-default",
+				title: "Issue 2",
+				labelIds: [labelId],
+			});
+
+			// Both should have the same label
+			expect(issue1.labelIds).toContain(labelId);
+			expect(issue2.labelIds).toContain(labelId);
+
+			const labels1 = await issue1.labels();
+			const labels2 = await issue2.labels();
+
+			expect(labels1.nodes[0].id).toBe(labels2.nodes[0].id);
+			expect(labels1.nodes[0].name).toBe("shared-label");
+		});
+	});
+
+	describe("getIssueLabels", () => {
+		it("should return label names for issue", async () => {
+			// Create labels and issue
+			const labelId1 = await service.findOrCreateLabel("alpha");
+			const labelId2 = await service.findOrCreateLabel("beta");
+
+			const issue = await service.createIssue({
+				teamId: "team-default",
+				title: "Test Issue",
+				labelIds: [labelId1, labelId2],
+			});
+
+			// Get label names
+			const labelNames = await service.getIssueLabels(issue.id);
+
+			expect(labelNames).toHaveLength(2);
+			expect(labelNames.sort()).toEqual(["alpha", "beta"]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds dynamic label support to the F1 testing framework's create-issue command, enabling testing of label-based features like model selection and routing.

- Add `--labels` flag to CLI accepting comma-separated label names
- Labels are created dynamically on first use (no seeding required)
- Labels persist across issues and can be reused

## Changes

### CLI (`apps/f1/src/commands/createIssue.ts`)
- Added `-l, --labels <labels>` option accepting comma-separated label names
- Labels are parsed, trimmed, and passed to the RPC server

### RPC Server (`packages/core/.../CLIRPCServer.ts`)
- Extended `CreateIssueParams` to include optional `labels?: string[]`
- Updated `handleCreateIssue` to resolve label names to IDs using `findOrCreateLabel()`

### Issue Tracker Service (`packages/core/.../CLIIssueTrackerService.ts`)
- Added `findOrCreateLabel(name: string)` method for dynamic label creation
- Added `generateLabelColor(name: string)` helper using hash-based color assignment

## Usage

```bash
# Single label
./f1 create-issue --title "Test" --labels sonnet

# Multiple labels
./f1 create-issue --title "Test" --labels sonnet,feature,urgent
```

## Test Plan

- [x] All 5 acceptance criteria validated
- [x] 7 new label-specific tests added and passing
- [x] All 13 core package tests passing
- [x] Full package test suite passing (285+ tests)
- [x] TypeScript typecheck passing across all packages
- [x] Biome linting passing

Resolves CYPACK-680

🤖 Generated with [Claude Code](https://claude.com/claude-code)