### PR TITLE
Release v0.2.28

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-03-04
+
 ### Added
 - Added `resolveVerification()` to `SlackEventTransport` and `GitHubEventTransport` that checks `SLACK_SIGNING_SECRET`/`GITHUB_WEBHOOK_SECRET` env vars (plus `CYRUS_HOST_EXTERNAL`) at request time instead of only at initialization. When started in proxy mode and the relevant env vars are added at runtime, the transport dynamically switches to direct/signature HMAC-SHA256 verification. Both transports now use the same dual-gate (`secret` + `CYRUS_HOST_EXTERNAL`) pattern. Follows the CYPACK-842 pattern of resolving from `process.env` at usage time. Handler methods (`handleDirectWebhook`, `handleProxyWebhook`, `handleSignatureWebhook`) now accept a `secret` parameter from the resolved config. Updated `EdgeWorker.registerGitHubEventTransport()` startup logic to also require `CYRUS_HOST_EXTERNAL` for consistency with Slack. Added "runtime mode switching" test suites to both transport packages. ([CYPACK-884](https://linear.app/ceedar/issue/CYPACK-884), [#934](https://github.com/ceedaragents/cyrus/pull/934))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,54 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-03-04
+
 ### Fixed
 - **Webhook verification mode now updates at runtime** - When `SLACK_SIGNING_SECRET` or `GITHUB_WEBHOOK_SECRET` environment variables are added after the process starts (along with `CYRUS_HOST_EXTERNAL=true`), Cyrus now automatically switches from proxied to direct webhook verification without requiring a restart. ([CYPACK-884](https://linear.app/ceedar/issue/CYPACK-884), [#934](https://github.com/ceedaragents/cyrus/pull/934))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.28
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.28
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.28
+
+#### cyrus-core
+- cyrus-core@0.2.28
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.28
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.28
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.28
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.28
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.28
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.28
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.28
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.28
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.28
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.28
 
 ## [0.2.27] - 2026-03-04 ([#933](https://github.com/ceedaragents/cyrus/pull/933))
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.27",
+	"version": "0.2.28",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.28 to npm
- Update changelogs (CHANGELOG.md and CHANGELOG.internal.md)
- Bump all package versions to 0.2.28
- Create git tag v0.2.28

## Changes
- **Webhook verification mode now updates at runtime** ([CYPACK-884](https://linear.app/ceedar/issue/CYPACK-884), [#934](https://github.com/ceedaragents/cyrus/pull/934))

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)