### PR TITLE
Update @anthropic-ai/claude-agent-sdk from 0.2.7 to 0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated dependencies** - Updated `@anthropic-ai/claude-agent-sdk` from 0.2.7 to 0.2.23 ([changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0223)). Includes 16 versions with enhancements: MCP server management with introspection and control, structured output validation fixes, task system support, query termination capabilities, notification hook support, and CLAUDE.md file loading from additional directories. ([CYPACK-770](https://linear.app/ceedar/issue/CYPACK-770), [#817](https://github.com/ceedaragents/cyrus/pull/817))
+
 ## [0.2.19] - 2026-01-24
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.7",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.23",
 		"@anthropic-ai/sdk": "^0.71.2",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.7",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.23",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.7",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.23",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.7
-        version: 0.2.7(zod@4.3.5)
+        specifier: ^0.2.23
+        version: 0.2.23(zod@4.3.5)
       '@anthropic-ai/sdk':
         specifier: ^0.71.2
         version: 0.71.2(zod@4.3.5)
@@ -205,8 +205,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.7
-        version: 0.2.7(zod@4.3.6)
+        specifier: ^0.2.23
+        version: 0.2.23(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -353,8 +353,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.7
-        version: 0.2.7(zod@4.3.6)
+        specifier: ^0.2.23
+        version: 0.2.23(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -378,8 +378,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.7':
-    resolution: {integrity: sha512-I1/zcnLah74kZeRkj/1QnDaC6ItJ2m/Bftlm25uoaRkZx7i7SkcpqM9jGE/r2A8PMxnw5WpabP60Xgj99CrTuw==}
+  '@anthropic-ai/claude-agent-sdk@0.2.23':
+    resolution: {integrity: sha512-pkY8vQu4cVoy43JaGNlnV7cl7RiaBjwt5kwiYucLqs37B/EUmvcM2LK44CgC9YyPSM0OTTAXaTYy7Bp4hje4UQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -3527,7 +3527,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.7(zod@4.3.5)':
+  '@anthropic-ai/claude-agent-sdk@0.2.23(zod@4.3.5)':
     dependencies:
       zod: 4.3.5
     optionalDependencies:
@@ -3540,7 +3540,7 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/claude-agent-sdk@0.2.7(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.23(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
     optionalDependencies:


### PR DESCRIPTION
## Summary

Updated `@anthropic-ai/claude-agent-sdk` from version 0.2.7 to 0.2.23 across three packages:
- `cyrus-core`
- `cyrus-claude-runner`
- `cyrus-simple-agent-runner`

The `@anthropic-ai/sdk` was already at the latest version (0.71.2), so no update was needed.

## Changes Included

This update includes 16 new versions (0.2.8 through 0.2.23) with the following key improvements:

- **MCP Server Management**: Enhanced introspection and control over MCP server connections with `reconnectMcpServer()` and `toggleMcpServer()` methods
- **Structured Outputs**: Fixed validation errors and handling of empty assistant messages
- **Task System**: Optional new task system integration via `CLAUDE_CODE_ENABLE_TASKS` env var
- **Agent Configuration**: Support for skills and max turns in custom agents
- **Query Management**: Added `close()` method to forcefully terminate running queries
- **Notifications**: Hook support for notifications
- **Settings Control**: Support for loading CLAUDE.md files from additional directories

See the [full changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0223) for complete details.

## Testing Performed

- ✅ All 109 tests passing (core: 13, claude-runner: 72, simple-agent-runner: 24)
- ✅ TypeScript type checking passes for all updated packages
- ✅ Build successful for all packages
- ✅ Pre-commit hooks (biome, typecheck) passed

## Previous PR Cleanup

- Closed PR #816 (which was updating to 0.2.22)
- Canceled Linear issue CYPACK-769

Closes [CYPACK-770](https://linear.app/ceedar/issue/CYPACK-770)