### PR TITLE
Fix self-auth not saving credentials when repositories array is empty (CYPACK-674)

### DIFF
--- a/apps/cli/src/commands/SelfAddRepoCommand.ts
+++ b/apps/cli/src/commands/SelfAddRepoCommand.ts
@@ -8,18 +8,9 @@ import {
 	DEFAULT_CONFIG_FILENAME,
 	DEFAULT_WORKTREES_DIR,
 	type EdgeConfig,
+	type WorkspaceCredentials,
 } from "cyrus-core";
 import { BaseCommand } from "./ICommand.js";
-
-/**
- * Workspace credentials extracted from existing repository configurations
- */
-interface WorkspaceCredentials {
-	id: string;
-	name: string;
-	token: string;
-	refreshToken?: string;
-}
 
 /**
  * Self-add-repo command - clones a repo and adds it to config.json
@@ -100,7 +91,18 @@ export class SelfAddRepoCommand extends BaseCommand {
 			}
 
 			// Find workspaces with Linear credentials
+			// First, check the dedicated workspaces array (populated by self-auth)
 			const workspaces = new Map<string, WorkspaceCredentials>();
+
+			if (config.workspaces) {
+				for (const ws of config.workspaces) {
+					if (ws.id && ws.token) {
+						workspaces.set(ws.id, ws);
+					}
+				}
+			}
+
+			// Also check repositories for backwards compatibility
 			for (const repo of config.repositories) {
 				if (
 					repo.linearWorkspaceId &&

--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -216,10 +216,22 @@ export interface EdgeWorkerConfig {
 }
 
 /**
+ * Workspace credentials stored independently of repositories
+ * This allows self-auth to save credentials before any repositories are added
+ */
+export interface WorkspaceCredentials {
+	id: string; // Linear workspace ID
+	name: string; // Linear workspace display name
+	token: string; // OAuth access token
+	refreshToken?: string; // OAuth refresh token
+}
+
+/**
  * Edge configuration containing all repositories and global settings
  */
 export interface EdgeConfig {
 	repositories: RepositoryConfig[];
+	workspaces?: WorkspaceCredentials[]; // Authenticated workspaces (used by self-auth/self-add-repo)
 	ngrokAuthToken?: string;
 	stripeCustomerId?: string;
 	linearWorkspaceSlug?: string; // Linear workspace URL slug (e.g., "ceedar" from "https://linear.app/ceedar/...")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
 	EdgeWorkerConfig,
 	OAuthCallbackHandler,
 	RepositoryConfig,
+	WorkspaceCredentials,
 } from "./config-types.js";
 export { resolvePath } from "./config-types.js";
 


### PR DESCRIPTION
## Summary
- Fixes bug where `cyrus self-auth` failed to save OAuth credentials when `config.json` had an empty `repositories` array
- After a fresh install, running `self-auth` followed by `self-add-repo` now works correctly

## Changes
- Added `WorkspaceCredentials` interface to store workspace credentials independently of repositories
- Added `workspaces` array to `EdgeConfig` type in `cyrus-core`
- Updated `SelfAuthCommand` to save credentials to the `workspaces` array (in addition to updating existing repos)
- Updated `SelfAddRepoCommand` to check `workspaces` array first, then fall back to repositories for backwards compatibility

## Test plan
- [x] Added test: "should save workspace credentials to workspaces array even with empty repositories" in SelfAuthCommand.test.ts
- [x] Added test: "should use credentials from workspaces array when repositories is empty (CYPACK-674 fix)" in SelfAddRepoCommand.test.ts
- [x] All 57 CLI tests passing
- [x] All package tests passing
- [x] TypeScript type-checking clean

## Related Issues
- Fixes CYPACK-674
- Fixes https://github.com/ceedaragents/cyrus/issues/716

🤖 Generated with [Claude Code](https://claude.com/claude-code)