### PR TITLE
fix(claude-runner): Add pathToClaudeCodeExecutable config option (CYPACK-762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed "Claude Code executable not found" error in global npm installs and pnpm workspaces by auto-resolving the executable path. ([CYPACK-762](https://linear.app/ceedar/issue/CYPACK-762), [#809](https://github.com/ceedaragents/cyrus/pull/809))
+
 ## [0.2.19] - 2026-01-24
 
 ### Fixed

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -35,6 +35,7 @@ export interface ClaudeRunnerConfig {
 	fallbackModel?: string; // Fallback model if primary model is unavailable
 	maxTurns?: number; // Maximum number of turns before completing the session
 	cyrusHome: string; // Cyrus home directory
+	pathToClaudeCodeExecutable?: string; // Path to Claude Code executable (cli.js) - use when SDK can't auto-detect
 	promptVersions?: {
 		// Optional prompt template version information
 		userPromptVersion?: string;

--- a/packages/claude-runner/test/executable-path.test.ts
+++ b/packages/claude-runner/test/executable-path.test.ts
@@ -1,0 +1,153 @@
+import { existsSync } from "node:fs";
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Test case for CYPACK-762: Claude Code executable not found error
+ *
+ * Root cause: When ClaudeRunner calls the SDK's query() function, it doesn't
+ * pass `pathToClaudeCodeExecutable`. The SDK then tries to derive the path
+ * from import.meta.url, which can fail in certain environments:
+ *
+ * 1. Global npm installs where the package is symlinked
+ * 2. pnpm's nested node_modules structure where the SDK is not directly
+ *    in the expected location
+ * 3. Bundled/compiled code where import.meta.url doesn't resolve correctly
+ *
+ * The error manifests as:
+ * "Claude Code executable not found at <path>/cli.js. Is options.pathToClaudeCodeExecutable set?"
+ *
+ * Solution: ClaudeRunner should explicitly pass pathToClaudeCodeExecutable
+ * to the SDK query() function, deriving it from:
+ * 1. An explicit config option if provided
+ * 2. The SDK's actual installed location (via require.resolve)
+ */
+
+// Store captured query options for inspection
+let capturedQueryOptions:
+	| Parameters<typeof import("@anthropic-ai/claude-agent-sdk").query>[0]
+	| null = null;
+
+// Mock the SDK to capture what options are passed
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: vi.fn(async function* (opts) {
+		capturedQueryOptions = opts;
+		// Yield a minimal response to complete the session
+		yield {
+			type: "assistant",
+			message: { content: [{ type: "text", text: "Test response" }] },
+			parent_tool_use_id: null,
+			session_id: "test-session",
+		};
+	}),
+}));
+
+// Mock file system operations - note: existsSync returns true by default
+// so that auto-resolution can verify the cli.js file exists
+vi.mock("fs", () => ({
+	mkdirSync: vi.fn(),
+	existsSync: vi.fn(() => true),
+	readFileSync: vi.fn(() => ""),
+	createWriteStream: vi.fn(() => ({
+		write: vi.fn(),
+		end: vi.fn(),
+		on: vi.fn(),
+	})),
+}));
+
+// Mock os module
+vi.mock("os", () => ({
+	homedir: vi.fn(() => "/mock/home"),
+}));
+
+import { ClaudeRunner } from "../src/ClaudeRunner";
+import type { ClaudeRunnerConfig } from "../src/types";
+
+describe("CYPACK-762: pathToClaudeCodeExecutable", () => {
+	const defaultConfig: ClaudeRunnerConfig = {
+		workingDirectory: "/tmp/test",
+		cyrusHome: "/tmp/test-cyrus-home",
+	};
+
+	beforeEach(() => {
+		capturedQueryOptions = null;
+		vi.clearAllMocks();
+		// Reset existsSync to return true by default
+		vi.mocked(existsSync).mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	/**
+	 * This test verifies that ClaudeRunner auto-resolves pathToClaudeCodeExecutable
+	 * when not explicitly provided in config, fixing issues in symlinked environments.
+	 */
+	it("should auto-resolve pathToClaudeCodeExecutable when not configured", async () => {
+		const runner = new ClaudeRunner(defaultConfig);
+		await runner.start("Test prompt");
+
+		expect(capturedQueryOptions).not.toBeNull();
+		const options = capturedQueryOptions!.options as Options;
+
+		// ClaudeRunner should auto-resolve the path using require.resolve
+		expect(options.pathToClaudeCodeExecutable).toBeDefined();
+		expect(options.pathToClaudeCodeExecutable).toMatch(/cli\.js$/);
+	});
+
+	/**
+	 * This test verifies that when a custom pathToClaudeCodeExecutable is
+	 * provided in the config, it takes precedence over auto-resolution.
+	 */
+	it("should respect custom pathToClaudeCodeExecutable from config", async () => {
+		const customPath = "/custom/path/to/cli.js";
+		const configWithPath: ClaudeRunnerConfig = {
+			...defaultConfig,
+			pathToClaudeCodeExecutable: customPath,
+		};
+
+		const runner = new ClaudeRunner(configWithPath);
+		await runner.start("Test prompt");
+
+		expect(capturedQueryOptions).not.toBeNull();
+		const options = capturedQueryOptions!.options as Options;
+
+		// Config value should take precedence over auto-resolution
+		expect(options.pathToClaudeCodeExecutable).toBe(customPath);
+	});
+
+	/**
+	 * This test verifies that if cli.js doesn't exist at the resolved path,
+	 * ClaudeRunner gracefully falls back to not passing the option.
+	 */
+	it("should not pass pathToClaudeCodeExecutable when cli.js doesn't exist", async () => {
+		// Mock existsSync to return false for cli.js check
+		vi.mocked(existsSync).mockReturnValue(false);
+
+		const runner = new ClaudeRunner(defaultConfig);
+		await runner.start("Test prompt");
+
+		expect(capturedQueryOptions).not.toBeNull();
+		const options = capturedQueryOptions!.options as Options;
+
+		// When cli.js doesn't exist, we don't pass pathToClaudeCodeExecutable
+		// The SDK will use its default resolution logic
+		expect(options.pathToClaudeCodeExecutable).toBeUndefined();
+	});
+
+	/**
+	 * This test verifies the resolved path ends with cli.js as expected by the SDK.
+	 */
+	it("should resolve to a path ending with cli.js", async () => {
+		const runner = new ClaudeRunner(defaultConfig);
+		await runner.start("Test prompt");
+
+		expect(capturedQueryOptions).not.toBeNull();
+		const options = capturedQueryOptions!.options as Options;
+
+		// The resolved path must end with cli.js
+		expect(options.pathToClaudeCodeExecutable).toBeDefined();
+		expect(options.pathToClaudeCodeExecutable).toMatch(/cli\.js$/);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the "Claude Code executable not found" error that occurs in global npm installs and pnpm workspaces where the SDK's path resolution via `import.meta.url` fails due to symlinked node_modules.

**Linear Issue:** [CYPACK-762](https://linear.app/ceedar/issue/CYPACK-762)

## Changes

### Added
- `pathToClaudeCodeExecutable` config option to `ClaudeRunnerConfig` for explicit SDK executable path configuration
- Auto-resolution of the SDK's `cli.js` path using `require.resolve()` when not explicitly configured
- Graceful fallback when path resolution fails (allows SDK to use its default logic)
- Comprehensive test coverage for all scenarios

### Implementation Details

The root cause was that when `ClaudeRunner` calls the SDK's `query()` function, it wasn't passing `pathToClaudeCodeExecutable`. The SDK tries to derive the path from `import.meta.url`, which can fail in:
1. Global npm installs where packages are symlinked
2. pnpm workspaces where the SDK is in a nested node_modules directory
3. Bundled/compiled code where `import.meta.url` doesn't resolve correctly

The fix:
1. Uses `require.resolve('@anthropic-ai/claude-agent-sdk')` to find the SDK's installation path
2. Constructs the `cli.js` path relative to the SDK directory
3. Verifies the file exists before passing it to the SDK
4. Allows explicit override via config for edge cases

## Test Plan

- [x] Unit tests for auto-resolution when path exists
- [x] Unit tests for custom config path override
- [x] Unit tests for graceful fallback when cli.js doesn't exist
- [x] All existing tests pass (76 tests)
- [x] TypeScript type checking passes
- [x] Linting passes

## Breaking Changes

None. This is backwards compatible - existing code will continue to work with the new auto-resolution, and explicit configuration is optional.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)