### PR TITLE
Add 0.2.9 release notes to CHANGELOG (CYPACK-691)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-01-06
+
+(No internal changes in this release)
+
 ## [0.2.8] - 2025-12-28
 
 (No internal changes in this release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,40 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Repository tag routing** - You can now specify which repository an issue should be routed to by adding a `[repo=...]` tag in the issue description. Supports `[repo=org/repo-name]` to match GitHub URLs, `[repo=repo-name]` to match by name, or `[repo=repo-id]` to match by ID. This takes precedence over label, project, and team-based routing. ([CYPACK-688](https://linear.app/ceedar/issue/CYPACK-688), [#732](https://github.com/ceedaragents/cyrus/pull/732))
+
+## [0.2.9] - 2026-01-06
+
+### Added
 - **GPT Image 1.5 support** - The image-tools MCP server now supports `gpt-image-1.5`, OpenAI's latest and highest quality image generation model. You can choose between `gpt-image-1.5` (default, best quality), `gpt-image-1`, or `gpt-image-1-mini` (faster, lower cost). ([CYPACK-675](https://linear.app/ceedar/issue/CYPACK-675), [#717](https://github.com/ceedaragents/cyrus/pull/717))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.9
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.9
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.9
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.9
+
+#### cyrus-core
+- cyrus-core@0.2.9
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.9
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.9
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.9
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.9
 
 ## [0.2.8] - 2025-12-28
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.8",
+	"version": "0.2.9",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Adds the 0.2.9 release notes to CHANGELOG.md (gpt-image-1.5 support was released on Dec 30, 2025)
- The release was already published to npm but the CHANGELOG update was not merged to main

The 0.2.9 release contains:
- **GPT Image 1.5 support** - The image-tools MCP server now supports `gpt-image-1.5`, OpenAI's latest and highest quality image generation model.

## Test plan
- [x] Verified all packages are published at 0.2.9 on npm
- [x] Verified v0.2.9 tag and GitHub release exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)