### PR TITLE
fix: use raw body for webhook signature verification

### DIFF
--- a/packages/linear-event-transport/src/LinearEventTransport.ts
+++ b/packages/linear-event-transport/src/LinearEventTransport.ts
@@ -123,7 +123,7 @@ export class LinearEventTransport
 
 		try {
 			// Verify the webhook signature using Linear's client
-			const bodyBuffer = Buffer.from(JSON.stringify(request.body));
+			const bodyBuffer = Buffer.from(request.rawBody || JSON.stringify(request.body));
 			const isValid = this.linearWebhookClient.verify(bodyBuffer, signature);
 
 			if (!isValid) {


### PR DESCRIPTION
## Summary

- Use `request.rawBody` instead of `JSON.stringify(request.body)` for webhook signature verification in direct mode

## Problem

`JSON.stringify(request.body)` re-serializes the already-parsed JSON object, which does not guarantee the same byte sequence as the original payload. Key ordering, whitespace, and Unicode escaping can all differ from the original bytes Linear sent.

This causes `Invalid webhook signature` errors when using webhook proxy services like Hookdeck CLI, because the HMAC signature is computed against the original bytes but verified against the re-serialized bytes.

## Fix

`request.rawBody` is already captured by `SharedApplicationServer`'s Fastify content type parser (via `addContentTypeParser`) and contains the exact bytes sent by Linear. The fix falls back to `JSON.stringify` for backwards compatibility in case `rawBody` is not available.

## File changed

- `packages/linear-event-transport/src/LinearEventTransport.ts` (line 126)

```diff
- const bodyBuffer = Buffer.from(JSON.stringify(request.body));
+ const bodyBuffer = Buffer.from(request.rawBody || JSON.stringify(request.body));
```