### PR TITLE
feat(edge-worker): Post subroutine transition notifications to Linear (CYPACK-717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Subroutine transition notifications** - Users now see messages in Linear when Cyrus transitions between sub-procedures, such as "Starting: **verifications** - Run tests, linting, and type checking". This helps clarify what Cyrus is doing during longer operations. ([CYPACK-717](https://linear.app/ceedar/issue/CYPACK-717), [#759](https://github.com/ceedaragents/cyrus/pull/759))
+
 ### Changed
 - **Orchestrator label routing is now hardcoded** - Issues with 'orchestrator' or 'Orchestrator' labels now always route to the orchestrator procedure, regardless of EdgeConfig settings. This ensures consistent orchestrator behavior without requiring explicit configuration. ([CYPACK-715](https://linear.app/ceedar/issue/CYPACK-715), [#757](https://github.com/ceedaragents/cyrus/pull/757))
 

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -1788,6 +1788,43 @@ export class AgentSessionManager extends EventEmitter {
 	}
 
 	/**
+	 * Post a subroutine transition notification to Linear
+	 * This informs the user which subroutine is starting next
+	 */
+	async postSubroutineTransitionThought(
+		linearAgentActivitySessionId: string,
+		subroutineName: string,
+		subroutineDescription: string,
+	): Promise<void> {
+		try {
+			const result = await this.issueTracker.createAgentActivity({
+				agentSessionId: linearAgentActivitySessionId,
+				content: {
+					type: "thought",
+					body: `Starting: **${subroutineName}** - ${subroutineDescription}`,
+				},
+				ephemeral: false,
+			});
+
+			if (result.success) {
+				console.log(
+					`[AgentSessionManager] Posted subroutine transition for session ${linearAgentActivitySessionId}: ${subroutineName}`,
+				);
+			} else {
+				console.error(
+					`[AgentSessionManager] Failed to post subroutine transition:`,
+					result,
+				);
+			}
+		} catch (error) {
+			console.error(
+				`[AgentSessionManager] Error posting subroutine transition:`,
+				error,
+			);
+		}
+	}
+
+	/**
 	 * Handle status messages (compacting, etc.)
 	 */
 	private async handleStatusMessage(

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -331,6 +331,7 @@ export class EdgeWorker extends EventEmitter {
 							agentSessionManager,
 							fixerPrompt,
 							iteration,
+							maxIterations,
 						);
 					},
 				);
@@ -730,6 +731,13 @@ export class EdgeWorker extends EventEmitter {
 			`[Subroutine Transition] Next subroutine: ${nextSubroutine.name}`,
 		);
 
+		// Post subroutine transition notification to Linear
+		await agentSessionManager.postSubroutineTransitionThought(
+			linearAgentActivitySessionId,
+			nextSubroutine.name,
+			nextSubroutine.description,
+		);
+
 		// Load subroutine prompt
 		let subroutinePrompt: string | null;
 		try {
@@ -784,9 +792,17 @@ export class EdgeWorker extends EventEmitter {
 		agentSessionManager: AgentSessionManager,
 		fixerPrompt: string,
 		iteration: number,
+		maxIterations: number,
 	): Promise<void> {
 		console.log(
 			`[Validation Loop] Running fixer for session ${linearAgentActivitySessionId}, iteration ${iteration}`,
+		);
+
+		// Post validation fixer notification to Linear
+		await agentSessionManager.postSubroutineTransitionThought(
+			linearAgentActivitySessionId,
+			"validation-fixer",
+			`Fixing validation failures (attempt ${iteration}/${maxIterations})`,
 		);
 
 		try {
@@ -838,6 +854,13 @@ export class EdgeWorker extends EventEmitter {
 			);
 			return;
 		}
+
+		// Post verifications re-run notification to Linear
+		await agentSessionManager.postSubroutineTransitionThought(
+			linearAgentActivitySessionId,
+			verificationsSubroutine.name,
+			"Re-running verifications after fixes",
+		);
 
 		try {
 			// Load the verifications prompt
@@ -1143,6 +1166,7 @@ export class EdgeWorker extends EventEmitter {
 							agentSessionManager,
 							fixerPrompt,
 							iteration,
+							maxIterations,
 						);
 					},
 				);


### PR DESCRIPTION
## Summary

When Cyrus transitions between sub-procedures, users now see clear messages in Linear indicating what the agent is currently doing. This addresses the issue where it wasn't clear what Cyrus was working on, especially during longer operations like the summary sub-procedure.

## Changes

- **Added `postSubroutineTransitionThought()` method** to `AgentSessionManager` - Posts a notification to Linear with format: `Starting: **{subroutine-name}** - {description}`
- **Updated `handleSubroutineTransition()`** in `EdgeWorker` - Calls the new notification method before starting the next subroutine
- **Added notifications for validation loop scenarios** - Users see messages when the validation fixer runs and when verifications are re-run after fixes

## Example Messages

Users will see messages like:
- `Starting: **verifications** - Run tests, linting, and type checking`
- `Starting: **git-commit** - Stage, commit, and push changes to remote`
- `Starting: **concise-summary** - Brief summary for simple requests`
- `Starting: **validation-fixer** - Fixing validation failures (attempt 1/2)`
- `Starting: **verifications** - Re-running verifications after fixes`

## Test Plan

- [x] All 337 edge-worker tests passing
- [x] TypeScript type checking passes
- [x] Linting passes (no new warnings)
- [x] Code follows existing patterns (matches `postProcedureSelectionThought()`)

## Linear Issue

Closes [CYPACK-717](https://linear.app/ceedar/issue/CYPACK-717/after-each-sub-procedure-post-a-message-to-linear-informing-the-user)

---
🤖 Generated with [Claude Code](https://claude.ai/code)