### PR TITLE
feat: Add Linear user whitelisting/blacklisting for access control

### DIFF
--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -209,6 +209,8 @@ export class WorkerService {
 			serverPort: parsePort(process.env.CYRUS_SERVER_PORT, DEFAULT_SERVER_PORT),
 			serverHost: isExternalHost ? "0.0.0.0" : "localhost",
 			ngrokAuthToken,
+			// User access control configuration
+			userAccessControl: edgeConfig.userAccessControl,
 			features: {
 				enableContinuation: true,
 			},

--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -142,6 +142,75 @@ Note: Linear MCP tools (`mcp__linear`) are always included automatically.
 
 ---
 
+## User Access Control
+
+Control which Linear users can delegate issues to Cyrus. Supports both global configuration and per-repository overrides.
+
+### `userAccessControl` (object)
+
+Can be configured at the global level or per-repository.
+
+**Properties:**
+
+- **`allowedUsers`** (array) - Users allowed to delegate issues. If specified, ONLY these users can trigger sessions. Omit to allow everyone.
+- **`blockedUsers`** (array) - Users blocked from delegating issues. Takes precedence over allowedUsers.
+- **`blockBehavior`** (string) - What happens when a blocked user tries to delegate:
+  - `"silent"` (default) - Ignore the webhook quietly
+  - `"comment"` - Post a message explaining the user is not authorized
+- **`blockMessage`** (string) - Custom message when blockBehavior is "comment". Supports template variables:
+  - `{{userName}}` - The user's display name
+  - `{{userId}}` - The user's Linear ID
+
+  Default: `"{{userName}}, you are not authorized to delegate issues to this agent."`
+
+**User Identifiers:**
+
+Users can be specified in three formats:
+- String (treated as Linear user ID): `"usr_abc123"`
+- Object with ID: `{ "id": "usr_abc123" }`
+- Object with email: `{ "email": "user@example.com" }` (case-insensitive)
+
+**Example - Global configuration:**
+
+```json
+{
+  "userAccessControl": {
+    "blockedUsers": ["usr_known_bad_actor"],
+    "blockBehavior": "comment",
+    "blockMessage": "{{userName}}, please contact your team lead to use this agent."
+  },
+  "repositories": [...]
+}
+```
+
+**Example - Per-repository configuration:**
+
+```json
+{
+  "repositories": [{
+    "id": "main-app",
+    "name": "Main Application",
+    "userAccessControl": {
+      "allowedUsers": [
+        "usr_senior_dev_1",
+        { "email": "lead@company.com" },
+        { "id": "usr_senior_dev_2" }
+      ],
+      "blockBehavior": "comment"
+    }
+  }]
+}
+```
+
+**Inheritance Rules:**
+
+- **allowedUsers**: Repository config OVERRIDES global (not merged)
+- **blockedUsers**: Repository config EXTENDS global (merged/additive)
+- **blockBehavior**: Repository config OVERRIDES global
+- **blockMessage**: Repository config OVERRIDES global
+
+---
+
 ## Global Configuration
 
 In addition to repository-specific settings, you can configure global defaults:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,8 @@ export type {
 	EdgeWorkerConfig,
 	OAuthCallbackHandler,
 	RepositoryConfig,
+	UserAccessControlConfig,
+	UserIdentifier,
 } from "./config-types.js";
 export { resolvePath } from "./config-types.js";
 

--- a/packages/edge-worker/src/UserAccessControl.ts
+++ b/packages/edge-worker/src/UserAccessControl.ts
@@ -1,0 +1,224 @@
+import type { UserAccessControlConfig, UserIdentifier } from "cyrus-core";
+
+/**
+ * Result of an access check operation.
+ */
+export type AccessCheckResult =
+	| { allowed: true }
+	| { allowed: false; reason: string };
+
+/**
+ * Default message shown when a user is blocked and blockBehavior is 'comment'.
+ * Supports template variables:
+ * - {{userName}} - The user's display name
+ * - {{userId}} - The user's Linear ID
+ */
+export const DEFAULT_BLOCK_MESSAGE =
+	"{{userName}}, you are not authorized to delegate issues to this agent.";
+
+/**
+ * Checks if a user matches a given identifier.
+ * @param userId - The user's Linear ID
+ * @param userEmail - The user's email address
+ * @param identifier - The identifier to match against
+ * @returns true if the user matches the identifier
+ */
+function userMatchesIdentifier(
+	userId: string | undefined,
+	userEmail: string | undefined,
+	identifier: UserIdentifier,
+): boolean {
+	if (typeof identifier === "string") {
+		// String is treated as user ID
+		return userId === identifier;
+	}
+	if ("id" in identifier) {
+		return userId === identifier.id;
+	}
+	if ("email" in identifier) {
+		// Case-insensitive email comparison
+		return userEmail?.toLowerCase() === identifier.email.toLowerCase();
+	}
+	return false;
+}
+
+/**
+ * Checks if a user matches any identifier in a list.
+ * @param userId - The user's Linear ID
+ * @param userEmail - The user's email address
+ * @param identifiers - List of identifiers to check against
+ * @returns true if the user matches any identifier
+ */
+function userMatchesAny(
+	userId: string | undefined,
+	userEmail: string | undefined,
+	identifiers: UserIdentifier[],
+): boolean {
+	return identifiers.some((identifier) =>
+		userMatchesIdentifier(userId, userEmail, identifier),
+	);
+}
+
+/**
+ * User access control manager for Linear user whitelisting/blacklisting.
+ *
+ * Access Check Logic:
+ * 1. Build effective blocklist: global blockedUsers + repo blockedUsers (union)
+ * 2. Check if user matches any entry in effective blocklist -> BLOCKED
+ * 3. Determine effective allowlist:
+ *    - If repo has allowedUsers -> use repo allowlist only
+ *    - Else if global has allowedUsers -> use global allowlist
+ *    - Else -> no allowlist (everyone allowed)
+ * 4. If effective allowlist exists and user NOT in it -> BLOCKED
+ * 5. Otherwise -> ALLOWED
+ */
+export class UserAccessControl {
+	private globalConfig: UserAccessControlConfig | undefined;
+	private repoConfigs: Map<string, UserAccessControlConfig | undefined>;
+
+	/**
+	 * Creates a new UserAccessControl instance.
+	 * @param globalConfig - Global access control configuration
+	 * @param repoConfigs - Map of repository ID to repository-specific access control config
+	 */
+	constructor(
+		globalConfig: UserAccessControlConfig | undefined,
+		repoConfigs: Map<string, UserAccessControlConfig | undefined>,
+	) {
+		this.globalConfig = globalConfig;
+		this.repoConfigs = repoConfigs;
+	}
+
+	/**
+	 * Check if a user is allowed to delegate issues to a specific repository.
+	 * @param userId - The user's Linear ID
+	 * @param userEmail - The user's email address
+	 * @param repositoryId - The target repository ID
+	 * @returns AccessCheckResult indicating if access is allowed
+	 */
+	checkAccess(
+		userId: string | undefined,
+		userEmail: string | undefined,
+		repositoryId: string,
+	): AccessCheckResult {
+		const repoConfig = this.repoConfigs.get(repositoryId);
+
+		// Step 1: Build effective blocklist (global + repo, union)
+		const effectiveBlocklist: UserIdentifier[] = [
+			...(this.globalConfig?.blockedUsers ?? []),
+			...(repoConfig?.blockedUsers ?? []),
+		];
+
+		// Step 2: Check if user is in blocklist
+		if (
+			effectiveBlocklist.length > 0 &&
+			userMatchesAny(userId, userEmail, effectiveBlocklist)
+		) {
+			return {
+				allowed: false,
+				reason: "User is in blocklist",
+			};
+		}
+
+		// Step 3: Determine effective allowlist
+		// Repo allowlist OVERRIDES global (not merged)
+		let effectiveAllowlist: UserIdentifier[] | undefined;
+		if (repoConfig?.allowedUsers !== undefined) {
+			effectiveAllowlist = repoConfig.allowedUsers;
+		} else if (this.globalConfig?.allowedUsers !== undefined) {
+			effectiveAllowlist = this.globalConfig.allowedUsers;
+		}
+
+		// Step 4: If allowlist exists, check if user is in it
+		if (effectiveAllowlist !== undefined) {
+			// Empty allowlist means no one is allowed
+			if (effectiveAllowlist.length === 0) {
+				return {
+					allowed: false,
+					reason: "No users are allowed (empty allowlist)",
+				};
+			}
+
+			if (!userMatchesAny(userId, userEmail, effectiveAllowlist)) {
+				return {
+					allowed: false,
+					reason: "User is not in allowlist",
+				};
+			}
+		}
+
+		// Step 5: User is allowed
+		return { allowed: true };
+	}
+
+	/**
+	 * Get the effective block behavior for a repository.
+	 * Repo config overrides global config.
+	 * @param repositoryId - The repository ID
+	 * @returns 'silent' or 'comment'
+	 */
+	getBlockBehavior(repositoryId: string): "silent" | "comment" {
+		const repoConfig = this.repoConfigs.get(repositoryId);
+
+		// Repo blockBehavior overrides global
+		if (repoConfig?.blockBehavior !== undefined) {
+			return repoConfig.blockBehavior;
+		}
+
+		if (this.globalConfig?.blockBehavior !== undefined) {
+			return this.globalConfig.blockBehavior;
+		}
+
+		// Default to silent
+		return "silent";
+	}
+
+	/**
+	 * Get the effective block message for a repository.
+	 * Repo config overrides global config.
+	 * @param repositoryId - The repository ID
+	 * @returns The block message to display
+	 */
+	getBlockMessage(repositoryId: string): string {
+		const repoConfig = this.repoConfigs.get(repositoryId);
+
+		// Repo blockMessage overrides global
+		if (repoConfig?.blockMessage !== undefined) {
+			return repoConfig.blockMessage;
+		}
+
+		if (this.globalConfig?.blockMessage !== undefined) {
+			return this.globalConfig.blockMessage;
+		}
+
+		// Default message
+		return DEFAULT_BLOCK_MESSAGE;
+	}
+
+	/**
+	 * Check if any access control is configured (either globally or for any repository).
+	 * Useful for short-circuiting when no access control is needed.
+	 * @returns true if any access control configuration exists
+	 */
+	hasAnyConfiguration(): boolean {
+		// Check global config
+		if (
+			this.globalConfig?.allowedUsers !== undefined ||
+			this.globalConfig?.blockedUsers !== undefined
+		) {
+			return true;
+		}
+
+		// Check repo configs
+		for (const config of this.repoConfigs.values()) {
+			if (
+				config?.allowedUsers !== undefined ||
+				config?.blockedUsers !== undefined
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -6,6 +6,8 @@ export type {
 	EdgeWorkerConfig,
 	OAuthCallbackHandler,
 	RepositoryConfig,
+	UserAccessControlConfig,
+	UserIdentifier,
 	Workspace,
 } from "cyrus-core";
 export { AgentSessionManager } from "./AgentSessionManager.js";
@@ -20,6 +22,12 @@ export { GitService } from "./GitService.js";
 export { RepositoryRouter } from "./RepositoryRouter.js";
 export { SharedApplicationServer } from "./SharedApplicationServer.js";
 export type { EdgeWorkerEvents } from "./types.js";
+// User access control
+export {
+	type AccessCheckResult,
+	DEFAULT_BLOCK_MESSAGE,
+	UserAccessControl,
+} from "./UserAccessControl.js";
 // Export validation loop module
 export {
 	DEFAULT_VALIDATION_LOOP_CONFIG,

--- a/packages/edge-worker/test/UserAccessControl.test.ts
+++ b/packages/edge-worker/test/UserAccessControl.test.ts
@@ -1,0 +1,561 @@
+import type { UserAccessControlConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_BLOCK_MESSAGE,
+	UserAccessControl,
+} from "../src/UserAccessControl.js";
+
+/**
+ * Test Suite for UserAccessControl
+ *
+ * Tests the user whitelisting/blacklisting functionality for Linear users.
+ */
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+/**
+ * Creates a UserAccessControl instance with the given configs
+ */
+function createAccessControl(
+	globalConfig?: UserAccessControlConfig,
+	repoConfigs?: Map<string, UserAccessControlConfig | undefined>,
+): UserAccessControl {
+	return new UserAccessControl(globalConfig, repoConfigs ?? new Map());
+}
+
+// ============================================================================
+// TESTS: checkAccess
+// ============================================================================
+
+describe("UserAccessControl", () => {
+	describe("checkAccess", () => {
+		describe("when no access control is configured", () => {
+			it("allows all users when no access control configured", () => {
+				const accessControl = createAccessControl(undefined, new Map());
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+
+			it("allows users with undefined id and email when no config", () => {
+				const accessControl = createAccessControl(undefined, new Map());
+
+				const result = accessControl.checkAccess(
+					undefined,
+					undefined,
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+		});
+
+		describe("blocklist behavior", () => {
+			it("blocks user in global blocklist by ID", () => {
+				const accessControl = createAccessControl(
+					{ blockedUsers: ["blocked-user-id"] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"blocked-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+				if (!result.allowed) {
+					expect(result.reason).toBe("User is in blocklist");
+				}
+			});
+
+			it("blocks user in global blocklist by explicit ID object", () => {
+				const accessControl = createAccessControl(
+					{ blockedUsers: [{ id: "blocked-user-id" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"blocked-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+			});
+
+			it("blocks user in global blocklist by email", () => {
+				const accessControl = createAccessControl(
+					{ blockedUsers: [{ email: "blocked@example.com" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"blocked@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+			});
+
+			it("blocks user in global blocklist by email (case-insensitive)", () => {
+				const accessControl = createAccessControl(
+					{ blockedUsers: [{ email: "BLOCKED@EXAMPLE.COM" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"blocked@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+			});
+
+			it("blocks user in repo-specific blocklist", () => {
+				const repoConfigs = new Map<string, UserAccessControlConfig>([
+					["repo-1", { blockedUsers: ["blocked-user-id"] }],
+				]);
+				const accessControl = createAccessControl(undefined, repoConfigs);
+
+				const result = accessControl.checkAccess(
+					"blocked-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+			});
+
+			it("blocks user in combined global + repo blocklist", () => {
+				const globalConfig = { blockedUsers: ["global-blocked"] };
+				const repoConfigs = new Map<string, UserAccessControlConfig>([
+					["repo-1", { blockedUsers: ["repo-blocked"] }],
+				]);
+				const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+				// Test global blocklist applies
+				const result1 = accessControl.checkAccess(
+					"global-blocked",
+					"user@example.com",
+					"repo-1",
+				);
+				expect(result1.allowed).toBe(false);
+
+				// Test repo blocklist applies
+				const result2 = accessControl.checkAccess(
+					"repo-blocked",
+					"user@example.com",
+					"repo-1",
+				);
+				expect(result2.allowed).toBe(false);
+			});
+
+			it("allows user not in any blocklist", () => {
+				const accessControl = createAccessControl(
+					{ blockedUsers: ["blocked-user-id"] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"allowed-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+		});
+
+		describe("allowlist behavior", () => {
+			it("allows user in global allowlist by ID", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: ["allowed-user-id"] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"allowed-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+
+			it("allows user in global allowlist by explicit ID object", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: [{ id: "allowed-user-id" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"allowed-user-id",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+
+			it("allows user in global allowlist by email", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: [{ email: "allowed@example.com" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"allowed@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+
+			it("allows user in global allowlist by email (case-insensitive)", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: [{ email: "ALLOWED@EXAMPLE.COM" }] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"allowed@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(true);
+			});
+
+			it("blocks user not in allowlist when allowlist exists", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: ["allowed-user-id"] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"other-user-id",
+					"other@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+				if (!result.allowed) {
+					expect(result.reason).toBe("User is not in allowlist");
+				}
+			});
+
+			it("blocks all users when allowlist is empty", () => {
+				const accessControl = createAccessControl(
+					{ allowedUsers: [] },
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"any-user-id",
+					"any@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+				if (!result.allowed) {
+					expect(result.reason).toBe("No users are allowed (empty allowlist)");
+				}
+			});
+
+			it("repo allowlist overrides global allowlist (not merged)", () => {
+				const globalConfig = { allowedUsers: ["global-allowed"] };
+				const repoConfigs = new Map<string, UserAccessControlConfig>([
+					["repo-1", { allowedUsers: ["repo-allowed"] }],
+				]);
+				const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+				// Global allowed user should be BLOCKED because repo has its own allowlist
+				const result1 = accessControl.checkAccess(
+					"global-allowed",
+					"user@example.com",
+					"repo-1",
+				);
+				expect(result1.allowed).toBe(false);
+
+				// Repo allowed user should be allowed
+				const result2 = accessControl.checkAccess(
+					"repo-allowed",
+					"user@example.com",
+					"repo-1",
+				);
+				expect(result2.allowed).toBe(true);
+			});
+
+			it("uses global allowlist for repos without their own allowlist", () => {
+				const globalConfig = { allowedUsers: ["global-allowed"] };
+				const repoConfigs = new Map<string, UserAccessControlConfig>([
+					["repo-1", { allowedUsers: ["repo-allowed"] }],
+					["repo-2", {}], // No allowlist, should use global
+				]);
+				const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+				// For repo-2, global allowlist should apply
+				const result = accessControl.checkAccess(
+					"global-allowed",
+					"user@example.com",
+					"repo-2",
+				);
+				expect(result.allowed).toBe(true);
+			});
+		});
+
+		describe("blocklist takes precedence over allowlist", () => {
+			it("blocks user even if in allowlist when also in blocklist", () => {
+				const accessControl = createAccessControl(
+					{
+						allowedUsers: ["user-123"],
+						blockedUsers: ["user-123"],
+					},
+					new Map(),
+				);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+				if (!result.allowed) {
+					expect(result.reason).toBe("User is in blocklist");
+				}
+			});
+
+			it("blocks user in global allowlist if in repo blocklist", () => {
+				const globalConfig = { allowedUsers: ["user-123"] };
+				const repoConfigs = new Map<string, UserAccessControlConfig>([
+					["repo-1", { blockedUsers: ["user-123"] }],
+				]);
+				const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+				const result = accessControl.checkAccess(
+					"user-123",
+					"user@example.com",
+					"repo-1",
+				);
+
+				expect(result.allowed).toBe(false);
+			});
+		});
+
+		describe("mixed identifier formats", () => {
+			it("handles mix of string and object identifiers", () => {
+				const accessControl = createAccessControl(
+					{
+						allowedUsers: [
+							"user-by-string",
+							{ id: "user-by-id-object" },
+							{ email: "user@by-email.com" },
+						],
+					},
+					new Map(),
+				);
+
+				// String ID match
+				const result1 = accessControl.checkAccess(
+					"user-by-string",
+					"any@example.com",
+					"repo-1",
+				);
+				expect(result1.allowed).toBe(true);
+
+				// Object ID match
+				const result2 = accessControl.checkAccess(
+					"user-by-id-object",
+					"any@example.com",
+					"repo-1",
+				);
+				expect(result2.allowed).toBe(true);
+
+				// Email match
+				const result3 = accessControl.checkAccess(
+					"any-id",
+					"user@by-email.com",
+					"repo-1",
+				);
+				expect(result3.allowed).toBe(true);
+
+				// No match
+				const result4 = accessControl.checkAccess(
+					"no-match",
+					"no-match@example.com",
+					"repo-1",
+				);
+				expect(result4.allowed).toBe(false);
+			});
+		});
+	});
+
+	// ============================================================================
+	// TESTS: getBlockBehavior
+	// ============================================================================
+
+	describe("getBlockBehavior", () => {
+		it("returns silent by default when not configured", () => {
+			const accessControl = createAccessControl(undefined, new Map());
+
+			const behavior = accessControl.getBlockBehavior("repo-1");
+
+			expect(behavior).toBe("silent");
+		});
+
+		it("returns global config when repo has no override", () => {
+			const accessControl = createAccessControl(
+				{ blockBehavior: "comment" },
+				new Map(),
+			);
+
+			const behavior = accessControl.getBlockBehavior("repo-1");
+
+			expect(behavior).toBe("comment");
+		});
+
+		it("returns repo config when specified (overrides global)", () => {
+			const globalConfig = { blockBehavior: "comment" as const };
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { blockBehavior: "silent" }],
+			]);
+			const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+			const behavior = accessControl.getBlockBehavior("repo-1");
+
+			expect(behavior).toBe("silent");
+		});
+
+		it("returns global config for repos without override", () => {
+			const globalConfig = { blockBehavior: "comment" as const };
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { blockBehavior: "silent" }],
+				["repo-2", {}], // No blockBehavior
+			]);
+			const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+			const behavior = accessControl.getBlockBehavior("repo-2");
+
+			expect(behavior).toBe("comment");
+		});
+	});
+
+	// ============================================================================
+	// TESTS: getBlockMessage
+	// ============================================================================
+
+	describe("getBlockMessage", () => {
+		it("returns default message when not configured", () => {
+			const accessControl = createAccessControl(undefined, new Map());
+
+			const message = accessControl.getBlockMessage("repo-1");
+
+			expect(message).toBe(DEFAULT_BLOCK_MESSAGE);
+		});
+
+		it("returns global message when repo has no override", () => {
+			const accessControl = createAccessControl(
+				{ blockMessage: "Global custom message" },
+				new Map(),
+			);
+
+			const message = accessControl.getBlockMessage("repo-1");
+
+			expect(message).toBe("Global custom message");
+		});
+
+		it("returns repo message when specified (overrides global)", () => {
+			const globalConfig = { blockMessage: "Global message" };
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { blockMessage: "Repo specific message" }],
+			]);
+			const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+			const message = accessControl.getBlockMessage("repo-1");
+
+			expect(message).toBe("Repo specific message");
+		});
+
+		it("returns global message for repos without override", () => {
+			const globalConfig = { blockMessage: "Global message" };
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { blockMessage: "Repo 1 message" }],
+				["repo-2", {}], // No blockMessage
+			]);
+			const accessControl = createAccessControl(globalConfig, repoConfigs);
+
+			const message = accessControl.getBlockMessage("repo-2");
+
+			expect(message).toBe("Global message");
+		});
+	});
+
+	// ============================================================================
+	// TESTS: hasAnyConfiguration
+	// ============================================================================
+
+	describe("hasAnyConfiguration", () => {
+		it("returns false when no config is set", () => {
+			const accessControl = createAccessControl(undefined, new Map());
+
+			expect(accessControl.hasAnyConfiguration()).toBe(false);
+		});
+
+		it("returns false when only blockBehavior is set (no actual lists)", () => {
+			const accessControl = createAccessControl(
+				{ blockBehavior: "comment" },
+				new Map(),
+			);
+
+			expect(accessControl.hasAnyConfiguration()).toBe(false);
+		});
+
+		it("returns true when global allowedUsers is set", () => {
+			const accessControl = createAccessControl(
+				{ allowedUsers: ["user-1"] },
+				new Map(),
+			);
+
+			expect(accessControl.hasAnyConfiguration()).toBe(true);
+		});
+
+		it("returns true when global blockedUsers is set", () => {
+			const accessControl = createAccessControl(
+				{ blockedUsers: ["user-1"] },
+				new Map(),
+			);
+
+			expect(accessControl.hasAnyConfiguration()).toBe(true);
+		});
+
+		it("returns true when repo allowedUsers is set", () => {
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { allowedUsers: ["user-1"] }],
+			]);
+			const accessControl = createAccessControl(undefined, repoConfigs);
+
+			expect(accessControl.hasAnyConfiguration()).toBe(true);
+		});
+
+		it("returns true when repo blockedUsers is set", () => {
+			const repoConfigs = new Map<string, UserAccessControlConfig>([
+				["repo-1", { blockedUsers: ["user-1"] }],
+			]);
+			const accessControl = createAccessControl(undefined, repoConfigs);
+
+			expect(accessControl.hasAnyConfiguration()).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
Adds the ability to whitelist/blacklist Linear users from delegating issues to Cyrus. Supports both global configuration and per-repository overrides. This is useful for ensuring that team members in Linear cannot accidentally delegate work to incorrect Cyrus instances.

Features:
- Block specific users by Linear ID or email address
- Allow only specific users (allowlist mode)
- Configurable block behavior: silent ignore or post comment
- Template variables in block messages ({{userName}}, {{userId}})
- Blocklist is additive (global + repo), allowlist overrides (repo replaces global)

Configuration example:
```json
{
  "userAccessControl": {
    "blockedUsers": ["usr_id", {"email": "user@example.com"}],
    "blockBehavior": "comment",
    "blockMessage": "{{userName}}, please contact your team lead."
  }
}
```