### PR TITLE
Release v0.2.33

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,17 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.33] - 2026-03-10
+
+### Fixed
+- ClaudeRunner now infers `type: "http"` for file-loaded MCP server configs that have a `url` but no `type` discriminator. The Claude Agent SDK requires an explicit `type` field — without it, sessions crash with 0 messages. Codex/Gemini runners are unaffected because they do property-based translation. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+
+### Changed
+- Replaced placeholder `testMcp` handler with actual MCP SDK integration: stdio spawns via `StdioClientTransport`, HTTP/SSE connects via `StreamableHTTPClientTransport`, both perform `tools/list` and return discovered tools. Added `@modelcontextprotocol/sdk` dependency to config-updater and `NodeNext` module resolution. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+- Refactored MCP test handler: fixed `withTimeout` timer leak by clearing setTimeout on settlement, extracted `connectAndDiscover()` to eliminate duplicated connect/list/respond logic, avoided mutating `payload.commandArgs` by copying before sort, added 5s timeout to `client.close()` to prevent zombie stdio processes. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+- MCP config files moved to `~/.cyrus/mcp-configs/` subdirectory; config-updater routes consolidated under `/api/update/` prefix. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+- Restored tab indentation in all package.json files.
+
 ## [0.2.32] - 2026-03-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.33] - 2026-03-10
+
+### Fixed
+- **MCP config files crashing ClaudeRunner sessions** - File-loaded MCP server configs (`.mcp.json`, `mcp-*.json`) that omit the `type` field for URL-based servers no longer crash sessions with 0 messages. ClaudeRunner now infers `type: "http"` when a `url` is present. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+
+### Added
+- **Real MCP connection testing** - The MCP test endpoint now performs actual SDK connections (stdio process spawn or HTTP/SSE) and returns discovered tools, replacing the previous placeholder response. ([#966](https://github.com/ceedaragents/cyrus/pull/966))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.33
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.33
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.33
+
+#### cyrus-core
+- cyrus-core@0.2.33
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.33
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.33
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.33
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.33
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.33
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.33
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.33
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.33
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.33
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.33
+
 ## [0.2.32] - 2026-03-10
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.32",
+	"version": "0.2.33",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.33 to npm
- Update changelogs (CHANGELOG.md and CHANGELOG.internal.md)
- Bump all package versions to 0.2.33

## Changes
- **Fixed**: MCP config files crashing ClaudeRunner sessions — file-loaded configs without `type` field now correctly infer `type: "http"` ([#966](https://github.com/ceedaragents/cyrus/pull/966))
- **Added**: Real MCP connection testing with tool discovery ([#966](https://github.com/ceedaragents/cyrus/pull/966))

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)