### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.1.76 (CYPACK-686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from v0.1.72 to v0.1.76 to maintain parity with Claude Code v2.0.74. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0174) for full details. (CYPACK-686)
+
 ### Added
 - **GPT Image 1.5 support** - The image-tools MCP server now supports `gpt-image-1.5`, OpenAI's latest and highest quality image generation model. You can choose between `gpt-image-1.5` (default, best quality), `gpt-image-1`, or `gpt-image-1-mini` (faster, lower cost). ([CYPACK-675](https://linear.app/ceedar/issue/CYPACK-675), [#717](https://github.com/ceedaragents/cyrus/pull/717))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.1.76",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,7 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
+        specifier: ^0.1.76
         version: 0.1.76(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
@@ -200,7 +200,7 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
+        specifier: ^0.1.76
         version: 0.1.76(zod@4.1.12)
       '@linear/sdk':
         specifier: ^64.0.0
@@ -345,7 +345,7 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
+        specifier: ^0.1.76
         version: 0.1.76(zod@4.1.12)
       cyrus-claude-runner:
         specifier: workspace:*


### PR DESCRIPTION
## Summary
Updated `@anthropic-ai/claude-agent-sdk` from v0.1.72 to v0.1.76 across all packages to maintain parity with Claude Code v2.0.74.

## Packages Updated
- `cyrus-core`
- `cyrus-claude-runner`
- `cyrus-simple-agent-runner`

Note: `@anthropic-ai/sdk` was already at the latest version (v0.71.2), so no update was needed.

## Changes
- Updated package.json files for the three packages using claude-agent-sdk
- Updated pnpm-lock.yaml with new dependency versions
- Updated CHANGELOG.md with entry linking to SDK changelog
- Closed duplicate PR #729 (CYPACK-685) and canceled that Linear issue

## Testing
- All 550+ package tests passing
- TypeScript type checking clean
- pnpm install successful
- Linting clean (17 pre-existing warnings, no new issues)

## References
- [Claude Agent SDK Changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0174)
- Linear Issue: CYPACK-686
- Closed duplicate: PR #729, CYPACK-685

🤖 Generated with [Claude Code](https://claude.com/claude-code)