### PR TITLE
Fix [repo=...] tag parsing for Linear's escaped brackets (CYPACK-688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Repository tag routing now works with Linear's escaped brackets** - Fixed a bug where `[repo=...]` tags weren't recognized because Linear escapes square brackets in descriptions (e.g., `\[repo=cyrus\]`). The parser now handles both escaped and unescaped formats. ([CYPACK-688](https://linear.app/ceedar/issue/CYPACK-688), [#738](https://github.com/ceedaragents/cyrus/pull/738))
+
 ## [0.2.10] - 2026-01-06
 
 ### Added
@@ -41,6 +44,7 @@ All notable changes to this project will be documented in this file.
 ## [0.2.9] - 2025-12-30
 
 ### Added
+- **Repository tag routing** - You can now specify which repository an issue should be routed to by adding a `[repo=...]` tag in the issue description. Supports `[repo=org/repo-name]` to match GitHub URLs, `[repo=repo-name]` to match by name, or `[repo=repo-id]` to match by ID. This takes precedence over label, project, and team-based routing. ([CYPACK-688](https://linear.app/ceedar/issue/CYPACK-688), [#732](https://github.com/ceedaragents/cyrus/pull/732))
 - **GPT Image 1.5 support** - The image-tools MCP server now supports `gpt-image-1.5`, OpenAI's latest and highest quality image generation model. You can choose between `gpt-image-1.5` (default, best quality), `gpt-image-1`, or `gpt-image-1-mini` (faster, lower cost). ([CYPACK-675](https://linear.app/ceedar/issue/CYPACK-675), [#717](https://github.com/ceedaragents/cyrus/pull/717))
 
 ### Packages

--- a/packages/edge-worker/src/RepositoryRouter.ts
+++ b/packages/edge-worker/src/RepositoryRouter.ts
@@ -415,12 +415,16 @@ export class RepositoryRouter {
 	 * - [repo=repo-name]
 	 * - [repo=repo-id]
 	 *
+	 * Also handles escaped brackets (\\[repo=...\\]) which Linear may produce
+	 * when the description contains markdown-escaped square brackets.
+	 *
 	 * Returns the tag value or null if not found.
 	 */
 	parseRepoTagFromDescription(description: string): string | null {
 		// Match [repo=...] pattern - captures everything between = and ]
 		// The pattern allows: alphanumeric, hyphens, underscores, forward slashes, dots
-		const match = description.match(/\[repo=([a-zA-Z0-9_\-/.]+)\]/);
+		// Also handles escaped brackets (\\[ and \\]) that Linear may produce
+		const match = description.match(/\\?\[repo=([a-zA-Z0-9_\-/.]+)\\?\]/);
 		return match?.[1] ?? null;
 	}
 

--- a/packages/edge-worker/test/RepositoryRouter.test.ts
+++ b/packages/edge-worker/test/RepositoryRouter.test.ts
@@ -777,6 +777,36 @@ describe("RepositoryRouter", () => {
 				);
 				expect(result).toBe("my-repo");
 			});
+
+			it("should handle escaped brackets from Linear (\\[repo=...\\])", () => {
+				// Linear escapes square brackets in descriptions
+				const result = env.router.parseRepoTagFromDescription(
+					"test\\n\\n\\[repo=cyrus\\]",
+				);
+				expect(result).toBe("cyrus");
+			});
+
+			it("should handle escaped brackets with org/repo format", () => {
+				const result = env.router.parseRepoTagFromDescription(
+					"Fix bug in \\[repo=org/repo-name\\]",
+				);
+				expect(result).toBe("org/repo-name");
+			});
+
+			it("should handle mixed escaped and unescaped brackets", () => {
+				// Only the opening bracket is escaped
+				const result = env.router.parseRepoTagFromDescription(
+					"Work on \\[repo=my-repo]",
+				);
+				expect(result).toBe("my-repo");
+			});
+
+			it("should handle only closing bracket escaped", () => {
+				const result = env.router.parseRepoTagFromDescription(
+					"Work on [repo=my-repo\\]",
+				);
+				expect(result).toBe("my-repo");
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Fixes a bug where `[repo=...]` tags weren't being recognized in production because Linear escapes square brackets in issue descriptions

## Problem
When a user writes `[repo=cyrus]` in Linear, the API returns it as `\[repo=cyrus\]` (escaped brackets). The original regex didn't handle this case, causing the tag to be missed.

## Solution
Updated the regex from `/\[repo=([a-zA-Z0-9_\-/.]+)\]/` to `/\\?\[repo=([a-zA-Z0-9_\-/.]+)\\?\]/` to handle both escaped and unescaped brackets.

## Test plan
- [x] Added 4 new tests for escaped bracket handling
- [x] All 306 edge-worker tests passing
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)