### PR TITLE
fix: PersistenceManager.deleteStateFile() now actually deletes the file

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Fixed
+- `PersistenceManager.deleteStateFile()` now actually deletes the state file using `unlink` instead of writing an empty string. Previously, `hasStateFile()` incorrectly returned `true` after "deletion" and `loadEdgeWorkerState()` relied on a JSON parse error path to return `null`. Added tests for `deleteStateFile` and `hasStateFile`. ([ENG-105](https://linear.app/payton-test1/issue/ENG-105/find-a-small-improvement), [#909](https://github.com/ceedaragents/cyrus/pull/909))
+
 ## [0.2.24] - 2026-02-26
 
 ### Fixed

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -248,7 +248,7 @@ export class PersistenceManager {
 		try {
 			const stateFile = this.getEdgeWorkerStateFilePath();
 			if (existsSync(stateFile)) {
-				await writeFile(stateFile, "", "utf8"); // Clear file instead of deleting
+				await unlink(stateFile);
 			}
 		} catch (error) {
 			this.logger.error("Failed to delete EdgeWorker state file:", error);


### PR DESCRIPTION
## Summary

- `PersistenceManager.deleteStateFile()` was writing an empty string to the state file instead of removing it. Now uses `unlink` to properly delete the file.
- Added tests for `deleteStateFile` (3 cases) and `hasStateFile` (2 cases).

## Problem

The method was named `deleteStateFile` but only cleared the file contents with `writeFile(stateFile, "", "utf8")`. This meant:
- `hasStateFile()` returned `true` after "deletion" since the empty file still existed on disk
- `loadEdgeWorkerState()` had to go through a JSON parse error path (`JSON.parse("")`) to return `null`, instead of the early `existsSync` check

## Changes

- **`packages/core/src/PersistenceManager.ts`**: Import `unlink` from `node:fs/promises`, replace `writeFile` call with `unlink` in `deleteStateFile()`
- **`packages/core/test/PersistenceManager.migration.test.ts`**: Add 5 new tests covering `deleteStateFile` and `hasStateFile`

## Testing

- All 47 core package tests pass (including 5 new ones)
- Full monorepo test suite passes (1081 tests across 13 packages)
- Linting clean (312 files)
- TypeScript typecheck clean (15 projects)

---

Closes [ENG-105](https://linear.app/payton-test1/issue/ENG-105/find-a-small-improvement)