### PR TITLE
Fix: Disable MCP tools when disallowAllTools is true for summary subroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Summary subroutines now properly disable all tools including MCP tools like Linear's create_comment ([#808](https://github.com/ceedaragents/cyrus/pull/808))
+
 ## [0.2.19] - 2026-01-24
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fixes an issue where summary subroutines (concise-summary, verbose-summary, question-answer, plan-summary, etc.) still had access to MCP tools like Linear's create_comment despite having `disallowAllTools: true`

## Changes
- Modified `buildAgentRunnerConfig` in EdgeWorker to accept a `disallowAllTools` parameter
- When `disallowAllTools` is true, both `mcpConfig` and `mcpConfigPath` are set to `undefined`, preventing MCP servers from being loaded
- Both call sites now pass `currentSubroutine?.disallowAllTools` to ensure MCP tools are disabled during summary subroutines

## Test Plan
- [x] All existing tests pass (636 tests)
- [x] Type checking passes
- [ ] Manual verification that summary subroutines no longer have MCP tool access

## Linear Issue
[CYPACK-760](https://linear.app/cypack/issue/CYPACK-760)

Closes CYPACK-760

🤖 Generated with [Claude Code](https://claude.com/claude-code)