### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.2.0 (CYPACK-692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated @anthropic-ai/claude-agent-sdk to v0.2.0** - Updated from v0.1.72 to v0.2.0. See the [Claude Agent SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#020) for details on what's new in v0.2.0. ([CYPACK-692](https://linear.app/ceedar/issue/CYPACK-692))
+- **Updated zod to v4.3.5** - Updated from v3.24.1 to v4.3.5 to satisfy @anthropic-ai/claude-agent-sdk v0.2.0's peer dependency requirement. ([CYPACK-692](https://linear.app/ceedar/issue/CYPACK-692))
+
 ### Fixed
 - **Repository tag routing now works with Linear's escaped brackets** - Fixed a bug where `[repo=...]` tags weren't recognized because Linear escapes square brackets in descriptions (e.g., `\[repo=cyrus\]`). The parser now handles both escaped and unescaped formats. ([CYPACK-688](https://linear.app/ceedar/issue/CYPACK-688), [#738](https://github.com/ceedaragents/cyrus/pull/738))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,14 +16,14 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.0",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",
 		"fs-extra": "^11.3.2",
 		"openai": "^6.9.1",
-		"zod": "^3.24.1"
+		"zod": "^4.3.5"
 	},
 	"devDependencies": {
 		"@types/fs-extra": "^11.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.0",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.1.72",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.0",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,11 +122,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.76(zod@3.25.76)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.3.5)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
-        version: 0.71.2(zod@3.25.76)
+        version: 0.71.2(zod@4.3.5)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -141,10 +141,10 @@ importers:
         version: 11.3.2
       openai:
         specifier: ^6.9.1
-        version: 6.9.1(ws@8.18.3)(zod@3.25.76)
+        version: 6.9.1(ws@8.18.3)(zod@4.3.5)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.3.5
+        version: 4.3.5
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -200,8 +200,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.76(zod@4.1.12)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.3.5)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -345,8 +345,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.72
-        version: 0.1.76(zod@4.1.12)
+        specifier: ^0.2.0
+        version: 0.2.0(zod@4.3.5)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -370,11 +370,11 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76':
-    resolution: {integrity: sha512-s7RvpXoFaLXLG7A1cJBAPD8ilwOhhc/12fb5mJXRuD561o4FmPtQ+WRfuy9akMmrFRfLsKv8Ornw3ClGAPL2fw==}
+  '@anthropic-ai/claude-agent-sdk@0.2.0':
+    resolution: {integrity: sha512-7ywAH1/yclqR4y1hQ1RZbYvqpP5paFpWK77rjE+il/HCzLZGCWCelob8S7PEBju++ad6uSiZzMLkF+oPnZoDiQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.24.1 || ^4.0.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.71.2':
     resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
@@ -3750,8 +3750,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
 snapshots:
 
@@ -3760,9 +3760,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.0(zod@4.3.5)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -3773,24 +3773,11 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@4.1.12)':
-    dependencies:
-      zod: 4.1.12
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-
-  '@anthropic-ai/sdk@0.71.2(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.71.2(zod@4.3.5)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.3.5
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6334,10 +6321,10 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@6.9.1(ws@8.18.3)(zod@3.25.76):
+  openai@6.9.1(ws@8.18.3)(zod@4.3.5):
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.3.5
 
   p-cancelable@4.0.1: {}
 
@@ -7265,4 +7252,4 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.1.12: {}
+  zod@4.3.5: {}


### PR DESCRIPTION
## Summary
Updated `@anthropic-ai/claude-agent-sdk` from v0.1.72 to v0.2.0 and `zod` from v3.24.1 to v4.3.5 across all packages to get the latest improvements and bug fixes.

## Packages Updated
- `cyrus-core`: claude-agent-sdk v0.1.72 → v0.2.0
- `cyrus-claude-runner`: claude-agent-sdk v0.1.72 → v0.2.0, zod v3.24.1 → v4.3.5
- `cyrus-simple-agent-runner`: claude-agent-sdk v0.1.72 → v0.2.0

Note: `@anthropic-ai/sdk` was already at the latest version (v0.71.2), so no update was needed.

## Changes
- Updated package.json files for the three packages using claude-agent-sdk
- Updated zod to v4.3.5 to satisfy peer dependency requirement of claude-agent-sdk v0.2.0
- Updated pnpm-lock.yaml with new dependency versions
- Updated CHANGELOG.md with entries linking to SDK changelog ([CYPACK-692](https://linear.app/ceedar/issue/CYPACK-692))

## Testing
- All 550+ package tests passing
- TypeScript type checking clean
- pnpm install successful
- Linting clean (17 pre-existing warnings, no new issues)

## References
- [Claude Agent SDK Changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#020)
- Linear Issue: [CYPACK-692](https://linear.app/ceedar/issue/CYPACK-692)

## Related PRs
- Will close PR #733 ([CYPACK-689](https://linear.app/ceedar/issue/CYPACK-689)) which updated to v0.1.76 (superseded by this v0.2.0 update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>