### PR TITLE
feat: CYPACK→CYHOST error telemetry pipeline for Mixpanel

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Added
+- **CYPACK→CYHOST error telemetry pipeline** — `LinearEventTransport` now extracts `X-Cyrus-Callback-Token`, `X-Cyrus-Callback-URL`, and `X-Cyrus-Team-Id` headers from CYHOST-forwarded webhooks. New `TelemetryReporter` service POSTs error events (crash, stall, rate_limit, billing, max_turns) back to CYHOST for Mixpanel tracking. `AgentSessionManager.completeSession()` classifies and reports session errors via fire-and-forget callback. Gracefully degrades when no callback context is available (self-hosted, older CYHOST). ([CYPACK-951](https://linear.app/ceedar/issue/CYPACK-951), [#975](https://github.com/ceedaragents/cyrus/pull/975))
+
 ## [0.2.33] - 2026-03-10
 
 ### Fixed

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -32,6 +32,7 @@ import type {
 	ActivitySignal,
 	IActivitySink,
 } from "./sinks/index.js";
+import type { TelemetryReporter } from "./TelemetryReporter.js";
 import {
 	DEFAULT_VALIDATION_LOOP_CONFIG,
 	parseValidationResult,
@@ -107,6 +108,7 @@ export class AgentSessionManager extends EventEmitter {
 	private stopRequestedSessions: Set<string> = new Set(); // Sessions explicitly stopped by user signal
 	private procedureAnalyzer?: ProcedureAnalyzer;
 	private sharedApplicationServer?: SharedApplicationServer;
+	private telemetryReporter?: TelemetryReporter;
 	private getParentSessionId?: (childSessionId: string) => string | undefined;
 	private resumeParentSession?: (
 		parentSessionId: string,
@@ -139,6 +141,14 @@ export class AgentSessionManager extends EventEmitter {
 	 */
 	setActivitySink(sessionId: string, sink: IActivitySink): void {
 		this.activitySinks.set(sessionId, sink);
+	}
+
+	/**
+	 * Set the telemetry reporter for error callback to CYHOST.
+	 * If not set, error telemetry is silently skipped (graceful degradation).
+	 */
+	setTelemetryReporter(reporter: TelemetryReporter): void {
+		this.telemetryReporter = reporter;
 	}
 
 	/**
@@ -399,6 +409,11 @@ export class AgentSessionManager extends EventEmitter {
 			usage: resultMessage.usage,
 		});
 
+		// Report error telemetry to CYHOST (fire-and-forget)
+		if (status === AgentSessionStatus.Error) {
+			this.reportSessionError(session, sessionId, resultMessage);
+		}
+
 		// Handle result using procedure routing system (skip for sessions without procedures, e.g. Slack)
 		if (!this.procedureAnalyzer) {
 			log.info(`Session completed (no procedure routing)`);
@@ -474,6 +489,112 @@ export class AgentSessionManager extends EventEmitter {
 			errorText.includes("turn limit") ||
 			errorText.includes("turns limit")
 		);
+	}
+
+	/**
+	 * Report a session error to CYHOST via telemetry callback.
+	 * Fire-and-forget: does not block session completion.
+	 */
+	private reportSessionError(
+		session: CyrusAgentSession,
+		sessionId: string,
+		resultMessage: SDKResultMessage,
+	): void {
+		if (!this.telemetryReporter) return;
+
+		const errorType = this.classifyErrorType(resultMessage);
+		const errorMessage = this.extractErrorMessage(resultMessage);
+		const durationSeconds = session.createdAt
+			? Math.round((Date.now() - session.createdAt) / 1000)
+			: undefined;
+
+		// Fire-and-forget — don't await, don't block session completion
+		this.telemetryReporter
+			.reportError({
+				error_type: errorType,
+				error_message: errorMessage,
+				issue_id: session.issueContext?.issueId,
+				issue_identifier: session.issueContext?.issueIdentifier,
+				session_id: sessionId,
+				duration_seconds: durationSeconds,
+			})
+			.catch(() => {
+				// Already logged inside TelemetryReporter; swallow here
+			});
+	}
+
+	/**
+	 * Classify the SDK result message into a telemetry error type.
+	 */
+	private classifyErrorType(
+		resultMessage: SDKResultMessage,
+	): "crash" | "stall" | "rate_limit" | "billing" | "max_turns" {
+		// Check subtype for max turns
+		if (resultMessage.subtype === "error_max_turns") {
+			return "max_turns";
+		}
+
+		// Check for rate limit or billing errors in the result text
+		const errorText = [
+			resultMessage.subtype ?? "",
+			...("errors" in resultMessage && Array.isArray(resultMessage.errors)
+				? resultMessage.errors
+				: []),
+			"result" in resultMessage && typeof resultMessage.result === "string"
+				? resultMessage.result
+				: "",
+		]
+			.join(" ")
+			.toLowerCase();
+
+		if (errorText.includes("rate_limit") || errorText.includes("rate limit")) {
+			return "rate_limit";
+		}
+		if (
+			errorText.includes("billing") ||
+			errorText.includes("quota") ||
+			errorText.includes("insufficient_credits")
+		) {
+			return "billing";
+		}
+		if (
+			errorText.includes("max turn") ||
+			errorText.includes("turn limit") ||
+			errorText.includes("turns limit")
+		) {
+			return "max_turns";
+		}
+		if (
+			errorText.includes("timeout") ||
+			errorText.includes("timed out") ||
+			errorText.includes("no response")
+		) {
+			return "stall";
+		}
+
+		// Default: treat as crash (SDK error, uncaught exception)
+		return "crash";
+	}
+
+	/**
+	 * Extract a human-readable error message from the SDK result.
+	 */
+	private extractErrorMessage(resultMessage: SDKResultMessage): string {
+		if (
+			"errors" in resultMessage &&
+			Array.isArray(resultMessage.errors) &&
+			resultMessage.errors.length > 0
+		) {
+			return resultMessage.errors.join("; ");
+		}
+		if (
+			"result" in resultMessage &&
+			typeof resultMessage.result === "string" &&
+			resultMessage.result
+		) {
+			return resultMessage.result.substring(0, 500);
+		}
+		return resultMessage.subtype ?? "unknown error";
 	}
 
 	private consumeStopRequest(linearAgentActivitySessionId: string): boolean {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -133,6 +133,7 @@ import { SharedApplicationServer } from "./SharedApplicationServer.js";
 import { SlackChatAdapter } from "./SlackChatAdapter.js";
 import type { IActivitySink } from "./sinks/IActivitySink.js";
 import { LinearActivitySink } from "./sinks/LinearActivitySink.js";
+import { TelemetryReporter } from "./TelemetryReporter.js";
 import type { AgentSessionData, EdgeWorkerEvents } from "./types.js";
 import { UserAccessControl } from "./UserAccessControl.js";
 
@@ -199,6 +200,7 @@ export class EdgeWorker extends EventEmitter {
 	private attachmentService: AttachmentService;
 	private runnerSelectionService: RunnerSelectionService;
 	private activityPoster: ActivityPoster;
+	private telemetryReporter: TelemetryReporter;
 	private configManager: ConfigManager;
 	private promptBuilder: PromptBuilder;
 	private readonly cyrusToolsMcpEndpoint = "/mcp/cyrus-tools";
@@ -347,6 +349,10 @@ export class EdgeWorker extends EventEmitter {
 			this.procedureAnalyzer,
 			this.sharedApplicationServer,
 		);
+
+		// Initialize telemetry reporter (context will be set later when first webhook arrives)
+		this.telemetryReporter = new TelemetryReporter(null);
+		this.agentSessionManager.setTelemetryReporter(this.telemetryReporter);
 
 		// Subscribe to session events once on the single ASM
 		this.agentSessionManager.on(
@@ -654,6 +660,12 @@ export class EdgeWorker extends EventEmitter {
 
 			// Listen for legacy webhook events (deprecated, kept for backward compatibility)
 			this.linearEventTransport.on("event", (event: AgentEvent) => {
+				// Propagate telemetry callback context from transport to reporter (lazy, once)
+				const cbCtx = this.linearEventTransport?.callbackContext;
+				if (cbCtx) {
+					this.telemetryReporter.setCallbackContext(cbCtx);
+				}
+
 				// Get all active repositories for webhook handling
 				const repos = Array.from(this.repositories.values());
 				this.handleWebhook(event as unknown as Webhook, repos);
@@ -661,6 +673,12 @@ export class EdgeWorker extends EventEmitter {
 
 			// Listen for unified internal messages (new message bus)
 			this.linearEventTransport.on("message", (message: InternalMessage) => {
+				// Forward telemetry callback context from transport to reporter (lazy, once)
+				const ctx = this.linearEventTransport?.callbackContext;
+				if (ctx) {
+					this.telemetryReporter.setCallbackContext(ctx);
+				}
+
 				this.handleMessage(message);
 			});
 

--- a/packages/edge-worker/src/TelemetryReporter.ts
+++ b/packages/edge-worker/src/TelemetryReporter.ts
@@ -1,0 +1,103 @@
+import { createLogger, type ILogger } from "cyrus-core";
+import type { TelemetryCallbackContext } from "cyrus-linear-event-transport";
+
+/**
+ * Error types reported back to CYHOST for Mixpanel tracking.
+ */
+export type TelemetryErrorType =
+	| "crash"
+	| "stall"
+	| "rate_limit"
+	| "billing"
+	| "max_turns";
+
+/**
+ * Payload POSTed to CYHOST's /api/telemetry/callback endpoint.
+ */
+export interface TelemetryErrorEvent {
+	team_id: string;
+	event_type: "agent_session_error";
+	error_type: TelemetryErrorType;
+	error_message: string;
+	issue_id?: string;
+	issue_identifier?: string;
+	session_id: string;
+	duration_seconds?: number;
+	timestamp: string;
+}
+
+/**
+ * TelemetryReporter — Fire-and-forget error telemetry to CYHOST.
+ *
+ * When CYHOST forwards a webhook to CYPACK, it includes callback headers
+ * (token, URL, team ID). This reporter uses those to POST error events
+ * back so CYHOST can resolve team/user identity and forward to Mixpanel.
+ *
+ * Graceful degradation: if no callback context is provided, all calls are no-ops.
+ */
+export class TelemetryReporter {
+	private callbackContext: TelemetryCallbackContext | null;
+	private logger: ILogger;
+
+	constructor(
+		callbackContext: TelemetryCallbackContext | null,
+		logger?: ILogger,
+	) {
+		this.callbackContext = callbackContext;
+		this.logger = logger ?? createLogger({ component: "TelemetryReporter" });
+	}
+
+	/**
+	 * Update the callback context (e.g., when it becomes available after first webhook).
+	 */
+	setCallbackContext(context: TelemetryCallbackContext): void {
+		this.callbackContext = context;
+	}
+
+	/**
+	 * Report an error event to CYHOST. Fire-and-forget: logs failures but never throws.
+	 */
+	async reportError(
+		event: Omit<TelemetryErrorEvent, "team_id" | "event_type" | "timestamp">,
+	): Promise<void> {
+		if (!this.callbackContext) {
+			this.logger.debug(
+				"Telemetry skipped: no callback context (self-hosted or older CYHOST)",
+			);
+			return;
+		}
+
+		const { callbackUrl, callbackToken, teamId } = this.callbackContext;
+
+		const payload: TelemetryErrorEvent = {
+			...event,
+			team_id: teamId,
+			event_type: "agent_session_error",
+			timestamp: new Date().toISOString(),
+		};
+
+		try {
+			const response = await fetch(callbackUrl, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${callbackToken}`,
+				},
+				body: JSON.stringify(payload),
+				signal: AbortSignal.timeout(10_000),
+			});
+
+			if (!response.ok) {
+				this.logger.warn(
+					`Telemetry callback returned ${response.status}: ${response.statusText}`,
+				);
+			} else {
+				this.logger.debug(
+					`Telemetry reported: ${event.error_type} for session ${event.session_id}`,
+				);
+			}
+		} catch (error) {
+			this.logger.warn("Telemetry callback failed", error);
+		}
+	}
+}

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -36,6 +36,11 @@ export type {
 	IActivitySink,
 } from "./sinks/index.js";
 export { LinearActivitySink } from "./sinks/index.js";
+export {
+	type TelemetryErrorEvent,
+	type TelemetryErrorType,
+	TelemetryReporter,
+} from "./TelemetryReporter.js";
 export type { EdgeWorkerEvents } from "./types.js";
 // User access control
 export {

--- a/packages/edge-worker/test/AgentSessionManager.telemetry.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.telemetry.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+import type { IActivitySink } from "../src/sinks/IActivitySink";
+import { TelemetryReporter } from "../src/TelemetryReporter";
+
+describe("AgentSessionManager telemetry integration", () => {
+	let manager: AgentSessionManager;
+	let mockActivitySink: IActivitySink;
+	let reportErrorSpy: ReturnType<typeof vi.fn>;
+	let mockProcedureAnalyzer: any;
+	const sessionId = "test-session-telemetry";
+	const issueId = "issue-telemetry";
+
+	beforeEach(() => {
+		mockActivitySink = {
+			id: "test-workspace",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "activity-1" }),
+			createAgentSession: vi.fn().mockResolvedValue("session-1"),
+		};
+
+		mockProcedureAnalyzer = {
+			getNextSubroutine: vi.fn().mockReturnValue(null),
+			getCurrentSubroutine: vi.fn().mockReturnValue(null),
+			advanceToNextSubroutine: vi.fn(),
+			getLastSubroutineResult: vi.fn().mockReturnValue(null),
+		};
+
+		manager = new AgentSessionManager(
+			undefined,
+			undefined,
+			mockProcedureAnalyzer,
+		);
+
+		// Create a mock telemetry reporter with spied reportError
+		const reporter = new TelemetryReporter({
+			callbackToken: "token",
+			callbackUrl: "https://host/callback",
+			teamId: "team-1",
+		});
+		reportErrorSpy = vi
+			.spyOn(reporter, "reportError")
+			.mockResolvedValue(undefined);
+		manager.setTelemetryReporter(reporter);
+
+		manager.createLinearAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "TEST-TEL",
+				title: "Telemetry Test Issue",
+				description: "test",
+				branchName: "test-telemetry",
+			},
+			{
+				path: "/tmp/workspace",
+				isGitWorktree: false,
+			},
+		);
+		manager.setActivitySink(sessionId, mockActivitySink);
+	});
+
+	const makeResultMessage = (overrides: Record<string, any> = {}) => ({
+		type: "result" as const,
+		subtype: "error" as string,
+		duration_ms: 60000,
+		duration_api_ms: 55000,
+		is_error: true,
+		num_turns: 10,
+		result: "",
+		stop_reason: null,
+		total_cost_usd: 0.5,
+		usage: {
+			input_tokens: 100,
+			output_tokens: 50,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation: null,
+		},
+		...overrides,
+	});
+
+	it("reports error telemetry when session completes with error", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({ subtype: "error", is_error: true }),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		const errorEvent = reportErrorSpy.mock.calls[0]![0];
+		expect(errorEvent.error_type).toBe("crash");
+		expect(errorEvent.session_id).toBe(sessionId);
+		expect(errorEvent.issue_id).toBe(issueId);
+		expect(errorEvent.issue_identifier).toBe("TEST-TEL");
+		expect(errorEvent.duration_seconds).toBeTypeOf("number");
+	});
+
+	it("classifies error_max_turns as max_turns", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({ subtype: "error_max_turns" }),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_type).toBe("max_turns");
+	});
+
+	it("classifies rate_limit errors", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error",
+				errors: ["rate_limit: too many requests"],
+			}),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_type).toBe("rate_limit");
+	});
+
+	it("classifies billing errors", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error",
+				errors: ["billing error: insufficient_credits"],
+			}),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_type).toBe("billing");
+	});
+
+	it("classifies timeout errors as stall", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error",
+				result: "Session timed out waiting for response",
+			}),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_type).toBe("stall");
+	});
+
+	it("does not report telemetry for successful sessions", async () => {
+		await manager.completeSession(sessionId, {
+			type: "result",
+			subtype: "success",
+			duration_ms: 1000,
+			duration_api_ms: 900,
+			is_error: false,
+			num_turns: 5,
+			result: "Task completed successfully",
+			stop_reason: null,
+			total_cost_usd: 0.1,
+			usage: {
+				input_tokens: 50,
+				output_tokens: 30,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation: null,
+			},
+		});
+
+		expect(reportErrorSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not block session completion if telemetry fails", async () => {
+		reportErrorSpy.mockRejectedValue(new Error("Telemetry failed"));
+
+		// Should not throw
+		await expect(
+			manager.completeSession(
+				sessionId,
+				makeResultMessage({ subtype: "error" }),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("extracts error message from errors array", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error",
+				errors: ["First error", "Second error"],
+			}),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_message).toBe(
+			"First error; Second error",
+		);
+	});
+
+	it("extracts error message from result text when no errors array", async () => {
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error",
+				result: "Something went wrong in the session",
+			}),
+		);
+
+		expect(reportErrorSpy).toHaveBeenCalledOnce();
+		expect(reportErrorSpy.mock.calls[0]![0].error_message).toBe(
+			"Something went wrong in the session",
+		);
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -125,6 +125,7 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 					removeSession: vi.fn(),
 					getAllSessions: vi.fn().mockReturnValue([]),
 					clearAllSessions: vi.fn(),
+					setTelemetryReporter: vi.fn(),
 					on: vi.fn(), // EventEmitter method
 				}) as any,
 		);

--- a/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
@@ -100,6 +100,7 @@ describe("EdgeWorker - Feedback Delivery", () => {
 			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 
@@ -107,6 +108,7 @@ describe("EdgeWorker - Feedback Delivery", () => {
 		mockAgentSessionManager = {
 			hasAgentRunner: vi.fn().mockReturnValue(false),
 			getSession: vi.fn().mockReturnValue(null),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 

--- a/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
@@ -102,6 +102,7 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 
@@ -109,6 +110,7 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 		mockAgentSessionManager = {
 			hasAgentRunner: vi.fn().mockReturnValue(false),
 			getSession: vi.fn().mockReturnValue(null),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 

--- a/packages/edge-worker/test/EdgeWorker.fetchPRBranchRef.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.fetchPRBranchRef.test.ts
@@ -72,6 +72,7 @@ describe("EdgeWorker - fetchPRBranchRefs", () => {
 			recordAction: vi.fn().mockResolvedValue(undefined),
 			completeSession: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(),
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -143,6 +143,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.missing-session-recovery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.missing-session-recovery.test.ts
@@ -104,6 +104,7 @@ describe("EdgeWorker - Missing Session/Repository Recovery (CYPACK-852)", () => 
 			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			requestSessionStop: vi.fn(),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(),
 		};
 

--- a/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.orchestrator-label-rerouting.test.ts
@@ -82,6 +82,7 @@ describe("EdgeWorker - Orchestrator Label Rerouting", () => {
 			postAnalyzingThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -137,6 +137,7 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -203,6 +203,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
@@ -165,6 +165,7 @@ describe("EdgeWorker - Screenshot Upload Guidance Hooks", () => {
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(),
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
@@ -37,6 +37,7 @@ vi.mock("../src/AgentSessionManager.js", () => ({
 		getSession: vi.fn(),
 		getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
 		setActivitySink: vi.fn(),
+		setTelemetryReporter: vi.fn(),
 		on: vi.fn(), // EventEmitter method
 		emit: vi.fn(), // EventEmitter method
 	})),

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -153,6 +153,7 @@ describe("EdgeWorker - System Prompt Resume", () => {
 			postProcedureSelectionThought: vi.fn().mockResolvedValue(undefined),
 			createThoughtActivity: vi.fn().mockResolvedValue(undefined),
 			setActivitySink: vi.fn(),
+			setTelemetryReporter: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
 		vi.mocked(AgentSessionManager).mockImplementation(

--- a/packages/edge-worker/test/EdgeWorker.version-endpoint.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.version-endpoint.test.ts
@@ -37,6 +37,7 @@ vi.mock("../src/AgentSessionManager.js", () => ({
 		getSession: vi.fn(),
 		getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
 		setActivitySink: vi.fn(),
+		setTelemetryReporter: vi.fn(),
 		on: vi.fn(), // EventEmitter method
 		emit: vi.fn(), // EventEmitter method
 	})),

--- a/packages/edge-worker/test/EdgeWorker.versioning.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.versioning.test.ts
@@ -32,7 +32,12 @@ vi.mock("@linear/sdk", async (importOriginal) => {
 	};
 });
 vi.mock("../src/SharedApplicationServer.js");
-vi.mock("../src/AgentSessionManager.js");
+vi.mock("../src/AgentSessionManager.js", () => ({
+	AgentSessionManager: vi.fn().mockImplementation(() => ({
+		setTelemetryReporter: vi.fn(),
+		on: vi.fn(),
+	})),
+}));
 vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("cyrus-core")>();
 	return {

--- a/packages/edge-worker/test/TelemetryReporter.test.ts
+++ b/packages/edge-worker/test/TelemetryReporter.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TelemetryReporter } from "../src/TelemetryReporter";
+
+describe("TelemetryReporter", () => {
+	const callbackContext = {
+		callbackToken: "test-token-abc123",
+		callbackUrl: "https://cyhost.example.com/api/telemetry/callback",
+		teamId: "team-uuid-123",
+	};
+
+	let fetchSpy: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("posts error event to CYHOST callback URL with correct auth", async () => {
+		const reporter = new TelemetryReporter(callbackContext);
+
+		await reporter.reportError({
+			error_type: "crash",
+			error_message: "Uncaught exception in session",
+			issue_id: "issue-123",
+			issue_identifier: "CYPACK-100",
+			session_id: "session-abc",
+			duration_seconds: 120,
+		});
+
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		const [url, options] = fetchSpy.mock.calls[0]!;
+		expect(url).toBe("https://cyhost.example.com/api/telemetry/callback");
+		expect(options.method).toBe("POST");
+		expect(options.headers["Content-Type"]).toBe("application/json");
+		expect(options.headers.Authorization).toBe("Bearer test-token-abc123");
+
+		const body = JSON.parse(options.body);
+		expect(body.team_id).toBe("team-uuid-123");
+		expect(body.event_type).toBe("agent_session_error");
+		expect(body.error_type).toBe("crash");
+		expect(body.error_message).toBe("Uncaught exception in session");
+		expect(body.issue_id).toBe("issue-123");
+		expect(body.issue_identifier).toBe("CYPACK-100");
+		expect(body.session_id).toBe("session-abc");
+		expect(body.duration_seconds).toBe(120);
+		expect(body.timestamp).toBeDefined();
+	});
+
+	it("skips silently when no callback context is provided", async () => {
+		const reporter = new TelemetryReporter(null);
+
+		await reporter.reportError({
+			error_type: "crash",
+			error_message: "some error",
+			session_id: "session-1",
+		});
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("does not throw when fetch fails", async () => {
+		fetchSpy.mockRejectedValue(new Error("Network error"));
+		const reporter = new TelemetryReporter(callbackContext);
+
+		// Should not throw
+		await expect(
+			reporter.reportError({
+				error_type: "rate_limit",
+				error_message: "rate limited",
+				session_id: "session-2",
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("does not throw when fetch returns non-OK status", async () => {
+		fetchSpy.mockResolvedValue({
+			ok: false,
+			status: 401,
+			statusText: "Unauthorized",
+		});
+		const reporter = new TelemetryReporter(callbackContext);
+
+		await expect(
+			reporter.reportError({
+				error_type: "billing",
+				error_message: "insufficient credits",
+				session_id: "session-3",
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("allows setting callback context after construction", async () => {
+		const reporter = new TelemetryReporter(null);
+
+		// Initially skips
+		await reporter.reportError({
+			error_type: "crash",
+			error_message: "error",
+			session_id: "s1",
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		// After setting context, sends
+		reporter.setCallbackContext(callbackContext);
+		await reporter.reportError({
+			error_type: "stall",
+			error_message: "timeout",
+			session_id: "s2",
+		});
+		expect(fetchSpy).toHaveBeenCalledOnce();
+
+		const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+		expect(body.error_type).toBe("stall");
+	});
+
+	it("includes ISO8601 timestamp in payload", async () => {
+		const reporter = new TelemetryReporter(callbackContext);
+
+		await reporter.reportError({
+			error_type: "max_turns",
+			error_message: "exceeded max turns",
+			session_id: "s3",
+		});
+
+		const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+		// Should be a valid ISO8601 date
+		expect(() => new Date(body.timestamp)).not.toThrow();
+		expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+	});
+});

--- a/packages/linear-event-transport/src/LinearEventTransport.ts
+++ b/packages/linear-event-transport/src/LinearEventTransport.ts
@@ -10,6 +10,7 @@ import { LinearMessageTranslator } from "./LinearMessageTranslator.js";
 import type {
 	LinearEventTransportConfig,
 	LinearEventTransportEvents,
+	TelemetryCallbackContext,
 } from "./types.js";
 
 export declare interface LinearEventTransport {
@@ -45,6 +46,7 @@ export class LinearEventTransport
 	private logger: ILogger;
 	private messageTranslator: LinearMessageTranslator;
 	private translationContext: TranslationContext;
+	private _callbackContext: TelemetryCallbackContext | null = null;
 
 	constructor(
 		config: LinearEventTransportConfig,
@@ -69,6 +71,14 @@ export class LinearEventTransport
 	 */
 	setTranslationContext(context: TranslationContext): void {
 		this.translationContext = { ...this.translationContext, ...context };
+	}
+
+	/**
+	 * Get the telemetry callback context extracted from CYHOST webhook headers.
+	 * Returns null if no callback headers were present (e.g., self-hosted, direct mode).
+	 */
+	get callbackContext(): TelemetryCallbackContext | null {
+		return this._callbackContext;
 	}
 
 	/**
@@ -172,6 +182,9 @@ export class LinearEventTransport
 			return;
 		}
 
+		// Extract telemetry callback headers from CYHOST (if present)
+		this.extractCallbackContext(request);
+
 		try {
 			const payload = request.body as LinearWebhookPayload;
 
@@ -190,6 +203,29 @@ export class LinearEventTransport
 			}
 			this.logger.error("Proxy webhook processing failed", err);
 			reply.code(500).send({ error: "Failed to process webhook" });
+		}
+	}
+
+	/**
+	 * Extract telemetry callback headers from CYHOST webhook requests.
+	 * Only stores context if all three required headers are present.
+	 * Skips silently if already captured (only needs to be extracted once).
+	 */
+	private extractCallbackContext(request: FastifyRequest): void {
+		// Only extract once — callback context is per-team and stable across webhooks
+		if (this._callbackContext) return;
+
+		const callbackToken = request.headers["x-cyrus-callback-token"] as
+			| string
+			| undefined;
+		const callbackUrl = request.headers["x-cyrus-callback-url"] as
+			| string
+			| undefined;
+		const teamId = request.headers["x-cyrus-team-id"] as string | undefined;
+
+		if (callbackToken && callbackUrl && teamId) {
+			this._callbackContext = { callbackToken, callbackUrl, teamId };
+			this.logger.info("Telemetry callback context captured from CYHOST");
 		}
 	}
 

--- a/packages/linear-event-transport/src/index.ts
+++ b/packages/linear-event-transport/src/index.ts
@@ -8,5 +8,6 @@ export { LinearMessageTranslator } from "./LinearMessageTranslator.js";
 export type {
 	LinearEventTransportConfig,
 	LinearEventTransportEvents,
+	TelemetryCallbackContext,
 	VerificationMode,
 } from "./types.js";

--- a/packages/linear-event-transport/src/types.ts
+++ b/packages/linear-event-transport/src/types.ts
@@ -25,6 +25,20 @@ export interface LinearEventTransportConfig {
 }
 
 /**
+ * Callback context extracted from CYHOST webhook headers.
+ * Used to POST error telemetry back to CYHOST for Mixpanel tracking.
+ * Only present when webhooks are forwarded from CYHOST (cloud droplets).
+ */
+export interface TelemetryCallbackContext {
+	/** Bearer token for authenticating callback POSTs to CYHOST */
+	callbackToken: string;
+	/** URL to POST telemetry events to (e.g., https://host/api/telemetry/callback) */
+	callbackUrl: string;
+	/** Team ID for CYHOST to resolve user identity */
+	teamId: string;
+}
+
+/**
  * Events emitted by LinearEventTransport
  */
 export interface LinearEventTransportEvents {

--- a/packages/linear-event-transport/test/LinearEventTransport.callback-headers.test.ts
+++ b/packages/linear-event-transport/test/LinearEventTransport.callback-headers.test.ts
@@ -1,0 +1,138 @@
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LinearEventTransport } from "../src/LinearEventTransport.js";
+
+/**
+ * Helper: create a transport, suppress event/error listeners (we only test header extraction),
+ * and return the registered transport instance.
+ */
+function createTransport(fastify: ReturnType<typeof Fastify>) {
+	const transport = new LinearEventTransport({
+		fastifyServer: fastify,
+		verificationMode: "proxy",
+		secret: "test-api-key",
+	});
+	// Suppress unhandled EventEmitter errors from minimal test payloads
+	transport.on("event", () => {});
+	transport.on("error", () => {});
+	transport.register();
+	return transport;
+}
+
+/** Minimal valid AgentSessionEvent payload for testing */
+const minimalPayload = {
+	type: "AgentSessionEvent",
+	action: "created",
+	organizationId: "org-1",
+	agentSession: {
+		id: "session-1",
+		issue: { id: "issue-1", identifier: "TEST-1" },
+	},
+};
+
+describe("LinearEventTransport callback header extraction", () => {
+	let fastify: ReturnType<typeof Fastify>;
+
+	beforeEach(async () => {
+		fastify = Fastify();
+	});
+
+	afterEach(async () => {
+		await fastify.close();
+	});
+
+	it("extracts callback context from CYHOST headers in proxy mode", async () => {
+		const transport = createTransport(fastify);
+		await fastify.ready();
+
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/webhook",
+			headers: {
+				authorization: "Bearer test-api-key",
+				"x-cyrus-callback-token": "cb-token-123",
+				"x-cyrus-callback-url":
+					"https://cyhost.example.com/api/telemetry/callback",
+				"x-cyrus-team-id": "team-uuid-abc",
+			},
+			payload: minimalPayload,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(transport.callbackContext).toEqual({
+			callbackToken: "cb-token-123",
+			callbackUrl: "https://cyhost.example.com/api/telemetry/callback",
+			teamId: "team-uuid-abc",
+		});
+	});
+
+	it("returns null callbackContext when no callback headers present", async () => {
+		const transport = createTransport(fastify);
+		await fastify.ready();
+
+		await fastify.inject({
+			method: "POST",
+			url: "/webhook",
+			headers: {
+				authorization: "Bearer test-api-key",
+			},
+			payload: minimalPayload,
+		});
+
+		expect(transport.callbackContext).toBeNull();
+	});
+
+	it("requires all three callback headers to set context", async () => {
+		const transport = createTransport(fastify);
+		await fastify.ready();
+
+		// Only 2 of 3 headers present
+		await fastify.inject({
+			method: "POST",
+			url: "/webhook",
+			headers: {
+				authorization: "Bearer test-api-key",
+				"x-cyrus-callback-token": "cb-token-123",
+				"x-cyrus-callback-url":
+					"https://cyhost.example.com/api/telemetry/callback",
+				// Missing x-cyrus-team-id
+			},
+			payload: minimalPayload,
+		});
+
+		expect(transport.callbackContext).toBeNull();
+	});
+
+	it("captures context only once (idempotent)", async () => {
+		const transport = createTransport(fastify);
+		await fastify.ready();
+
+		const headers = {
+			authorization: "Bearer test-api-key",
+			"x-cyrus-callback-token": "first-token",
+			"x-cyrus-callback-url": "https://first.example.com/callback",
+			"x-cyrus-team-id": "team-1",
+		};
+
+		await fastify.inject({
+			method: "POST",
+			url: "/webhook",
+			headers,
+			payload: minimalPayload,
+		});
+
+		// Second webhook with different token
+		await fastify.inject({
+			method: "POST",
+			url: "/webhook",
+			headers: {
+				...headers,
+				"x-cyrus-callback-token": "second-token",
+			},
+			payload: minimalPayload,
+		});
+
+		// Should still have the first token
+		expect(transport.callbackContext!.callbackToken).toBe("first-token");
+	});
+});


### PR DESCRIPTION
## Summary

Implements the CYPACK side of the error telemetry pipeline that reports agent session errors back to CYHOST for Mixpanel tracking. When agents crash, stall, hit rate limits, or exceed turn limits on CYPACK droplets, error events are now POSTed back to CYHOST which has the team/user identity context needed for analytics.

- Extract `X-Cyrus-Callback-Token`, `X-Cyrus-Callback-URL`, and `X-Cyrus-Team-Id` headers from CYHOST-forwarded webhooks in `LinearEventTransport`
- New `TelemetryReporter` service that POSTs error events to CYHOST's callback endpoint with Bearer token auth
- `AgentSessionManager.completeSession()` classifies session errors into 5 types (`crash`, `stall`, `rate_limit`, `billing`, `max_turns`) and reports them via fire-and-forget callback
- Graceful degradation: silently skips telemetry when no callback headers are present (self-hosted, direct mode, older CYHOST)

## Implementation

**Header extraction** (`LinearEventTransport`): Callback context is captured once from the first proxy webhook and stored on the transport instance. All three headers must be present; partial headers are ignored.

**Error classification** (`AgentSessionManager`): Maps SDK result messages to error types by checking `subtype` (e.g., `error_max_turns`) and scanning error text for keywords (`rate_limit`, `billing`, `timeout`, etc.). Falls back to `crash` for unrecognized errors.

**Reporting** (`TelemetryReporter`): Fire-and-forget HTTP POST with 10s timeout. Never blocks session completion. Logs warnings on failure but never throws.

**Wiring** (`EdgeWorker`): Creates `TelemetryReporter` with null context at startup, lazily forwards callback context from transport on first webhook message.

## Testing

- 4 tests for callback header extraction (extraction, missing headers, partial headers, idempotency)
- 6 tests for TelemetryReporter (auth, graceful degradation, error handling, lazy context, timestamps)
- 8 tests for AgentSessionManager telemetry integration (error classification for all 5 types, success skipping, non-blocking behavior, error message extraction)
- All 596 package tests passing, lint clean, typecheck clean

## Linear Issue

[CYPACK-951](https://linear.app/ceedar/issue/CYPACK-951/cypackcyhost-error-telemetry-pipeline-for-mixpanel)

<!-- generated-by-cyrus -->