### PR TITLE
Prepare release v0.2.24

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-02-26
+
 ### Fixed
 - Added fallback recovery to 4 EdgeWorker webhook handlers (`handleUserPromptedAgentActivity` Branch 3, `handleStopSignal`, `handleIssueUnassignedWebhook`, `handleIssueContentUpdate`) that previously returned silently when `issueRepositoryCache` or session mappings were missing after restart/migration. Prompted webhook now performs 3-tier fallback: search all managers → re-route via `RepositoryRouter.determineRepositoryForWebhook` → post error activity. Stop signal now posts acknowledgment activity via any available manager. Unassignment and issue update handlers now search all `agentSessionManagers` for sessions matching the issue. Warnings downgraded to `info` for expected recovery cases, `warn` reserved for true failures. Added 8 tests in `EdgeWorker.missing-session-recovery.test.ts`. ([CYPACK-852](https://linear.app/ceedar/issue/CYPACK-852), [#905](https://github.com/ceedaragents/cyrus/pull/905))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,54 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-02-26
+
 ### Fixed
 - **Sessions no longer appear stuck after restart** - When the system restarts or migrates, user prompts, stop signals, and other interactions that target older sessions are now recovered instead of silently dropped. Users will see clear feedback instead of a hanging state. ([CYPACK-852](https://linear.app/ceedar/issue/CYPACK-852), [#905](https://github.com/ceedaragents/cyrus/pull/905))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.24
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.24
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.24
+
+#### cyrus-core
+- cyrus-core@0.2.24
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.24
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.24
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.24
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.24
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.24
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.24
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.24
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.24
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.24
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.24
 
 ## [0.2.23] - 2026-02-25
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.23",
+	"version": "0.2.24",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.24 to npm
- Updated changelogs (CHANGELOG.md and CHANGELOG.internal.md)
- Bumped all package versions to 0.2.24
- Created git tag v0.2.24

## Changes
- **Sessions no longer appear stuck after restart** - Recovery for missing session/repository mappings after restart ([CYPACK-852](https://linear.app/ceedar/issue/CYPACK-852))

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.24)
- [npm: cyrus-ai@0.2.24](https://www.npmjs.com/package/cyrus-ai/v/0.2.24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)