### PR TITLE
Release v0.2.18

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-01-23
+
 ### Changed
 - Replaced manual TypeScript interfaces with Zod schemas as the source of truth for `EdgeConfig`, `RepositoryConfig`, and related configuration types. This ensures type safety at both compile-time and runtime, and fixes type drift where `CyrusConfigPayload` was missing fields like `issueUpdateTrigger`. ([#800](https://github.com/ceedaragents/cyrus/pull/800))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-01-23
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.18
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.18
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.18
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.18
+
+#### cyrus-core
+- cyrus-core@0.2.18
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.18
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.18
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.18
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.18
+
 ## [0.2.17] - 2026-01-23
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.17",
+	"version": "0.2.18",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.18 to npm
- Update changelogs
- Create git tag

## Changes
- CHANGELOG.md updated with v0.2.18 release notes
- CHANGELOG.internal.md updated with internal changes
- Package versions bumped to 0.2.18

## Internal Changes
- Replaced manual TypeScript interfaces with Zod schemas as the source of truth for configuration types ([#800](https://github.com/ceedaragents/cyrus/pull/800))

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.18)
- [npm: cyrus-ai@0.2.18](https://www.npmjs.com/package/cyrus-ai/v/0.2.18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)