### PR TITLE
fix: Clear token promise on setAccessToken to prevent stale token reuse

### DIFF
--- a/packages/claude-runner/src/tools/cyrus-tools/index.ts
+++ b/packages/claude-runner/src/tools/cyrus-tools/index.ts
@@ -1,6 +1,6 @@
 import { basename, extname } from "node:path";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
-import { IssueRelationType, LinearClient } from "@linear/sdk";
+import { IssueRelationType, type LinearClient } from "@linear/sdk";
 import fs from "fs-extra";
 import { z } from "zod";
 
@@ -96,11 +96,9 @@ export interface CyrusToolsOptions {
  * Create an SDK MCP server with the inline Cyrus tools
  */
 export function createCyrusToolsServer(
-	linearApiToken: string,
+	linearClient: LinearClient,
 	options: CyrusToolsOptions = {},
 ) {
-	const linearClient = new LinearClient({ apiKey: linearApiToken });
-
 	// Create tools with bound linear client
 	const uploadTool = tool(
 		"linear_upload_file",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4393,6 +4393,10 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 	): Record<string, McpServerConfig> {
 		// Always inject the Linear MCP servers with the repository's token
 		// https://linear.app/docs/mcp
+		const its = this.issueTrackers.get(
+			repository.id,
+		) as LinearIssueTrackerService;
+		const lc = its.getClient();
 		const mcpConfig: Record<string, McpServerConfig> = {
 			linear: {
 				type: "http",
@@ -4401,7 +4405,7 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 					Authorization: `Bearer ${repository.linearToken}`,
 				},
 			},
-			"cyrus-tools": createCyrusToolsServer(repository.linearToken, {
+			"cyrus-tools": createCyrusToolsServer(lc, {
 				parentSessionId,
 				onSessionCreated: (childSessionId, parentId) => {
 					console.log(

--- a/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
@@ -185,6 +185,12 @@ describe("EdgeWorker - Feedback Delivery", () => {
 			mockChildAgentSessionManager,
 		);
 		(edgeWorker as any).repositories.set("test-repo", mockRepository);
+
+		// Setup mock issueTracker with getClient()
+		const mockIssueTracker = {
+			getClient: vi.fn().mockReturnValue({}),
+		};
+		(edgeWorker as any).issueTrackers.set("test-repo", mockIssueTracker);
 	});
 
 	afterEach(() => {
@@ -449,7 +455,7 @@ describe("EdgeWorker - Feedback Delivery", () => {
 
 			// Verify createCyrusToolsServer was called with correct options
 			expect(createCyrusToolsServer).toHaveBeenCalledWith(
-				mockRepository.linearToken,
+				expect.any(Object), // LinearClient from issueTracker.getClient()
 				expect.objectContaining({
 					parentSessionId,
 					onFeedbackDelivery: expect.any(Function),

--- a/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
@@ -182,6 +182,12 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 			mockChildAgentSessionManager,
 		);
 		(edgeWorker as any).repositories.set("test-repo", mockRepository);
+
+		// Setup mock issueTracker with getClient()
+		const mockIssueTracker = {
+			getClient: vi.fn().mockReturnValue({}),
+		};
+		(edgeWorker as any).issueTrackers.set("test-repo", mockIssueTracker);
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -220,6 +220,7 @@ Issue: {{issue_identifier}}`;
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([{ name: "bug" }]),
+			getClient: vi.fn().mockReturnValue({}),
 		};
 		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
 	});

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -201,6 +201,7 @@ Base Branch: {{base_branch}}`;
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([]),
+			getClient: vi.fn().mockReturnValue({}),
 		};
 		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
 

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -219,6 +219,7 @@ Issue: {{issue_identifier}}`;
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn(),
+			getClient: vi.fn().mockReturnValue({}),
 		};
 		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
 	});

--- a/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
@@ -225,6 +225,7 @@ Issue: {{issue_identifier}}`;
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn(),
+			getClient: vi.fn().mockReturnValue({}),
 		};
 		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
 	});

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -206,6 +206,7 @@ Issue: {{issue_identifier}}`;
 				return mockLinearClient.issue(issueId);
 			}),
 			getIssueLabels: vi.fn().mockResolvedValue([{ name: "bug" }]),
+			getClient: vi.fn().mockReturnValue({}),
 		};
 		(edgeWorker as any).issueTrackers.set(mockRepository.id, mockIssueTracker);
 	});

--- a/packages/edge-worker/test/prompt-assembly-utils.ts
+++ b/packages/edge-worker/test/prompt-assembly-utils.ts
@@ -24,6 +24,7 @@ export function createTestWorker(
 			getComments: () => Promise.resolve([]),
 			getComment: () => Promise.resolve(null),
 			getIssueLabels: () => Promise.resolve([]),
+			getClient: () => ({}),
 			client: {
 				rawRequest: () => Promise.resolve({ data: { comment: { body: "" } } }),
 			},
@@ -138,6 +139,7 @@ export class PromptScenario {
 				getComments: () => Promise.resolve([]),
 				getComment: () => Promise.resolve(null),
 				getIssueLabels: () => Promise.resolve([]),
+				getClient: () => ({}),
 				client: {
 					rawRequest: () =>
 						Promise.resolve({ data: { comment: { body: "" } } }),


### PR DESCRIPTION
## Summary

- Fix stale token refresh promise bug by moving `refreshPromise` from closure variable to instance property (`this.rp`)
- Clear `this.rp = null` in `setAccessToken()` to prevent stale promises being reused after token refresh
- Add `getClient()` method to `LinearIssueTrackerService` to expose `LinearClient` for shared use

## Problem

The refresh promise was stored as a closure variable that wasn't cleared when `setAccessToken()` was called with a new token. This caused stale promises to be reused after token refresh.

## Changes

| File | Change |
|------|--------|
| `LinearIssueTrackerService.ts` | Core fix: instance property + clear on setAccessToken + getClient() |
| `cyrus-tools/index.ts` | Accept `LinearClient` instead of token string |
| `EdgeWorker.ts` | Pass shared client via `issueTracker.getClient()` |
| Test files (8) | Add `getClient` mock to issueTracker mocks |

## Test plan

- [x] All 349 edge-worker tests pass
- [x] Lint passes (same 17 warnings as main branch)
- [x] Single clean commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)