### PR TITLE
Prepare release v0.2.11

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-01-07
+
+(No internal changes in this release)
+
 ## [0.2.10] - 2026-01-06
 
 (No internal changes in this release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-01-07
+
 ### Fixed
 - **Repository tag routing now works with Linear's escaped brackets** - Fixed a bug where `[repo=...]` tags weren't recognized because Linear escapes square brackets in descriptions (e.g., `\[repo=cyrus\]`). The parser now handles both escaped and unescaped formats. ([CYPACK-688](https://linear.app/ceedar/issue/CYPACK-688), [#738](https://github.com/ceedaragents/cyrus/pull/738))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.11
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.11
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.11
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.11
+
+#### cyrus-core
+- cyrus-core@0.2.11
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.11
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.11
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.11
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.11
 
 ## [0.2.10] - 2026-01-06
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumped all package versions from 0.2.10 to 0.2.11
- Updated CHANGELOG.md with release notes for v0.2.11
- Updated CHANGELOG.internal.md with version entry

## Test plan
- [x] All packages published successfully to npm
- [x] GitHub release created: https://github.com/ceedaragents/cyrus/releases/tag/v0.2.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)