### PR TITLE
Add hidden Cyrus marker to PR body in gh-pr subroutine

### DIFF
--- a/packages/edge-worker/src/prompts/subroutines/gh-pr.md
+++ b/packages/edge-worker/src/prompts/subroutines/gh-pr.md
@@ -29,6 +29,13 @@ Check the `<assignee>` section from the issue context and add assignee informati
 
 Follow this with a blank line, then the rest of the description. If no assignee information is available at all, skip this step.
 
+**IMPORTANT: Cyrus attribution marker**
+You MUST include the following hidden HTML comment somewhere in the PR body (e.g. at the very end). This marker is used to identify Cyrus-authored PRs for tracking purposes:
+```
+<!-- generated-by-cyrus -->
+```
+This marker is invisible when rendered on GitHub but allows the webhook to detect that this PR was authored by Cyrus, even when the PR is created under a human user's GitHub account.
+
 The PR description should include:
 - Summary of changes
 - Implementation approach


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

<!-- generated-by-cyrus -->

## Summary
- Updated the `gh-pr` subroutine prompt to instruct agents to include `<!-- generated-by-cyrus -->` in every PR body
- This hidden HTML comment is used by the CYHOST webhook to detect Cyrus-authored PRs from non-bot user accounts

## Test plan
- [x] Prompt change only — no code changes to test
- [x] Companion PR in cyrus-hosted adds webhook detection: ceedaragents/cyrus-hosted#cyhost-697

[CYPACK-901](https://linear.app/ceedar/issue/CYPACK-901)