### PR TITLE
Update @anthropic-ai/claude-agent-sdk to v0.2.6 (CYPACK-710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated dependencies** - Updated `@anthropic-ai/claude-agent-sdk` from 0.2.2 to 0.2.6 ([changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#026-2026-01-12)). This update brings parity with Claude Code v2.1.6 and adds programmatic access to compatible CLI version. ([CYPACK-710](https://linear.app/ceedar/issue/CYPACK-710), [#754](https://github.com/ceedaragents/cyrus/pull/754))
+
 ## [0.2.12] - 2026-01-09
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.2",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.6",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.2",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.6",
 		"@linear/sdk": "^64.0.0"
 	},
 	"devDependencies": {

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.2",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.6",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(zod@4.3.5)
+        specifier: ^0.2.6
+        version: 0.2.6(zod@4.3.5)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@4.3.5)
@@ -202,8 +202,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(zod@4.3.5)
+        specifier: ^0.2.6
+        version: 0.2.6(zod@4.3.5)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -347,8 +347,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(zod@4.3.5)
+        specifier: ^0.2.6
+        version: 0.2.6(zod@4.3.5)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -372,8 +372,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.2':
-    resolution: {integrity: sha512-0cdYe0o3FI13JFtyewMdAdhO9ShF0FrrD9gqpTeuTht4VrqdMTzzYuVyfl4VszgHwmpSc5weEL0OTTdqstnk2Q==}
+  '@anthropic-ai/claude-agent-sdk@0.2.6':
+    resolution: {integrity: sha512-lwswHo6z/Kh9djafk2ajPju62+VqHwJ23gueG1alfaLNK4GRYHgCROfiX6/wlxAd8sRvgTo6ry1hNzkyz7bOpw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -3518,7 +3518,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.2(zod@4.3.5)':
+  '@anthropic-ai/claude-agent-sdk@0.2.6(zod@4.3.5)':
     dependencies:
       zod: 4.3.5
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from version 0.2.2 to 0.2.6 across three packages. The `@anthropic-ai/sdk` package is already at the latest version (0.71.2) and required no update.

## Changes

### Package Updates
- **packages/claude-runner**: Updated claude-agent-sdk to 0.2.6
- **packages/core**: Updated claude-agent-sdk to 0.2.6  
- **packages/simple-agent-runner**: Updated claude-agent-sdk to 0.2.6

### Changelog
- Added entry to CHANGELOG.md under `[Unreleased]` section
- Included link to upstream changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#026-2026-01-12

## Implementation Details

This update brings parity with Claude Code v2.1.6. The version 0.2.6 release of the claude-agent-sdk includes:
- v0.2.3: Updates to parity with Claude Code v2.1.3
- v0.2.4: Updates to parity with Claude Code v2.1.4
- v0.2.5: Updates to parity with Claude Code v2.1.5
- v0.2.6: Adds `claudeCodeVersion` field for programmatically determining compatible CLI version

## Testing

- ✅ All 637 package tests passing
- ✅ TypeScript type checking clean
- ✅ Build successful
- ✅ pnpm install completed without errors
- ✅ Linting clean (17 pre-existing warnings, not from this change)

## Related

This PR supersedes #752 (CYPACK-707) which updated to v0.2.5. That PR has been closed and its associated Linear issue has been canceled as this update to v0.2.6 is more current.

Closes CYPACK-710

🤖 Generated with [Claude Code](https://claude.com/claude-code)