### PR TITLE
Add edit_issue_description tool for diff-based Linear issue editing (CYPACK-754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Edit issue description tool** - New MCP tool `edit_issue_description` allows diff-based editing of Linear issue descriptions. Works like Claude Code's Edit tool - finds and replaces exact strings with proper error handling for edge cases (string not found, non-unique matches, empty descriptions). Supports `replace_all` option for global find-and-replace. ([CYPACK-754](https://linear.app/ceedar/issue/CYPACK-754), [#799](https://github.com/ceedaragents/cyrus/pull/799))
+
 ## [0.2.17] - 2026-01-23
 
 ### Added


### PR DESCRIPTION
## Summary
Adds a new MCP tool `edit_issue_description` that performs exact string replacements in Linear issue descriptions, similar to Claude Code's Edit tool.

## Changes
- Added `edit_issue_description` tool to `packages/claude-runner/src/tools/cyrus-tools/index.ts`
- Tool finds `old_string` in the issue description and replaces it with `new_string`
- Supports `replace_all` option for global find-and-replace operations

## Error Handling
The tool mirrors Claude Code's Edit tool error patterns:
- **Issue not found**: Returns error when the specified issue doesn't exist
- **String not found**: Returns error when `old_string` isn't in the description
- **Non-unique string**: Returns error when `old_string` appears multiple times (unless `replace_all` is true)
- **Empty description**: Returns error when the issue has no description
- **Same old/new string**: Validates that `old_string` differs from `new_string`

## Testing
- [x] Created throwaway test script using Linear SDK to verify all edge cases
- [x] All 383 edge-worker tests pass
- [x] TypeScript typecheck passes
- [x] Linting passes

## Linear Issue
[CYPACK-754](https://linear.app/ceedar/issue/CYPACK-754)

🤖 Generated with [Claude Code](https://claude.com/claude-code)