### PR TITLE
Fix labelPrompts schema to accept both simple and complex forms

### DIFF
--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -58,20 +58,34 @@ const ToolRestrictionSchema = z.union([
 ]);
 
 /**
- * Label prompt configuration with optional tool restrictions
+ * Label prompt configuration with optional tool restrictions.
+ * Accepts either:
+ * - Simple form: string[] (e.g., ["Bug", "Fix"])
+ * - Complex form: { labels: string[], allowedTools?: ..., disallowedTools?: ... }
  */
-const LabelPromptConfigSchema = z.object({
-	labels: z.array(z.string()),
-	allowedTools: ToolRestrictionSchema.optional(),
-	disallowedTools: z.array(z.string()).optional(),
-});
+const LabelPromptConfigSchema = z.union([
+	// Simple form: just an array of label strings
+	z.array(z.string()),
+	// Complex form: object with labels and optional tool restrictions
+	z.object({
+		labels: z.array(z.string()),
+		allowedTools: ToolRestrictionSchema.optional(),
+		disallowedTools: z.array(z.string()).optional(),
+	}),
+]);
 
 /**
- * Graphite label configuration (labels only, no tool restrictions)
+ * Graphite label configuration (labels only, no tool restrictions).
+ * Accepts either:
+ * - Simple form: string[] (e.g., ["Bug", "Fix"])
+ * - Complex form: { labels: string[] }
  */
-const GraphiteLabelConfigSchema = z.object({
-	labels: z.array(z.string()),
-});
+const GraphiteLabelConfigSchema = z.union([
+	z.array(z.string()),
+	z.object({
+		labels: z.array(z.string()),
+	}),
+]);
 
 /**
  * Label-based system prompt configuration

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2108,8 +2108,10 @@ export class EdgeWorker extends EventEmitter {
 
 		// Check for graphite label (for graphite-orchestrator combination)
 		const graphiteConfig = repository.labelPrompts?.graphite;
-		const graphiteLabels = graphiteConfig?.labels ?? ["graphite"];
-		const hasGraphiteLabel = graphiteLabels?.some((label) =>
+		const graphiteLabels = Array.isArray(graphiteConfig)
+			? graphiteConfig
+			: (graphiteConfig?.labels ?? ["graphite"]);
+		const hasGraphiteLabel = graphiteLabels?.some((label: string) =>
 			lowercaseLabels.includes(label.toLowerCase()),
 		);
 
@@ -3091,8 +3093,10 @@ export class EdgeWorker extends EventEmitter {
 
 		// Check for graphite-orchestrator first (requires BOTH graphite AND orchestrator labels)
 		const graphiteConfig = repository.labelPrompts.graphite;
-		const graphiteLabels = graphiteConfig?.labels ?? ["graphite"];
-		const hasGraphiteLabel = graphiteLabels?.some((label) =>
+		const graphiteLabels = Array.isArray(graphiteConfig)
+			? graphiteConfig
+			: (graphiteConfig?.labels ?? ["graphite"]);
+		const hasGraphiteLabel = graphiteLabels?.some((label: string) =>
 			lowercaseLabels.includes(label.toLowerCase()),
 		);
 
@@ -3759,10 +3763,12 @@ Focus on addressing the specific request in the mention. You can use the Linear 
 		repository: RepositoryConfig,
 	): Promise<boolean> {
 		const graphiteConfig = repository.labelPrompts?.graphite;
-		const graphiteLabels = graphiteConfig?.labels ?? ["graphite"];
+		const graphiteLabels = Array.isArray(graphiteConfig)
+			? graphiteConfig
+			: (graphiteConfig?.labels ?? ["graphite"]);
 
 		const issueLabels = await this.fetchIssueLabels(issue);
-		return graphiteLabels.some((label) => issueLabels.includes(label));
+		return graphiteLabels.some((label: string) => issueLabels.includes(label));
 	}
 
 	/**
@@ -5538,12 +5544,16 @@ ${input.userComment}
 
 		// Priority order (same as allowedTools):
 		// 1. Repository-specific prompt type configuration
-		if (
-			effectivePromptType &&
-			repository.labelPrompts?.[effectivePromptType]?.disallowedTools
-		) {
-			disallowedTools =
-				repository.labelPrompts[effectivePromptType].disallowedTools;
+		const promptConfig = effectivePromptType
+			? repository.labelPrompts?.[effectivePromptType]
+			: undefined;
+		// Only access disallowedTools if config is object form (not simple string[])
+		const promptDisallowedTools =
+			promptConfig && !Array.isArray(promptConfig)
+				? promptConfig.disallowedTools
+				: undefined;
+		if (promptDisallowedTools) {
+			disallowedTools = promptDisallowedTools;
 			toolSource = `repository label prompt (${effectivePromptType})`;
 		}
 		// 2. Global prompt type defaults
@@ -5630,13 +5640,16 @@ ${input.userComment}
 
 		// Priority order:
 		// 1. Repository-specific prompt type configuration
-		if (
-			effectivePromptType &&
-			repository.labelPrompts?.[effectivePromptType]?.allowedTools
-		) {
-			baseTools = this.resolveToolPreset(
-				repository.labelPrompts[effectivePromptType].allowedTools,
-			);
+		const promptConfig = effectivePromptType
+			? repository.labelPrompts?.[effectivePromptType]
+			: undefined;
+		// Only access allowedTools if config is object form (not simple string[])
+		const promptAllowedTools =
+			promptConfig && !Array.isArray(promptConfig)
+				? promptConfig.allowedTools
+				: undefined;
+		if (promptAllowedTools) {
+			baseTools = this.resolveToolPreset(promptAllowedTools);
 			toolSource = `repository label prompt (${effectivePromptType})`;
 		}
 		// 2. Global prompt type defaults


### PR DESCRIPTION
## Summary
Updates the Zod schema to accept both forms of labelPrompts configuration:
- Simple form: `{ debugger: ["Bug"] }` 
- Complex form: `{ debugger: { labels: ["Bug"], allowedTools?: ... } }`

## Changes
- `config-schemas.ts`: Updated `LabelPromptConfigSchema` and `GraphiteLabelConfigSchema` to use union types
- `EdgeWorker.ts`: Updated all places that access label configs to handle both forms

This fixes the type mismatch where cyrus-hosted sends the simple form but the schema only accepted the complex form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)