### PR TITLE
fix: prevent pipeline hang when subroutine completes with empty result

### DIFF
--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -387,7 +387,14 @@ export class AgentSessionManager extends EventEmitter {
 		// to prevent memory leaks
 
 		const wasStopRequested = this.consumeStopRequest(sessionId);
-		const status = wasStopRequested
+
+		// If stop was requested but the session completed successfully, the stop
+		// arrived too late — the runner had already finished its work. In this case,
+		// treat it as a normal completion so the pipeline can continue.
+		const stopWasEffective =
+			wasStopRequested && resultMessage.subtype !== "success";
+
+		const status = stopWasEffective
 			? AgentSessionStatus.Error
 			: resultMessage.subtype === "success"
 				? AgentSessionStatus.Complete
@@ -405,19 +412,32 @@ export class AgentSessionManager extends EventEmitter {
 			return;
 		}
 
-		if (wasStopRequested) {
+		if (stopWasEffective) {
 			log.info(
-				`Session ${sessionId} was stopped by user; skipping procedure continuation`,
+				`Session ${sessionId} was stopped by user (result: ${resultMessage.subtype}); skipping procedure continuation`,
 			);
 			return;
 		}
 
-		if ("result" in resultMessage && resultMessage.result) {
-			await this.handleProcedureCompletion(session, sessionId, resultMessage);
-		} else if (
-			resultMessage.subtype !== "success" &&
-			this.shouldRecoverFromPreviousSubroutine(resultMessage)
-		) {
+		if (wasStopRequested && resultMessage.subtype === "success") {
+			log.info(
+				`Stop requested for ${sessionId} but session completed successfully; continuing pipeline`,
+			);
+		}
+
+		if (resultMessage.subtype === "success") {
+			// FIX: Advance pipeline on ANY success, not just when result text is present.
+			// Some subroutines (e.g., changelog-update) complete successfully with no result text,
+			// which previously caused the pipeline to silently hang.
+			let effectiveResult = resultMessage;
+			if (!("result" in resultMessage) || !resultMessage.result) {
+				effectiveResult = {
+					...resultMessage,
+					result: "(completed successfully)",
+				};
+			}
+			await this.handleProcedureCompletion(session, sessionId, effectiveResult);
+		} else if (this.shouldRecoverFromPreviousSubroutine(resultMessage)) {
 			// Error result (e.g. error_max_turns from singleTurn subroutines) — try to
 			// recover from the last completed subroutine's result so the procedure can still complete.
 			const recoveredText =
@@ -444,7 +464,7 @@ export class AgentSessionManager extends EventEmitter {
 				);
 				await this.addResultEntry(sessionId, resultMessage);
 			}
-		} else if (resultMessage.subtype !== "success") {
+		} else {
 			// Non-recoverable errors (e.g. stop/abort) should not advance procedures.
 			await this.addResultEntry(sessionId, resultMessage);
 		}

--- a/packages/edge-worker/test/AgentSessionManager.stop-session.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.stop-session.test.ts
@@ -11,6 +11,30 @@ describe("AgentSessionManager stop-session behavior", () => {
 	const issueId = "issue-stop";
 	let mockProcedureAnalyzer: any;
 
+	const makeResultMessage = (overrides: Record<string, any> = {}): any => ({
+		type: "result",
+		subtype: "success",
+		duration_ms: 1,
+		duration_api_ms: 1,
+		is_error: false,
+		num_turns: 1,
+		result: "Completed work",
+		stop_reason: null,
+		total_cost_usd: 0,
+		usage: {
+			input_tokens: 1,
+			output_tokens: 1,
+			cache_creation_input_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation: null,
+		},
+		modelUsage: {},
+		permission_denials: [],
+		uuid: "result-1",
+		session_id: "sdk-session",
+		...overrides,
+	});
+
 	beforeEach(() => {
 		mockActivitySink = {
 			id: "test-workspace",
@@ -55,34 +79,21 @@ describe("AgentSessionManager stop-session behavior", () => {
 		manager.setActivitySink(sessionId, mockActivitySink);
 	});
 
-	it("does not advance procedure when a session stop is requested", async () => {
+	it("skips pipeline when stop is effective (non-success result)", async () => {
 		const subroutineCompleteSpy = vi.fn();
 		manager.on("subroutineComplete", subroutineCompleteSpy);
 
 		manager.requestSessionStop(sessionId);
 
-		await manager.completeSession(sessionId, {
-			type: "result",
-			subtype: "success",
-			duration_ms: 1,
-			duration_api_ms: 1,
-			is_error: false,
-			num_turns: 1,
-			result: "Stopped run should not continue",
-			stop_reason: null,
-			total_cost_usd: 0,
-			usage: {
-				input_tokens: 1,
-				output_tokens: 1,
-				cache_creation_input_tokens: 0,
-				cache_read_input_tokens: 0,
-				cache_creation: null,
-			},
-			modelUsage: {},
-			permission_denials: [],
-			uuid: "result-1",
-			session_id: "sdk-session",
-		} as any);
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error_during_execution",
+				is_error: true,
+				errors: ["aborted by user"],
+				result: undefined,
+			}),
+		);
 
 		expect(subroutineCompleteSpy).not.toHaveBeenCalled();
 		expect(
@@ -93,32 +104,51 @@ describe("AgentSessionManager stop-session behavior", () => {
 		);
 	});
 
+	it("continues pipeline when stop arrives too late (session already completed successfully)", async () => {
+		// This reproduces the real-world scenario:
+		// 1. Claude finishes a subroutine (e.g., coding) and returns success
+		// 2. User clicks "stop" in Linear because it appears hung between subroutines
+		// 3. The stop flag gets set, but the result is already "success"
+		// 4. The pipeline should CONTINUE because the work was completed
+		const subroutineCompleteSpy = vi.fn();
+		manager.on("subroutineComplete", subroutineCompleteSpy);
+
+		// Simulate that Claude has been initialized (session needs a runner session ID)
+		const session = manager.getSession(sessionId)!;
+		session.claudeSessionId = "claude-session-123";
+
+		manager.requestSessionStop(sessionId);
+
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "success",
+				result: "All work completed successfully",
+			}),
+		);
+
+		// Pipeline should advance — the stop arrived too late
+		expect(subroutineCompleteSpy).toHaveBeenCalled();
+		expect(mockProcedureAnalyzer.advanceToNextSubroutine).toHaveBeenCalled();
+		// Session should be marked Complete, not Error
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Complete,
+		);
+	});
+
 	it("does not recover-and-advance for non max-turn execution errors", async () => {
 		const subroutineCompleteSpy = vi.fn();
 		manager.on("subroutineComplete", subroutineCompleteSpy);
 
-		await manager.completeSession(sessionId, {
-			type: "result",
-			subtype: "error_during_execution",
-			duration_ms: 1,
-			duration_api_ms: 1,
-			is_error: true,
-			num_turns: 1,
-			errors: ["aborted by user"],
-			stop_reason: null,
-			total_cost_usd: 0,
-			usage: {
-				input_tokens: 1,
-				output_tokens: 1,
-				cache_creation_input_tokens: 0,
-				cache_read_input_tokens: 0,
-				cache_creation: null,
-			},
-			modelUsage: {},
-			permission_denials: [],
-			uuid: "result-2",
-			session_id: "sdk-session",
-		} as any);
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error_during_execution",
+				is_error: true,
+				errors: ["aborted by user"],
+				result: undefined,
+			}),
+		);
 
 		expect(subroutineCompleteSpy).not.toHaveBeenCalled();
 		expect(
@@ -126,32 +156,45 @@ describe("AgentSessionManager stop-session behavior", () => {
 		).not.toHaveBeenCalled();
 	});
 
+	it("advances pipeline when success result has empty result text", async () => {
+		// This is the root cause of the pipeline hang bug:
+		// Some subroutines (e.g., changelog-update) complete with subtype=success
+		// but result=undefined. Previously the pipeline silently died because the
+		// condition was: "result" in resultMessage && resultMessage.result
+		const subroutineCompleteSpy = vi.fn();
+		manager.on("subroutineComplete", subroutineCompleteSpy);
+
+		const session = manager.getSession(sessionId)!;
+		session.claudeSessionId = "claude-session-456";
+
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "success",
+				result: undefined, // <-- This is the trigger: success with no result text
+			}),
+		);
+
+		expect(subroutineCompleteSpy).toHaveBeenCalled();
+		expect(mockProcedureAnalyzer.advanceToNextSubroutine).toHaveBeenCalled();
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Complete,
+		);
+	});
+
 	it("posts actual error message to Linear for usage limit errors (not generic)", async () => {
 		const usageLimitError =
 			"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Feb 16th, 2026 8:09 PM.";
 
-		await manager.completeSession(sessionId, {
-			type: "result",
-			subtype: "error_during_execution",
-			duration_ms: 1,
-			duration_api_ms: 1,
-			is_error: true,
-			num_turns: 1,
-			errors: [usageLimitError],
-			stop_reason: null,
-			total_cost_usd: 0,
-			usage: {
-				input_tokens: 1,
-				output_tokens: 1,
-				cache_creation_input_tokens: 0,
-				cache_read_input_tokens: 0,
-				cache_creation: null,
-			},
-			modelUsage: {},
-			permission_denials: [],
-			uuid: "result-3",
-			session_id: "sdk-session",
-		} as any);
+		await manager.completeSession(
+			sessionId,
+			makeResultMessage({
+				subtype: "error_during_execution",
+				is_error: true,
+				errors: [usageLimitError],
+				result: undefined,
+			}),
+		);
 
 		const postActivityCalls = postActivitySpy.mock.calls;
 		const errorActivity = postActivityCalls.find(


### PR DESCRIPTION
## Problem

Cyrus intermittently appears "hung" in Linear — the timer keeps running, the transcript shows work is done, but the ticket is never updated with a commit, PR, or summary. The only recourse is to manually stop the session.

## Root Cause

In `AgentSessionManager.completeSession()`, the condition that decides whether to advance the subroutine pipeline is:

```js
if ("result" in resultMessage && resultMessage.result) {
```

Some subroutines (observed on `changelog-update`, but could affect any) complete with `subtype: "success"` but **no result text** — `result` is `undefined` or empty string. When this happens:

1. The `if` above evaluates to `false` (result is falsy)
2. All `else if` branches check `subtype !== "success"`, which is also `false`
3. The function **silently returns** — no pipeline advancement, no error, no log
4. The Linear ticket shows "still working" indefinitely

## Fix

Change the primary check from requiring result text to checking the success status:

```js
if (resultMessage.subtype === "success") {
```

When result text is empty, a placeholder `"(completed successfully)"` is synthesized so downstream code that expects a string still works.

Also fixes a secondary issue: when a user clicks "stop" in Linear but the session had already completed successfully, the pipeline was being abandoned. Now it checks whether the stop was actually effective (non-success result) vs. arrived too late (success result).

## Evidence

### Reproduced
- **ABC-215, ABC-216**: Both hung at `changelog-update` with diagnostic logs showing `subtype=success hasResult=false` followed by silence
- **ABC-227, ABC-231**: Hit the same `hasResult=false` condition, but with the fix active — logs show `success with empty result — synthesizing result text` and the pipeline continued to completion

### Diagnostic log showing the fix in action (WAZ-227)
```
completeSession ENTERED ... subtype=success hasResult=true    ← normal subroutine
completeSession ENTERED ... subtype=success hasResult=true    ← normal subroutine
completeSession ENTERED ... subtype=success hasResult=false   ← BUG TRIGGERED
  success with empty result — synthesizing result text        ← FIX CAUGHT IT
  calling handleProcedureCompletion                           ← pipeline continued
completeSession ENTERED ... subtype=success hasResult=true    ← rest completed normally
```

### Historical analysis
Analyzed 28 previous Cyrus tickets. 6 hung with the same pattern — `Session completed with N messages` logged by ClaudeRunner but no `Subroutine completed, advancing to next` from AgentSessionManager. Task type and complexity showed no correlation — both simple (Settings screen) and complex (4-package polling system) tickets hung.

## Test plan

- [x] New test: `advances pipeline when success result has empty result text` — the core regression test
- [x] New test: `continues pipeline when stop arrives too late` — stop + success doesn't kill pipeline  
- [x] Updated test: `skips pipeline when stop is effective` — uses non-success subtype
- [x] All 630 existing tests pass
- [x] TypeScript compiles cleanly (typecheck passes in pre-commit hook)
- [x] Verified with 16+ live Cyrus tickets across multiple batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)