### PR TITLE
feat(codex): pre-flight model availability check with fallback

### DIFF
--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -460,6 +460,8 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		this.startTimestampMs = Date.now();
 		this.emittedToolUseIds.clear();
 
+		await this.resolveModelWithFallback();
+
 		const prompt = (stringPrompt ?? streamingInitialPrompt ?? "").trim();
 		const threadOptions = this.buildThreadOptions();
 		const codex = this.createCodexClient();
@@ -479,6 +481,45 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		return this.sessionInfo;
+	}
+
+	/**
+	 * Check if the configured model is accessible via the OpenAI API.
+	 * If not, swap to the fallback model before starting the session.
+	 */
+	private async resolveModelWithFallback(): Promise<void> {
+		const model = this.config.model;
+		const fallback = this.config.fallbackModel;
+		if (!model || !fallback || fallback === model) return;
+
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (!apiKey) return;
+
+		const baseUrl = (
+			process.env.OPENAI_BASE_URL ||
+			process.env.OPENAI_API_BASE ||
+			"https://api.openai.com/v1"
+		).replace(/\/+$/, "");
+
+		try {
+			const response = await fetch(
+				`${baseUrl}/models/${encodeURIComponent(model)}`,
+				{
+					method: "GET",
+					headers: { Authorization: `Bearer ${apiKey}` },
+					signal: AbortSignal.timeout(10_000),
+				},
+			);
+			if (response.status === 404) {
+				console.log(
+					`[CodexRunner] Model "${model}" not found (404), falling back to "${fallback}"`,
+				);
+				this.config.model = fallback;
+			}
+		} catch {
+			// Network error or timeout — proceed with the original model
+			// and let the Codex SDK handle any downstream failure.
+		}
 	}
 
 	private createCodexClient(): Codex {

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -94,6 +94,9 @@ export class RunnerSelectionService {
 		if (runnerType === "gemini") {
 			return "gemini-2.5-flash";
 		}
+		if (runnerType === "codex") {
+			return "gpt-5.2-codex";
+		}
 		if (runnerType === "cursor") {
 			return "gpt-5";
 		}
@@ -225,10 +228,7 @@ export class RunnerSelectionService {
 				return "gemini-2.5-flash";
 			}
 			if (isCodexModel(normalizedModel)) {
-				if (normalizedModel.endsWith("-codex")) {
-					return model.slice(0, -"-codex".length);
-				}
-				return "gpt-5";
+				return "gpt-5.2-codex";
 			}
 			return "gpt-5";
 		};


### PR DESCRIPTION
## Summary

- Before starting a Codex session, CodexRunner now hits `GET /v1/models/{model}` to verify the configured model is accessible via the OpenAI API
- If the model returns 404 (e.g. `gpt-5.3-codex` not available via `OPENAI_API_KEY` auth), automatically swaps to the fallback model before creating the session
- Updated `RunnerSelectionService` to use `gpt-5.2-codex` as the default Codex fallback model (instead of stripping `-codex` suffix or falling through to `gpt-5`)

## Test plan

- [x] All codex-runner tests pass (15/15)
- [x] All edge-worker tests pass (524/524)
- [x] Verified via curl: `gpt-5.3-codex` returns 404, `gpt-5.2-codex` returns 200 on OpenAI models API

🤖 Generated with [Claude Code](https://claude.com/claude-code)