### PR TITLE
feat: add mcp-language-server as first-party LSP MCP

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Added
+- Added `packages/edge-worker/src/lsp/` module with `detectLanguages()` (scans workspace for `tsconfig.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, etc.) and `buildLspMcpConfig()` (generates `mcp-language-server` stdio MCP entries keyed as `lsp-<language>`). Extended `buildMcpConfig()` options with `workspacePath` to auto-inject LSP servers at all three `buildAgentRunnerConfig` call sites (GitHub sessions, new sessions, resume sessions). ([CYPACK-894](https://linear.app/ceedar/issue/CYPACK-894), [#945](https://github.com/ceedaragents/cyrus/pull/945))
+
 ## [0.2.30] - 2026-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Built-in LSP tools for agent sessions** - Agent sessions now automatically get language server tools (go-to-definition, find-references, diagnostics, hover, rename) for detected project languages (TypeScript, Go, Rust, Python) via `mcp-language-server`. ([CYPACK-894](https://linear.app/ceedar/issue/CYPACK-894), [#945](https://github.com/ceedaragents/cyrus/pull/945))
+
 ## [0.2.30] - 2026-03-05
 
 ### Fixed

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -110,6 +110,7 @@ import { ChatSessionHandler } from "./ChatSessionHandler.js";
 import { ConfigManager, type RepositoryChanges } from "./ConfigManager.js";
 import { GitService } from "./GitService.js";
 import { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
+import { buildLspMcpConfig } from "./lsp/index.js";
 import { PromptBuilder } from "./PromptBuilder.js";
 import {
 	ProcedureAnalyzer,
@@ -1099,7 +1100,7 @@ export class EdgeWorker extends EventEmitter {
 				200, // maxTurns
 				false, // singleTurn
 				undefined, // disallowAllTools
-				{ excludeSlackMcp: true }, // Exclude Slack MCP server from GitHub sessions
+				{ excludeSlackMcp: true, workspacePath: session.workspace.path }, // Exclude Slack MCP; inject LSP servers
 			);
 
 			const runner = this.createRunnerForType(runnerType, runnerConfig);
@@ -3099,6 +3100,7 @@ ${taskSection}`;
 				undefined, // maxTurns
 				currentSubroutine?.singleTurn, // singleTurn flag
 				currentSubroutine?.disallowAllTools, // disallowAllTools flag - also disables MCP tools
+				{ workspacePath: session.workspace.path }, // Inject LSP MCP servers based on detected languages
 			);
 
 			log.debug(
@@ -4481,12 +4483,14 @@ ${taskSection}`;
 	/**
 	 * Build MCP configuration with automatic Linear server injection and cyrus-tools over Fastify MCP.
 	 * Optionally includes the Slack MCP server when the SLACK_BOT_TOKEN environment variable is set.
+	 * Optionally includes LSP MCP servers when a workspace path is provided and language markers are detected.
 	 * @param options.excludeSlackMcp - When true, excludes the Slack MCP server even if SLACK_BOT_TOKEN is set (e.g., for GitHub sessions)
+	 * @param options.workspacePath - When provided, auto-detects languages and injects LSP MCP servers via mcp-language-server
 	 */
 	private buildMcpConfig(
 		repository: RepositoryConfig,
 		parentSessionId?: string,
-		options?: { excludeSlackMcp?: boolean },
+		options?: { excludeSlackMcp?: boolean; workspacePath?: string },
 	): Record<string, McpServerConfig> {
 		const contextId = this.buildCyrusToolsMcpContextId(
 			repository,
@@ -4547,6 +4551,15 @@ ${taskSection}`;
 					SLACK_MCP_XOXB_TOKEN: slackBotToken,
 				},
 			};
+		}
+
+		// Conditionally inject LSP MCP servers when a workspace path is provided.
+		// Auto-detects languages (TypeScript, Go, Rust, Python) from project marker files
+		// and adds mcp-language-server instances for each detected language.
+		// https://github.com/isaacphi/mcp-language-server
+		if (options?.workspacePath) {
+			const lspConfigs = buildLspMcpConfig(options.workspacePath);
+			Object.assign(mcpConfig, lspConfigs);
 		}
 
 		return mcpConfig;
@@ -4971,7 +4984,7 @@ ${input.userComment}
 		maxTurns?: number,
 		singleTurn?: boolean,
 		disallowAllTools?: boolean,
-		mcpOptions?: { excludeSlackMcp?: boolean },
+		mcpOptions?: { excludeSlackMcp?: boolean; workspacePath?: string },
 	): {
 		config: AgentRunnerConfig;
 		runnerType: RunnerType;
@@ -5927,6 +5940,7 @@ ${input.userComment}
 			maxTurns, // Pass maxTurns if specified
 			currentSubroutine?.singleTurn, // singleTurn flag
 			currentSubroutine?.disallowAllTools, // disallowAllTools flag - also disables MCP tools
+			{ workspacePath: session.workspace.path }, // Inject LSP MCP servers based on detected languages
 		);
 
 		// Create the appropriate runner based on session state

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -30,6 +30,7 @@ export { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
 export {
 	buildLspMcpConfig,
 	detectLanguages,
+	isBinaryAvailable,
 	type LspLanguageConfig,
 	SUPPORTED_LANGUAGES,
 	type SupportedLanguage,

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -32,6 +32,7 @@ export {
 	detectLanguages,
 	type LspLanguageConfig,
 	SUPPORTED_LANGUAGES,
+	type SupportedLanguage,
 } from "./lsp/index.js";
 export { RepositoryRouter } from "./RepositoryRouter.js";
 export { SharedApplicationServer } from "./SharedApplicationServer.js";

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -26,6 +26,13 @@ export { EdgeWorker } from "./EdgeWorker.js";
 export { GitService } from "./GitService.js";
 export type { SerializedGlobalRegistryState } from "./GlobalSessionRegistry.js";
 export { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
+// LSP MCP integration
+export {
+	buildLspMcpConfig,
+	detectLanguages,
+	type LspLanguageConfig,
+	SUPPORTED_LANGUAGES,
+} from "./lsp/index.js";
 export { RepositoryRouter } from "./RepositoryRouter.js";
 export { SharedApplicationServer } from "./SharedApplicationServer.js";
 export { SlackChatAdapter } from "./SlackChatAdapter.js";

--- a/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
+++ b/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
@@ -1,0 +1,43 @@
+import type { McpServerConfig } from "cyrus-claude-runner";
+import { detectLanguages, SUPPORTED_LANGUAGES } from "./detectLanguages.js";
+
+/**
+ * Build MCP server configurations for detected languages in a workspace.
+ *
+ * Uses `mcp-language-server` (https://github.com/isaacphi/mcp-language-server)
+ * to wrap language-specific LSP servers and expose them as MCP tools:
+ * - `definition` – retrieve source code of symbol definitions
+ * - `references` – find all usages of a symbol
+ * - `diagnostics` – get warnings/errors for a file
+ * - `hover` – show documentation and type info
+ * - `rename_symbol` – rename across the project
+ * - `edit_file` – apply text edits by line number
+ *
+ * @param workspacePath Absolute path to the project root / worktree
+ * @returns Record of MCP server configs keyed as `lsp-<language>`
+ */
+export function buildLspMcpConfig(
+	workspacePath: string,
+): Record<string, McpServerConfig> {
+	const languages = detectLanguages(workspacePath);
+	const config: Record<string, McpServerConfig> = {};
+
+	for (const language of languages) {
+		const langConfig = SUPPORTED_LANGUAGES[language];
+		if (!langConfig) continue;
+
+		const args = ["--workspace", workspacePath, "--lsp", langConfig.lspCommand];
+
+		// Append language-server-specific arguments after the `--` separator
+		if (langConfig.lspArgs && langConfig.lspArgs.length > 0) {
+			args.push("--", ...langConfig.lspArgs);
+		}
+
+		config[`lsp-${language}`] = {
+			command: "mcp-language-server",
+			args,
+		};
+	}
+
+	return config;
+}

--- a/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
+++ b/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
@@ -1,9 +1,37 @@
 import type { McpServerConfig } from "cyrus-claude-runner";
 import {
 	detectLanguages,
+	isBinaryAvailable,
 	type LspLanguageConfig,
 	SUPPORTED_LANGUAGES,
 } from "./detectLanguages.js";
+
+/** Go module path for mcp-language-server, used with `go run`. */
+const MCP_LANGUAGE_SERVER_MODULE =
+	"github.com/isaacphi/mcp-language-server@latest";
+
+/**
+ * Resolve the command + prefix args needed to invoke `mcp-language-server`.
+ *
+ * 1. If the `mcp-language-server` binary is on PATH → use it directly.
+ * 2. Else if `go` is on PATH → use `go run <module>` (auto-downloads & caches).
+ * 3. Otherwise → return `null` (LSP MCP cannot be started).
+ */
+function resolveMcpLanguageServerCommand(): {
+	command: string;
+	prefixArgs: string[];
+} | null {
+	if (isBinaryAvailable("mcp-language-server")) {
+		return { command: "mcp-language-server", prefixArgs: [] };
+	}
+	if (isBinaryAvailable("go")) {
+		return {
+			command: "go",
+			prefixArgs: ["run", MCP_LANGUAGE_SERVER_MODULE],
+		};
+	}
+	return null;
+}
 
 /**
  * Build MCP server configurations for detected languages in a workspace.
@@ -17,6 +45,11 @@ import {
  * - `rename_symbol` – rename across the project
  * - `edit_file` – apply text edits by line number
  *
+ * The function checks binary availability before injecting configs:
+ * - Requires `mcp-language-server` on PATH, or `go` (for `go run` fallback)
+ * - Requires the language-specific LSP binary (e.g. `typescript-language-server`)
+ * - Skips languages whose LSP binary is not installed
+ *
  * @param workspacePath Absolute path to the project root / worktree
  * @returns Record of MCP server configs keyed as `lsp-<language>`
  */
@@ -25,13 +58,26 @@ export function buildLspMcpConfig(
 ): Record<string, McpServerConfig> {
 	if (!workspacePath) return {};
 
+	// Ensure mcp-language-server (or Go toolchain) is available
+	const resolved = resolveMcpLanguageServerCommand();
+	if (!resolved) return {};
+
 	const languages = detectLanguages(workspacePath);
 	const config: Record<string, McpServerConfig> = {};
 
 	for (const language of languages) {
 		const langConfig: LspLanguageConfig = SUPPORTED_LANGUAGES[language];
 
-		const args = ["--workspace", workspacePath, "--lsp", langConfig.lspCommand];
+		// Skip if the language server binary is not installed
+		if (!isBinaryAvailable(langConfig.lspCommand)) continue;
+
+		const args = [
+			...resolved.prefixArgs,
+			"--workspace",
+			workspacePath,
+			"--lsp",
+			langConfig.lspCommand,
+		];
 
 		// Append language-server-specific arguments after the `--` separator
 		if (langConfig.lspArgs && langConfig.lspArgs.length > 0) {
@@ -39,7 +85,7 @@ export function buildLspMcpConfig(
 		}
 
 		config[`lsp-${language}`] = {
-			command: "mcp-language-server",
+			command: resolved.command,
 			args,
 		};
 	}

--- a/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
+++ b/packages/edge-worker/src/lsp/buildLspMcpConfig.ts
@@ -1,5 +1,9 @@
 import type { McpServerConfig } from "cyrus-claude-runner";
-import { detectLanguages, SUPPORTED_LANGUAGES } from "./detectLanguages.js";
+import {
+	detectLanguages,
+	type LspLanguageConfig,
+	SUPPORTED_LANGUAGES,
+} from "./detectLanguages.js";
 
 /**
  * Build MCP server configurations for detected languages in a workspace.
@@ -19,12 +23,13 @@ import { detectLanguages, SUPPORTED_LANGUAGES } from "./detectLanguages.js";
 export function buildLspMcpConfig(
 	workspacePath: string,
 ): Record<string, McpServerConfig> {
+	if (!workspacePath) return {};
+
 	const languages = detectLanguages(workspacePath);
 	const config: Record<string, McpServerConfig> = {};
 
 	for (const language of languages) {
-		const langConfig = SUPPORTED_LANGUAGES[language];
-		if (!langConfig) continue;
+		const langConfig: LspLanguageConfig = SUPPORTED_LANGUAGES[language];
 
 		const args = ["--workspace", workspacePath, "--lsp", langConfig.lspCommand];
 

--- a/packages/edge-worker/src/lsp/detectLanguages.ts
+++ b/packages/edge-worker/src/lsp/detectLanguages.ts
@@ -15,7 +15,7 @@ export interface LspLanguageConfig {
 	markers: string[];
 }
 
-export const SUPPORTED_LANGUAGES: Record<string, LspLanguageConfig> = {
+export const SUPPORTED_LANGUAGES = {
 	typescript: {
 		lspCommand: "typescript-language-server",
 		lspArgs: ["--stdio"],
@@ -23,12 +23,10 @@ export const SUPPORTED_LANGUAGES: Record<string, LspLanguageConfig> = {
 	},
 	go: {
 		lspCommand: "gopls",
-		lspArgs: [],
 		markers: ["go.mod"],
 	},
 	rust: {
 		lspCommand: "rust-analyzer",
-		lspArgs: [],
 		markers: ["Cargo.toml"],
 	},
 	python: {
@@ -36,18 +34,27 @@ export const SUPPORTED_LANGUAGES: Record<string, LspLanguageConfig> = {
 		lspArgs: ["--stdio"],
 		markers: ["pyproject.toml", "setup.py", "requirements.txt"],
 	},
-};
+} satisfies Record<string, LspLanguageConfig>;
+
+export type SupportedLanguage = keyof typeof SUPPORTED_LANGUAGES;
 
 /**
  * Detect which languages are present in a workspace by checking for marker files.
  *
+ * Uses synchronous `existsSync` intentionally — the number of marker checks is
+ * small (≤ 8 for 4 languages) so the blocking cost is negligible. If the
+ * supported language set grows significantly, consider switching to async I/O.
+ *
  * Returns an array of language keys (e.g. `["typescript", "go"]`) that have at
  * least one marker file present in `workspacePath`.
  */
-export function detectLanguages(workspacePath: string): string[] {
-	const detected: string[] = [];
+export function detectLanguages(workspacePath: string): SupportedLanguage[] {
+	const detected: SupportedLanguage[] = [];
 
-	for (const [language, config] of Object.entries(SUPPORTED_LANGUAGES)) {
+	for (const language of Object.keys(
+		SUPPORTED_LANGUAGES,
+	) as SupportedLanguage[]) {
+		const config = SUPPORTED_LANGUAGES[language];
 		const hasMarker = config.markers.some((marker) =>
 			existsSync(join(workspacePath, marker)),
 		);

--- a/packages/edge-worker/src/lsp/detectLanguages.ts
+++ b/packages/edge-worker/src/lsp/detectLanguages.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -64,4 +65,20 @@ export function detectLanguages(workspacePath: string): SupportedLanguage[] {
 	}
 
 	return detected;
+}
+
+/**
+ * Check whether a binary is available on the system PATH.
+ *
+ * Uses `which` (macOS/Linux) to probe. Returns `true` if the binary resolves,
+ * `false` otherwise. The check is intentionally synchronous and fast — it only
+ * runs once per session startup and the result is used to gate MCP injection.
+ */
+export function isBinaryAvailable(name: string): boolean {
+	try {
+		execSync(`which ${name}`, { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/packages/edge-worker/src/lsp/detectLanguages.ts
+++ b/packages/edge-worker/src/lsp/detectLanguages.ts
@@ -1,0 +1,60 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Supported language server identifiers and their detection config.
+ *
+ * Each entry maps a human-readable language key to:
+ * - `lspCommand`: the language server binary invoked by mcp-language-server
+ * - `lspArgs`: extra arguments passed *after* `--` to the language server
+ * - `markers`: file/directory names whose presence in the workspace root signals the language
+ */
+export interface LspLanguageConfig {
+	lspCommand: string;
+	lspArgs?: string[];
+	markers: string[];
+}
+
+export const SUPPORTED_LANGUAGES: Record<string, LspLanguageConfig> = {
+	typescript: {
+		lspCommand: "typescript-language-server",
+		lspArgs: ["--stdio"],
+		markers: ["tsconfig.json", "tsconfig.base.json"],
+	},
+	go: {
+		lspCommand: "gopls",
+		lspArgs: [],
+		markers: ["go.mod"],
+	},
+	rust: {
+		lspCommand: "rust-analyzer",
+		lspArgs: [],
+		markers: ["Cargo.toml"],
+	},
+	python: {
+		lspCommand: "pyright-langserver",
+		lspArgs: ["--stdio"],
+		markers: ["pyproject.toml", "setup.py", "requirements.txt"],
+	},
+};
+
+/**
+ * Detect which languages are present in a workspace by checking for marker files.
+ *
+ * Returns an array of language keys (e.g. `["typescript", "go"]`) that have at
+ * least one marker file present in `workspacePath`.
+ */
+export function detectLanguages(workspacePath: string): string[] {
+	const detected: string[] = [];
+
+	for (const [language, config] of Object.entries(SUPPORTED_LANGUAGES)) {
+		const hasMarker = config.markers.some((marker) =>
+			existsSync(join(workspacePath, marker)),
+		);
+		if (hasMarker) {
+			detected.push(language);
+		}
+	}
+
+	return detected;
+}

--- a/packages/edge-worker/src/lsp/index.ts
+++ b/packages/edge-worker/src/lsp/index.ts
@@ -1,6 +1,7 @@
 export { buildLspMcpConfig } from "./buildLspMcpConfig.js";
 export {
 	detectLanguages,
+	isBinaryAvailable,
 	type LspLanguageConfig,
 	SUPPORTED_LANGUAGES,
 	type SupportedLanguage,

--- a/packages/edge-worker/src/lsp/index.ts
+++ b/packages/edge-worker/src/lsp/index.ts
@@ -3,4 +3,5 @@ export {
 	detectLanguages,
 	type LspLanguageConfig,
 	SUPPORTED_LANGUAGES,
+	type SupportedLanguage,
 } from "./detectLanguages.js";

--- a/packages/edge-worker/src/lsp/index.ts
+++ b/packages/edge-worker/src/lsp/index.ts
@@ -1,0 +1,6 @@
+export { buildLspMcpConfig } from "./buildLspMcpConfig.js";
+export {
+	detectLanguages,
+	type LspLanguageConfig,
+	SUPPORTED_LANGUAGES,
+} from "./detectLanguages.js";

--- a/packages/edge-worker/test/lsp.test.ts
+++ b/packages/edge-worker/test/lsp.test.ts
@@ -1,12 +1,33 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type MockInstance,
+	vi,
+} from "vitest";
 import { buildLspMcpConfig } from "../src/lsp/buildLspMcpConfig.js";
 import {
 	detectLanguages,
+	isBinaryAvailable,
 	SUPPORTED_LANGUAGES,
 } from "../src/lsp/detectLanguages.js";
+
+// Mock isBinaryAvailable so tests don't depend on host machine tooling
+vi.mock("../src/lsp/detectLanguages.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../src/lsp/detectLanguages.js")>();
+	return {
+		...actual,
+		isBinaryAvailable: vi.fn(actual.isBinaryAvailable),
+	};
+});
+
+const mockedIsBinaryAvailable = isBinaryAvailable as MockInstance;
 
 describe("LSP MCP integration", () => {
 	let workspacePath: string;
@@ -15,6 +36,7 @@ describe("LSP MCP integration", () => {
 		const uniqueId = Date.now() + Math.random().toString(36).substring(7);
 		workspacePath = join(tmpdir(), `test-workspace-lsp-${uniqueId}`);
 		mkdirSync(workspacePath, { recursive: true });
+		vi.restoreAllMocks();
 	});
 
 	afterEach(() => {
@@ -88,20 +110,47 @@ describe("LSP MCP integration", () => {
 		});
 	});
 
-	describe("buildLspMcpConfig", () => {
-		it("should return empty config for workspace with no languages", () => {
-			expect(buildLspMcpConfig(workspacePath)).toEqual({});
+	describe("isBinaryAvailable", () => {
+		it("should return true for a common binary", () => {
+			// Restore real implementation for this test
+			mockedIsBinaryAvailable.mockRestore();
+			expect(isBinaryAvailable("node")).toBe(true);
 		});
 
+		it("should return false for a non-existent binary", () => {
+			mockedIsBinaryAvailable.mockRestore();
+			expect(isBinaryAvailable("__nonexistent_binary_xyz__")).toBe(false);
+		});
+	});
+
+	describe("buildLspMcpConfig", () => {
 		it("should return empty config for empty workspace path", () => {
 			expect(buildLspMcpConfig("")).toEqual({});
 		});
 
-		it("should build TypeScript LSP config", () => {
-			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
-			const config = buildLspMcpConfig(workspacePath);
+		it("should return empty config for workspace with no languages", () => {
+			mockedIsBinaryAvailable.mockReturnValue(true);
+			expect(buildLspMcpConfig(workspacePath)).toEqual({});
+		});
 
-			expect(config).toHaveProperty("lsp-typescript");
+		it("should return empty config when neither mcp-language-server nor go is available", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			mockedIsBinaryAvailable.mockReturnValue(false);
+
+			expect(buildLspMcpConfig(workspacePath)).toEqual({});
+		});
+
+		it("should use mcp-language-server directly when available", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			// mcp-language-server: available, typescript-language-server: available
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return (
+					name === "mcp-language-server" ||
+					name === "typescript-language-server"
+				);
+			});
+
+			const config = buildLspMcpConfig(workspacePath);
 			expect(config["lsp-typescript"]).toEqual({
 				command: "mcp-language-server",
 				args: [
@@ -115,10 +164,37 @@ describe("LSP MCP integration", () => {
 			});
 		});
 
-		it("should build Go LSP config without extra args", () => {
+		it("should fall back to go run when mcp-language-server is not on PATH but go is", () => {
 			writeFileSync(join(workspacePath, "go.mod"), "module test");
-			const config = buildLspMcpConfig(workspacePath);
+			// mcp-language-server: NOT available, go: available, gopls: available
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return name === "go" || name === "gopls";
+			});
 
+			const config = buildLspMcpConfig(workspacePath);
+			expect(config["lsp-go"]).toEqual({
+				command: "go",
+				args: [
+					"run",
+					"github.com/isaacphi/mcp-language-server@latest",
+					"--workspace",
+					workspacePath,
+					"--lsp",
+					"gopls",
+				],
+			});
+		});
+
+		it("should skip languages whose LSP binary is not installed", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			writeFileSync(join(workspacePath, "go.mod"), "module test");
+			// mcp-language-server: available, gopls: available, typescript-language-server: NOT available
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return name === "mcp-language-server" || name === "gopls";
+			});
+
+			const config = buildLspMcpConfig(workspacePath);
+			expect(config).not.toHaveProperty("lsp-typescript");
 			expect(config).toHaveProperty("lsp-go");
 			expect(config["lsp-go"]).toEqual({
 				command: "mcp-language-server",
@@ -128,9 +204,11 @@ describe("LSP MCP integration", () => {
 
 		it("should build Rust LSP config without extra args", () => {
 			writeFileSync(join(workspacePath, "Cargo.toml"), "[package]");
-			const config = buildLspMcpConfig(workspacePath);
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return name === "mcp-language-server" || name === "rust-analyzer";
+			});
 
-			expect(config).toHaveProperty("lsp-rust");
+			const config = buildLspMcpConfig(workspacePath);
 			expect(config["lsp-rust"]).toEqual({
 				command: "mcp-language-server",
 				args: ["--workspace", workspacePath, "--lsp", "rust-analyzer"],
@@ -139,9 +217,11 @@ describe("LSP MCP integration", () => {
 
 		it("should build Python LSP config with --stdio", () => {
 			writeFileSync(join(workspacePath, "pyproject.toml"), "[project]");
-			const config = buildLspMcpConfig(workspacePath);
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return name === "mcp-language-server" || name === "pyright-langserver";
+			});
 
-			expect(config).toHaveProperty("lsp-python");
+			const config = buildLspMcpConfig(workspacePath);
 			expect(config["lsp-python"]).toEqual({
 				command: "mcp-language-server",
 				args: [
@@ -158,11 +238,24 @@ describe("LSP MCP integration", () => {
 		it("should build configs for multiple detected languages", () => {
 			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
 			writeFileSync(join(workspacePath, "go.mod"), "module test");
-			const config = buildLspMcpConfig(workspacePath);
+			mockedIsBinaryAvailable.mockReturnValue(true);
 
+			const config = buildLspMcpConfig(workspacePath);
 			expect(Object.keys(config)).toHaveLength(2);
 			expect(config).toHaveProperty("lsp-typescript");
 			expect(config).toHaveProperty("lsp-go");
+		});
+
+		it("should return empty config when all language servers are missing even if mcp binary exists", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			writeFileSync(join(workspacePath, "go.mod"), "module test");
+			// Only mcp-language-server is available, but no language servers
+			mockedIsBinaryAvailable.mockImplementation((name: string) => {
+				return name === "mcp-language-server";
+			});
+
+			const config = buildLspMcpConfig(workspacePath);
+			expect(config).toEqual({});
 		});
 	});
 

--- a/packages/edge-worker/test/lsp.test.ts
+++ b/packages/edge-worker/test/lsp.test.ts
@@ -1,0 +1,188 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildLspMcpConfig } from "../src/lsp/buildLspMcpConfig.js";
+import {
+	detectLanguages,
+	SUPPORTED_LANGUAGES,
+} from "../src/lsp/detectLanguages.js";
+
+describe("LSP MCP integration", () => {
+	let workspacePath: string;
+
+	beforeEach(() => {
+		const uniqueId = Date.now() + Math.random().toString(36).substring(7);
+		workspacePath = join(tmpdir(), `test-workspace-lsp-${uniqueId}`);
+		mkdirSync(workspacePath, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(workspacePath)) {
+			rmSync(workspacePath, { recursive: true, force: true });
+		}
+	});
+
+	describe("detectLanguages", () => {
+		it("should return empty array for workspace with no language markers", () => {
+			expect(detectLanguages(workspacePath)).toEqual([]);
+		});
+
+		it("should detect TypeScript from tsconfig.json", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			expect(detectLanguages(workspacePath)).toEqual(["typescript"]);
+		});
+
+		it("should detect TypeScript from tsconfig.base.json", () => {
+			writeFileSync(join(workspacePath, "tsconfig.base.json"), "{}");
+			expect(detectLanguages(workspacePath)).toEqual(["typescript"]);
+		});
+
+		it("should detect Go from go.mod", () => {
+			writeFileSync(join(workspacePath, "go.mod"), "module example.com/test");
+			expect(detectLanguages(workspacePath)).toEqual(["go"]);
+		});
+
+		it("should detect Rust from Cargo.toml", () => {
+			writeFileSync(
+				join(workspacePath, "Cargo.toml"),
+				'[package]\nname = "test"',
+			);
+			expect(detectLanguages(workspacePath)).toEqual(["rust"]);
+		});
+
+		it("should detect Python from pyproject.toml", () => {
+			writeFileSync(join(workspacePath, "pyproject.toml"), "[project]");
+			expect(detectLanguages(workspacePath)).toEqual(["python"]);
+		});
+
+		it("should detect Python from requirements.txt", () => {
+			writeFileSync(join(workspacePath, "requirements.txt"), "requests");
+			expect(detectLanguages(workspacePath)).toEqual(["python"]);
+		});
+
+		it("should detect Python from setup.py", () => {
+			writeFileSync(
+				join(workspacePath, "setup.py"),
+				"from setuptools import setup",
+			);
+			expect(detectLanguages(workspacePath)).toEqual(["python"]);
+		});
+
+		it("should detect multiple languages", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			writeFileSync(join(workspacePath, "go.mod"), "module test");
+			writeFileSync(join(workspacePath, "Cargo.toml"), "[package]");
+			const detected = detectLanguages(workspacePath);
+			expect(detected).toContain("typescript");
+			expect(detected).toContain("go");
+			expect(detected).toContain("rust");
+			expect(detected).toHaveLength(3);
+		});
+
+		it("should not duplicate language when multiple markers present", () => {
+			writeFileSync(join(workspacePath, "pyproject.toml"), "[project]");
+			writeFileSync(join(workspacePath, "requirements.txt"), "requests");
+			const detected = detectLanguages(workspacePath);
+			expect(detected).toEqual(["python"]);
+		});
+	});
+
+	describe("buildLspMcpConfig", () => {
+		it("should return empty config for workspace with no languages", () => {
+			expect(buildLspMcpConfig(workspacePath)).toEqual({});
+		});
+
+		it("should build TypeScript LSP config", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			const config = buildLspMcpConfig(workspacePath);
+
+			expect(config).toHaveProperty("lsp-typescript");
+			expect(config["lsp-typescript"]).toEqual({
+				command: "mcp-language-server",
+				args: [
+					"--workspace",
+					workspacePath,
+					"--lsp",
+					"typescript-language-server",
+					"--",
+					"--stdio",
+				],
+			});
+		});
+
+		it("should build Go LSP config without extra args", () => {
+			writeFileSync(join(workspacePath, "go.mod"), "module test");
+			const config = buildLspMcpConfig(workspacePath);
+
+			expect(config).toHaveProperty("lsp-go");
+			expect(config["lsp-go"]).toEqual({
+				command: "mcp-language-server",
+				args: ["--workspace", workspacePath, "--lsp", "gopls"],
+			});
+		});
+
+		it("should build Rust LSP config without extra args", () => {
+			writeFileSync(join(workspacePath, "Cargo.toml"), "[package]");
+			const config = buildLspMcpConfig(workspacePath);
+
+			expect(config).toHaveProperty("lsp-rust");
+			expect(config["lsp-rust"]).toEqual({
+				command: "mcp-language-server",
+				args: ["--workspace", workspacePath, "--lsp", "rust-analyzer"],
+			});
+		});
+
+		it("should build Python LSP config with --stdio", () => {
+			writeFileSync(join(workspacePath, "pyproject.toml"), "[project]");
+			const config = buildLspMcpConfig(workspacePath);
+
+			expect(config).toHaveProperty("lsp-python");
+			expect(config["lsp-python"]).toEqual({
+				command: "mcp-language-server",
+				args: [
+					"--workspace",
+					workspacePath,
+					"--lsp",
+					"pyright-langserver",
+					"--",
+					"--stdio",
+				],
+			});
+		});
+
+		it("should build configs for multiple detected languages", () => {
+			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
+			writeFileSync(join(workspacePath, "go.mod"), "module test");
+			const config = buildLspMcpConfig(workspacePath);
+
+			expect(Object.keys(config)).toHaveLength(2);
+			expect(config).toHaveProperty("lsp-typescript");
+			expect(config).toHaveProperty("lsp-go");
+		});
+	});
+
+	describe("SUPPORTED_LANGUAGES", () => {
+		it("should have entries for typescript, go, rust, and python", () => {
+			expect(Object.keys(SUPPORTED_LANGUAGES)).toEqual([
+				"typescript",
+				"go",
+				"rust",
+				"python",
+			]);
+		});
+
+		it("should have valid lspCommand for each language", () => {
+			for (const config of Object.values(SUPPORTED_LANGUAGES)) {
+				expect(config.lspCommand).toBeTruthy();
+				expect(typeof config.lspCommand).toBe("string");
+			}
+		});
+
+		it("should have at least one marker for each language", () => {
+			for (const config of Object.values(SUPPORTED_LANGUAGES)) {
+				expect(config.markers.length).toBeGreaterThan(0);
+			}
+		});
+	});
+});

--- a/packages/edge-worker/test/lsp.test.ts
+++ b/packages/edge-worker/test/lsp.test.ts
@@ -93,6 +93,10 @@ describe("LSP MCP integration", () => {
 			expect(buildLspMcpConfig(workspacePath)).toEqual({});
 		});
 
+		it("should return empty config for empty workspace path", () => {
+			expect(buildLspMcpConfig("")).toEqual({});
+		});
+
 		it("should build TypeScript LSP config", () => {
 			writeFileSync(join(workspacePath, "tsconfig.json"), "{}");
 			const config = buildLspMcpConfig(workspacePath);


### PR DESCRIPTION
Assignee: [payton](https://linear.app/ceedar/profiles/payton)

## Summary

Adds [`mcp-language-server`](https://github.com/isaacphi/mcp-language-server) as a first-party MCP integration for Cyrus agent sessions, similar to the existing Linear MCP. Agent sessions now automatically get language server tools (go-to-definition, find-references, diagnostics, hover, rename, edit-file) for detected project languages.

Resolves [CYPACK-894](https://linear.app/ceedar/issue/CYPACK-894).

## Implementation

- **Language detection** (`packages/edge-worker/src/lsp/detectLanguages.ts`): Scans workspace root for marker files to detect languages:
  - TypeScript: `tsconfig.json`, `tsconfig.base.json`
  - Go: `go.mod`
  - Rust: `Cargo.toml`
  - Python: `pyproject.toml`, `setup.py`, `requirements.txt`

- **Binary availability checks** (`isBinaryAvailable()`): Verifies both `mcp-language-server` and the language-specific LSP binary are on PATH before injecting configs. Three-tier resolution:
  1. `mcp-language-server` on PATH → use directly
  2. `go` on PATH → use `go run github.com/isaacphi/mcp-language-server@latest` (auto-downloads and caches)
  3. Neither available → skip LSP MCP entirely (graceful degradation)

- **MCP config builder** (`packages/edge-worker/src/lsp/buildLspMcpConfig.ts`): For each detected language with an available LSP binary, creates a stdio MCP server entry. Languages whose LSP binary is missing are silently skipped.

- **EdgeWorker integration**: Extended `buildMcpConfig()` with an optional `workspacePath` parameter. All three `buildAgentRunnerConfig` call sites (GitHub sessions, new sessions, resume sessions) now pass the workspace path, enabling automatic LSP injection.

## Testing

- 25 tests in `packages/edge-worker/test/lsp.test.ts` covering:
  - Language detection from individual and multiple marker files
  - No-duplicate detection when multiple markers for the same language exist
  - Binary availability checks (`isBinaryAvailable`)
  - Direct binary usage vs `go run` fallback
  - Graceful skipping when LSP binaries are missing
  - Empty workspace handling
  - `SUPPORTED_LANGUAGES` registry validation
- All 566 edge-worker tests passing
- Full monorepo typecheck passing
- Lint clean

## Prerequisites

For LSP tools to function at runtime:
- **`mcp-language-server`** binary on PATH (via `go install github.com/isaacphi/mcp-language-server@latest`), OR Go toolchain for automatic `go run` fallback
- **Language-specific LSP servers**: `typescript-language-server` (npm), `gopls` (Go), `rust-analyzer` (Rust), `pyright-langserver` (npm/pip)

If neither `mcp-language-server` nor `go` is available, the feature gracefully degrades — no LSP MCP servers are injected and existing functionality is unaffected.