### PR TITLE
fix(linear-event-transport): use raw body for webhook signature verification

### DIFF
--- a/packages/linear-event-transport/src/LinearEventTransport.ts
+++ b/packages/linear-event-transport/src/LinearEventTransport.ts
@@ -122,8 +122,13 @@ export class LinearEventTransport
 		}
 
 		try {
-			// Verify the webhook signature using Linear's client
-			const bodyBuffer = Buffer.from(JSON.stringify(request.body));
+			// Use the raw body bytes that SharedApplicationServer stashed on the request
+			// so signature verification uses the exact payload Linear signed, rather than
+			// a re-serialized version that may differ in key order or whitespace.
+			const rawBody = (request as FastifyRequest & { rawBody: string }).rawBody;
+			const bodyBuffer = rawBody
+				? Buffer.from(rawBody)
+				: Buffer.from(JSON.stringify(request.body));
 			const isValid = this.linearWebhookClient.verify(bodyBuffer, signature);
 
 			if (!isValid) {


### PR DESCRIPTION
## Summary

Fixes webhook signature verification failure in direct mode (`LINEAR_DIRECT_WEBHOOKS=true`).

**Bug**: `LinearEventTransport.handleDirectWebhook` uses `Buffer.from(JSON.stringify(request.body))` to reconstruct the request body for HMAC verification. `JSON.stringify` does not guarantee the same byte sequence as the original HTTP request body — key ordering, whitespace, and Unicode escaping may all differ, causing Linear's HMAC-SHA256 signature check to always fail.

**Fix**: Use `request.rawBody` (already stashed by `SharedApplicationServer`'s custom content-type parser) instead of re-serializing. Falls back to `JSON.stringify` for backward compatibility.

**Context**: `GitHubEventTransport` and `SlackEventTransport` already use `request.rawBody` correctly. This was previously fixed in PR #251 but regressed when `LinearEventTransport` was restructured in the v0.2.x rewrite.

## Changes

- `packages/linear-event-transport/src/LinearEventTransport.ts`: `handleDirectWebhook` now reads `request.rawBody` (cast via `FastifyRequest & { rawBody?: string }`, matching the pattern in `GitHubEventTransport` and `SlackEventTransport`), falling back to `JSON.stringify(request.body)` when rawBody is unavailable.

## Test plan

- [ ] Verify signature verification passes with real Linear webhooks in direct mode
- [ ] Confirm no regression in proxy mode (unchanged code path)
- [ ] Existing tests still pass

<!-- generated-by-cyrus -->