### PR TITLE
Respect agent guidance for draft PRs and use --track for worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Agent guidance for draft PRs now respected** - When your Linear workspace guidance specifies `--draft` or requests PRs remain as drafts, Cyrus will no longer automatically convert them to ready for review. PRs also now correctly target the configured base branch instead of defaulting to main. ([CYPACK-784](https://linear.app/ceedar/issue/CYPACK-784))
+
 ## [0.2.19] - 2026-01-24
 
 ### Fixed

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -327,12 +327,12 @@ export class GitService {
 					}
 
 					if (useRemoteBranch) {
-						// Use remote version of base branch
+						// Use remote version of base branch with --track to set upstream
 						const remoteBranch = `origin/${baseBranch}`;
 						this.logger.info(
-							`Creating git worktree at ${workspacePath} from ${remoteBranch}`,
+							`Creating git worktree at ${workspacePath} from ${remoteBranch} (tracking ${baseBranch})`,
 						);
-						worktreeCmd = `git worktree add "${workspacePath}" -b "${branchName}" "${remoteBranch}"`;
+						worktreeCmd = `git worktree add --track -b "${branchName}" "${workspacePath}" "${remoteBranch}"`;
 					} else {
 						// Check if base branch exists locally
 						try {
@@ -340,26 +340,26 @@ export class GitService {
 								cwd: repository.repositoryPath,
 								stdio: "pipe",
 							});
-							// Use local base branch
+							// Use local base branch (can't track since remote doesn't have it)
 							this.logger.info(
 								`Creating git worktree at ${workspacePath} from local ${baseBranch}`,
 							);
-							worktreeCmd = `git worktree add "${workspacePath}" -b "${branchName}" "${baseBranch}"`;
+							worktreeCmd = `git worktree add -b "${branchName}" "${workspacePath}" "${baseBranch}"`;
 						} catch {
-							// Base branch doesn't exist locally either, fall back to remote default
+							// Base branch doesn't exist locally either, fall back to remote default with --track
 							this.logger.info(
-								`Base branch '${baseBranch}' not found locally, falling back to remote ${repository.baseBranch}`,
+								`Base branch '${baseBranch}' not found locally, falling back to remote ${repository.baseBranch} (tracking ${repository.baseBranch})`,
 							);
 							const defaultRemoteBranch = `origin/${repository.baseBranch}`;
-							worktreeCmd = `git worktree add "${workspacePath}" -b "${branchName}" "${defaultRemoteBranch}"`;
+							worktreeCmd = `git worktree add --track -b "${branchName}" "${workspacePath}" "${defaultRemoteBranch}"`;
 						}
 					}
 				} else {
-					// No remote, use local branch
+					// No remote, use local branch (no tracking since no remote)
 					this.logger.info(
 						`Creating git worktree at ${workspacePath} from local ${baseBranch}`,
 					);
-					worktreeCmd = `git worktree add "${workspacePath}" -b "${branchName}" "${baseBranch}"`;
+					worktreeCmd = `git worktree add -b "${branchName}" "${workspacePath}" "${baseBranch}"`;
 				}
 			} else {
 				// Branch already exists, just check it out

--- a/packages/edge-worker/src/prompts/subroutines/changelog-update.md
+++ b/packages/edge-worker/src/prompts/subroutines/changelog-update.md
@@ -12,7 +12,8 @@ First, push the current branch (even if there are no new commits) and create a d
 git push -u origin HEAD
 
 # Check if PR already exists, if not create a draft PR
-gh pr view --json url,number 2>/dev/null || gh pr create --draft --title "WIP: [brief description]" --body "Work in progress for [ISSUE-ID]. Full description to follow."
+# IMPORTANT: The --base flag MUST match the base_branch from the issue context
+gh pr view --json url,number 2>/dev/null || gh pr create --draft --base [base_branch from context] --title "WIP: [brief description]" --body "Work in progress for [ISSUE-ID]. Full description to follow."
 ```
 
 Record the PR URL and number for use in the changelog entry.
@@ -47,6 +48,7 @@ If changelog files exist and no entry exists (or entry needs PR link):
 ## Important Notes
 
 - **Create draft PR first** - this gives you the PR number to include in the changelog
+- **Always specify `--base`** - use the base branch from the `<base_branch>` tag in the issue context. Do NOT rely on the repository's default branch setting.
 - **Only update changelogs if they exist** - not all projects use changelogs
 - **Avoid duplicate entries** - check if an entry already exists for this issue before adding
 - **Follow Keep a Changelog format** - https://keepachangelog.com/

--- a/packages/edge-worker/src/prompts/subroutines/gh-pr.md
+++ b/packages/edge-worker/src/prompts/subroutines/gh-pr.md
@@ -1,13 +1,18 @@
 # GitHub PR - Pull Request Management
 
-A draft PR exists and all changes have been committed and pushed. Now update the PR with a full description and mark it as ready.
+A draft PR exists and all changes have been committed and pushed. Now update the PR with a full description and optionally mark it as ready.
 
 ## Your Tasks
 
 ### 1. Get PR Information
-First, get the current PR URL:
+First, get the current PR URL and verify the base branch:
 ```bash
-gh pr view --json url -q '.url'
+gh pr view --json url,baseRefName -q '"\(.url) targeting \(.baseRefName)"'
+```
+
+**IMPORTANT**: Verify that the PR targets the correct base branch (from `<base_branch>` in the issue context). If it doesn't, update it:
+```bash
+gh pr edit --base [correct base branch]
 ```
 
 ### 2. Update PR with Full Description
@@ -25,35 +30,51 @@ The PR description should include:
 
 Ensure the PR has a clear, descriptive title (remove "WIP:" prefix if present).
 
-### 3. Mark PR as Ready
-Convert the draft PR to ready for review:
+### 3. Mark PR as Ready (CONDITIONAL)
+
+**CRITICAL**: Before running `gh pr ready`, you MUST check the `<agent_guidance>` section in your context.
+
+**DO NOT run `gh pr ready` if ANY of the following conditions are true:**
+- The agent guidance specifies `--draft` in PR creation commands
+- The agent guidance mentions keeping PRs as drafts
+- The user has explicitly requested the PR remain as a draft
+- The project instructions specify draft PRs
+
+**Only if none of the above conditions apply**, convert the draft PR to ready for review:
 ```bash
 gh pr ready
 ```
 
-Unless the project instructions specify to keep it as draft, or the user has requested it remain as draft.
-
 ### 4. Final Checks
 - Confirm the PR URL is valid and accessible
 - Verify all commits are included in the PR
+- Verify the PR targets the correct base branch (from `<base_branch>` in context)
 - Check that CI/CD pipelines start running (if applicable)
 
 ## Important Notes
 
-- **A draft PR already exists** - you're updating it and marking it ready
+- **A draft PR already exists** - you're updating it and optionally marking it ready
 - **All commits are pushed** - the changelog already includes the PR link
 - **Be thorough with the PR description** - it should be self-contained and informative
-- **Verify the correct base branch** - ensure PR targets the right base branch
+- **RESPECT AGENT GUIDANCE** - if guidance specifies draft PRs, do NOT mark as ready
+- **Verify the correct base branch** - ensure PR targets the `<base_branch>` from context
 - Take as many turns as needed to complete these tasks
 
 ## Expected Output
 
 **IMPORTANT: Do NOT post Linear comments.** Your output is for internal workflow only.
 
-Provide a brief completion message (1 sentence max) that includes the PR URL:
+Provide a brief completion message (1 sentence max) that includes the PR URL and status:
 
+If marked as ready:
 ```
 PR ready at [PR URL].
 ```
 
+If kept as draft (due to agent guidance or user request):
+```
+Draft PR updated at [PR URL] (kept as draft per guidance).
+```
+
 Example: "PR ready at https://github.com/org/repo/pull/123."
+Example: "Draft PR updated at https://github.com/org/repo/pull/123 (kept as draft per guidance)."


### PR DESCRIPTION
## Summary
Fixes customer support issue (CYHOST-614) where Cyrus was not respecting workspace guidance for draft PRs and worktrees weren't tracking the correct upstream branch.

- **GH subroutines respect agent guidance for draft PRs** - The `gh pr ready` command is now conditional and checks `<agent_guidance>` before running. If guidance specifies `--draft` or requests PRs remain as drafts, they will NOT be auto-converted to ready.
- **PR creation includes `--base` flag** - The `gh pr create` command now explicitly includes `--base [base_branch from context]` to ensure PRs target the correct configured branch.
- **Worktree creation uses `--track` flag** - The `git worktree add` command now includes `--track` when creating branches from remote, ensuring proper upstream tracking configuration.

## Implementation
1. Updated `packages/edge-worker/src/prompts/subroutines/gh-pr.md`:
   - Made "Mark PR as Ready" step conditional
   - Added explicit conditions when NOT to run `gh pr ready`
   - Added verification step to check PR targets correct base branch
   - Added `gh pr edit --base` command to fix incorrect base branch if needed

2. Updated `packages/edge-worker/src/prompts/subroutines/changelog-update.md`:
   - Added `--base [base_branch from context]` to `gh pr create` command
   - Added note emphasizing the importance of specifying `--base`

3. Updated `packages/edge-worker/src/GitService.ts`:
   - Added `--track` flag to `git worktree add` commands when creating new branches from remote
   - Updated log messages to indicate tracking is being set up

## Test plan
- [ ] Verify that when agent guidance specifies `--draft`, PRs are not auto-converted to ready
- [ ] Verify that worktrees track the correct upstream branch (configured `baseBranch`)
- [ ] Verify that PRs target the correct base branch from repository configuration

## Breaking changes
None - this is a bug fix that makes Cyrus respect existing configuration.

## Related issues
- Fixes [CYPACK-784](https://linear.app/ceedar/issue/CYPACK-784)
- Parent issue: [CYHOST-614](https://linear.app/ceedar/issue/CYHOST-614)

🤖 Generated with [Claude Code](https://claude.com/claude-code)