### PR TITLE
Add support for dynamic Skills

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Added
+- Added dynamic skills system with `SkillLoader` (parses SKILL.md frontmatter from `~/.cyrus/skills/`), `SkillRouter` (5 routing strategies: always, label, team, repository, keyword, extensible via `registerStrategy()`), and `SkillInjector` (merges skill instructions into `appendSystemPrompt` and `allowedTools`). Integrated into `EdgeWorker.buildAgentRunnerConfig()` with skills loaded on startup and resolved per session. New types exported from `cyrus-core`: `SkillDefinition`, `SkillRoutingConfig`, `SkillRoutingContext`, `ISkillLoader`, `ISkillRouter`, `ISkillRoutingStrategy`. 41 new tests. ([CYPACK-896](https://linear.app/ceedar/issue/CYPACK-896), [#947](https://github.com/ceedaragents/cyrus/pull/947))
+
 ### Fixed
 - Added proper handling for `rate_limit_event` messages from Claude runners in `AgentSessionManager` with tiered logging (warn/info/debug by status), and silenced all unhandled informational message types (`rate_limit_event`, `stream_event`, `tool_progress`, `auth_status`, `tool_use_summary`, `prompt_suggestion`) in `ClaudeRunner.processMessage`. ([CYPACK-895](https://linear.app/ceedar/issue/CYPACK-895), [#946](https://github.com/ceedaragents/cyrus/pull/946))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Dynamic skills** - Skills can now be dynamically loaded from `~/.cyrus/skills/` and injected into agent sessions based on routing strategies (always, label, team, repository, keyword). Compatible with all runners (Claude, Codex, Cursor, Gemini). ([CYPACK-896](https://linear.app/ceedar/issue/CYPACK-896), [#947](https://github.com/ceedaragents/cyrus/pull/947))
+
 ### Fixed
 - **Rate limit event handling** - Rate limit events from Claude are now properly handled instead of producing "Unknown message type" warnings in logs. ([CYPACK-895](https://linear.app/ceedar/issue/CYPACK-895), [#946](https://github.com/ceedaragents/cyrus/pull/946))
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -201,6 +201,18 @@ export type {
 	ISimpleAgentRunner,
 	ISimpleAgentRunnerConfig,
 } from "./simple-agent-runner-types.js";
+
+// Dynamic Skills
+export type {
+	ISkillLoader,
+	ISkillRouter,
+	ISkillRoutingStrategy,
+	SkillDefinition,
+	SkillInjectionResult,
+	SkillRoutingConfig,
+	SkillRoutingContext,
+	SkillRoutingStrategy,
+} from "./skills/index.js";
 // Platform-agnostic webhook type aliases - exported from issue-tracker
 // These are now defined in issue-tracker/types.ts as aliases to Linear SDK webhook types
 // EdgeWorker and other high-level code should use these generic names via issue-tracker exports

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,0 +1,10 @@
+export type {
+	ISkillLoader,
+	ISkillRouter,
+	ISkillRoutingStrategy,
+	SkillDefinition,
+	SkillInjectionResult,
+	SkillRoutingConfig,
+	SkillRoutingContext,
+	SkillRoutingStrategy,
+} from "./types.js";

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Dynamic Skills System - Type Definitions
+ *
+ * Defines the interfaces for loading, routing, and injecting skills into
+ * agent runner configurations. Skills are loaded from SKILL.md files and
+ * dynamically applied to sessions based on routing strategies.
+ *
+ * Designed for cross-runner compatibility (Claude, Codex, Cursor, Gemini).
+ */
+
+/**
+ * Supported routing strategies for skill activation.
+ *
+ * - `always`: Skill is always loaded for every session
+ * - `label`: Skill is loaded when issue has matching labels
+ * - `team`: Skill is loaded for specific Linear teams
+ * - `repository`: Skill is loaded for specific repositories
+ * - `keyword`: Skill is loaded when issue content matches keywords
+ */
+export type SkillRoutingStrategy =
+	| "always"
+	| "label"
+	| "team"
+	| "repository"
+	| "keyword";
+
+/**
+ * Routing configuration parsed from SKILL.md frontmatter.
+ *
+ * Uses flat frontmatter keys for simplicity:
+ * - `routing`: strategy name
+ * - `routing-labels`: comma-separated labels (for label strategy)
+ * - `routing-teams`: comma-separated team keys (for team strategy)
+ * - `routing-repositories`: comma-separated repository IDs (for repository strategy)
+ * - `routing-keywords`: comma-separated keywords (for keyword strategy)
+ */
+export interface SkillRoutingConfig {
+	/** The routing strategy to use */
+	strategy: SkillRoutingStrategy;
+	/** Labels to match (for 'label' strategy) */
+	labels?: string[];
+	/** Team keys to match (for 'team' strategy) */
+	teams?: string[];
+	/** Repository IDs or names to match (for 'repository' strategy) */
+	repositories?: string[];
+	/** Keywords to match in issue content (for 'keyword' strategy) */
+	keywords?: string[];
+}
+
+/**
+ * A parsed skill definition loaded from a SKILL.md file.
+ */
+export interface SkillDefinition {
+	/** Unique skill name from frontmatter */
+	name: string;
+	/** Human-readable description from frontmatter */
+	description: string;
+	/** Tools required by this skill (from `allowed-tools` frontmatter) */
+	allowedTools?: string[];
+	/** Routing configuration (defaults to 'always' if not specified) */
+	routing: SkillRoutingConfig;
+	/** The markdown content after frontmatter (skill instructions) */
+	instructions: string;
+	/** Filesystem path where the skill was loaded from */
+	sourcePath: string;
+}
+
+/**
+ * Context provided to routing strategies for skill resolution.
+ * Contains session-level information used to determine which skills to activate.
+ */
+export interface SkillRoutingContext {
+	/** Labels attached to the issue */
+	labels?: string[];
+	/** Linear team key (e.g., "CYPACK") */
+	teamKey?: string;
+	/** Repository identifier */
+	repositoryId?: string;
+	/** Repository name */
+	repositoryName?: string;
+	/** Issue title for keyword matching */
+	issueTitle?: string;
+	/** Issue description for keyword matching */
+	issueDescription?: string;
+}
+
+/**
+ * Interface for loading skills from the filesystem.
+ * Single Responsibility: only handles filesystem I/O and parsing.
+ */
+export interface ISkillLoader {
+	/**
+	 * Load all skills from a directory.
+	 * Scans for SKILL.md files in immediate subdirectories.
+	 *
+	 * @param directory - Path to scan for skill directories
+	 * @returns Array of parsed skill definitions
+	 */
+	loadSkills(directory: string): Promise<SkillDefinition[]>;
+}
+
+/**
+ * Interface for a single routing strategy implementation.
+ * Open/Closed: new strategies can be added without modifying existing ones.
+ */
+export interface ISkillRoutingStrategy {
+	/** The strategy name this implementation handles */
+	readonly strategyName: SkillRoutingStrategy;
+
+	/**
+	 * Determine if a skill should be activated for the given context.
+	 *
+	 * @param skill - The skill to evaluate
+	 * @param context - The session context to match against
+	 * @returns true if the skill should be activated
+	 */
+	matches(skill: SkillDefinition, context: SkillRoutingContext): boolean;
+}
+
+/**
+ * Interface for resolving which skills to activate for a session.
+ * Dependency Inversion: depends on ISkillRoutingStrategy abstraction.
+ */
+export interface ISkillRouter {
+	/**
+	 * Resolve which skills should be active for the given context.
+	 *
+	 * @param skills - All available skills
+	 * @param context - The session context to match against
+	 * @returns Skills that should be activated
+	 */
+	resolveSkills(
+		skills: SkillDefinition[],
+		context: SkillRoutingContext,
+	): SkillDefinition[];
+}
+
+/**
+ * Result of injecting skills into a runner configuration.
+ */
+export interface SkillInjectionResult {
+	/** Skill instructions to append to the system prompt */
+	appendedPrompt: string;
+	/** Additional tools to add to allowedTools */
+	additionalTools: string[];
+	/** Names of skills that were injected */
+	injectedSkillNames: string[];
+}

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -37,6 +37,8 @@ import type {
 	SerializedCyrusAgentSession,
 	SerializedCyrusAgentSessionEntry,
 	SessionStartMessage,
+	SkillDefinition,
+	SkillRoutingContext,
 	StopSignalMessage,
 	UnassignMessage,
 	UserPromptMessage,
@@ -132,6 +134,7 @@ import { RunnerSelectionService } from "./RunnerSelectionService.js";
 import { SharedApplicationServer } from "./SharedApplicationServer.js";
 import { SlackChatAdapter } from "./SlackChatAdapter.js";
 import { LinearActivitySink } from "./sinks/LinearActivitySink.js";
+import { SkillInjector, SkillLoader, SkillRouter } from "./skills/index.js";
 import type { AgentSessionData, EdgeWorkerEvents } from "./types.js";
 import { UserAccessControl } from "./UserAccessControl.js";
 
@@ -199,6 +202,11 @@ export class EdgeWorker extends EventEmitter {
 	private activityPoster: ActivityPoster;
 	private configManager: ConfigManager;
 	private promptBuilder: PromptBuilder;
+	// Dynamic skills system
+	private skillLoader: SkillLoader;
+	private skillRouter: SkillRouter;
+	private skillInjector: SkillInjector;
+	private cachedSkills: SkillDefinition[] = [];
 	private readonly cyrusToolsMcpEndpoint = "/mcp/cyrus-tools";
 	private cyrusToolsMcpRegistered = false;
 	private cyrusToolsMcpContexts = new Map<string, CyrusToolsMcpContextEntry>();
@@ -292,6 +300,11 @@ export class EdgeWorker extends EventEmitter {
 		};
 		this.repositoryRouter = new RepositoryRouter(repositoryRouterDeps);
 		this.gitService = new GitService();
+
+		// Initialize dynamic skills system
+		this.skillLoader = new SkillLoader(this.logger);
+		this.skillRouter = new SkillRouter();
+		this.skillInjector = new SkillInjector();
 
 		// Initialize AskUserQuestion handler for elicitation via Linear select signal
 		this.askUserQuestionHandler = new AskUserQuestionHandler({
@@ -491,6 +504,9 @@ export class EdgeWorker extends EventEmitter {
 	async start(): Promise<void> {
 		// Load persisted state for each repository
 		await this.loadPersistedState();
+
+		// Load dynamic skills from ~/.cyrus/skills/
+		await this.loadDynamicSkills();
 
 		// Start config file watcher via ConfigManager
 		this.configManager.on(
@@ -5126,16 +5142,52 @@ ${input.userComment}
 			);
 		}
 
+		// Resolve dynamic skills for this session
+		const skillRoutingContext: SkillRoutingContext = {
+			labels,
+			teamKey: session.issue?.identifier?.split("-")[0],
+			repositoryId: repository.id,
+			repositoryName: repository.name,
+			issueTitle: session.issue?.title,
+			issueDescription: issueDescription,
+		};
+		const skillInjection = disallowAllTools
+			? {
+					appendedPrompt: "",
+					additionalTools: [] as string[],
+					injectedSkillNames: [] as string[],
+				}
+			: this.resolveSkillsForSession(skillRoutingContext);
+
+		if (skillInjection.injectedSkillNames.length > 0) {
+			log.info(
+				`Injected ${skillInjection.injectedSkillNames.length} dynamic skill(s): ${skillInjection.injectedSkillNames.join(", ")}`,
+			);
+		}
+
+		// Merge skill tools into allowed tools
+		const mergedAllowedTools =
+			skillInjection.additionalTools.length > 0
+				? [...new Set([...allowedTools, ...skillInjection.additionalTools])]
+				: allowedTools;
+
+		// Merge skill instructions into system prompt
+		const mergedSystemPrompt = skillInjection.appendedPrompt
+			? [systemPrompt || "", skillInjection.appendedPrompt]
+					.filter(Boolean)
+					.join("\n\n")
+			: systemPrompt || "";
+
 		const config = {
 			workingDirectory: session.workspace.path,
-			allowedTools,
+			allowedTools: mergedAllowedTools,
 			disallowedTools,
 			allowedDirectories,
 			workspaceName: session.issue?.identifier || session.issueId,
 			cyrusHome: this.cyrusHome,
 			mcpConfigPath,
 			mcpConfig,
-			appendSystemPrompt: systemPrompt || "",
+			appendSystemPrompt: mergedSystemPrompt,
 			// When disallowAllTools is true, remove all built-in tools from model context
 			// so Claude cannot see or attempt tool use (distinct from allowedTools which only controls permissions)
 			...(disallowAllTools && { tools: [] }),
@@ -5196,6 +5248,40 @@ ${input.userComment}
 		}
 
 		return { config, runnerType };
+	}
+
+	/**
+	 * Load dynamic skills from ~/.cyrus/skills/ directory.
+	 * Called during startup and can be called to reload skills.
+	 */
+	private async loadDynamicSkills(): Promise<void> {
+		const skillsDir = join(this.cyrusHome, "skills");
+		this.cachedSkills = await this.skillLoader.loadSkills(skillsDir);
+	}
+
+	/**
+	 * Resolve which dynamic skills should be active for a session.
+	 * Uses the SkillRouter to match skills against session context,
+	 * then uses the SkillInjector to build injection result.
+	 */
+	private resolveSkillsForSession(context: SkillRoutingContext): {
+		appendedPrompt: string;
+		additionalTools: string[];
+		injectedSkillNames: string[];
+	} {
+		if (this.cachedSkills.length === 0) {
+			return {
+				appendedPrompt: "",
+				additionalTools: [],
+				injectedSkillNames: [],
+			};
+		}
+
+		const resolvedSkills = this.skillRouter.resolveSkills(
+			this.cachedSkills,
+			context,
+		);
+		return this.skillInjector.buildInjection(resolvedSkills);
 	}
 
 	/**

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -36,6 +36,17 @@ export type {
 	IActivitySink,
 } from "./sinks/index.js";
 export { LinearActivitySink } from "./sinks/index.js";
+// Dynamic skills
+export {
+	AlwaysRoutingStrategy,
+	KeywordRoutingStrategy,
+	LabelRoutingStrategy,
+	RepositoryRoutingStrategy,
+	SkillInjector,
+	SkillLoader,
+	SkillRouter,
+	TeamRoutingStrategy,
+} from "./skills/index.js";
 export type { EdgeWorkerEvents } from "./types.js";
 // User access control
 export {

--- a/packages/edge-worker/src/skills/SkillInjector.ts
+++ b/packages/edge-worker/src/skills/SkillInjector.ts
@@ -1,0 +1,82 @@
+import type { SkillDefinition, SkillInjectionResult } from "cyrus-core";
+
+/**
+ * Injects resolved skills into agent runner configurations.
+ *
+ * Cross-runner compatible: uses appendSystemPrompt and allowedTools,
+ * which are supported by all runners (Claude, Codex, Cursor, Gemini).
+ *
+ * Single Responsibility: only handles merging skill content into runner config.
+ */
+export class SkillInjector {
+	/**
+	 * Build the injection result from resolved skills.
+	 *
+	 * @param skills - Skills to inject
+	 * @returns Prompt text and tools to merge into runner config
+	 */
+	buildInjection(skills: SkillDefinition[]): SkillInjectionResult {
+		if (skills.length === 0) {
+			return {
+				appendedPrompt: "",
+				additionalTools: [],
+				injectedSkillNames: [],
+			};
+		}
+
+		const promptSections: string[] = [];
+		const allTools = new Set<string>();
+		const skillNames: string[] = [];
+
+		for (const skill of skills) {
+			skillNames.push(skill.name);
+
+			// Collect allowed tools
+			if (skill.allowedTools) {
+				for (const tool of skill.allowedTools) {
+					allTools.add(tool);
+				}
+			}
+
+			// Build skill prompt section
+			promptSections.push(this.formatSkillPrompt(skill));
+		}
+
+		const appendedPrompt = [
+			"<dynamic_skills>",
+			`The following ${skills.length} skill(s) have been dynamically loaded for this session:`,
+			"",
+			promptSections.join("\n\n"),
+			"</dynamic_skills>",
+		].join("\n");
+
+		return {
+			appendedPrompt,
+			additionalTools: [...allTools],
+			injectedSkillNames: skillNames,
+		};
+	}
+
+	/**
+	 * Format a single skill as a prompt section.
+	 */
+	private formatSkillPrompt(skill: SkillDefinition): string {
+		const parts: string[] = [];
+
+		parts.push(`<skill name="${skill.name}">`);
+
+		if (skill.description) {
+			parts.push(`<description>${skill.description}</description>`);
+		}
+
+		if (skill.instructions) {
+			parts.push(`<instructions>`);
+			parts.push(skill.instructions);
+			parts.push(`</instructions>`);
+		}
+
+		parts.push(`</skill>`);
+
+		return parts.join("\n");
+	}
+}

--- a/packages/edge-worker/src/skills/SkillLoader.ts
+++ b/packages/edge-worker/src/skills/SkillLoader.ts
@@ -1,0 +1,210 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import type {
+	ILogger,
+	ISkillLoader,
+	SkillDefinition,
+	SkillRoutingConfig,
+	SkillRoutingStrategy,
+} from "cyrus-core";
+
+const SKILL_FILENAME = "SKILL.md";
+
+const VALID_STRATEGIES: Set<string> = new Set([
+	"always",
+	"label",
+	"team",
+	"repository",
+	"keyword",
+]);
+
+/**
+ * Loads skill definitions from SKILL.md files in a directory.
+ *
+ * Expected directory structure:
+ * ```
+ * ~/.cyrus/skills/
+ * ├── google/SKILL.md
+ * ├── security-review/SKILL.md
+ * └── deployment/SKILL.md
+ * ```
+ *
+ * Each SKILL.md uses YAML-like frontmatter:
+ * ```
+ * ---
+ * name: google
+ * description: Search the web
+ * allowed-tools: WebSearch, WebFetch
+ * routing: always
+ * ---
+ * # Instructions...
+ * ```
+ */
+export class SkillLoader implements ISkillLoader {
+	private logger: ILogger;
+
+	constructor(logger: ILogger) {
+		this.logger = logger;
+	}
+
+	async loadSkills(directory: string): Promise<SkillDefinition[]> {
+		const skills: SkillDefinition[] = [];
+
+		let entries: string[];
+		try {
+			entries = await readdir(directory);
+		} catch {
+			this.logger.debug(`Skills directory not found: ${directory}`);
+			return [];
+		}
+
+		for (const entry of entries) {
+			const skillDir = join(directory, entry);
+
+			try {
+				const stats = await stat(skillDir);
+				if (!stats.isDirectory()) continue;
+			} catch {
+				continue;
+			}
+
+			const skillPath = join(skillDir, SKILL_FILENAME);
+
+			try {
+				const content = await readFile(skillPath, "utf-8");
+				const skill = this.parseSkillFile(content, skillPath);
+				if (skill) {
+					skills.push(skill);
+					this.logger.debug(
+						`Loaded skill: ${skill.name} (strategy: ${skill.routing.strategy}) from ${skillPath}`,
+					);
+				}
+			} catch {}
+		}
+
+		this.logger.info(`Loaded ${skills.length} skill(s) from ${directory}`);
+		return skills;
+	}
+
+	/**
+	 * Parse a SKILL.md file into a SkillDefinition.
+	 * Handles frontmatter extraction and field parsing.
+	 */
+	parseSkillFile(content: string, sourcePath: string): SkillDefinition | null {
+		const { frontmatter, body } = this.extractFrontmatter(content);
+		if (!frontmatter) {
+			this.logger.warn(`No frontmatter found in ${sourcePath}`);
+			return null;
+		}
+
+		const fields = this.parseFrontmatter(frontmatter);
+
+		const name = fields.get("name");
+		if (!name) {
+			this.logger.warn(`Missing 'name' in frontmatter: ${sourcePath}`);
+			return null;
+		}
+
+		const description = fields.get("description") || "";
+
+		const allowedToolsRaw = fields.get("allowed-tools");
+		const allowedTools = allowedToolsRaw
+			? this.parseCommaSeparated(allowedToolsRaw)
+			: undefined;
+
+		const routing = this.parseRoutingConfig(fields);
+
+		return {
+			name,
+			description,
+			allowedTools,
+			routing,
+			instructions: body.trim(),
+			sourcePath,
+		};
+	}
+
+	/**
+	 * Extract frontmatter block and body from a SKILL.md file.
+	 */
+	private extractFrontmatter(content: string): {
+		frontmatter: string | null;
+		body: string;
+	} {
+		const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+		if (!match) {
+			return { frontmatter: null, body: content };
+		}
+		return { frontmatter: match[1] || "", body: match[2] || "" };
+	}
+
+	/**
+	 * Parse frontmatter into key-value pairs.
+	 * Handles simple `key: value` lines.
+	 */
+	private parseFrontmatter(raw: string): Map<string, string> {
+		const fields = new Map<string, string>();
+
+		for (const line of raw.split("\n")) {
+			const trimmed = line.trim();
+			if (!trimmed || trimmed.startsWith("#")) continue;
+
+			const colonIndex = trimmed.indexOf(":");
+			if (colonIndex === -1) continue;
+
+			const key = trimmed.slice(0, colonIndex).trim().toLowerCase();
+			const value = trimmed.slice(colonIndex + 1).trim();
+			if (key) {
+				fields.set(key, value);
+			}
+		}
+
+		return fields;
+	}
+
+	/**
+	 * Parse routing configuration from frontmatter fields.
+	 * Defaults to 'always' strategy if no routing is specified.
+	 */
+	private parseRoutingConfig(fields: Map<string, string>): SkillRoutingConfig {
+		const strategyRaw = fields.get("routing") || "always";
+		const strategy: SkillRoutingStrategy = VALID_STRATEGIES.has(strategyRaw)
+			? (strategyRaw as SkillRoutingStrategy)
+			: "always";
+
+		const config: SkillRoutingConfig = { strategy };
+
+		const labels = fields.get("routing-labels");
+		if (labels) {
+			config.labels = this.parseCommaSeparated(labels);
+		}
+
+		const teams = fields.get("routing-teams");
+		if (teams) {
+			config.teams = this.parseCommaSeparated(teams);
+		}
+
+		const repositories = fields.get("routing-repositories");
+		if (repositories) {
+			config.repositories = this.parseCommaSeparated(repositories);
+		}
+
+		const keywords = fields.get("routing-keywords");
+		if (keywords) {
+			config.keywords = this.parseCommaSeparated(keywords);
+		}
+
+		return config;
+	}
+
+	/**
+	 * Parse a comma-separated string into trimmed, non-empty values.
+	 */
+	private parseCommaSeparated(value: string): string[] {
+		return value
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
+	}
+}

--- a/packages/edge-worker/src/skills/SkillRouter.ts
+++ b/packages/edge-worker/src/skills/SkillRouter.ts
@@ -1,0 +1,149 @@
+import type {
+	ISkillRouter,
+	ISkillRoutingStrategy,
+	SkillDefinition,
+	SkillRoutingContext,
+} from "cyrus-core";
+
+/**
+ * Always strategy - skill is loaded for every session.
+ */
+export class AlwaysRoutingStrategy implements ISkillRoutingStrategy {
+	readonly strategyName = "always" as const;
+
+	matches(): boolean {
+		return true;
+	}
+}
+
+/**
+ * Label strategy - skill is loaded when issue has any matching label.
+ * Case-insensitive matching.
+ */
+export class LabelRoutingStrategy implements ISkillRoutingStrategy {
+	readonly strategyName = "label" as const;
+
+	matches(skill: SkillDefinition, context: SkillRoutingContext): boolean {
+		const requiredLabels = skill.routing.labels;
+		if (!requiredLabels || requiredLabels.length === 0) return false;
+
+		const issueLabels = context.labels?.map((l) => l.toLowerCase()) || [];
+		return requiredLabels.some((label) =>
+			issueLabels.includes(label.toLowerCase()),
+		);
+	}
+}
+
+/**
+ * Team strategy - skill is loaded for specific Linear teams.
+ * Case-insensitive matching.
+ */
+export class TeamRoutingStrategy implements ISkillRoutingStrategy {
+	readonly strategyName = "team" as const;
+
+	matches(skill: SkillDefinition, context: SkillRoutingContext): boolean {
+		const requiredTeams = skill.routing.teams;
+		if (!requiredTeams || requiredTeams.length === 0) return false;
+		if (!context.teamKey) return false;
+
+		return requiredTeams.some(
+			(team) => team.toLowerCase() === context.teamKey!.toLowerCase(),
+		);
+	}
+}
+
+/**
+ * Repository strategy - skill is loaded for specific repositories.
+ * Matches against repository ID or name, case-insensitive.
+ */
+export class RepositoryRoutingStrategy implements ISkillRoutingStrategy {
+	readonly strategyName = "repository" as const;
+
+	matches(skill: SkillDefinition, context: SkillRoutingContext): boolean {
+		const requiredRepos = skill.routing.repositories;
+		if (!requiredRepos || requiredRepos.length === 0) return false;
+
+		const repoId = context.repositoryId?.toLowerCase();
+		const repoName = context.repositoryName?.toLowerCase();
+
+		return requiredRepos.some((repo) => {
+			const lower = repo.toLowerCase();
+			return lower === repoId || lower === repoName;
+		});
+	}
+}
+
+/**
+ * Keyword strategy - skill is loaded when issue title or description
+ * contains any matching keyword. Case-insensitive.
+ */
+export class KeywordRoutingStrategy implements ISkillRoutingStrategy {
+	readonly strategyName = "keyword" as const;
+
+	matches(skill: SkillDefinition, context: SkillRoutingContext): boolean {
+		const keywords = skill.routing.keywords;
+		if (!keywords || keywords.length === 0) return false;
+
+		const searchText = [
+			context.issueTitle || "",
+			context.issueDescription || "",
+		]
+			.join(" ")
+			.toLowerCase();
+
+		return keywords.some((keyword) =>
+			searchText.includes(keyword.toLowerCase()),
+		);
+	}
+}
+
+/**
+ * Routes skills to sessions based on their routing strategy.
+ *
+ * Follows Open/Closed Principle: new strategies are added by registering
+ * new ISkillRoutingStrategy implementations, not by modifying this class.
+ *
+ * Follows Dependency Inversion: depends on ISkillRoutingStrategy abstraction.
+ */
+export class SkillRouter implements ISkillRouter {
+	private strategies: Map<string, ISkillRoutingStrategy>;
+
+	constructor(strategies?: ISkillRoutingStrategy[]) {
+		this.strategies = new Map();
+
+		// Register default strategies
+		const defaults: ISkillRoutingStrategy[] = strategies || [
+			new AlwaysRoutingStrategy(),
+			new LabelRoutingStrategy(),
+			new TeamRoutingStrategy(),
+			new RepositoryRoutingStrategy(),
+			new KeywordRoutingStrategy(),
+		];
+
+		for (const strategy of defaults) {
+			this.strategies.set(strategy.strategyName, strategy);
+		}
+	}
+
+	/**
+	 * Register a new routing strategy.
+	 * Enables extension without modification (Open/Closed).
+	 */
+	registerStrategy(strategy: ISkillRoutingStrategy): void {
+		this.strategies.set(strategy.strategyName, strategy);
+	}
+
+	resolveSkills(
+		skills: SkillDefinition[],
+		context: SkillRoutingContext,
+	): SkillDefinition[] {
+		return skills.filter((skill) => {
+			const strategy = this.strategies.get(skill.routing.strategy);
+			if (!strategy) {
+				// Unknown strategy - skip the skill
+				return false;
+			}
+			return strategy.matches(skill, context);
+		});
+	}
+}

--- a/packages/edge-worker/src/skills/index.ts
+++ b/packages/edge-worker/src/skills/index.ts
@@ -1,0 +1,10 @@
+export { SkillInjector } from "./SkillInjector.js";
+export { SkillLoader } from "./SkillLoader.js";
+export {
+	AlwaysRoutingStrategy,
+	KeywordRoutingStrategy,
+	LabelRoutingStrategy,
+	RepositoryRoutingStrategy,
+	SkillRouter,
+	TeamRoutingStrategy,
+} from "./SkillRouter.js";

--- a/packages/edge-worker/test/skills/SkillInjector.test.ts
+++ b/packages/edge-worker/test/skills/SkillInjector.test.ts
@@ -1,0 +1,122 @@
+import type { SkillDefinition } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import { SkillInjector } from "../../src/skills/SkillInjector.js";
+
+function makeSkill(
+	overrides: Partial<SkillDefinition> & { name: string },
+): SkillDefinition {
+	return {
+		description: "",
+		instructions: "",
+		sourcePath: "/test/SKILL.md",
+		routing: { strategy: "always" },
+		allowedTools: undefined,
+		...overrides,
+	};
+}
+
+describe("SkillInjector", () => {
+	const injector = new SkillInjector();
+
+	it("returns empty result for no skills", () => {
+		const result = injector.buildInjection([]);
+
+		expect(result.appendedPrompt).toBe("");
+		expect(result.additionalTools).toHaveLength(0);
+		expect(result.injectedSkillNames).toHaveLength(0);
+	});
+
+	it("builds prompt section for a single skill", () => {
+		const skill = makeSkill({
+			name: "google",
+			description: "Search the web.",
+			instructions: "Use WebSearch to find results.",
+		});
+
+		const result = injector.buildInjection([skill]);
+
+		expect(result.injectedSkillNames).toEqual(["google"]);
+		expect(result.appendedPrompt).toContain("<dynamic_skills>");
+		expect(result.appendedPrompt).toContain("</dynamic_skills>");
+		expect(result.appendedPrompt).toContain('<skill name="google">');
+		expect(result.appendedPrompt).toContain(
+			"<description>Search the web.</description>",
+		);
+		expect(result.appendedPrompt).toContain("Use WebSearch to find results.");
+	});
+
+	it("collects allowed tools from multiple skills", () => {
+		const skill1 = makeSkill({
+			name: "google",
+			allowedTools: ["WebSearch", "WebFetch"],
+		});
+		const skill2 = makeSkill({
+			name: "code-review",
+			allowedTools: ["Read", "Grep", "WebFetch"], // WebFetch duplicated
+		});
+
+		const result = injector.buildInjection([skill1, skill2]);
+
+		expect(result.additionalTools).toContain("WebSearch");
+		expect(result.additionalTools).toContain("WebFetch");
+		expect(result.additionalTools).toContain("Read");
+		expect(result.additionalTools).toContain("Grep");
+		// No duplicates
+		expect(result.additionalTools.filter((t) => t === "WebFetch")).toHaveLength(
+			1,
+		);
+	});
+
+	it("handles skills without allowed tools", () => {
+		const skill = makeSkill({
+			name: "summary",
+			instructions: "Summarize the issue.",
+		});
+
+		const result = injector.buildInjection([skill]);
+
+		expect(result.additionalTools).toHaveLength(0);
+	});
+
+	it("handles skills without instructions", () => {
+		const skill = makeSkill({
+			name: "minimal",
+			description: "Minimal skill.",
+			instructions: "",
+		});
+
+		const result = injector.buildInjection([skill]);
+
+		expect(result.appendedPrompt).toContain('<skill name="minimal">');
+		expect(result.appendedPrompt).toContain(
+			"<description>Minimal skill.</description>",
+		);
+		expect(result.appendedPrompt).not.toContain("<instructions>");
+	});
+
+	it("builds injection for multiple skills", () => {
+		const skills = [
+			makeSkill({
+				name: "skill-a",
+				description: "Skill A",
+				instructions: "Do A.",
+				allowedTools: ["ToolA"],
+			}),
+			makeSkill({
+				name: "skill-b",
+				description: "Skill B",
+				instructions: "Do B.",
+				allowedTools: ["ToolB"],
+			}),
+		];
+
+		const result = injector.buildInjection(skills);
+
+		expect(result.injectedSkillNames).toEqual(["skill-a", "skill-b"]);
+		expect(result.additionalTools).toContain("ToolA");
+		expect(result.additionalTools).toContain("ToolB");
+		expect(result.appendedPrompt).toContain("2 skill(s)");
+		expect(result.appendedPrompt).toContain('<skill name="skill-a">');
+		expect(result.appendedPrompt).toContain('<skill name="skill-b">');
+	});
+});

--- a/packages/edge-worker/test/skills/SkillLoader.test.ts
+++ b/packages/edge-worker/test/skills/SkillLoader.test.ts
@@ -1,0 +1,287 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SkillLoader } from "../../src/skills/SkillLoader.js";
+
+const createMockLogger = () => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	withContext: vi.fn().mockReturnThis(),
+	getLevel: vi.fn().mockReturnValue(0),
+	setLevel: vi.fn(),
+});
+
+describe("SkillLoader", () => {
+	let loader: SkillLoader;
+	let testDir: string;
+	let logger: ReturnType<typeof createMockLogger>;
+
+	beforeEach(async () => {
+		logger = createMockLogger();
+		loader = new SkillLoader(logger);
+		testDir = join(tmpdir(), `skill-loader-test-${Date.now()}`);
+		await mkdir(testDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it("loads a skill with basic frontmatter", async () => {
+		const skillDir = join(testDir, "google");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: google
+description: Search the web for information.
+allowed-tools: WebSearch, WebFetch
+---
+# Google
+
+Search the web for information.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]).toMatchObject({
+			name: "google",
+			description: "Search the web for information.",
+			allowedTools: ["WebSearch", "WebFetch"],
+			routing: { strategy: "always" },
+			instructions: expect.stringContaining("# Google"),
+		});
+	});
+
+	it("loads a skill with routing configuration", async () => {
+		const skillDir = join(testDir, "security");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: security-review
+description: Security code review skill.
+allowed-tools: Read, Grep, Glob
+routing: label
+routing-labels: security, review, audit
+---
+# Security Review
+
+Review code for security issues.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]).toMatchObject({
+			name: "security-review",
+			description: "Security code review skill.",
+			allowedTools: ["Read", "Grep", "Glob"],
+			routing: {
+				strategy: "label",
+				labels: ["security", "review", "audit"],
+			},
+		});
+	});
+
+	it("loads multiple skills from directory", async () => {
+		// Skill 1
+		const skill1Dir = join(testDir, "google");
+		await mkdir(skill1Dir, { recursive: true });
+		await writeFile(
+			join(skill1Dir, "SKILL.md"),
+			`---
+name: google
+description: Web search.
+---
+Search the web.
+`,
+		);
+
+		// Skill 2
+		const skill2Dir = join(testDir, "deploy");
+		await mkdir(skill2Dir, { recursive: true });
+		await writeFile(
+			join(skill2Dir, "SKILL.md"),
+			`---
+name: deploy
+description: Deployment skill.
+routing: team
+routing-teams: CYPACK, CYHOST
+---
+Deploy to production.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(2);
+		const names = skills.map((s) => s.name).sort();
+		expect(names).toEqual(["deploy", "google"]);
+	});
+
+	it("skips directories without SKILL.md", async () => {
+		const emptyDir = join(testDir, "no-skill-here");
+		await mkdir(emptyDir, { recursive: true });
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(0);
+	});
+
+	it("returns empty array for non-existent directory", async () => {
+		const skills = await loader.loadSkills("/non/existent/path");
+
+		expect(skills).toHaveLength(0);
+		expect(logger.debug).toHaveBeenCalledWith(
+			expect.stringContaining("not found"),
+		);
+	});
+
+	it("skips skills without name in frontmatter", async () => {
+		const skillDir = join(testDir, "bad-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+description: No name field
+---
+Missing name.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(0);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("Missing 'name'"),
+		);
+	});
+
+	it("skips files without frontmatter", async () => {
+		const skillDir = join(testDir, "no-frontmatter");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`# Just a regular markdown file
+No frontmatter here.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(0);
+	});
+
+	it("defaults to 'always' strategy for unknown routing value", async () => {
+		const skillDir = join(testDir, "bad-routing");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: test
+description: Test skill.
+routing: unknown_strategy
+---
+Test.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.routing.strategy).toBe("always");
+	});
+
+	it("parses keyword routing strategy", async () => {
+		const skillDir = join(testDir, "keyword-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: perf
+description: Performance optimization.
+routing: keyword
+routing-keywords: performance, optimization, speed
+---
+Optimize performance.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]).toMatchObject({
+			routing: {
+				strategy: "keyword",
+				keywords: ["performance", "optimization", "speed"],
+			},
+		});
+	});
+
+	it("parses repository routing strategy", async () => {
+		const skillDir = join(testDir, "repo-skill");
+		await mkdir(skillDir, { recursive: true });
+		await writeFile(
+			join(skillDir, "SKILL.md"),
+			`---
+name: repo-specific
+description: Only for specific repos.
+routing: repository
+routing-repositories: cyrus, cyrus-hosted
+---
+Repo-specific instructions.
+`,
+		);
+
+		const skills = await loader.loadSkills(testDir);
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0]).toMatchObject({
+			routing: {
+				strategy: "repository",
+				repositories: ["cyrus", "cyrus-hosted"],
+			},
+		});
+	});
+
+	describe("parseSkillFile", () => {
+		it("handles empty instructions body", () => {
+			const result = loader.parseSkillFile(
+				`---
+name: minimal
+description: Minimal skill.
+---
+`,
+				"/test/SKILL.md",
+			);
+
+			expect(result).toMatchObject({
+				name: "minimal",
+				description: "Minimal skill.",
+				instructions: "",
+			});
+		});
+
+		it("preserves sourcePath", () => {
+			const path = "/home/user/.cyrus/skills/test/SKILL.md";
+			const result = loader.parseSkillFile(
+				`---
+name: test
+description: Test.
+---
+Content.
+`,
+				path,
+			);
+
+			expect(result?.sourcePath).toBe(path);
+		});
+	});
+});

--- a/packages/edge-worker/test/skills/SkillRouter.test.ts
+++ b/packages/edge-worker/test/skills/SkillRouter.test.ts
@@ -1,0 +1,323 @@
+import type { SkillDefinition, SkillRoutingContext } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	AlwaysRoutingStrategy,
+	KeywordRoutingStrategy,
+	LabelRoutingStrategy,
+	RepositoryRoutingStrategy,
+	SkillRouter,
+	TeamRoutingStrategy,
+} from "../../src/skills/SkillRouter.js";
+
+function makeSkill(
+	overrides: Partial<SkillDefinition> & { name: string },
+): SkillDefinition {
+	return {
+		description: "",
+		instructions: "",
+		sourcePath: "/test/SKILL.md",
+		routing: { strategy: "always" },
+		allowedTools: undefined,
+		...overrides,
+	};
+}
+
+describe("SkillRouter", () => {
+	describe("AlwaysRoutingStrategy", () => {
+		it("always matches", () => {
+			const strategy = new AlwaysRoutingStrategy();
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "always" },
+			});
+
+			expect(strategy.matches(skill, {})).toBe(true);
+			expect(strategy.matches(skill, { labels: ["bug"] })).toBe(true);
+		});
+	});
+
+	describe("LabelRoutingStrategy", () => {
+		const strategy = new LabelRoutingStrategy();
+
+		it("matches when issue has a matching label", () => {
+			const skill = makeSkill({
+				name: "security",
+				routing: { strategy: "label", labels: ["security", "audit"] },
+			});
+
+			expect(strategy.matches(skill, { labels: ["security", "bug"] })).toBe(
+				true,
+			);
+		});
+
+		it("does not match when no labels overlap", () => {
+			const skill = makeSkill({
+				name: "security",
+				routing: { strategy: "label", labels: ["security", "audit"] },
+			});
+
+			expect(strategy.matches(skill, { labels: ["bug", "feature"] })).toBe(
+				false,
+			);
+		});
+
+		it("matches case-insensitively", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "label", labels: ["Security"] },
+			});
+
+			expect(strategy.matches(skill, { labels: ["SECURITY"] })).toBe(true);
+		});
+
+		it("does not match when context has no labels", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "label", labels: ["security"] },
+			});
+
+			expect(strategy.matches(skill, {})).toBe(false);
+			expect(strategy.matches(skill, { labels: [] })).toBe(false);
+		});
+
+		it("does not match when skill has no routing labels", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "label" },
+			});
+
+			expect(strategy.matches(skill, { labels: ["security"] })).toBe(false);
+		});
+	});
+
+	describe("TeamRoutingStrategy", () => {
+		const strategy = new TeamRoutingStrategy();
+
+		it("matches when team key matches", () => {
+			const skill = makeSkill({
+				name: "team-skill",
+				routing: { strategy: "team", teams: ["CYPACK", "CYHOST"] },
+			});
+
+			expect(strategy.matches(skill, { teamKey: "CYPACK" })).toBe(true);
+		});
+
+		it("matches case-insensitively", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "team", teams: ["cypack"] },
+			});
+
+			expect(strategy.matches(skill, { teamKey: "CYPACK" })).toBe(true);
+		});
+
+		it("does not match different team", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "team", teams: ["CYPACK"] },
+			});
+
+			expect(strategy.matches(skill, { teamKey: "OTHER" })).toBe(false);
+		});
+
+		it("does not match when no team in context", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "team", teams: ["CYPACK"] },
+			});
+
+			expect(strategy.matches(skill, {})).toBe(false);
+		});
+	});
+
+	describe("RepositoryRoutingStrategy", () => {
+		const strategy = new RepositoryRoutingStrategy();
+
+		it("matches by repository ID", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "repository", repositories: ["repo-1"] },
+			});
+
+			expect(strategy.matches(skill, { repositoryId: "repo-1" })).toBe(true);
+		});
+
+		it("matches by repository name", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "repository", repositories: ["cyrus"] },
+			});
+
+			expect(strategy.matches(skill, { repositoryName: "cyrus" })).toBe(true);
+		});
+
+		it("matches case-insensitively", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "repository", repositories: ["Cyrus"] },
+			});
+
+			expect(strategy.matches(skill, { repositoryName: "CYRUS" })).toBe(true);
+		});
+
+		it("does not match different repository", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "repository", repositories: ["other"] },
+			});
+
+			expect(
+				strategy.matches(skill, {
+					repositoryId: "repo-1",
+					repositoryName: "cyrus",
+				}),
+			).toBe(false);
+		});
+	});
+
+	describe("KeywordRoutingStrategy", () => {
+		const strategy = new KeywordRoutingStrategy();
+
+		it("matches keyword in issue title", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "keyword", keywords: ["performance"] },
+			});
+
+			expect(
+				strategy.matches(skill, {
+					issueTitle: "Improve performance of API",
+				}),
+			).toBe(true);
+		});
+
+		it("matches keyword in issue description", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "keyword", keywords: ["optimization"] },
+			});
+
+			expect(
+				strategy.matches(skill, {
+					issueDescription: "We need to do some optimization here.",
+				}),
+			).toBe(true);
+		});
+
+		it("matches case-insensitively", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "keyword", keywords: ["Performance"] },
+			});
+
+			expect(
+				strategy.matches(skill, {
+					issueTitle: "PERFORMANCE ISSUE",
+				}),
+			).toBe(true);
+		});
+
+		it("does not match when no keywords found", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "keyword", keywords: ["security"] },
+			});
+
+			expect(
+				strategy.matches(skill, {
+					issueTitle: "Add new feature",
+					issueDescription: "Build login page",
+				}),
+			).toBe(false);
+		});
+
+		it("does not match when no content in context", () => {
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "keyword", keywords: ["test"] },
+			});
+
+			expect(strategy.matches(skill, {})).toBe(false);
+		});
+	});
+
+	describe("SkillRouter (composite)", () => {
+		it("resolves skills based on their routing strategy", () => {
+			const router = new SkillRouter();
+
+			const alwaysSkill = makeSkill({
+				name: "always-skill",
+				routing: { strategy: "always" },
+			});
+			const labelSkill = makeSkill({
+				name: "label-skill",
+				routing: { strategy: "label", labels: ["security"] },
+			});
+			const teamSkill = makeSkill({
+				name: "team-skill",
+				routing: { strategy: "team", teams: ["CYPACK"] },
+			});
+
+			const context: SkillRoutingContext = {
+				labels: ["bug"],
+				teamKey: "CYPACK",
+			};
+
+			const resolved = router.resolveSkills(
+				[alwaysSkill, labelSkill, teamSkill],
+				context,
+			);
+
+			expect(resolved.map((s) => s.name)).toEqual([
+				"always-skill",
+				"team-skill",
+			]);
+		});
+
+		it("returns empty array when no skills match", () => {
+			const router = new SkillRouter();
+
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "label", labels: ["security"] },
+			});
+
+			const resolved = router.resolveSkills([skill], {
+				labels: ["bug"],
+			});
+
+			expect(resolved).toHaveLength(0);
+		});
+
+		it("skips skills with unknown routing strategy", () => {
+			const router = new SkillRouter();
+
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "unknown" as any },
+			});
+
+			const resolved = router.resolveSkills([skill], {});
+
+			expect(resolved).toHaveLength(0);
+		});
+
+		it("allows registering custom strategies", () => {
+			const router = new SkillRouter();
+
+			router.registerStrategy({
+				strategyName: "custom" as any,
+				matches: () => true,
+			});
+
+			const skill = makeSkill({
+				name: "test",
+				routing: { strategy: "custom" as any },
+			});
+
+			const resolved = router.resolveSkills([skill], {});
+
+			expect(resolved).toHaveLength(1);
+		});
+	});
+});


### PR DESCRIPTION
Assignee: [payton](https://linear.app/ceedar/profiles/payton)

## Summary

Adds a dynamic skills system that loads `SKILL.md` files from `~/.cyrus/skills/` and injects them into agent runner sessions based on configurable routing strategies. Cross-runner compatible with Claude, Codex, Cursor, and Gemini.

- **SkillLoader** — Reads and parses `SKILL.md` files from `~/.cyrus/skills/<name>/SKILL.md`, extracting frontmatter (name, description, allowed-tools, routing config) and markdown instructions
- **SkillRouter** — Resolves which skills to activate per session using 5 built-in routing strategies (`always`, `label`, `team`, `repository`, `keyword`), extensible via `registerStrategy()`
- **SkillInjector** — Merges resolved skill instructions into `appendSystemPrompt` and `allowedTools`, providing cross-runner compatibility
- **EdgeWorker integration** — Skills loaded on startup, resolved per session in `buildAgentRunnerConfig()`, respects `disallowAllTools` flag

### SKILL.md Format

```yaml
---
name: security-review
description: Security code review skill.
allowed-tools: Read, Grep, Glob
routing: label
routing-labels: security, audit
---
# Instructions
Review code for security vulnerabilities...
```

### SOLID Principles

| Principle | Implementation |
|-----------|---------------|
| **S**ingle Responsibility | Separate classes: SkillLoader (I/O), SkillRouter (routing), SkillInjector (merging) |
| **O**pen/Closed | New strategies added via `registerStrategy()` without modifying existing code |
| **L**iskov Substitution | All strategies substitutable via `ISkillRoutingStrategy` interface |
| **I**nterface Segregation | Focused interfaces: `ISkillLoader`, `ISkillRouter`, `ISkillRoutingStrategy` |
| **D**ependency Inversion | EdgeWorker depends on abstractions, not concrete implementations |

## Test Plan

- [x] 41 new unit tests covering SkillLoader (12), SkillRouter (23), SkillInjector (6)
- [x] All 582 existing tests pass
- [x] TypeScript typecheck clean across all packages
- [x] Biome lint clean

## Linear Issue

[CYPACK-896](https://linear.app/ceedar/issue/CYPACK-896/add-support-for-dynamic-skills)