### PR TITLE
feat: AWS CDK infrastructure scaffold for ECS Fargate deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+node_modules
+.git
+dist
+*.tgz
+
+# Apps not needed in container (keep package.json for workspace resolution)
+apps/electron
+apps/f1/src
+apps/f1/test-drives
+apps/f1/dist
+
+# Documentation and config
+docs
+*.md
+!package.json
+
+# Development tooling
+.claude
+.codex
+.opencode
+.husky
+.cursor
+.vscode
+.idea
+
+# Test files
+**/*.test.ts
+**/*.test.js
+**/test-scripts
+**/vitest.config.ts
+**/__mocks__
+
+# Misc
+.env
+.env.*
+*.log
+coverage
+.turbo
+infra

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+
+# ─── base ────────────────────────────────────────────────────────────────────
+FROM node:20-slim AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    jq \
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Enable corepack for pnpm
+RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+WORKDIR /app
+
+# ─── deps ────────────────────────────────────────────────────────────────────
+# Separate layer for dependency caching — rebuild only when package.json or lockfile changes
+FROM base AS deps
+
+# Copy workspace config and all package.json files for dependency install
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc* ./
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/f1/package.json apps/f1/package.json
+COPY packages/core/package.json packages/core/package.json
+COPY packages/claude-runner/package.json packages/claude-runner/package.json
+COPY packages/cloudflare-tunnel-client/package.json packages/cloudflare-tunnel-client/package.json
+COPY packages/codex-runner/package.json packages/codex-runner/package.json
+COPY packages/config-updater/package.json packages/config-updater/package.json
+COPY packages/cursor-runner/package.json packages/cursor-runner/package.json
+COPY packages/edge-worker/package.json packages/edge-worker/package.json
+COPY packages/gemini-runner/package.json packages/gemini-runner/package.json
+COPY packages/github-event-transport/package.json packages/github-event-transport/package.json
+COPY packages/linear-event-transport/package.json packages/linear-event-transport/package.json
+COPY packages/mcp-tools/package.json packages/mcp-tools/package.json
+COPY packages/simple-agent-runner/package.json packages/simple-agent-runner/package.json
+COPY packages/slack-event-transport/package.json packages/slack-event-transport/package.json
+
+RUN pnpm install --frozen-lockfile
+
+# ─── build ───────────────────────────────────────────────────────────────────
+FROM base AS build
+
+# Copy cached node_modules from deps stage
+COPY --from=deps /app /app
+
+# Copy source code into a separate location, then merge without clobbering node_modules
+COPY . /tmp/src
+RUN cp -a /tmp/src/. /app/ && rm -rf /tmp/src
+
+# Rebuild pnpm symlinks after source overlay
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm -r --filter='!@cyrus/electron' --filter='!cyrus-f1' build
+
+# ─── production ──────────────────────────────────────────────────────────────
+FROM base AS production
+
+# Repurpose the existing node user (UID/GID 1000) as cyrus
+RUN usermod -l cyrus -d /home/cyrus -m node \
+  && groupmod -n cyrus node
+
+WORKDIR /app
+
+# Copy built application from build stage
+COPY --from=build --chown=cyrus:cyrus /app /app
+
+# Configure git identity for the cyrus user
+RUN git config --system user.name "Cyrus" \
+  && git config --system user.email "cyrus@ceedar.com" \
+  && git config --system --add safe.directory '*'
+
+# Create data directory (will be overlaid by EFS mount)
+RUN mkdir -p /home/cyrus/.cyrus && chown -R cyrus:cyrus /home/cyrus/.cyrus
+
+USER cyrus
+
+ENV NODE_ENV=production
+ENV CYRUS_HOST_EXTERNAL=true
+
+EXPOSE 3456
+
+CMD ["node", "apps/cli/dist/src/app.js", "start"]

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,4 @@
+cdk.out/
+cdk.context.json
+node_modules/
+dist/

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,153 @@
+# Cyrus AWS Infrastructure
+
+AWS CDK infrastructure for deploying Cyrus as a containerized service on ECS Fargate.
+
+## Architecture
+
+```
+                    ┌─────────────┐
+  Linear Webhooks → │     ALB     │ (public, internet-facing)
+                    │  :80 / :443 │
+                    └──────┬──────┘
+                           │
+                    ┌──────▼──────┐
+                    │   Fargate   │ (private subnet)
+                    │  Cyrus Task │ :3456
+                    │  2 vCPU/4GB │
+                    └──────┬──────┘
+                           │
+            ┌──────────────┼──────────────┐
+            │              │              │
+     ┌──────▼──────┐ ┌────▼────┐  ┌──────▼──────┐
+     │     EFS     │ │ Secrets │  │     ECR     │
+     │  /cyrus-data│ │ Manager │  │ cyrus:latest│
+     └─────────────┘ └─────────┘  └─────────────┘
+```
+
+**Key components:**
+
+- **ECS Fargate** — single task (Cyrus is stateful: in-memory sessions + filesystem worktrees)
+- **EFS** — persistent storage mounted at `/home/cyrus/.cyrus` for repos, worktrees, and config
+- **ALB** — internet-facing load balancer receiving Linear webhooks
+- **Secrets Manager** — stores Linear OAuth credentials and Anthropic API key
+- **ECR** — private Docker image registry
+
+## Stacks
+
+| Stack | Description |
+|-------|-------------|
+| `CyrusVpc` | VPC with 2 AZs, public + private subnets, 1 NAT gateway |
+| `CyrusService` | ECS cluster, Fargate task, EFS, ALB, ECR, Secrets Manager |
+
+## Prerequisites
+
+- AWS CLI configured with credentials
+- Node.js 20+
+- Docker (for building the container image)
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+cd infra
+npm install
+```
+
+### 2. Synthesize CloudFormation templates
+
+```bash
+npx cdk synth
+```
+
+### 3. Deploy the stacks
+
+```bash
+npx cdk deploy --all
+```
+
+After deployment, note the outputs:
+- **AlbDnsName** — configure this as your Linear webhook URL
+- **EcrRepositoryUri** — push your Docker image here
+- **SecretsArn** — update with your real credentials
+
+### 4. Update secrets
+
+Replace placeholder values in Secrets Manager:
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id cyrus/config \
+  --secret-string '{
+    "LINEAR_CLIENT_ID": "your-client-id",
+    "LINEAR_CLIENT_SECRET": "your-client-secret",
+    "LINEAR_WEBHOOK_SECRET": "your-webhook-secret",
+    "ANTHROPIC_API_KEY": "sk-ant-..."
+  }'
+```
+
+### 5. Build and push the Docker image
+
+```bash
+# From monorepo root
+docker build -t cyrus:latest .
+
+# Authenticate with ECR
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <ECR_URI>
+
+# Tag and push
+docker tag cyrus:latest <ECR_URI>:latest
+docker push <ECR_URI>:latest
+```
+
+### 6. Force a new deployment
+
+```bash
+aws ecs update-service --cluster cyrus --service <service-name> --force-new-deployment
+```
+
+## HTTPS Setup (Optional)
+
+To enable HTTPS, provide a certificate ARN and domain name via CDK context:
+
+```bash
+npx cdk deploy --all \
+  -c certificateArn=arn:aws:acm:us-east-1:123456789:certificate/abc-123 \
+  -c domainName=cyrus.example.com
+```
+
+This will:
+- Add an HTTPS listener on port 443
+- Redirect all HTTP traffic to HTTPS
+- Use the provided ACM certificate
+
+You'll also need to create a CNAME/A record pointing your domain to the ALB DNS name.
+
+## Verification
+
+After deployment, verify the service is healthy:
+
+```bash
+# Check the ALB health endpoint
+curl http://<ALB_DNS>/status
+# Expected: {"status":"idle"}
+
+# Check ECS service status
+aws ecs describe-services --cluster cyrus --services <service-name>
+
+# View container logs
+aws logs tail /ecs/cyrus --follow
+
+# ECS Exec into the running container
+aws ecs execute-command --cluster cyrus --task <task-id> \
+  --container cyrus --interactive --command /bin/bash
+```
+
+## Design Decisions
+
+- **Single instance (`desiredCount: 1`)** — Cyrus is stateful with in-memory session maps and filesystem-bound git worktrees. Horizontal scaling requires architectural changes.
+- **EFS over EBS** — Fargate doesn't support EBS volumes; EFS is the only persistent storage option.
+- **UID 1000 alignment** — The Dockerfile creates a `cyrus` user with UID 1000, and the EFS access point enforces the same UID/GID. This ensures file permissions work correctly.
+- **`CYRUS_HOST_EXTERNAL=true`** — Required so Fastify binds to `0.0.0.0` instead of `localhost`, allowing the ALB to reach the container.
+- **No Cloudflare tunnel** — The ALB replaces it for webhook ingress. The tunnel only activates when `CLOUDFLARE_TOKEN` is set (which is not provided here).
+- **ECS Exec enabled** — Allows `aws ecs execute-command` for debugging running containers.

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { ServiceStack } from "../lib/service-stack";
+import { VpcStack } from "../lib/vpc-stack";
+
+const app = new cdk.App();
+
+const env: cdk.Environment = {
+	account: process.env.CDK_DEFAULT_ACCOUNT,
+	region: process.env.CDK_DEFAULT_REGION ?? "us-east-1",
+};
+
+const vpcStack = new VpcStack(app, "CyrusVpc", { env });
+
+new ServiceStack(app, "CyrusService", {
+	env,
+	vpc: vpcStack.vpc,
+	certificateArn: app.node.tryGetContext("certificateArn"),
+	domainName: app.node.tryGetContext("domainName"),
+});

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,20 @@
+{
+	"app": "npx ts-node --prefer-ts-exts bin/infra.ts",
+	"watch": {
+		"include": ["**"],
+		"exclude": [
+			"README.md",
+			"cdk*.json",
+			"**/*.d.ts",
+			"**/*.js",
+			"tsconfig.json",
+			"package*.json",
+			"node_modules"
+		]
+	},
+	"context": {
+		"@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+		"@aws-cdk/core:checkSecretUsage": true,
+		"@aws-cdk/core:target-partitions": ["aws"]
+	}
+}

--- a/infra/lib/service-stack.ts
+++ b/infra/lib/service-stack.ts
@@ -1,0 +1,264 @@
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as efs from "aws-cdk-lib/aws-efs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import type { Construct } from "constructs";
+
+export interface ServiceStackProps extends cdk.StackProps {
+	vpc: ec2.Vpc;
+	certificateArn?: string;
+	domainName?: string;
+}
+
+export class ServiceStack extends cdk.Stack {
+	constructor(scope: Construct, id: string, props: ServiceStackProps) {
+		super(scope, id, props);
+
+		const { vpc, certificateArn, domainName } = props;
+
+		// ── ECR Repository ────────────────────────────────────────────────
+		const repository = new ecr.Repository(this, "Repository", {
+			repositoryName: "cyrus",
+			removalPolicy: cdk.RemovalPolicy.RETAIN,
+			lifecycleRules: [
+				{
+					maxImageCount: 10,
+					description: "Keep last 10 images",
+				},
+			],
+		});
+
+		// ── Secrets Manager ───────────────────────────────────────────────
+		const secrets = new secretsmanager.Secret(this, "Secrets", {
+			secretName: "cyrus/config",
+			description: "Cyrus application secrets",
+			generateSecretString: {
+				secretStringTemplate: JSON.stringify({
+					LINEAR_CLIENT_ID: "CHANGE_ME",
+					LINEAR_CLIENT_SECRET: "CHANGE_ME",
+					LINEAR_WEBHOOK_SECRET: "CHANGE_ME",
+					ANTHROPIC_API_KEY: "CHANGE_ME",
+				}),
+				generateStringKey: "_placeholder",
+			},
+		});
+
+		// ── EFS File System ───────────────────────────────────────────────
+		const fileSystem = new efs.FileSystem(this, "FileSystem", {
+			vpc,
+			vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+			encrypted: true,
+			performanceMode: efs.PerformanceMode.GENERAL_PURPOSE,
+			throughputMode: efs.ThroughputMode.ELASTIC,
+			removalPolicy: cdk.RemovalPolicy.RETAIN,
+		});
+
+		const accessPoint = fileSystem.addAccessPoint("DataAccessPoint", {
+			path: "/cyrus-data",
+			posixUser: { uid: "1000", gid: "1000" },
+			createAcl: { ownerUid: "1000", ownerGid: "1000", permissions: "755" },
+		});
+
+		// ── ECS Cluster ───────────────────────────────────────────────────
+		const cluster = new ecs.Cluster(this, "Cluster", {
+			vpc,
+			clusterName: "cyrus",
+			containerInsightsV2: ecs.ContainerInsights.ENHANCED,
+		});
+
+		// ── Fargate Task Definition ───────────────────────────────────────
+		const taskDefinition = new ecs.FargateTaskDefinition(this, "TaskDef", {
+			cpu: 2048,
+			memoryLimitMiB: 4096,
+			runtimePlatform: {
+				cpuArchitecture: ecs.CpuArchitecture.X86_64,
+				operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+			},
+		});
+
+		// EFS volume
+		taskDefinition.addVolume({
+			name: "cyrus-data",
+			efsVolumeConfiguration: {
+				fileSystemId: fileSystem.fileSystemId,
+				transitEncryption: "ENABLED",
+				authorizationConfig: {
+					accessPointId: accessPoint.accessPointId,
+					iam: "ENABLED",
+				},
+			},
+		});
+
+		// Grant EFS access to the task role
+		fileSystem.grantRootAccess(taskDefinition.taskRole);
+		taskDefinition.taskRole.addToPrincipalPolicy(
+			new iam.PolicyStatement({
+				actions: [
+					"elasticfilesystem:ClientMount",
+					"elasticfilesystem:ClientWrite",
+				],
+				resources: [fileSystem.fileSystemArn],
+			}),
+		);
+
+		// ── Container Definition ──────────────────────────────────────────
+		const container = taskDefinition.addContainer("cyrus", {
+			image: ecs.ContainerImage.fromEcrRepository(repository, "latest"),
+			logging: ecs.LogDrivers.awsLogs({
+				streamPrefix: "cyrus",
+				logRetention: logs.RetentionDays.TWO_WEEKS,
+			}),
+			environment: {
+				NODE_ENV: "production",
+				CYRUS_HOST_EXTERNAL: "true",
+				CYRUS_SERVER_PORT: "3456",
+			},
+			secrets: {
+				LINEAR_CLIENT_ID: ecs.Secret.fromSecretsManager(
+					secrets,
+					"LINEAR_CLIENT_ID",
+				),
+				LINEAR_CLIENT_SECRET: ecs.Secret.fromSecretsManager(
+					secrets,
+					"LINEAR_CLIENT_SECRET",
+				),
+				LINEAR_WEBHOOK_SECRET: ecs.Secret.fromSecretsManager(
+					secrets,
+					"LINEAR_WEBHOOK_SECRET",
+				),
+				ANTHROPIC_API_KEY: ecs.Secret.fromSecretsManager(
+					secrets,
+					"ANTHROPIC_API_KEY",
+				),
+			},
+			portMappings: [{ containerPort: 3456, protocol: ecs.Protocol.TCP }],
+			healthCheck: {
+				command: [
+					"CMD-SHELL",
+					"curl -f http://localhost:3456/status || exit 1",
+				],
+				interval: cdk.Duration.seconds(30),
+				timeout: cdk.Duration.seconds(5),
+				retries: 3,
+				startPeriod: cdk.Duration.seconds(60),
+			},
+		});
+
+		container.addMountPoints({
+			containerPath: "/home/cyrus/.cyrus",
+			sourceVolume: "cyrus-data",
+			readOnly: false,
+		});
+
+		// ── Fargate Service ───────────────────────────────────────────────
+		const service = new ecs.FargateService(this, "Service", {
+			cluster,
+			taskDefinition,
+			desiredCount: 1,
+			vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+			enableExecuteCommand: true,
+			circuitBreaker: { rollback: true },
+			assignPublicIp: false,
+		});
+
+		// Allow Fargate tasks to reach EFS
+		service.connections.allowTo(fileSystem, ec2.Port.tcp(2049), "EFS access");
+
+		// ── Application Load Balancer ─────────────────────────────────────
+		const alb = new elbv2.ApplicationLoadBalancer(this, "Alb", {
+			vpc,
+			internetFacing: true,
+			vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+		});
+
+		// HTTP listener (always created)
+		const httpListener = alb.addListener("HttpListener", {
+			port: 80,
+			protocol: elbv2.ApplicationProtocol.HTTP,
+		});
+
+		// If a certificate ARN is provided, add HTTPS and redirect HTTP → HTTPS
+		if (certificateArn) {
+			const certificate = acm.Certificate.fromCertificateArn(
+				this,
+				"Certificate",
+				certificateArn,
+			);
+
+			const httpsListener = alb.addListener("HttpsListener", {
+				port: 443,
+				protocol: elbv2.ApplicationProtocol.HTTPS,
+				certificates: [certificate],
+			});
+
+			httpsListener.addTargets("HttpsTarget", {
+				port: 3456,
+				protocol: elbv2.ApplicationProtocol.HTTP,
+				targets: [service],
+				healthCheck: {
+					path: "/status",
+					interval: cdk.Duration.seconds(30),
+					healthyThresholdCount: 2,
+					unhealthyThresholdCount: 3,
+				},
+			});
+
+			// Redirect HTTP → HTTPS
+			httpListener.addAction("HttpRedirect", {
+				action: elbv2.ListenerAction.redirect({
+					protocol: "HTTPS",
+					port: "443",
+					permanent: true,
+				}),
+			});
+		} else {
+			// No certificate — route HTTP directly to the service
+			httpListener.addTargets("HttpTarget", {
+				port: 3456,
+				protocol: elbv2.ApplicationProtocol.HTTP,
+				targets: [service],
+				healthCheck: {
+					path: "/status",
+					interval: cdk.Duration.seconds(30),
+					healthyThresholdCount: 2,
+					unhealthyThresholdCount: 3,
+				},
+			});
+		}
+
+		// ── Outputs ───────────────────────────────────────────────────────
+		new cdk.CfnOutput(this, "AlbDnsName", {
+			value: alb.loadBalancerDnsName,
+			description: "ALB DNS name for Linear webhook URL",
+		});
+
+		new cdk.CfnOutput(this, "WebhookUrl", {
+			value:
+				certificateArn && domainName
+					? `https://${domainName}/webhook`
+					: `http://${alb.loadBalancerDnsName}/webhook`,
+			description: "Webhook URL to configure in Linear",
+		});
+
+		new cdk.CfnOutput(this, "EcrRepositoryUri", {
+			value: repository.repositoryUri,
+			description: "ECR repository URI for docker push",
+		});
+
+		new cdk.CfnOutput(this, "SecretsArn", {
+			value: secrets.secretArn,
+			description: "Secrets Manager ARN (update with real values)",
+		});
+
+		new cdk.CfnOutput(this, "FileSystemId", {
+			value: fileSystem.fileSystemId,
+			description: "EFS file system ID",
+		});
+	}
+}

--- a/infra/lib/vpc-stack.ts
+++ b/infra/lib/vpc-stack.ts
@@ -1,0 +1,28 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import type { Construct } from "constructs";
+
+export class VpcStack extends cdk.Stack {
+	public readonly vpc: ec2.Vpc;
+
+	constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+		super(scope, id, props);
+
+		this.vpc = new ec2.Vpc(this, "Vpc", {
+			maxAzs: 2,
+			natGateways: 1,
+			subnetConfiguration: [
+				{
+					name: "Public",
+					subnetType: ec2.SubnetType.PUBLIC,
+					cidrMask: 24,
+				},
+				{
+					name: "Private",
+					subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+					cidrMask: 24,
+				},
+			],
+		});
+	}
+}

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,0 +1,701 @@
+{
+  "name": "cyrus-infra",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cyrus-infra",
+      "version": "0.1.0",
+      "dependencies": {
+        "aws-cdk-lib": "^2.180.0",
+        "constructs": "^10.4.2"
+      },
+      "devDependencies": {
+        "aws-cdk": "^2.180.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.263",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
+      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
+      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "50.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-50.4.0.tgz",
+      "integrity": "sha512-9Cplwc5C+SNe3hMfqZET7gXeM68tiH2ytQytCi+zz31Bn7O3GAgAnC2dYe+HWnZAgVH788ZkkBwnYXkeqx7v4g==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
+      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1108.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1108.0.tgz",
+      "integrity": "sha512-FHnyhnYZoRc2W0C9mNzhNn6fO2vH4xNINsKfJaA7AFDuymgQ39JhEnrM4AHaoikIBqXYeNLWElvvkusY9l3ulw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.240.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.240.0.tgz",
+      "integrity": "sha512-3dXmUnPB5kK0VgrNHOlV3jiQM4Dungukk/CV91nclO2lgNcrGyigauJdzmz9sOmI1gbKJJ2SRAotaXityzZMRw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.263",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-api": "^2.0.1",
+        "@aws-cdk/cloud-assembly-schema": "^50.3.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.3",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.4",
+        "table": "^6.9.0",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.0.1",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=50.3.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.2",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
+      "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "cyrus-infra",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"cdk": "cdk",
+		"synth": "cdk synth",
+		"deploy": "cdk deploy --all",
+		"diff": "cdk diff"
+	},
+	"dependencies": {
+		"aws-cdk-lib": "^2.180.0",
+		"constructs": "^10.4.2"
+	},
+	"devDependencies": {
+		"aws-cdk": "^2.180.0",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.3.3"
+	}
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "commonjs",
+		"lib": ["ES2022"],
+		"declaration": true,
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"outDir": "dist",
+		"rootDir": "."
+	},
+	"include": ["bin/**/*.ts", "lib/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` for the pnpm monorepo (node:20-slim + git/jq/gh CLI, pnpm install, build, production image with `cyrus` user UID 1000)
- Adds AWS CDK infrastructure (`infra/`) with two stacks:
  - **CyrusVpc** — VPC with 2 AZs, public + private subnets, 1 NAT gateway
  - **CyrusService** — ECS Fargate (2 vCPU/4 GB), EFS persistent storage, ALB webhook ingress, ECR image registry, Secrets Manager for credentials
- Optional HTTPS support via CDK context (`-c certificateArn=... -c domainName=...`)
- `cdk.context.json` gitignored to prevent AWS account ID leakage
- Full deployment documentation in `infra/README.md`

## Verification

- `cd infra && npm install && npx cdk synth` — synthesizes both CloudFormation stacks successfully
- `docker build -t cyrus:latest .` — builds the full monorepo image successfully
- `docker run` — container starts, Fastify binds on `0.0.0.0:3456`

## Test plan

- [ ] Verify `npx cdk synth` produces valid CloudFormation templates
- [ ] Verify `docker build` completes without errors
- [ ] Verify container starts and listens on port 3456
- [ ] Review no secrets/credentials are committed (cdk.context.json gitignored, Secrets Manager uses CHANGE_ME placeholders)
- [ ] Deploy to a test AWS account and verify ALB → Fargate → `/status` health check works

🤖 Generated with [Claude Code](https://claude.com/claude-code)