### PR TITLE
Start cloudflare tunnel when running self-auth

### DIFF
--- a/apps/cli/src/commands/SelfAuthCommand.ts
+++ b/apps/cli/src/commands/SelfAuthCommand.ts
@@ -54,6 +54,20 @@ export class SelfAuthCommand extends BaseCommand {
 		console.log();
 
 		try {
+			if (process.env.CLOUDFLARE_TOKEN) {
+				this.logger.info("Starting cloudflare tunnel...");
+
+				const { SharedApplicationServer } = await import("cyrus-edge-worker");
+				const sharedApplicationServer = new SharedApplicationServer(
+					this.callbackPort,
+					baseUrl,
+					false,
+				);
+				await sharedApplicationServer.startCloudflareTunnel(
+					process.env.CLOUDFLARE_TOKEN,
+				);
+			}
+
 			// Start temporary server to receive OAuth callback
 			const authCode = await this.waitForCallback(clientId);
 

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -135,7 +135,7 @@ export class SharedApplicationServer {
 	/**
 	 * Start Cloudflare tunnel and wait for 4 'connected' events
 	 */
-	private async startCloudflareTunnel(cloudflareToken: string): Promise<void> {
+	async startCloudflareTunnel(cloudflareToken: string): Promise<void> {
 		return new Promise<void>((resolve, reject) => {
 			let connectionCount = 0;
 			const requiredConnections = 4;


### PR DESCRIPTION
Start cloudflare tunnel when running self-auth.

This way Cyrus can run completely isolated inside docker without having to change the CYRUS_BASE_URL config for running self-auth later on.