### PR TITLE
feat: detect invalid MCP credentials quickly via stderr monitoring and process exit detection

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Added stderr monitoring and process exit detection to MCP test handler for fast-fail on invalid credentials. Replaced single 25s `TEST_TIMEOUT_MS` with per-step 10s timeouts for `client.connect()` and `client.listTools()`. New `raceWithSignals()` helper races promises against timeout, stderr auth errors, and process exit signals. Timeout errors enriched with captured stderr context. ([CYPACK-932](https://linear.app/ceedar/issue/CYPACK-932), [#970](https://github.com/ceedaragents/cyrus/pull/970))
+- Added 25 unit tests for MCP test handler covering stderr auth detection, process exit, timeouts, and HTTP transport. ([CYPACK-932](https://linear.app/ceedar/issue/CYPACK-932), [#970](https://github.com/ceedaragents/cyrus/pull/970))
+
 ## [0.2.33] - 2026-03-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **MCP connection tests no longer hang on invalid credentials** - Testing MCP servers with bad API keys or credentials now fails near-instantly instead of waiting 25 seconds. Stderr output from the MCP process (e.g., "Invalid API key") is included in the error message. ([CYPACK-932](https://linear.app/ceedar/issue/CYPACK-932), [#970](https://github.com/ceedaragents/cyrus/pull/970))
+
 ## [0.2.33] - 2026-03-10
 
 ### Fixed

--- a/packages/config-updater/src/handlers/testMcp.ts
+++ b/packages/config-updater/src/handlers/testMcp.ts
@@ -7,8 +7,26 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { ApiResponse, TestMcpPayload } from "../types.js";
 
-const TEST_TIMEOUT_MS = 25_000; // 25s (edge request timeout is 30s)
+const CONNECT_TIMEOUT_MS = 10_000; // 10s for protocol handshake
+const LIST_TOOLS_TIMEOUT_MS = 10_000; // 10s for tool discovery
 const CLOSE_TIMEOUT_MS = 5_000; // 5s for graceful close
+
+/** Patterns that indicate credential/auth failures on stderr. */
+const STDERR_ERROR_PATTERNS = [
+	/unauthori[zs]ed/i,
+	/invalid[_ -]?(api[_ -]?)?key/i,
+	/authentication failed/i,
+	/auth(entication|orization)?\s+error/i,
+	/forbidden/i,
+	/401/,
+	/403/,
+	/invalid[_ -]?token/i,
+	/access[_ -]?denied/i,
+	/permission[_ -]?denied/i,
+	/credentials?\s+(are\s+)?invalid/i,
+	/api[_ -]?key\s+(is\s+)?invalid/i,
+	/not[_ -]?authori[zs]ed/i,
+];
 
 /**
  * Handle MCP connection test
@@ -60,6 +78,7 @@ export async function handleTestMcp(
 
 /**
  * Test a stdio MCP server by spawning the process, connecting, and listing tools.
+ * Monitors stderr for auth errors and detects process exit for fast failure.
  */
 async function testStdioMcp(payload: TestMcpPayload): Promise<ApiResponse> {
 	const args = payload.commandArgs
@@ -85,7 +104,49 @@ async function testStdioMcp(payload: TestMcpPayload): Promise<ApiResponse> {
 		stderr: "pipe",
 	});
 
-	return await connectAndDiscover(transport, payload.command!);
+	// Set up stderr monitoring and process exit detection before connecting
+	const stderrChunks: string[] = [];
+	let earlyFailure: Promise<never> | undefined;
+
+	const stderrStream = transport.stderr;
+	if (stderrStream) {
+		earlyFailure = new Promise<never>((_resolve, reject) => {
+			stderrStream.on("data", (chunk: Buffer) => {
+				const text = chunk.toString();
+				stderrChunks.push(text);
+
+				// Check if stderr contains auth error patterns
+				if (containsAuthError(text)) {
+					reject(
+						new McpCredentialError(
+							`MCP server reported an authentication error: ${text.trim()}`,
+						),
+					);
+				}
+			});
+		});
+	}
+
+	// Detect process exit via the transport's onclose callback
+	const processExitPromise = new Promise<never>((_resolve, reject) => {
+		const originalOnClose = transport.onclose;
+		transport.onclose = () => {
+			originalOnClose?.();
+			const stderrOutput = stderrChunks.join("").trim();
+			const message = stderrOutput
+				? `MCP process exited unexpectedly: ${stderrOutput}`
+				: "MCP process exited unexpectedly before completing the test";
+			reject(new McpProcessExitError(message));
+		};
+	});
+
+	return await connectAndDiscover(
+		transport,
+		payload.command!,
+		earlyFailure,
+		processExitPromise,
+		() => stderrChunks.join("").trim(),
+	);
 }
 
 /**
@@ -126,22 +187,38 @@ async function testHttpMcp(payload: TestMcpPayload): Promise<ApiResponse> {
 
 /**
  * Connect to an MCP server via the given transport, list tools, and return the result.
+ * Optionally races against early failure signals (stderr auth errors, process exit).
  */
 async function connectAndDiscover(
 	transport: Transport,
 	fallbackName: string,
+	earlyFailure?: Promise<never>,
+	processExit?: Promise<never>,
+	getStderr?: () => string,
 ): Promise<ApiResponse> {
 	const client = new Client({
 		name: "cyrus-mcp-tester",
 		version: "1.0.0",
 	});
 
-	try {
-		await withTimeout(client.connect(transport), "Connection timed out");
+	// Build the list of signals to race against
+	const raceSignals = [earlyFailure, processExit].filter(
+		(p): p is Promise<never> => p !== undefined,
+	);
 
-		const toolsResult = await withTimeout(
+	try {
+		await raceWithSignals(
+			client.connect(transport),
+			"Connection timed out",
+			CONNECT_TIMEOUT_MS,
+			raceSignals,
+		);
+
+		const toolsResult = await raceWithSignals(
 			client.listTools(),
 			"Tool listing timed out",
+			LIST_TOOLS_TIMEOUT_MS,
+			raceSignals,
 		);
 
 		const tools = toolsResult.tools.map((t) => ({
@@ -163,6 +240,19 @@ async function connectAndDiscover(
 				},
 			},
 		};
+	} catch (error) {
+		// Enrich timeout errors with stderr context when available
+		if (
+			error instanceof Error &&
+			error.message.includes("timed out") &&
+			getStderr
+		) {
+			const stderr = getStderr();
+			if (stderr) {
+				throw new Error(`${error.message}\nServer stderr: ${stderr}`);
+			}
+		}
+		throw error;
 	} finally {
 		try {
 			await withTimeout(client.close(), "Close timed out", CLOSE_TIMEOUT_MS);
@@ -172,11 +262,36 @@ async function connectAndDiscover(
 	}
 }
 
+/** Check whether a stderr line contains a known auth/credential error pattern. */
+function containsAuthError(text: string): boolean {
+	return STDERR_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Race a promise against a timeout and optional early-failure signals.
+ * Clears the timer on settlement.
+ */
+function raceWithSignals<T>(
+	promise: Promise<T>,
+	timeoutMessage: string,
+	ms: number,
+	signals: Promise<never>[] = [],
+): Promise<T> {
+	let timer: ReturnType<typeof setTimeout>;
+	return Promise.race([
+		promise,
+		new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error(timeoutMessage)), ms);
+		}),
+		...signals,
+	]).finally(() => clearTimeout(timer));
+}
+
 /** Race a promise against a timeout, clearing the timer on settlement. */
 function withTimeout<T>(
 	promise: Promise<T>,
 	message: string,
-	ms: number = TEST_TIMEOUT_MS,
+	ms: number,
 ): Promise<T> {
 	let timer: ReturnType<typeof setTimeout>;
 	return Promise.race([
@@ -186,3 +301,26 @@ function withTimeout<T>(
 		}),
 	]).finally(() => clearTimeout(timer));
 }
+
+/** Error thrown when stderr contains auth/credential error patterns. */
+class McpCredentialError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "McpCredentialError";
+	}
+}
+
+/** Error thrown when the MCP process exits unexpectedly. */
+class McpProcessExitError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "McpProcessExitError";
+	}
+}
+
+export {
+	containsAuthError,
+	McpCredentialError,
+	McpProcessExitError,
+	STDERR_ERROR_PATTERNS,
+};

--- a/packages/config-updater/test/handlers/testMcp.test.ts
+++ b/packages/config-updater/test/handlers/testMcp.test.ts
@@ -1,0 +1,430 @@
+import { PassThrough } from "node:stream";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	containsAuthError,
+	handleTestMcp,
+} from "../../src/handlers/testMcp.js";
+import type { TestMcpPayload } from "../../src/types.js";
+
+// Mock the MCP SDK modules
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+	StdioClientTransport: vi.fn(),
+	getDefaultEnvironment: vi.fn(() => ({ PATH: "/usr/bin", HOME: "/home" })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+	StreamableHTTPClientTransport: vi.fn(),
+}));
+
+describe("containsAuthError", () => {
+	it("should detect 'unauthorized' (case insensitive)", () => {
+		expect(containsAuthError("Error: Unauthorized")).toBe(true);
+		expect(containsAuthError("UNAUTHORIZED")).toBe(true);
+		expect(containsAuthError("unauthorised")).toBe(true);
+	});
+
+	it("should detect 'invalid key' variants", () => {
+		expect(containsAuthError("invalid key")).toBe(true);
+		expect(containsAuthError("invalid_key")).toBe(true);
+		expect(containsAuthError("invalid-key")).toBe(true);
+		expect(containsAuthError("Invalid API key")).toBe(true);
+		expect(containsAuthError("invalid_api_key")).toBe(true);
+		expect(containsAuthError("invalid-api-key")).toBe(true);
+	});
+
+	it("should detect 'authentication failed'", () => {
+		expect(containsAuthError("authentication failed")).toBe(true);
+		expect(containsAuthError("Authentication Failed")).toBe(true);
+	});
+
+	it("should detect auth error variations", () => {
+		expect(containsAuthError("auth error")).toBe(true);
+		expect(containsAuthError("authentication error")).toBe(true);
+		expect(containsAuthError("authorization error")).toBe(true);
+	});
+
+	it("should detect HTTP status codes", () => {
+		expect(containsAuthError("HTTP 401")).toBe(true);
+		expect(containsAuthError("status: 403")).toBe(true);
+	});
+
+	it("should detect 'forbidden'", () => {
+		expect(containsAuthError("Forbidden")).toBe(true);
+	});
+
+	it("should detect 'invalid token'", () => {
+		expect(containsAuthError("invalid token")).toBe(true);
+		expect(containsAuthError("invalid_token")).toBe(true);
+	});
+
+	it("should detect 'access denied'", () => {
+		expect(containsAuthError("access denied")).toBe(true);
+		expect(containsAuthError("Access_Denied")).toBe(true);
+	});
+
+	it("should detect 'permission denied'", () => {
+		expect(containsAuthError("permission denied")).toBe(true);
+	});
+
+	it("should detect 'credentials invalid'", () => {
+		expect(containsAuthError("credentials are invalid")).toBe(true);
+		expect(containsAuthError("credential invalid")).toBe(true);
+	});
+
+	it("should detect 'api key is invalid'", () => {
+		expect(containsAuthError("api key is invalid")).toBe(true);
+		expect(containsAuthError("api_key invalid")).toBe(true);
+	});
+
+	it("should detect 'not authorized'", () => {
+		expect(containsAuthError("not authorized")).toBe(true);
+		expect(containsAuthError("not authorised")).toBe(true);
+	});
+
+	it("should NOT match normal output", () => {
+		expect(containsAuthError("Server started successfully")).toBe(false);
+		expect(containsAuthError("Listening on port 3000")).toBe(false);
+		expect(containsAuthError("Connected to database")).toBe(false);
+	});
+});
+
+describe("handleTestMcp", () => {
+	let mockClient: {
+		connect: ReturnType<typeof vi.fn>;
+		listTools: ReturnType<typeof vi.fn>;
+		close: ReturnType<typeof vi.fn>;
+		getServerVersion: ReturnType<typeof vi.fn>;
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockClient = {
+			connect: vi.fn(),
+			listTools: vi.fn(),
+			close: vi.fn().mockResolvedValue(undefined),
+			getServerVersion: vi.fn().mockReturnValue({
+				name: "test-server",
+				version: "1.0.0",
+			}),
+		};
+
+		vi.mocked(Client).mockImplementation(() => mockClient as any);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("validation", () => {
+		it("should reject missing transport type", async () => {
+			const result = await handleTestMcp({} as TestMcpPayload);
+			expect(result).toEqual({
+				success: false,
+				error: "MCP test requires transport type",
+			});
+		});
+
+		it("should reject stdio without command", async () => {
+			const result = await handleTestMcp({
+				transportType: "stdio",
+			});
+			expect(result).toEqual({
+				success: false,
+				error: "MCP stdio transport requires a command",
+			});
+		});
+
+		it("should reject http without server URL", async () => {
+			const result = await handleTestMcp({
+				transportType: "http",
+			});
+			expect(result).toEqual({
+				success: false,
+				error: "MCP HTTP/SSE transport requires a server URL",
+			});
+		});
+
+		it("should reject unsupported transport type", async () => {
+			const result = await handleTestMcp({
+				transportType: "grpc" as any,
+			});
+			expect(result).toEqual({
+				success: false,
+				error: "Unsupported transport type: grpc",
+			});
+		});
+	});
+
+	describe("stdio transport — successful connection", () => {
+		it("should return discovered tools on success", async () => {
+			const stderrStream = new PassThrough();
+
+			vi.mocked(StdioClientTransport).mockImplementation(
+				() =>
+					({
+						stderr: stderrStream,
+						onclose: null,
+						start: vi.fn().mockResolvedValue(undefined),
+					}) as any,
+			);
+
+			mockClient.connect.mockResolvedValue(undefined);
+			mockClient.listTools.mockResolvedValue({
+				tools: [
+					{ name: "tool1", description: "First tool" },
+					{ name: "tool2", description: "Second tool" },
+				],
+			});
+
+			const result = await handleTestMcp({
+				transportType: "stdio",
+				command: "node",
+				commandArgs: [{ value: "server.js", order: 0 }],
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data.tools).toHaveLength(2);
+			expect(result.message).toContain("discovered 2 tool(s)");
+		});
+	});
+
+	describe("stdio transport — stderr auth error detection", () => {
+		it("should fail immediately when stderr contains auth error", async () => {
+			const stderrStream = new PassThrough();
+
+			vi.mocked(StdioClientTransport).mockImplementation(
+				() =>
+					({
+						stderr: stderrStream,
+						onclose: null,
+						start: vi.fn().mockResolvedValue(undefined),
+					}) as any,
+			);
+
+			// Make connect hang forever so we can test that stderr wins the race
+			mockClient.connect.mockImplementation(
+				() => new Promise(() => {}), // never resolves
+			);
+
+			const resultPromise = handleTestMcp({
+				transportType: "stdio",
+				command: "stripe-mcp",
+			});
+
+			// Simulate auth error on stderr after a small delay
+			await new Promise((r) => setTimeout(r, 10));
+			stderrStream.write(
+				"Error: Invalid API key provided: sk_test_****invalid\n",
+			);
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("authentication error");
+			expect(result.error).toContain("Invalid API key");
+		});
+
+		it("should fail immediately when stderr contains 401", async () => {
+			const stderrStream = new PassThrough();
+
+			vi.mocked(StdioClientTransport).mockImplementation(
+				() =>
+					({
+						stderr: stderrStream,
+						onclose: null,
+						start: vi.fn().mockResolvedValue(undefined),
+					}) as any,
+			);
+
+			mockClient.connect.mockImplementation(() => new Promise(() => {}));
+
+			const resultPromise = handleTestMcp({
+				transportType: "stdio",
+				command: "some-mcp",
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+			stderrStream.write("HTTP 401 Unauthorized\n");
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("authentication error");
+		});
+	});
+
+	describe("stdio transport — process exit detection", () => {
+		it("should fail immediately when process exits with stderr output", async () => {
+			const stderrStream = new PassThrough();
+			let capturedOnClose: (() => void) | null = null;
+
+			vi.mocked(StdioClientTransport).mockImplementation(() => {
+				const transport = {
+					stderr: stderrStream,
+					_onclose: null as (() => void) | null,
+					get onclose() {
+						return this._onclose;
+					},
+					set onclose(fn: (() => void) | null) {
+						this._onclose = fn;
+						capturedOnClose = fn;
+					},
+					start: vi.fn().mockResolvedValue(undefined),
+				};
+				return transport as any;
+			});
+
+			mockClient.connect.mockImplementation(() => new Promise(() => {}));
+
+			const resultPromise = handleTestMcp({
+				transportType: "stdio",
+				command: "bad-mcp",
+			});
+
+			// Simulate stderr output followed by process exit
+			await new Promise((r) => setTimeout(r, 10));
+			stderrStream.write("Error: missing required configuration\n");
+
+			// Trigger process close
+			await new Promise((r) => setTimeout(r, 10));
+			capturedOnClose?.();
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("MCP process exited unexpectedly");
+			expect(result.error).toContain("missing required configuration");
+		});
+
+		it("should fail with generic message when process exits without stderr", async () => {
+			const stderrStream = new PassThrough();
+			let capturedOnClose: (() => void) | null = null;
+
+			vi.mocked(StdioClientTransport).mockImplementation(() => {
+				const transport = {
+					stderr: stderrStream,
+					_onclose: null as (() => void) | null,
+					get onclose() {
+						return this._onclose;
+					},
+					set onclose(fn: (() => void) | null) {
+						this._onclose = fn;
+						capturedOnClose = fn;
+					},
+					start: vi.fn().mockResolvedValue(undefined),
+				};
+				return transport as any;
+			});
+
+			mockClient.connect.mockImplementation(() => new Promise(() => {}));
+
+			const resultPromise = handleTestMcp({
+				transportType: "stdio",
+				command: "bad-mcp",
+			});
+
+			await new Promise((r) => setTimeout(r, 10));
+			capturedOnClose?.();
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain(
+				"MCP process exited unexpectedly before completing the test",
+			);
+		});
+	});
+
+	describe("stdio transport — timeout with stderr context", () => {
+		it("should include stderr in timeout error message", async () => {
+			const stderrStream = new PassThrough();
+
+			vi.mocked(StdioClientTransport).mockImplementation(
+				() =>
+					({
+						stderr: stderrStream,
+						onclose: null,
+						start: vi.fn().mockResolvedValue(undefined),
+					}) as any,
+			);
+
+			// Connect succeeds but listTools hangs
+			mockClient.connect.mockResolvedValue(undefined);
+			mockClient.listTools.mockImplementation(() => new Promise(() => {}));
+
+			const resultPromise = handleTestMcp({
+				transportType: "stdio",
+				command: "slow-mcp",
+			});
+
+			// Write non-auth stderr (won't trigger early failure but should be captured)
+			await new Promise((r) => setTimeout(r, 10));
+			stderrStream.write("Warning: slow startup detected\n");
+
+			const result = await resultPromise;
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain("Tool listing timed out");
+			expect(result.error).toContain("slow startup detected");
+		}, 15_000);
+	});
+
+	describe("http transport", () => {
+		it("should connect and discover tools for HTTP transport", async () => {
+			vi.mocked(StreamableHTTPClientTransport).mockImplementation(
+				() =>
+					({
+						start: vi.fn().mockResolvedValue(undefined),
+					}) as any,
+			);
+
+			mockClient.connect.mockResolvedValue(undefined);
+			mockClient.listTools.mockResolvedValue({
+				tools: [{ name: "http-tool", description: "An HTTP tool" }],
+			});
+
+			const result = await handleTestMcp({
+				transportType: "http",
+				serverUrl: "https://example.com/mcp",
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.data.tools).toHaveLength(1);
+		});
+
+		it("should substitute env vars in URL and headers", async () => {
+			let capturedUrl: URL | undefined;
+
+			vi.mocked(StreamableHTTPClientTransport).mockImplementation(
+				(url: URL) => {
+					capturedUrl = url;
+					return {
+						start: vi.fn().mockResolvedValue(undefined),
+					} as any;
+				},
+			);
+
+			mockClient.connect.mockResolvedValue(undefined);
+			mockClient.listTools.mockResolvedValue({ tools: [] });
+
+			const serverUrl = "https://example.com/" + "${API_KEY}" + "/mcp";
+			await handleTestMcp({
+				transportType: "http",
+				serverUrl,
+				envVars: [{ key: "API_KEY", value: "my-secret-key" }],
+			});
+
+			expect(capturedUrl?.toString()).toBe(
+				"https://example.com/my-secret-key/mcp",
+			);
+		});
+	});
+});


### PR DESCRIPTION
Assignee: [payton](https://linear.app/ceedar/profiles/payton)

## Summary

Resolves [CYPACK-932](https://linear.app/ceedar/issue/CYPACK-932) — MCP connection tests with invalid credentials (e.g., `@stripe/mcp` with a bad `STRIPE_SECRET_KEY`) previously hung for the full 25s timeout. This PR makes credential failures near-instant by:

- **Monitoring stderr** for auth error patterns (`unauthorized`, `invalid key`, `401`, `403`, `authentication failed`, etc.) and aborting the test immediately when detected
- **Detecting process exit** via the transport's `onclose` callback — if the MCP process crashes on startup due to bad credentials, the test fails instantly instead of waiting for timeout
- **Using per-step timeouts** — replaced the single 25s `TEST_TIMEOUT_MS` with 10s for `client.connect()` and 10s for `client.listTools()`, giving faster and more specific feedback on which step failed
- **Enriching error messages** with captured stderr content, so users see the actual error from the MCP server (e.g., "Invalid API key provided") rather than a generic timeout

## Implementation

### `packages/config-updater/src/handlers/testMcp.ts`

- Added `STDERR_ERROR_PATTERNS` — array of regexes matching common auth/credential error messages
- `testStdioMcp()` now sets up stderr monitoring and process exit detection before calling `connectAndDiscover()`
- New `raceWithSignals()` helper races the main promise against timeout, stderr auth errors, and process exit signals simultaneously
- `connectAndDiscover()` accepts optional early-failure signals and enriches timeout errors with stderr context
- New error classes: `McpCredentialError` and `McpProcessExitError` for structured error handling

### `packages/config-updater/test/handlers/testMcp.test.ts` (new)

25 new tests covering:
- `containsAuthError` pattern matching (13 tests for all error patterns + negative cases)
- Validation (4 tests)
- Successful stdio connection
- Stderr auth error detection (immediate failure on `Invalid API key`, `401`)
- Process exit detection (with and without stderr output)
- Timeout with stderr context enrichment
- HTTP transport (connection, env var substitution)

## Testing

- 30 tests passing (25 new + 5 existing in config-updater)
- All package tests passing (`pnpm test:packages:run` — 543 tests across 44 files)
- TypeScript typecheck clean
- Lint clean

## Breaking Changes

None. The `handleTestMcp` API contract is unchanged — same input/output types. The behavior change is strictly faster failure with better error messages.

<!-- generated-by-cyrus -->