### PR TITLE
Add MCP config validation before SDK invocation (CYPACK-708)

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -69,6 +69,11 @@ import { AgentSessionManager } from "./AgentSessionManager.js";
 import { AskUserQuestionHandler } from "./AskUserQuestionHandler.js";
 import { GitService } from "./GitService.js";
 import {
+	formatValidationErrorsForLinear,
+	loadAndValidateMcpConfigs,
+	type McpServerValidationResult,
+} from "./mcp-validation/index.js";
+import {
 	ProcedureAnalyzer,
 	type ProcedureDefinition,
 	type RequestClassification,
@@ -4905,6 +4910,58 @@ ${input.userComment}
 		const finalModel =
 			modelOverride || repository.model || this.config.defaultModel;
 
+		// Validate user MCP configs before passing to runner
+		// This prevents opaque SDK crashes from invalid configurations
+		const userMcpValidation = loadAndValidateMcpConfigs(
+			session.workspace.path,
+			repository.mcpConfigPath,
+		);
+
+		// Report invalid MCP configs to Linear (async, non-blocking)
+		if (
+			userMcpValidation.allInvalidServers.length > 0 ||
+			userMcpValidation.parseErrors.length > 0
+		) {
+			console.log(
+				`[EdgeWorker] Found ${userMcpValidation.allInvalidServers.length} invalid MCP server configs and ${userMcpValidation.parseErrors.length} parse errors for session ${linearAgentActivitySessionId}`,
+			);
+
+			// Report to Linear asynchronously (don't block session start)
+			this.reportMcpValidationErrors(
+				linearAgentActivitySessionId,
+				repository.id,
+				userMcpValidation.allInvalidServers,
+				userMcpValidation.parseErrors,
+			).catch((error) => {
+				console.error(
+					`[EdgeWorker] Failed to report MCP validation errors:`,
+					error,
+				);
+			});
+		}
+
+		// Merge valid user MCP servers with Cyrus's programmatic MCP servers
+		// Cyrus servers (Linear, cyrus-tools) override user configs for same server names
+		const programmaticMcpServers = this.buildMcpConfig(
+			repository,
+			linearAgentActivitySessionId,
+		);
+		// Cast is safe because we've already validated the user configs
+		const mergedMcpConfig: Record<string, McpServerConfig> = {
+			...(userMcpValidation.validServers as Record<string, McpServerConfig>),
+			...programmaticMcpServers,
+		};
+
+		// Log merged MCP config
+		const validUserServerCount = Object.keys(
+			userMcpValidation.validServers,
+		).length;
+		if (validUserServerCount > 0) {
+			console.log(
+				`[EdgeWorker] Loaded ${validUserServerCount} valid user MCP servers: ${Object.keys(userMcpValidation.validServers).join(", ")}`,
+			);
+		}
+
 		const config = {
 			workingDirectory: session.workspace.path,
 			allowedTools,
@@ -4912,8 +4969,10 @@ ${input.userComment}
 			allowedDirectories,
 			workspaceName: session.issue?.identifier || session.issueId,
 			cyrusHome: this.cyrusHome,
-			mcpConfigPath: repository.mcpConfigPath,
-			mcpConfig: this.buildMcpConfig(repository, linearAgentActivitySessionId),
+			// Don't pass mcpConfigPath - we've already validated and loaded configs
+			// Passing both mcpConfigPath and mcpConfig would cause double-loading and potentially
+			// include invalid servers that we've filtered out
+			mcpConfig: mergedMcpConfig,
 			appendSystemPrompt: systemPrompt || "",
 			// Priority order: label override > repository config > global default
 			model: finalModel,
@@ -4955,6 +5014,61 @@ ${input.userComment}
 		}
 
 		return { config, runnerType };
+	}
+
+	/**
+	 * Report MCP validation errors to Linear as an agent activity.
+	 * This is called asynchronously and should not block session startup.
+	 *
+	 * @param linearAgentSessionId - Linear agent session ID
+	 * @param repositoryId - Repository ID for getting issue tracker
+	 * @param invalidServers - List of invalid server validation results
+	 * @param parseErrors - List of file parse errors
+	 */
+	private async reportMcpValidationErrors(
+		linearAgentSessionId: string,
+		repositoryId: string,
+		invalidServers: McpServerValidationResult[],
+		parseErrors: { path: string; error: string }[],
+	): Promise<void> {
+		const issueTracker = this.issueTrackers.get(repositoryId);
+		if (!issueTracker) {
+			console.warn(
+				`[EdgeWorker] Cannot report MCP validation errors: no issue tracker for repository ${repositoryId}`,
+			);
+			return;
+		}
+
+		const errorMessage = formatValidationErrorsForLinear(
+			invalidServers,
+			parseErrors,
+		);
+
+		try {
+			const result = await issueTracker.createAgentActivity({
+				agentSessionId: linearAgentSessionId,
+				content: {
+					type: "thought",
+					body: errorMessage,
+				},
+			});
+
+			if (result.success) {
+				console.log(
+					`[EdgeWorker] Posted MCP validation error thought for session ${linearAgentSessionId}`,
+				);
+			} else {
+				console.error(
+					`[EdgeWorker] Failed to post MCP validation error thought:`,
+					result,
+				);
+			}
+		} catch (error) {
+			console.error(
+				`[EdgeWorker] Error posting MCP validation error thought:`,
+				error,
+			);
+		}
 	}
 
 	/**

--- a/packages/edge-worker/src/mcp-validation/McpConfigValidator.ts
+++ b/packages/edge-worker/src/mcp-validation/McpConfigValidator.ts
@@ -1,0 +1,510 @@
+/**
+ * MCP Configuration Validator
+ *
+ * Validates user-provided MCP server configurations before passing them to the Claude Agent SDK.
+ * This prevents opaque SDK crashes from invalid configurations.
+ *
+ * Based on SDK types (from @anthropic-ai/claude-agent-sdk):
+ * - McpStdioServerConfig: { type?: 'stdio'; command: string; args?: string[]; env?: Record<string, string>; }
+ * - McpSSEServerConfig: { type: 'sse'; url: string; headers?: Record<string, string>; }
+ * - McpHttpServerConfig: { type: 'http'; url: string; headers?: Record<string, string>; }
+ * - McpSdkServerConfig: { type: 'sdk'; name: string; } (not serializable when contains instance)
+ *
+ * @see https://github.com/anthropics/claude-agent-sdk-typescript/issues/131
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Result of validating a single MCP server configuration
+ */
+export interface McpServerValidationResult {
+	serverName: string;
+	isValid: boolean;
+	error?: string;
+	inferredType?: "stdio" | "sse" | "http" | "sdk";
+	warning?: string;
+}
+
+/**
+ * Result of validating an MCP configuration file or merged config
+ */
+export interface McpConfigValidationResult {
+	isValid: boolean;
+	validServers: Record<string, unknown>;
+	invalidServers: McpServerValidationResult[];
+	warnings: string[];
+}
+
+/**
+ * Raw MCP server config as it might appear in user's .mcp.json
+ * More permissive than SDK types to catch all possible misconfigurations
+ */
+interface RawMcpServerConfig {
+	type?: string;
+	command?: string;
+	args?: string[];
+	env?: Record<string, unknown>;
+	url?: string;
+	headers?: Record<string, unknown>;
+	transport?: string;
+	name?: string;
+	instance?: unknown;
+	[key: string]: unknown;
+}
+
+/**
+ * Validate a single MCP server configuration
+ */
+export function validateMcpServerConfig(
+	serverName: string,
+	config: unknown,
+): McpServerValidationResult {
+	// Basic type check
+	if (!config || typeof config !== "object") {
+		return {
+			serverName,
+			isValid: false,
+			error: "Configuration must be an object",
+		};
+	}
+
+	const rawConfig = config as RawMcpServerConfig;
+
+	// Check for SDK type with unserializable instance
+	if (rawConfig.type === "sdk") {
+		if (rawConfig.instance !== undefined) {
+			return {
+				serverName,
+				isValid: false,
+				error:
+					"SDK server configs with 'instance' property cannot be serialized. SDK servers must be created programmatically using createSdkMcpServer().",
+				inferredType: "sdk",
+			};
+		}
+		// SDK config without instance needs a name
+		if (!rawConfig.name || typeof rawConfig.name !== "string") {
+			return {
+				serverName,
+				isValid: false,
+				error: "SDK server config requires a 'name' property of type string",
+				inferredType: "sdk",
+			};
+		}
+		return {
+			serverName,
+			isValid: true,
+			inferredType: "sdk",
+		};
+	}
+
+	// Check for URL-based servers (HTTP or SSE)
+	if (rawConfig.url !== undefined) {
+		// URL is present - must have explicit type
+		if (typeof rawConfig.url !== "string") {
+			return {
+				serverName,
+				isValid: false,
+				error: "'url' property must be a string",
+			};
+		}
+
+		// Validate URL format
+		try {
+			new URL(rawConfig.url);
+		} catch {
+			return {
+				serverName,
+				isValid: false,
+				error: `Invalid URL format: ${rawConfig.url}`,
+			};
+		}
+
+		// Check for missing type - this is the key validation from the issue
+		if (rawConfig.type === undefined) {
+			return {
+				serverName,
+				isValid: false,
+				error: `URL-based MCP server requires explicit 'type' field. Add "type": "http" or "type": "sse" to your configuration.`,
+			};
+		}
+
+		// Validate type value for URL-based configs
+		if (rawConfig.type !== "http" && rawConfig.type !== "sse") {
+			return {
+				serverName,
+				isValid: false,
+				error: `URL-based MCP server has invalid type '${rawConfig.type}'. Must be 'http' or 'sse'.`,
+			};
+		}
+
+		// Validate headers if present
+		if (rawConfig.headers !== undefined) {
+			if (
+				typeof rawConfig.headers !== "object" ||
+				rawConfig.headers === null ||
+				Array.isArray(rawConfig.headers)
+			) {
+				return {
+					serverName,
+					isValid: false,
+					error: "'headers' must be an object with string key-value pairs",
+					inferredType: rawConfig.type as "http" | "sse",
+				};
+			}
+			// Check all header values are strings
+			for (const [key, value] of Object.entries(rawConfig.headers)) {
+				if (typeof value !== "string") {
+					return {
+						serverName,
+						isValid: false,
+						error: `Header '${key}' has non-string value. All header values must be strings.`,
+						inferredType: rawConfig.type as "http" | "sse",
+					};
+				}
+			}
+		}
+
+		return {
+			serverName,
+			isValid: true,
+			inferredType: rawConfig.type as "http" | "sse",
+		};
+	}
+
+	// Check for command-based servers (stdio)
+	if (rawConfig.command !== undefined) {
+		if (typeof rawConfig.command !== "string") {
+			return {
+				serverName,
+				isValid: false,
+				error: "'command' property must be a string",
+			};
+		}
+
+		if (rawConfig.command.trim() === "") {
+			return {
+				serverName,
+				isValid: false,
+				error: "'command' cannot be empty",
+			};
+		}
+
+		// Validate type if explicitly set
+		if (rawConfig.type !== undefined && rawConfig.type !== "stdio") {
+			return {
+				serverName,
+				isValid: false,
+				error: `Command-based MCP server has invalid type '${rawConfig.type}'. Must be 'stdio' or omitted.`,
+				inferredType: "stdio",
+			};
+		}
+
+		// Validate args if present
+		if (rawConfig.args !== undefined) {
+			if (!Array.isArray(rawConfig.args)) {
+				return {
+					serverName,
+					isValid: false,
+					error: "'args' must be an array of strings",
+					inferredType: "stdio",
+				};
+			}
+			for (let i = 0; i < rawConfig.args.length; i++) {
+				if (typeof rawConfig.args[i] !== "string") {
+					return {
+						serverName,
+						isValid: false,
+						error: `'args[${i}]' is not a string. All args must be strings.`,
+						inferredType: "stdio",
+					};
+				}
+			}
+		}
+
+		// Validate env if present
+		if (rawConfig.env !== undefined) {
+			if (
+				typeof rawConfig.env !== "object" ||
+				rawConfig.env === null ||
+				Array.isArray(rawConfig.env)
+			) {
+				return {
+					serverName,
+					isValid: false,
+					error: "'env' must be an object with string key-value pairs",
+					inferredType: "stdio",
+				};
+			}
+			for (const [key, value] of Object.entries(rawConfig.env)) {
+				if (typeof value !== "string") {
+					return {
+						serverName,
+						isValid: false,
+						error: `env['${key}'] has non-string value. All env values must be strings.`,
+						inferredType: "stdio",
+					};
+				}
+			}
+		}
+
+		return {
+			serverName,
+			isValid: true,
+			inferredType: "stdio",
+			// Add warning for stdio configs that explicitly set type
+			...(rawConfig.type === undefined && {
+				warning: 'Consider adding explicit "type": "stdio" for clarity',
+			}),
+		};
+	}
+
+	// No recognizable configuration pattern
+	return {
+		serverName,
+		isValid: false,
+		error:
+			"MCP server config must have either 'command' (for stdio) or 'url' (for http/sse). " +
+			"See https://docs.anthropic.com/en/docs/claude-code/mcp for configuration examples.",
+	};
+}
+
+/**
+ * Validate an entire MCP configuration object (e.g., from .mcp.json mcpServers field)
+ */
+export function validateMcpConfig(
+	mcpServers: Record<string, unknown>,
+): McpConfigValidationResult {
+	const validServers: Record<string, unknown> = {};
+	const invalidServers: McpServerValidationResult[] = [];
+	const warnings: string[] = [];
+
+	for (const [serverName, config] of Object.entries(mcpServers)) {
+		const result = validateMcpServerConfig(serverName, config);
+
+		if (result.isValid) {
+			validServers[serverName] = config;
+			if (result.warning) {
+				warnings.push(`${serverName}: ${result.warning}`);
+			}
+		} else {
+			invalidServers.push(result);
+		}
+	}
+
+	return {
+		isValid: invalidServers.length === 0,
+		validServers,
+		invalidServers,
+		warnings,
+	};
+}
+
+/**
+ * Load and validate MCP config from a file path
+ * Returns the validated config with invalid servers filtered out
+ */
+export function loadAndValidateMcpConfigFile(filePath: string): {
+	success: boolean;
+	config?: { mcpServers: Record<string, unknown> };
+	validationResult?: McpConfigValidationResult;
+	parseError?: string;
+} {
+	if (!existsSync(filePath)) {
+		return {
+			success: false,
+			parseError: `File not found: ${filePath}`,
+		};
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(filePath, "utf8");
+	} catch (error) {
+		return {
+			success: false,
+			parseError: `Failed to read file: ${(error as Error).message}`,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(content);
+	} catch (error) {
+		return {
+			success: false,
+			parseError: `Invalid JSON: ${(error as Error).message}`,
+		};
+	}
+
+	if (!parsed || typeof parsed !== "object") {
+		return {
+			success: false,
+			parseError: "MCP config file must contain a JSON object",
+		};
+	}
+
+	const configObj = parsed as Record<string, unknown>;
+	const mcpServers = configObj.mcpServers;
+
+	if (mcpServers === undefined) {
+		// No mcpServers field - valid but empty config
+		return {
+			success: true,
+			config: { mcpServers: {} },
+			validationResult: {
+				isValid: true,
+				validServers: {},
+				invalidServers: [],
+				warnings: [],
+			},
+		};
+	}
+
+	if (
+		typeof mcpServers !== "object" ||
+		mcpServers === null ||
+		Array.isArray(mcpServers)
+	) {
+		return {
+			success: false,
+			parseError: "'mcpServers' must be an object",
+		};
+	}
+
+	const validationResult = validateMcpConfig(
+		mcpServers as Record<string, unknown>,
+	);
+
+	return {
+		success: true,
+		config: { mcpServers: validationResult.validServers },
+		validationResult,
+	};
+}
+
+/**
+ * Load and validate MCP configs from multiple paths, merging them in order
+ * Later configs override earlier ones for the same server name
+ *
+ * @param workingDirectory - Working directory to check for auto-detected .mcp.json
+ * @param explicitPaths - Explicitly configured MCP config paths
+ * @returns Merged validation result with valid servers and collected errors
+ */
+export function loadAndValidateMcpConfigs(
+	workingDirectory?: string,
+	explicitPaths?: string | string[],
+): {
+	validServers: Record<string, unknown>;
+	allInvalidServers: McpServerValidationResult[];
+	allWarnings: string[];
+	parseErrors: { path: string; error: string }[];
+} {
+	const configPaths: string[] = [];
+	const parseErrors: { path: string; error: string }[] = [];
+
+	// Auto-detect .mcp.json in working directory
+	if (workingDirectory) {
+		const autoMcpPath = join(workingDirectory, ".mcp.json");
+		if (existsSync(autoMcpPath)) {
+			configPaths.push(autoMcpPath);
+		}
+	}
+
+	// Add explicit paths
+	if (explicitPaths) {
+		const paths = Array.isArray(explicitPaths)
+			? explicitPaths
+			: [explicitPaths];
+		configPaths.push(...paths);
+	}
+
+	let mergedServers: Record<string, unknown> = {};
+	const allInvalidServers: McpServerValidationResult[] = [];
+	const allWarnings: string[] = [];
+
+	for (const path of configPaths) {
+		const result = loadAndValidateMcpConfigFile(path);
+
+		if (!result.success) {
+			parseErrors.push({ path, error: result.parseError || "Unknown error" });
+			continue;
+		}
+
+		if (result.validationResult) {
+			// Merge valid servers (later paths override earlier)
+			mergedServers = {
+				...mergedServers,
+				...result.validationResult.validServers,
+			};
+
+			// Collect invalid servers with path context
+			for (const invalid of result.validationResult.invalidServers) {
+				allInvalidServers.push({
+					...invalid,
+					error: `[${path}] ${invalid.error}`,
+				});
+			}
+
+			// Collect warnings with path context
+			for (const warning of result.validationResult.warnings) {
+				allWarnings.push(`[${path}] ${warning}`);
+			}
+		}
+	}
+
+	return {
+		validServers: mergedServers,
+		allInvalidServers,
+		allWarnings,
+		parseErrors,
+	};
+}
+
+/**
+ * Format validation errors for display in Linear agent activity
+ */
+export function formatValidationErrorsForLinear(
+	invalidServers: McpServerValidationResult[],
+	parseErrors: { path: string; error: string }[],
+): string {
+	const lines: string[] = [];
+
+	lines.push("## ⚠️ MCP Configuration Validation Errors\n");
+	lines.push(
+		"The following MCP server configurations are invalid and will be omitted from this session:\n",
+	);
+
+	if (parseErrors.length > 0) {
+		lines.push("### File Parse Errors\n");
+		for (const { path, error } of parseErrors) {
+			lines.push(`- **${path}**: ${error}`);
+		}
+		lines.push("");
+	}
+
+	if (invalidServers.length > 0) {
+		lines.push("### Invalid Server Configurations\n");
+		for (const result of invalidServers) {
+			lines.push(`- **${result.serverName}**: ${result.error}`);
+		}
+		lines.push("");
+	}
+
+	lines.push("### How to Fix\n");
+	lines.push("Common issues and solutions:");
+	lines.push(
+		'- **Missing type field**: URL-based servers require `"type": "http"` or `"type": "sse"`',
+	);
+	lines.push(
+		"- **Invalid URL**: Ensure URLs are properly formatted (e.g., `https://example.com/mcp`)",
+	);
+	lines.push(
+		"- **Empty command**: Stdio servers require a non-empty `command` field",
+	);
+	lines.push("");
+	lines.push("See: https://docs.anthropic.com/en/docs/claude-code/mcp");
+
+	return lines.join("\n");
+}

--- a/packages/edge-worker/src/mcp-validation/index.ts
+++ b/packages/edge-worker/src/mcp-validation/index.ts
@@ -1,0 +1,16 @@
+/**
+ * MCP Configuration Validation Module
+ *
+ * Provides validation for user-provided MCP server configurations before
+ * passing them to the Claude Agent SDK, preventing opaque crashes.
+ */
+
+export {
+	formatValidationErrorsForLinear,
+	loadAndValidateMcpConfigFile,
+	loadAndValidateMcpConfigs,
+	type McpConfigValidationResult,
+	type McpServerValidationResult,
+	validateMcpConfig,
+	validateMcpServerConfig,
+} from "./McpConfigValidator.js";

--- a/packages/edge-worker/test/mcp-config-validation.test.ts
+++ b/packages/edge-worker/test/mcp-config-validation.test.ts
@@ -1,0 +1,509 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	formatValidationErrorsForLinear,
+	loadAndValidateMcpConfigFile,
+	loadAndValidateMcpConfigs,
+	validateMcpConfig,
+	validateMcpServerConfig,
+} from "../src/mcp-validation/index.js";
+
+describe("MCP Config Validation", () => {
+	describe("validateMcpServerConfig", () => {
+		describe("valid HTTP server configs", () => {
+			it("should accept valid HTTP config with type", () => {
+				const result = validateMcpServerConfig("sentry", {
+					type: "http",
+					url: "https://mcp.sentry.dev/mcp",
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("http");
+				expect(result.error).toBeUndefined();
+			});
+
+			it("should accept HTTP config with headers", () => {
+				const result = validateMcpServerConfig("linear", {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+					headers: {
+						Authorization: "Bearer token123",
+					},
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("http");
+			});
+		});
+
+		describe("valid SSE server configs", () => {
+			it("should accept valid SSE config with type", () => {
+				const result = validateMcpServerConfig("streaming-server", {
+					type: "sse",
+					url: "https://example.com/sse",
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("sse");
+			});
+		});
+
+		describe("valid stdio server configs", () => {
+			it("should accept stdio config with command only", () => {
+				const result = validateMcpServerConfig("local-server", {
+					command: "node",
+					args: ["./mcp-server.js"],
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("stdio");
+			});
+
+			it("should accept stdio config with explicit type", () => {
+				const result = validateMcpServerConfig("local-server", {
+					type: "stdio",
+					command: "npx",
+					args: ["mcp-server"],
+					env: { DEBUG: "true" },
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("stdio");
+			});
+		});
+
+		describe("valid SDK server configs", () => {
+			it("should accept SDK config without instance", () => {
+				const result = validateMcpServerConfig("sdk-server", {
+					type: "sdk",
+					name: "my-sdk-server",
+				});
+
+				expect(result.isValid).toBe(true);
+				expect(result.inferredType).toBe("sdk");
+			});
+		});
+
+		describe("invalid configs - missing type for URL-based servers", () => {
+			it("should reject URL-based config without type (issue root cause)", () => {
+				// This is the exact scenario from CYPACK-708
+				const result = validateMcpServerConfig("sentry", {
+					url: "https://mcp.sentry.dev/mcp",
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("type");
+				expect(result.error).toContain("http");
+				expect(result.error).toContain("sse");
+			});
+		});
+
+		describe("invalid configs - wrong type for URL-based servers", () => {
+			it("should reject URL-based config with stdio type", () => {
+				const result = validateMcpServerConfig("confused-server", {
+					type: "stdio",
+					url: "https://example.com/mcp",
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("invalid type");
+			});
+		});
+
+		describe("invalid configs - malformed inputs", () => {
+			it("should reject non-object configs", () => {
+				const result = validateMcpServerConfig("bad-server", "not-an-object");
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("object");
+			});
+
+			it("should reject null configs", () => {
+				const result = validateMcpServerConfig("null-server", null);
+
+				expect(result.isValid).toBe(false);
+			});
+
+			it("should reject empty objects", () => {
+				const result = validateMcpServerConfig("empty-server", {});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("command");
+				expect(result.error).toContain("url");
+			});
+
+			it("should reject invalid URL format", () => {
+				const result = validateMcpServerConfig("bad-url", {
+					type: "http",
+					url: "not-a-valid-url",
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("Invalid URL");
+			});
+
+			it("should reject empty command", () => {
+				const result = validateMcpServerConfig("empty-cmd", {
+					command: "",
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("empty");
+			});
+
+			it("should reject non-string args", () => {
+				const result = validateMcpServerConfig("bad-args", {
+					command: "node",
+					args: [123, "valid"],
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("args");
+			});
+
+			it("should reject non-string header values", () => {
+				const result = validateMcpServerConfig("bad-headers", {
+					type: "http",
+					url: "https://example.com",
+					headers: {
+						Authorization: 12345, // should be string
+					},
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("Header");
+			});
+
+			it("should reject non-string env values", () => {
+				const result = validateMcpServerConfig("bad-env", {
+					command: "node",
+					env: {
+						PORT: 3000, // should be string
+					},
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("env");
+			});
+		});
+
+		describe("invalid SDK configs", () => {
+			it("should reject SDK config with instance (not serializable)", () => {
+				const result = validateMcpServerConfig("sdk-with-instance", {
+					type: "sdk",
+					name: "test",
+					instance: {}, // Real instance would be an McpServer object
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("serialized");
+				expect(result.error).toContain("createSdkMcpServer");
+			});
+
+			it("should reject SDK config without name", () => {
+				const result = validateMcpServerConfig("sdk-no-name", {
+					type: "sdk",
+				});
+
+				expect(result.isValid).toBe(false);
+				expect(result.error).toContain("name");
+			});
+		});
+	});
+
+	describe("validateMcpConfig", () => {
+		it("should validate multiple servers and separate valid from invalid", () => {
+			const mcpServers = {
+				"valid-http": {
+					type: "http",
+					url: "https://example.com/mcp",
+				},
+				"valid-stdio": {
+					command: "node",
+					args: ["server.js"],
+				},
+				"invalid-missing-type": {
+					url: "https://mcp.sentry.dev/mcp", // Missing type
+				},
+				"invalid-bad-url": {
+					type: "http",
+					url: "not-a-url",
+				},
+			};
+
+			const result = validateMcpConfig(mcpServers);
+
+			expect(result.isValid).toBe(false);
+			expect(Object.keys(result.validServers)).toHaveLength(2);
+			expect(result.validServers["valid-http"]).toBeDefined();
+			expect(result.validServers["valid-stdio"]).toBeDefined();
+			expect(result.invalidServers).toHaveLength(2);
+			expect(result.invalidServers.map((s) => s.serverName)).toContain(
+				"invalid-missing-type",
+			);
+			expect(result.invalidServers.map((s) => s.serverName)).toContain(
+				"invalid-bad-url",
+			);
+		});
+
+		it("should return isValid true when all servers are valid", () => {
+			const mcpServers = {
+				server1: { type: "http", url: "https://example.com" },
+				server2: { command: "node", args: ["test.js"] },
+			};
+
+			const result = validateMcpConfig(mcpServers);
+
+			expect(result.isValid).toBe(true);
+			expect(result.invalidServers).toHaveLength(0);
+		});
+
+		it("should handle empty config", () => {
+			const result = validateMcpConfig({});
+
+			expect(result.isValid).toBe(true);
+			expect(Object.keys(result.validServers)).toHaveLength(0);
+			expect(result.invalidServers).toHaveLength(0);
+		});
+	});
+
+	describe("loadAndValidateMcpConfigFile", () => {
+		const testDir = join(process.cwd(), "test-tmp-mcp-config");
+
+		beforeEach(() => {
+			mkdirSync(testDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			rmSync(testDir, { recursive: true, force: true });
+		});
+
+		it("should load and validate a valid .mcp.json file", () => {
+			const configPath = join(testDir, ".mcp.json");
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					mcpServers: {
+						"test-server": {
+							type: "http",
+							url: "https://example.com/mcp",
+						},
+					},
+				}),
+			);
+
+			const result = loadAndValidateMcpConfigFile(configPath);
+
+			expect(result.success).toBe(true);
+			expect(result.validationResult?.isValid).toBe(true);
+			expect(result.config?.mcpServers["test-server"]).toBeDefined();
+		});
+
+		it("should handle file not found", () => {
+			const result = loadAndValidateMcpConfigFile(
+				"/nonexistent/path/.mcp.json",
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.parseError).toContain("not found");
+		});
+
+		it("should handle invalid JSON", () => {
+			const configPath = join(testDir, "invalid.json");
+			writeFileSync(configPath, "{ not valid json }");
+
+			const result = loadAndValidateMcpConfigFile(configPath);
+
+			expect(result.success).toBe(false);
+			expect(result.parseError).toContain("Invalid JSON");
+		});
+
+		it("should handle missing mcpServers field", () => {
+			const configPath = join(testDir, "empty.json");
+			writeFileSync(configPath, JSON.stringify({ otherField: "value" }));
+
+			const result = loadAndValidateMcpConfigFile(configPath);
+
+			expect(result.success).toBe(true);
+			expect(result.config?.mcpServers).toEqual({});
+		});
+
+		it("should filter out invalid servers from config", () => {
+			const configPath = join(testDir, "mixed.json");
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					mcpServers: {
+						valid: { type: "http", url: "https://example.com" },
+						invalid: { url: "https://missing-type.com" }, // Missing type
+					},
+				}),
+			);
+
+			const result = loadAndValidateMcpConfigFile(configPath);
+
+			expect(result.success).toBe(true);
+			expect(result.validationResult?.isValid).toBe(false);
+			expect(result.config?.mcpServers.valid).toBeDefined();
+			expect(result.config?.mcpServers.invalid).toBeUndefined();
+			expect(result.validationResult?.invalidServers).toHaveLength(1);
+		});
+	});
+
+	describe("loadAndValidateMcpConfigs", () => {
+		const testDir = join(process.cwd(), "test-tmp-mcp-configs");
+
+		beforeEach(() => {
+			mkdirSync(testDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			rmSync(testDir, { recursive: true, force: true });
+		});
+
+		it("should auto-detect .mcp.json in working directory", () => {
+			const workDir = join(testDir, "workspace");
+			mkdirSync(workDir, { recursive: true });
+			writeFileSync(
+				join(workDir, ".mcp.json"),
+				JSON.stringify({
+					mcpServers: {
+						"auto-detected": { type: "http", url: "https://example.com" },
+					},
+				}),
+			);
+
+			const result = loadAndValidateMcpConfigs(workDir);
+
+			expect(Object.keys(result.validServers)).toContain("auto-detected");
+		});
+
+		it("should merge configs with later paths overriding earlier ones", () => {
+			const workDir = join(testDir, "workspace");
+			const extraConfigPath = join(testDir, "extra.json");
+			mkdirSync(workDir, { recursive: true });
+
+			// Base config in working directory
+			writeFileSync(
+				join(workDir, ".mcp.json"),
+				JSON.stringify({
+					mcpServers: {
+						server1: { type: "http", url: "https://base.com" },
+						server2: { type: "http", url: "https://base.com" },
+					},
+				}),
+			);
+
+			// Override config
+			writeFileSync(
+				extraConfigPath,
+				JSON.stringify({
+					mcpServers: {
+						server1: { type: "http", url: "https://override.com" },
+						server3: { command: "node", args: ["new.js"] },
+					},
+				}),
+			);
+
+			const result = loadAndValidateMcpConfigs(workDir, extraConfigPath);
+
+			expect(result.validServers.server1).toEqual({
+				type: "http",
+				url: "https://override.com",
+			});
+			expect(result.validServers.server2).toEqual({
+				type: "http",
+				url: "https://base.com",
+			});
+			expect(result.validServers.server3).toBeDefined();
+		});
+
+		it("should collect errors from multiple files", () => {
+			const config1 = join(testDir, "config1.json");
+			const config2 = join(testDir, "config2.json");
+
+			writeFileSync(
+				config1,
+				JSON.stringify({
+					mcpServers: {
+						invalid1: { url: "https://no-type.com" },
+					},
+				}),
+			);
+			writeFileSync(
+				config2,
+				JSON.stringify({
+					mcpServers: {
+						invalid2: { url: "https://also-no-type.com" },
+					},
+				}),
+			);
+
+			const result = loadAndValidateMcpConfigs(undefined, [config1, config2]);
+
+			expect(result.allInvalidServers).toHaveLength(2);
+			expect(result.allInvalidServers[0].error).toContain(config1);
+			expect(result.allInvalidServers[1].error).toContain(config2);
+		});
+
+		it("should handle parse errors gracefully", () => {
+			const validConfig = join(testDir, "valid.json");
+			const invalidConfig = join(testDir, "invalid.json");
+
+			writeFileSync(
+				validConfig,
+				JSON.stringify({
+					mcpServers: {
+						valid: { type: "http", url: "https://example.com" },
+					},
+				}),
+			);
+			writeFileSync(invalidConfig, "{ broken json }");
+
+			const result = loadAndValidateMcpConfigs(undefined, [
+				validConfig,
+				invalidConfig,
+			]);
+
+			expect(result.parseErrors).toHaveLength(1);
+			expect(result.parseErrors[0].path).toBe(invalidConfig);
+			expect(result.validServers.valid).toBeDefined();
+		});
+	});
+
+	describe("formatValidationErrorsForLinear", () => {
+		it("should format errors for Linear display", () => {
+			const invalidServers = [
+				{
+					serverName: "sentry",
+					isValid: false,
+					error: "[/path/.mcp.json] Missing type field",
+				},
+			];
+			const parseErrors = [
+				{ path: "/path/invalid.json", error: "Invalid JSON" },
+			];
+
+			const message = formatValidationErrorsForLinear(
+				invalidServers,
+				parseErrors,
+			);
+
+			expect(message).toContain("MCP Configuration Validation Errors");
+			expect(message).toContain("sentry");
+			expect(message).toContain("Missing type field");
+			expect(message).toContain("Invalid JSON");
+			expect(message).toContain("How to Fix");
+			expect(message).toContain("http");
+			expect(message).toContain("sse");
+		});
+
+		it("should handle empty errors gracefully", () => {
+			const message = formatValidationErrorsForLinear([], []);
+
+			expect(message).toContain("MCP Configuration Validation Errors");
+			expect(message).toContain("How to Fix");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Add pre-validation of user `.mcp.json` configurations before passing to Claude Agent SDK
- Report invalid MCP configs to Linear via issueTracker as agent activity
- Omit invalid servers from SDK session while allowing valid ones to proceed

## Background

Addresses issue where invalid MCP server configuration (e.g., missing `type` field on URL-based servers) caused opaque SDK crashes:

```
Error: Claude Code process exited with code 1
    at ProcessTransport.getProcessExitError (.../sdk.mjs:7836:14)
```

## Implementation

### New MCP Validation Module (`packages/edge-worker/src/mcp-validation/`)

- `validateMcpServerConfig()` - Validates individual server configs against SDK types
- `validateMcpConfig()` - Validates collection, separating valid from invalid
- `loadAndValidateMcpConfigs()` - Loads and merges multiple config files with validation
- `formatValidationErrorsForLinear()` - Formats errors for display in Linear activities

### Validation Rules (from SDK types)

| Server Type | Required Fields | Notes |
|-------------|-----------------|-------|
| HTTP | `type: "http"`, `url` | Headers optional |
| SSE | `type: "sse"`, `url` | Headers optional |
| Stdio | `command` | `type: "stdio"` optional |
| SDK | `type: "sdk"`, `name` | Cannot have `instance` (not serializable) |

### EdgeWorker Integration

Modified `buildAgentRunnerConfig()` to:
1. Validate user MCP configs before constructing runner config
2. Report invalid configs via `issueTracker.createAgentActivity()` (async, non-blocking)
3. Merge valid user servers with Cyrus programmatic servers (Linear, cyrus-tools)

## Test plan

- [x] 32 new test cases covering all validation scenarios
- [x] All 366 edge-worker tests passing
- [x] TypeScript compilation clean
- [x] Linting clean

## Related

- Issue: [CYPACK-708](https://linear.app/ceedar/issue/CYPACK-708)
- Upstream: https://github.com/anthropics/claude-agent-sdk-typescript/issues/131

🤖 Generated with [Claude Code](https://claude.com/claude-code)