### PR TITLE
Release v0.2.13

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-01-15
+
+(No internal changes in this release)
+
 ## [0.2.12] - 2026-01-09
 
 (No internal changes in this release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-01-15
+
 ### Added
 - **Multi-repository orchestration routing context** - Orchestrator prompts now receive routing context when multiple repositories are configured in the same workspace. This enables orchestrators to intelligently route sub-issues to different repositories using description tags (`[repo=org/repo-name]`), routing labels, team keys, or project keys. ([CYPACK-711](https://linear.app/ceedar/issue/CYPACK-711), [#756](https://github.com/ceedaragents/cyrus/pull/756))
 
@@ -13,6 +15,35 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - **Orchestrator label routing is now hardcoded** - Issues with 'orchestrator' or 'Orchestrator' labels now always route to the orchestrator procedure, regardless of EdgeConfig settings. This ensures consistent orchestrator behavior without requiring explicit configuration. ([CYPACK-715](https://linear.app/ceedar/issue/CYPACK-715), [#757](https://github.com/ceedaragents/cyrus/pull/757))
 - **Updated dependencies** - Updated `@anthropic-ai/claude-agent-sdk` from 0.2.2 to 0.2.7 ([changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#027-2026-01-14)). This brings compatibility with Claude Code v2.1.7, which enables MCP tool search auto mode by default. When MCP tool descriptions exceed 10% of the context window, they are automatically deferred and discovered via the MCPSearch tool instead of being loaded upfront, reducing context usage for sessions with many MCP tools configured. ([CYPACK-716](https://linear.app/ceedar/issue/CYPACK-716), [#758](https://github.com/ceedaragents/cyrus/pull/758))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.13
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.13
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.13
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.13
+
+#### cyrus-core
+- cyrus-core@0.2.13
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.13
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.13
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.13
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.13
 
 ## [0.2.12] - 2026-01-09
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.13 to npm
- Update changelogs
- Create git tag

## Changes
- CHANGELOG.md updated with v0.2.13 release notes
- CHANGELOG.internal.md updated
- Package versions bumped to 0.2.13

## Related Linear Issues
- [CYPACK-711](https://linear.app/ceedar/issue/CYPACK-711) - Multi-repository orchestration routing context
- [CYPACK-719](https://linear.app/ceedar/issue/CYPACK-719) - Usage limit errors display as errors
- [CYPACK-715](https://linear.app/ceedar/issue/CYPACK-715) - Orchestrator label routing hardcoded
- [CYPACK-716](https://linear.app/ceedar/issue/CYPACK-716) - Updated @anthropic-ai/claude-agent-sdk to v0.2.7

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)