### PR TITLE
switch codex exec to codex app-server

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Replaced the Codex SDK exec/thread integration in `packages/codex-runner` with a new `CodexAppServerClient` that speaks the `codex app-server` JSON-RPC protocol (`initialize`, `thread/start`, `turn/start`, interrupts, notifications) and re-normalizes those events back into Cyrus's existing activity pipeline. Added `CodexRunner.app-server.test.ts` coverage for the handshake and updated the F1 harness plus test-drive docs to validate the new path end-to-end. ([CYPACK-998](https://linear.app/ceedar/issue/CYPACK-998), [#1020](https://github.com/ceedaragents/cyrus/pull/1020))
+
 ## [0.2.37] - 2026-03-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **Cyrus docs MCP available in all sessions** - Cyrus now has access to its own documentation via the Mintlify docs MCP server, enabling better self-reference and user guidance. ([CYPACK-995](https://linear.app/ceedar/issue/CYPACK-995), [#1016](https://github.com/ceedaragents/cyrus/pull/1016))
 
+### Changed
+- **Codex sessions now use the Codex app-server backend** - Cyrus now runs Codex issue sessions through `codex app-server` instead of the older exec path, keeping Codex activity reporting intact while aligning with the current Codex runtime. ([CYPACK-998](https://linear.app/ceedar/issue/CYPACK-998), [#1020](https://github.com/ceedaragents/cyrus/pull/1020))
+
 ## [0.2.37] - 2026-03-18
 
 ### Added

--- a/apps/f1/server.ts
+++ b/apps/f1/server.ts
@@ -21,6 +21,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { LinearClient } from "@linear/sdk";
 import { getAllTools } from "cyrus-claude-runner";
 import {
 	DEFAULT_WORKTREES_DIR,
@@ -37,6 +38,14 @@ import { bold, cyan, dim, gray, green, success } from "./src/utils/colors.js";
 const CYRUS_PORT = Number.parseInt(process.env.CYRUS_PORT || "3600", 10);
 const CYRUS_REPO_PATH = process.env.CYRUS_REPO_PATH || process.cwd();
 const CYRUS_HOME = join(tmpdir(), `cyrus-f1-${Date.now()}`);
+const CYRUS_DEFAULT_RUNNER = process.env.CYRUS_DEFAULT_RUNNER as
+	| "claude"
+	| "gemini"
+	| "codex"
+	| "cursor"
+	| undefined;
+const CYRUS_CODEX_DEFAULT_MODEL =
+	process.env.CYRUS_CODEX_DEFAULT_MODEL || undefined;
 const DEFAULT_WORKTREES_BASE_DIR =
 	process.env.CYRUS_WORKTREES_DIR?.trim() ||
 	join(CYRUS_HOME, DEFAULT_WORKTREES_DIR);
@@ -158,11 +167,21 @@ function createEdgeWorkerConfig(): EdgeWorkerConfig {
 	const config: EdgeWorkerConfig = {
 		platform: "cli" as const,
 		repositories,
+		linearWorkspaces: {
+			"cli-workspace": {
+				linearToken: "cli-f1-token",
+				linearWorkspaceName: "F1 CLI Workspace",
+			},
+		},
 		cyrusHome: CYRUS_HOME,
 		serverPort: CYRUS_PORT,
 		serverHost: "localhost",
 		claudeDefaultModel: "sonnet",
 		claudeDefaultFallbackModel: "haiku",
+		...(CYRUS_DEFAULT_RUNNER ? { defaultRunner: CYRUS_DEFAULT_RUNNER } : {}),
+		...(CYRUS_CODEX_DEFAULT_MODEL
+			? { codexDefaultModel: CYRUS_CODEX_DEFAULT_MODEL }
+			: {}),
 		// Enable all tools including Edit(**), Bash, etc. for full testing capability
 		defaultAllowedTools: getAllTools(),
 	};
@@ -220,6 +239,15 @@ async function startServer(): Promise<void> {
 
 		// Initialize EdgeWorker
 		const edgeWorker = new EdgeWorker(config);
+		const cliIssueTracker = (edgeWorker as any).issueTrackers?.get(
+			"cli-workspace",
+		);
+		if (cliIssueTracker && typeof cliIssueTracker.getClient !== "function") {
+			cliIssueTracker.getClient = () =>
+				new LinearClient({
+					accessToken: "cli-f1-token",
+				});
+		}
 
 		// Setup graceful shutdown
 		const shutdown = async (signal: string): Promise<void> => {

--- a/apps/f1/test-drives/2026-03-19-codex-app-server-validation.md
+++ b/apps/f1/test-drives/2026-03-19-codex-app-server-validation.md
@@ -1,0 +1,75 @@
+# Test Drive: Codex App-Server Validation
+
+**Date**: 2026-03-19
+**Goal**: Verify the Codex runner uses `codex app-server` end-to-end through the F1 harness.
+**Test Repo**: `/tmp/f1-codex-app-server-1773988022`
+**Server Env**: `CYRUS_PORT=3631 CYRUS_DEFAULT_RUNNER=codex CYRUS_CODEX_DEFAULT_MODEL=gpt-5.4`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Session created on issue
+- [x] Session prompt/elicitation loop worked
+
+### EdgeWorker
+- [x] F1 server started in CLI mode
+- [x] `SimpleRunner` resolved from config to `codex`
+- [x] Codex runner selected `gpt-5.4`
+- [x] Codex app-server session produced thought/action activity
+- [x] Session posted a final `response` activity
+
+### Renderer / Activities
+- [x] Activity timeline recorded elicitation, prompt, thought, action, error, and response entries
+- [x] Todo-style plan activity rendered in the timeline
+- [x] Action activity rendered from Codex tool usage
+
+## Commands
+
+```bash
+cd apps/f1
+./f1 init-test-repo --path /tmp/f1-codex-app-server-1773988022
+
+CYRUS_PORT=3631 \
+CYRUS_REPO_PATH=/tmp/f1-codex-app-server-1773988022 \
+CYRUS_DEFAULT_RUNNER=codex \
+CYRUS_CODEX_DEFAULT_MODEL=gpt-5.4 \
+bun run apps/f1/server.ts
+
+CYRUS_PORT=3631 ./f1 ping
+CYRUS_PORT=3631 ./f1 create-issue \
+  --title "Codex app-server validation" \
+  --description "Validate Codex end-to-end through F1." \
+  --labels codex
+CYRUS_PORT=3631 ./f1 start-session --issue-id issue-1
+CYRUS_PORT=3631 ./f1 prompt-session --session-id session-1 --message "Use the F1 Test Repository."
+CYRUS_PORT=3631 ./f1 view-session --session-id session-1
+CYRUS_PORT=3631 ./f1 stop-session --session-id session-1
+```
+
+## Key Evidence
+
+- Server startup confirmed the codex path:
+  - `[EdgeWorker] 🏃 SimpleRunner type resolved from config.defaultRunner: codex`
+- Codex runner initialization appeared in server logs:
+  - `[CodexRunner] hasCodexSubscription: true`
+  - `[CodexRunner] Configured 4 MCP server(s) for codex config`
+  - `[EdgeWorker] cyrus-tools MCP session connected: ...`
+- `session-1` timeline showed Codex-selected execution:
+  - `Selected procedure: **user-testing**`
+  - `Using model: gpt-5.4`
+  - action entries from Codex tool usage
+  - final `response` activity present
+
+## Observations
+
+- The app-server migration is working: the Codex harness starts, emits tool/thought activity, and reaches a final response path in F1.
+- Two pre-existing or adjacent issues were observed during the drive:
+  - `SimpleCodexRunner` classification sometimes raises `NoResponseError`, but the worker still falls back to a usable procedure.
+  - follow-up summary/plan subroutines can emit `no rollout found for thread id ...` errors in F1.
+- The F1 server itself needed CLI-harness wiring fixes for `linearWorkspaces`, a dummy `getClient()`, and env-selectable default runner/model so the codex path could be exercised reliably.
+
+## Conclusion
+
+Pass with caveats. The F1 harness now proves Cyrus can start Codex sessions through the app-server path, surface Codex activities in the timeline, and emit a final response activity. Residual F1 issues remain around classification/summary subroutines, but they did not block validation of the app-server migration itself.

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -11,6 +11,9 @@
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsc --watch",
+		"generate:app-server:ts": "codex app-server generate-ts --out ./schemas/ts",
+		"generate:app-server:json": "codex app-server generate-json-schema --out ./schemas/json",
+		"generate:app-server": "pnpm run generate:app-server:ts && pnpm run generate:app-server:json",
 		"test": "vitest",
 		"test:run": "vitest run --passWithNoTests",
 		"typecheck": "tsc --noEmit"

--- a/packages/codex-runner/schemas/.gitignore
+++ b/packages/codex-runner/schemas/.gitignore
@@ -1,0 +1,3 @@
+/*
+!.gitignore
+!README.md

--- a/packages/codex-runner/schemas/README.md
+++ b/packages/codex-runner/schemas/README.md
@@ -1,0 +1,18 @@
+`schemas/` is the regeneration workspace for Codex app-server protocol artifacts.
+
+From `packages/codex-runner/`, refresh the protocol reference with:
+
+```bash
+codex app-server generate-ts --out ./schemas/ts
+codex app-server generate-json-schema --out ./schemas/json
+```
+
+Equivalent package scripts:
+
+```bash
+pnpm run generate:app-server:ts
+pnpm run generate:app-server:json
+pnpm run generate:app-server
+```
+
+`src/appServerProtocol.ts` is the curated subset Cyrus actually consumes. Regenerate the artifacts above before editing that shim so manual changes stay aligned with the upstream app-server protocol.

--- a/packages/codex-runner/src/CodexAppServerClient.ts
+++ b/packages/codex-runner/src/CodexAppServerClient.ts
@@ -14,6 +14,8 @@ import type {
 	AppServerTurnInterruptParams,
 	AppServerTurnStartParams,
 	AppServerTurnStartResponse,
+	AppServerTurnSteerParams,
+	AppServerTurnSteerResponse,
 	JsonRpcResponse,
 } from "./appServerProtocol.js";
 
@@ -145,6 +147,12 @@ export class CodexAppServerClient {
 		params: AppServerTurnStartParams,
 	): Promise<AppServerTurnStartResponse> {
 		return this.request<AppServerTurnStartResponse>("turn/start", params);
+	}
+
+	async steerTurn(
+		params: AppServerTurnSteerParams,
+	): Promise<AppServerTurnSteerResponse> {
+		return this.request<AppServerTurnSteerResponse>("turn/steer", params);
 	}
 
 	async interruptTurn(params: AppServerTurnInterruptParams): Promise<void> {

--- a/packages/codex-runner/src/CodexAppServerClient.ts
+++ b/packages/codex-runner/src/CodexAppServerClient.ts
@@ -1,0 +1,295 @@
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import {
+	createInterface,
+	type Interface as ReadLineInterface,
+} from "node:readline";
+import type {
+	AppServerInitializeParams,
+	AppServerNotification,
+	AppServerRequest,
+	AppServerThreadResumeParams,
+	AppServerThreadStartParams,
+	AppServerThreadStartResponse,
+	AppServerTurnInterruptParams,
+	AppServerTurnStartParams,
+	AppServerTurnStartResponse,
+	JsonRpcResponse,
+} from "./appServerProtocol.js";
+
+interface PendingRequest {
+	resolve: (value: any) => void;
+	reject: (error: Error) => void;
+}
+
+export interface CodexAppServerClientOptions {
+	codexPath?: string;
+	env?: Record<string, string>;
+	configOverrides?: string[];
+	onNotification: (notification: AppServerNotification) => void;
+	onRequest?: (request: AppServerRequest) => Promise<unknown> | unknown;
+}
+
+function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	if (typeof error === "string") {
+		return error;
+	}
+	return "Unknown Codex app-server error";
+}
+
+function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"id" in value &&
+			("result" in value || "error" in value),
+	);
+}
+
+function isServerRequest(value: unknown): value is AppServerRequest {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			"id" in value &&
+			"method" in value &&
+			!("result" in value) &&
+			!("error" in value),
+	);
+}
+
+function isNotification(value: unknown): value is AppServerNotification {
+	return Boolean(
+		value && typeof value === "object" && "method" in value && !("id" in value),
+	);
+}
+
+export class CodexAppServerClient {
+	private readonly options: CodexAppServerClientOptions;
+	private readonly pendingRequests = new Map<number, PendingRequest>();
+	private readonly stderrChunks: string[] = [];
+	private readonly nextRequestId = { value: 1 };
+	private child: ChildProcess | null = null;
+	private readline: ReadLineInterface | null = null;
+	private closed = false;
+
+	constructor(options: CodexAppServerClientOptions) {
+		this.options = options;
+	}
+
+	async connect(initialization: AppServerInitializeParams): Promise<void> {
+		if (this.child) {
+			throw new Error("Codex app-server client already connected");
+		}
+
+		const args = ["app-server"];
+		for (const override of this.options.configOverrides || []) {
+			args.push("--config", override);
+		}
+
+		const child = spawn(this.options.codexPath || "codex", args, {
+			env: this.options.env,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+
+		this.child = child;
+		this.closed = false;
+		this.stderrChunks.length = 0;
+
+		if (!child.stdin || !child.stdout) {
+			child.kill();
+			throw new Error("Codex app-server did not expose stdio pipes");
+		}
+
+		this.readline = createInterface({ input: child.stdout });
+		this.readline.on("line", (line) => void this.handleStdoutLine(line));
+
+		child.stderr?.on("data", (chunk) => {
+			this.stderrChunks.push(String(chunk));
+		});
+
+		child.once("error", (error) => {
+			this.rejectAllPending(
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		});
+
+		child.once("exit", (code, signal) => {
+			const stderr = this.stderrChunks.join("").trim();
+			const reason =
+				stderr ||
+				`Codex app-server exited unexpectedly (code=${code ?? "null"}, signal=${signal ?? "null"})`;
+			this.rejectAllPending(new Error(reason));
+			this.cleanupHandles();
+		});
+
+		await this.request("initialize", initialization);
+		this.notify("initialized");
+	}
+
+	async startThread(
+		params: AppServerThreadStartParams,
+	): Promise<AppServerThreadStartResponse> {
+		return this.request<AppServerThreadStartResponse>("thread/start", params);
+	}
+
+	async resumeThread(
+		params: AppServerThreadResumeParams,
+	): Promise<AppServerThreadStartResponse> {
+		return this.request<AppServerThreadStartResponse>("thread/resume", params);
+	}
+
+	async startTurn(
+		params: AppServerTurnStartParams,
+	): Promise<AppServerTurnStartResponse> {
+		return this.request<AppServerTurnStartResponse>("turn/start", params);
+	}
+
+	async interruptTurn(params: AppServerTurnInterruptParams): Promise<void> {
+		await this.request("turn/interrupt", params);
+	}
+
+	close(): void {
+		if (this.closed) {
+			return;
+		}
+
+		this.closed = true;
+		this.cleanupHandles();
+		this.child?.kill();
+		this.child = null;
+	}
+
+	private cleanupHandles(): void {
+		if (this.readline) {
+			this.readline.close();
+			this.readline.removeAllListeners();
+			this.readline = null;
+		}
+	}
+
+	private async handleStdoutLine(line: string): Promise<void> {
+		const trimmed = line.trim();
+		if (!trimmed) {
+			return;
+		}
+
+		let payload: unknown;
+		try {
+			payload = JSON.parse(trimmed);
+		} catch (error) {
+			const message = toErrorMessage(error);
+			this.rejectAllPending(
+				new Error(`Failed to parse Codex app-server JSON: ${message}`),
+			);
+			return;
+		}
+
+		if (isJsonRpcResponse(payload)) {
+			this.handleResponse(payload);
+			return;
+		}
+
+		if (isServerRequest(payload)) {
+			await this.handleServerRequest(payload);
+			return;
+		}
+
+		if (isNotification(payload)) {
+			this.options.onNotification(payload);
+			return;
+		}
+	}
+
+	private handleResponse(response: JsonRpcResponse): void {
+		const pending = this.pendingRequests.get(response.id);
+		if (!pending) {
+			return;
+		}
+
+		this.pendingRequests.delete(response.id);
+		if ("error" in response) {
+			pending.reject(new Error(response.error.message));
+			return;
+		}
+
+		pending.resolve(response.result);
+	}
+
+	private async handleServerRequest(request: AppServerRequest): Promise<void> {
+		try {
+			const result = this.options.onRequest
+				? await this.options.onRequest(request)
+				: this.defaultRequestResult(request);
+			this.writeMessage({ id: request.id, result });
+		} catch (error) {
+			this.writeMessage({
+				id: request.id,
+				error: {
+					code: -32603,
+					message: toErrorMessage(error),
+				},
+			});
+		}
+	}
+
+	private defaultRequestResult(request: AppServerRequest): unknown {
+		switch (request.method) {
+			case "item/commandExecution/requestApproval":
+				return { decision: "decline" };
+			case "item/fileChange/requestApproval":
+				return { decision: "decline" };
+			case "applyPatchApproval":
+				return { decision: "denied" };
+			case "execCommandApproval":
+				return { decision: "denied" };
+			default:
+				throw new Error(
+					`Unsupported Codex app-server request: ${request.method}`,
+				);
+		}
+	}
+
+	private request<Result = unknown>(
+		method: string,
+		params?: unknown,
+	): Promise<Result> {
+		const id = this.nextRequestId.value++;
+		return new Promise<Result>((resolve, reject) => {
+			this.pendingRequests.set(id, { resolve, reject });
+			try {
+				this.writeMessage(
+					params === undefined ? { method, id } : { method, id, params },
+				);
+			} catch (error) {
+				this.pendingRequests.delete(id);
+				reject(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+	}
+
+	private notify(method: string, params?: unknown): void {
+		this.writeMessage(params === undefined ? { method } : { method, params });
+	}
+
+	private writeMessage(message: unknown): void {
+		if (!this.child?.stdin) {
+			throw new Error("Codex app-server stdin is unavailable");
+		}
+
+		this.child.stdin.write(`${JSON.stringify(message)}\n`);
+	}
+
+	private rejectAllPending(error: Error): void {
+		if (this.pendingRequests.size === 0) {
+			return;
+		}
+
+		for (const pending of this.pendingRequests.values()) {
+			pending.reject(error);
+		}
+		this.pendingRequests.clear();
+	}
+}

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -838,6 +838,14 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private createAppServerClient(): CodexAppServerClient {
 		const codexHome = this.resolveCodexHome();
 		const envOverride = this.buildEnvOverride(codexHome);
+		// Cyrus intentionally runs one codex app-server per runner/session.
+		// In theory, a shared app-server could still segment cwd/worktree, model,
+		// developer instructions, approval policy, and sandbox policy per
+		// thread/turn. The remaining hard boundary is MCP config, which we load as
+		// startup config overrides (`mcp_servers`) before the app-server starts.
+		// Until Codex supports dynamic per-session MCP registration, a shared
+		// app-server would need an extra broker/proxy layer or a pool keyed by MCP
+		// config shape. Per-runner app-servers keep that state isolated.
 		return new CodexAppServerClient({
 			...(this.config.codexPath ? { codexPath: this.config.codexPath } : {}),
 			...(envOverride ? { env: envOverride } : {}),

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1161,7 +1161,18 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	private buildSandboxPolicy(): AppServerSandboxPolicy {
-		const readOnlyAccess: AppServerReadOnlyAccess = { type: "fullAccess" };
+		const readableRoots = [
+			this.config.workingDirectory,
+			...(this.config.allowedDirectories || []),
+		].filter((value): value is string => Boolean(value));
+		// Codex app-server docs recommend restricted read access with
+		// includePlatformDefaults enabled so macOS gets the curated platform
+		// Seatbelt allowances without reopening broad filesystem reads.
+		const readOnlyAccess: AppServerReadOnlyAccess = {
+			type: "restricted",
+			includePlatformDefaults: true,
+			readableRoots: [...new Set(readableRoots)],
+		};
 		switch (this.config.sandbox) {
 			case "read-only":
 				return {
@@ -1171,16 +1182,12 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			case "danger-full-access":
 				return { type: "dangerFullAccess" };
 			default: {
-				const writableRoots = [
-					this.config.workingDirectory,
-					...(this.config.allowedDirectories || []),
-				].filter((value): value is string => Boolean(value));
 				const networkAccess = this.extractWorkspaceNetworkAccess(
 					this.buildConfigOverrides(),
 				);
 				return {
 					type: "workspaceWrite",
-					writableRoots: [...new Set(writableRoots)],
+					writableRoots: [...new Set(readableRoots)],
 					readOnlyAccess,
 					networkAccess,
 					excludeTmpdirEnvVar: false,

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -5,18 +5,6 @@ import { homedir } from "node:os";
 import { join, relative as pathRelative } from "node:path";
 import { cwd } from "node:process";
 import type {
-	CommandExecutionItem,
-	FileChangeItem,
-	McpToolCallItem,
-	Thread,
-	ThreadItem,
-	ThreadOptions,
-	TodoListItem,
-	Usage,
-	WebSearchItem,
-} from "@openai/codex-sdk";
-import { Codex } from "@openai/codex-sdk";
-import type {
 	IAgentRunner,
 	IMessageFormatter,
 	McpServerConfig,
@@ -25,14 +13,30 @@ import type {
 	SDKResultMessage,
 	SDKUserMessage,
 } from "cyrus-core";
+import type {
+	AppServerApprovalPolicy,
+	AppServerNotification,
+	AppServerReadOnlyAccess,
+	AppServerRequest,
+	AppServerSandboxPolicy,
+	AppServerThreadItem,
+	AppServerTokenUsage,
+	AppServerTurnStartParams,
+	JsonValue,
+} from "./appServerProtocol.js";
+import { CodexAppServerClient } from "./CodexAppServerClient.js";
 import { CodexMessageFormatter } from "./formatter.js";
 import type {
 	CodexConfigOverrides,
 	CodexConfigValue,
 	CodexJsonEvent,
+	CodexMcpToolCallItem,
 	CodexRunnerConfig,
 	CodexRunnerEvents,
 	CodexSessionInfo,
+	CodexThreadItem,
+	CodexTodoListItem,
+	CodexUsage,
 } from "./types.js";
 
 type SDKSystemInitMessage = Extract<
@@ -59,7 +63,7 @@ interface ToolProjection {
 const DEFAULT_CODEX_MODEL = "gpt-5.3-codex";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
 
-function toFiniteNumber(value: number | undefined): number {
+function toFiniteNumber(value: unknown): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
@@ -164,7 +168,7 @@ function createAssistantBetaMessage(
 	};
 }
 
-function parseUsage(usage: Usage | null | undefined): ParsedUsage {
+function parseUsage(usage: CodexUsage | null | undefined): ParsedUsage {
 	if (!usage) {
 		return {
 			inputTokens: 0,
@@ -204,7 +208,6 @@ function createResultUsage(parsed: ParsedUsage): SDKResultMessage["usage"] {
 function getDefaultReasoningEffortForModel(
 	model?: string,
 ): CodexRunnerConfig["modelReasoningEffort"] | undefined {
-	// All gpt-5 variants (including plain "gpt-5") reject xhigh; pin to "high".
 	return /^gpt-5/i.test(model || "") ? "high" : undefined;
 }
 
@@ -254,7 +257,7 @@ function normalizeFilePath(path: string, workingDirectory?: string): string {
 }
 
 function summarizeFileChanges(
-	item: FileChangeItem,
+	item: Extract<CodexThreadItem, { type: "file_change" }>,
 	workingDirectory?: string,
 ): string {
 	if (!item.changes.length) {
@@ -276,7 +279,7 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 	return null;
 }
 
-function toMcpResultString(item: McpToolCallItem): string {
+function toMcpResultString(item: CodexMcpToolCallItem): string {
 	if (item.error?.message) {
 		return item.error.message;
 	}
@@ -370,6 +373,199 @@ function loadMcpConfigFromPaths(
 	return mcpServers;
 }
 
+function isJsonValue(value: unknown): value is JsonValue {
+	if (
+		value === null ||
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	) {
+		return true;
+	}
+
+	if (Array.isArray(value)) {
+		return value.every((entry) => isJsonValue(entry));
+	}
+
+	if (value && typeof value === "object") {
+		return Object.values(value as Record<string, unknown>).every((entry) =>
+			entry === undefined ? true : isJsonValue(entry),
+		);
+	}
+
+	return false;
+}
+
+function serializeConfigOverrides(
+	configOverrides: CodexConfigOverrides | undefined,
+): string[] {
+	if (!configOverrides) {
+		return [];
+	}
+
+	const overrides: string[] = [];
+	flattenConfigOverrides(configOverrides, "", overrides);
+	return overrides;
+}
+
+function flattenConfigOverrides(
+	value: CodexConfigValue | CodexConfigOverrides,
+	prefix: string,
+	overrides: string[],
+): void {
+	if (!isPlainObject(value)) {
+		if (!prefix) {
+			throw new Error("Codex config overrides must be a plain object");
+		}
+		overrides.push(`${prefix}=${toTomlValue(value, prefix)}`);
+		return;
+	}
+
+	const entries = Object.entries(value);
+	if (!prefix && entries.length === 0) {
+		return;
+	}
+	if (prefix && entries.length === 0) {
+		overrides.push(`${prefix}={}`);
+		return;
+	}
+
+	for (const [key, child] of entries) {
+		if (!key) {
+			throw new Error("Codex config override keys must be non-empty strings");
+		}
+		if (child === undefined) {
+			continue;
+		}
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (isPlainObject(child)) {
+			flattenConfigOverrides(child as CodexConfigOverrides, path, overrides);
+		} else {
+			overrides.push(`${path}=${toTomlValue(child, path)}`);
+		}
+	}
+}
+
+function toTomlValue(value: CodexConfigValue, path: string): string {
+	if (typeof value === "string") {
+		return JSON.stringify(value);
+	}
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) {
+			throw new Error(
+				`Codex config override at ${path} must be a finite number`,
+			);
+		}
+		return `${value}`;
+	}
+	if (typeof value === "boolean") {
+		return value ? "true" : "false";
+	}
+	if (Array.isArray(value)) {
+		return `[${value
+			.map((entry, index) => toTomlValue(entry, `${path}[${index}]`))
+			.join(", ")}]`;
+	}
+	if (isPlainObject(value)) {
+		return `{${Object.entries(value)
+			.filter(([, child]) => child !== undefined)
+			.map(
+				([key, child]) =>
+					`${formatTomlKey(key)} = ${toTomlValue(child as CodexConfigValue, `${path}.${key}`)}`,
+			)
+			.join(", ")}}`;
+	}
+	throw new Error(`Unsupported Codex config override value at ${path}`);
+}
+
+function formatTomlKey(key: string): string {
+	return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeThreadItem(
+	item: AppServerThreadItem,
+): CodexThreadItem | null {
+	switch (item.type) {
+		case "agentMessage":
+			return {
+				id: item.id,
+				type: "agent_message",
+				text: item.text,
+			};
+		case "commandExecution":
+			return {
+				id: item.id,
+				type: "command_execution",
+				command: item.command,
+				aggregated_output: item.aggregatedOutput || "",
+				...(typeof item.exitCode === "number"
+					? { exit_code: item.exitCode }
+					: {}),
+				status: item.status === "inProgress" ? "in_progress" : item.status,
+			};
+		case "fileChange":
+			return {
+				id: item.id,
+				type: "file_change",
+				status: item.status,
+				changes: item.changes.map((change) => ({
+					path: change.path,
+					kind: change.kind,
+				})),
+			};
+		case "mcpToolCall":
+			return {
+				id: item.id,
+				type: "mcp_tool_call",
+				server: item.server,
+				tool: item.tool,
+				arguments: item.arguments,
+				result: item.result
+					? {
+							content: item.result.content,
+							structured_content:
+								item.result.structured_content ?? item.result.structuredContent,
+						}
+					: undefined,
+				error: item.error ?? undefined,
+				status: item.status === "inProgress" ? "in_progress" : item.status,
+			};
+		case "webSearch":
+			return {
+				id: item.id,
+				type: "web_search",
+				query: item.query,
+				action: item.action,
+			};
+		default:
+			return null;
+	}
+}
+
+function buildTodoEvent(
+	turnId: string,
+	plan: Array<{ step: string; status: "pending" | "inProgress" | "completed" }>,
+): CodexJsonEvent {
+	const todoItem: CodexTodoListItem = {
+		id: `plan_${turnId}`,
+		type: "todo_list",
+		items: plan.map((entry) => ({
+			text: entry.step,
+			completed: entry.status === "completed",
+			in_progress: entry.status === "inProgress",
+		})),
+	};
+
+	return {
+		type: "item.completed",
+		item: todoItem,
+	};
+}
+
 export declare interface CodexRunner {
 	on<K extends keyof CodexRunnerEvents>(
 		event: K,
@@ -381,9 +577,6 @@ export declare interface CodexRunner {
 	): boolean;
 }
 
-/**
- * Runner that adapts Codex SDK streaming output to Cyrus SDK message types.
- */
 export class CodexRunner extends EventEmitter implements IAgentRunner {
 	readonly supportsStreamingInput = false;
 
@@ -402,8 +595,11 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private errorMessages: string[] = [];
 	private startTimestampMs = 0;
 	private wasStopped = false;
-	private abortController: AbortController | null = null;
 	private emittedToolUseIds: Set<string> = new Set();
+	private tokenUsageByTurn = new Map<string, AppServerTokenUsage>();
+	private appServerClient: CodexAppServerClient | null = null;
+	private terminalTurnResolver: (() => void) | null = null;
+	private terminalTurnRejecter: ((error: Error) => void) | null = null;
 
 	constructor(config: CodexRunnerConfig) {
 		super();
@@ -427,9 +623,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		throw new Error("CodexRunner does not support streaming input messages");
 	}
 
-	completeStream(): void {
-		// No-op: CodexRunner does not support streaming input.
-	}
+	completeStream(): void {}
 
 	private async startWithPrompt(
 		stringPrompt?: string | null,
@@ -459,38 +653,36 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		this.wasStopped = false;
 		this.startTimestampMs = Date.now();
 		this.emittedToolUseIds.clear();
+		this.tokenUsageByTurn.clear();
 
 		await this.resolveModelWithFallback();
 
 		const prompt = (stringPrompt ?? streamingInitialPrompt ?? "").trim();
-		const threadOptions = this.buildThreadOptions();
-		const codex = this.createCodexClient();
-		const thread = this.config.resumeSessionId
-			? codex.resumeThread(this.config.resumeSessionId, threadOptions)
-			: codex.startThread(threadOptions);
-		const abortController = new AbortController();
-		this.abortController = abortController;
-
 		let caughtError: unknown;
+
 		try {
-			await this.runTurn(thread, prompt, abortController.signal);
+			const client = this.createAppServerClient();
+			this.appServerClient = client;
+			await client.connect({
+				clientInfo: {
+					name: "cyrus_codex_runner",
+					title: "Cyrus Codex Runner",
+					version: "0.1.0",
+				},
+				capabilities: {
+					experimentalApi: false,
+				},
+			});
+			await this.runTurn(client, prompt);
 		} catch (error) {
 			caughtError = error;
 		} finally {
 			this.finalizeSession(caughtError);
 		}
 
-		return this.sessionInfo;
+		return this.sessionInfo!;
 	}
 
-	/**
-	 * Check if the configured model is accessible via the OpenAI API.
-	 * If not, swap to the fallback model before starting the session.
-	 *
-	 * Skipped when:
-	 * - No OPENAI_API_KEY is set (Codex-native auth handles model access)
-	 * - The user has a ChatGPT subscription (`codex login status` reports "Logged in using ChatGPT")
-	 */
 	private async resolveModelWithFallback(): Promise<void> {
 		const model = this.config.model;
 		const fallback = this.config.fallbackModel;
@@ -523,16 +715,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				this.config.model = fallback;
 			}
 		} catch {
-			// Network error or timeout — proceed with the original model
-			// and let the Codex SDK handle any downstream failure.
+			// Keep the original model and let Codex surface any downstream issue.
 		}
 	}
 
-	/**
-	 * Check if the user has a ChatGPT/Codex subscription by running `codex login status`.
-	 * Returns true when the output contains "Logged in using ChatGPT",
-	 * meaning the user has native Codex auth and can access gpt-5.3-codex.
-	 */
 	private async hasCodexSubscription(): Promise<boolean> {
 		const codexBin = this.config.codexPath || "codex";
 		try {
@@ -557,55 +743,313 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 	}
 
-	private createCodexClient(): Codex {
+	private createAppServerClient(): CodexAppServerClient {
 		const codexHome = this.resolveCodexHome();
 		const envOverride = this.buildEnvOverride(codexHome);
-		const configOverrides = this.buildConfigOverrides();
-
-		return new Codex({
-			...(this.config.codexPath
-				? { codexPathOverride: this.config.codexPath }
-				: {}),
+		return new CodexAppServerClient({
+			...(this.config.codexPath ? { codexPath: this.config.codexPath } : {}),
 			...(envOverride ? { env: envOverride } : {}),
-			...(configOverrides ? { config: configOverrides } : {}),
+			configOverrides: serializeConfigOverrides(
+				this.buildAppServerConfigOverrides(),
+			),
+			onNotification: (notification) => {
+				const event = this.translateNotification(notification);
+				if (event) {
+					this.handleEvent(event);
+				}
+			},
+			onRequest: async (request) => this.handleAppServerRequest(request),
 		});
 	}
 
-	private buildThreadOptions(): ThreadOptions {
-		const additionalDirectories = this.getAdditionalDirectories();
-		const reasoningEffort =
-			this.config.modelReasoningEffort ??
-			getDefaultReasoningEffortForModel(this.config.model);
-		const webSearchMode =
-			this.config.webSearchMode ??
-			(this.config.includeWebSearch ? "live" : undefined);
+	private async handleAppServerRequest(
+		request: AppServerRequest,
+	): Promise<unknown> {
+		if (
+			request.method === "item/tool/requestUserInput" &&
+			this.config.onAskUserQuestion
+		) {
+			const params = request.params as {
+				questions: Array<{
+					id: string;
+					header: string;
+					question: string;
+					options: Array<{ label: string; description: string }> | null;
+				}>;
+			};
+			const result = await this.config.onAskUserQuestion(
+				{
+					questions: params.questions.map((question) => ({
+						header: question.header,
+						question: question.question,
+						options: question.options || [],
+						multiSelect: false,
+					})),
+				} as any,
+				this.sessionInfo?.sessionId || "pending",
+				new AbortController().signal,
+			);
 
-		const threadOptions: ThreadOptions = {
-			model: this.config.model,
-			sandboxMode: this.config.sandbox || "workspace-write",
-			workingDirectory: this.config.workingDirectory,
-			skipGitRepoCheck: this.config.skipGitRepoCheck ?? true,
-			approvalPolicy: this.config.askForApproval || "never",
-			...(reasoningEffort ? { modelReasoningEffort: reasoningEffort } : {}),
-			...(webSearchMode ? { webSearchMode } : {}),
-			...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
-		};
-
-		return threadOptions;
-	}
-
-	private getAdditionalDirectories(): string[] {
-		const workingDirectory = this.config.workingDirectory;
-		const uniqueDirectories = new Set<string>();
-
-		for (const directory of this.config.allowedDirectories || []) {
-			if (!directory || directory === workingDirectory) {
-				continue;
+			if (!result.answered || !result.answers) {
+				throw new Error(result.message || "User input request was declined");
 			}
-			uniqueDirectories.add(directory);
+
+			return {
+				answers: Object.fromEntries(
+					params.questions.map((question) => {
+						const answer = result.answers?.[question.question];
+						return [
+							question.id,
+							{
+								answers: answer ? [answer] : [],
+							},
+						];
+					}),
+				),
+			};
 		}
 
-		return [...uniqueDirectories];
+		switch (request.method) {
+			case "item/commandExecution/requestApproval":
+				return { decision: "decline" };
+			case "item/fileChange/requestApproval":
+				return { decision: "decline" };
+			case "applyPatchApproval":
+				return { decision: "denied" };
+			case "execCommandApproval":
+				return { decision: "denied" };
+			default:
+				throw new Error(
+					`Unsupported Codex app-server request in Cyrus: ${request.method}`,
+				);
+		}
+	}
+
+	private translateNotification(
+		notification: AppServerNotification,
+	): CodexJsonEvent | null {
+		switch (notification.method) {
+			case "thread/started": {
+				const params = notification.params as { thread: { id: string } };
+				return {
+					type: "thread.started",
+					thread_id: params.thread.id,
+				};
+			}
+			case "item/started": {
+				const params = notification.params as {
+					item: AppServerThreadItem;
+				};
+				const item = normalizeThreadItem(params.item);
+				return item ? { type: "item.started", item } : null;
+			}
+			case "item/completed": {
+				const params = notification.params as {
+					item: AppServerThreadItem;
+				};
+				const item = normalizeThreadItem(params.item);
+				return item ? { type: "item.completed", item } : null;
+			}
+			case "turn/plan/updated": {
+				const params = notification.params as {
+					turnId: string;
+					plan: Array<{
+						step: string;
+						status: "pending" | "inProgress" | "completed";
+					}>;
+				};
+				return buildTodoEvent(params.turnId, params.plan);
+			}
+			case "thread/tokenUsage/updated": {
+				const params = notification.params as {
+					turnId: string;
+					tokenUsage: AppServerTokenUsage;
+				};
+				this.tokenUsageByTurn.set(params.turnId, params.tokenUsage);
+				return null;
+			}
+			case "turn/completed": {
+				const params = notification.params as {
+					turn: {
+						id: string;
+						status: "completed" | "failed" | "interrupted" | "inProgress";
+						error: { message: string } | null;
+					};
+				};
+				const turn = params.turn;
+				if (turn.status === "failed") {
+					return {
+						type: "turn.failed",
+						error: {
+							message: turn.error?.message || "Codex execution failed",
+						},
+					};
+				}
+				if (turn.status === "interrupted" && this.wasStopped) {
+					return null;
+				}
+				const usage = this.tokenUsageByTurn.get(turn.id);
+				return {
+					type: "turn.completed",
+					...(usage
+						? {
+								usage: {
+									input_tokens: usage.last.inputTokens,
+									output_tokens: usage.last.outputTokens,
+									cached_input_tokens: usage.last.cachedInputTokens,
+								},
+							}
+						: {}),
+				};
+			}
+			case "error": {
+				const params = notification.params as { message: string };
+				return {
+					type: "error",
+					message: params.message,
+				};
+			}
+			default:
+				return null;
+		}
+	}
+
+	private async runTurn(
+		client: CodexAppServerClient,
+		prompt: string,
+	): Promise<void> {
+		const threadConfig = this.buildThreadConfig();
+		const threadResponse = this.config.resumeSessionId
+			? await client.resumeThread({
+					threadId: this.config.resumeSessionId,
+				})
+			: await client.startThread({
+					model: this.config.model,
+					cwd: this.config.workingDirectory,
+					approvalPolicy: this.buildApprovalPolicy(),
+					sandbox: this.config.sandbox || "workspace-write",
+					developerInstructions: threadConfig.developerInstructions,
+					ephemeral: false,
+				});
+
+		if (this.sessionInfo) {
+			this.sessionInfo.sessionId = threadResponse.thread.id;
+		}
+		this.emitSystemInitMessage(threadResponse.thread.id);
+
+		const turnParams: AppServerTurnStartParams = {
+			threadId: threadResponse.thread.id,
+			input: [
+				{
+					type: "text",
+					text: prompt,
+					text_elements: [],
+				},
+			],
+			cwd: this.config.workingDirectory,
+			approvalPolicy: this.buildApprovalPolicy(),
+			sandboxPolicy: this.buildSandboxPolicy(),
+			model: this.config.model,
+			effort:
+				this.config.modelReasoningEffort ??
+				getDefaultReasoningEffortForModel(this.config.model),
+			...(isJsonValue(threadConfig.outputSchema)
+				? { outputSchema: threadConfig.outputSchema }
+				: {}),
+		};
+
+		const completionPromise = new Promise<void>((resolve, reject) => {
+			this.terminalTurnResolver = resolve;
+			this.terminalTurnRejecter = reject;
+		});
+
+		await client.startTurn(turnParams);
+		await completionPromise;
+	}
+
+	private buildApprovalPolicy(): AppServerApprovalPolicy {
+		return this.config.askForApproval || "never";
+	}
+
+	private buildSandboxPolicy(): AppServerSandboxPolicy {
+		const readOnlyAccess: AppServerReadOnlyAccess = { type: "fullAccess" };
+		switch (this.config.sandbox) {
+			case "read-only":
+				return {
+					type: "readOnly",
+					access: readOnlyAccess,
+				};
+			case "danger-full-access":
+				return { type: "dangerFullAccess" };
+			default: {
+				const writableRoots = [
+					this.config.workingDirectory,
+					...(this.config.allowedDirectories || []),
+				].filter((value): value is string => Boolean(value));
+				const networkAccess = this.extractWorkspaceNetworkAccess(
+					this.buildConfigOverrides(),
+				);
+				return {
+					type: "workspaceWrite",
+					writableRoots: [...new Set(writableRoots)],
+					readOnlyAccess,
+					networkAccess,
+					excludeTmpdirEnvVar: false,
+					excludeSlashTmp: false,
+				};
+			}
+		}
+	}
+
+	private extractWorkspaceNetworkAccess(
+		configOverrides: CodexConfigOverrides | undefined,
+	): boolean {
+		const sandboxWorkspaceWrite = configOverrides?.sandbox_workspace_write;
+		if (
+			sandboxWorkspaceWrite &&
+			typeof sandboxWorkspaceWrite === "object" &&
+			!Array.isArray(sandboxWorkspaceWrite) &&
+			typeof sandboxWorkspaceWrite.network_access === "boolean"
+		) {
+			return sandboxWorkspaceWrite.network_access;
+		}
+		return true;
+	}
+
+	private buildThreadConfig(): {
+		developerInstructions?: string;
+		outputSchema?: JsonValue;
+	} {
+		const rawConfig = this.buildConfigOverrides();
+		if (!rawConfig) {
+			return {};
+		}
+
+		const { developer_instructions } = rawConfig as CodexConfigOverrides & {
+			developer_instructions?: CodexConfigValue;
+		};
+
+		return {
+			...(typeof developer_instructions === "string"
+				? { developerInstructions: developer_instructions }
+				: {}),
+			...(isJsonValue(this.config.outputSchema)
+				? { outputSchema: this.config.outputSchema }
+				: {}),
+		};
+	}
+
+	private buildAppServerConfigOverrides(): CodexConfigOverrides | undefined {
+		const rawConfig = this.buildConfigOverrides();
+		if (!rawConfig) {
+			return undefined;
+		}
+
+		const { developer_instructions, ...rest } =
+			rawConfig as CodexConfigOverrides & {
+				developer_instructions?: CodexConfigValue;
+			};
+		return Object.keys(rest).length > 0 ? rest : undefined;
 	}
 
 	private resolveCodexHome(): string {
@@ -640,9 +1084,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		const autoDetectedPath = autoDetectMcpConfigPath(
 			this.config.workingDirectory,
 		);
-		const configPaths = autoDetectedPath
-			? [autoDetectedPath]
-			: ([] as string[]);
+		const configPaths = autoDetectedPath ? [autoDetectedPath] : [];
 		if (this.config.mcpConfigPath) {
 			const explicitPaths = Array.isArray(this.config.mcpConfigPath)
 				? this.config.mcpConfigPath
@@ -658,8 +1100,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			return undefined;
 		}
 
-		// Codex MCP configuration reference:
-		// https://platform.openai.com/docs/docs-mcp
 		const codexServers: Record<string, CodexConfigOverrides> = {};
 		for (const [serverName, rawConfig] of Object.entries(mergedServers)) {
 			const configAny = rawConfig as Record<string, unknown>;
@@ -769,9 +1209,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		const sandboxWorkspaceWrite = configOverrides.sandbox_workspace_write;
-		// Keep workspace-write as the default sandbox, but enable outbound network so
-		// common remote workflows (for example `git`/`gh` against GitHub) work without
-		// requiring danger-full-access.
 		if (
 			sandboxWorkspaceWrite &&
 			typeof sandboxWorkspaceWrite === "object" &&
@@ -797,22 +1234,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			...configOverrides,
 			developer_instructions: appendSystemPrompt,
 		};
-	}
-
-	private async runTurn(
-		thread: Thread,
-		prompt: string,
-		signal: AbortSignal,
-	): Promise<void> {
-		const streamedTurn = await thread.runStreamed(prompt, {
-			signal,
-			...(this.config.outputSchema
-				? { outputSchema: this.config.outputSchema }
-				: {}),
-		});
-		for await (const event of streamedTurn.events) {
-			this.handleEvent(event);
-		}
 	}
 
 	private handleEvent(event: CodexJsonEvent): void {
@@ -843,16 +1264,21 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				this.pendingResultMessage = this.createSuccessResultMessage(
 					this.lastAssistantText || "Codex session completed successfully",
 				);
+				this.terminalTurnResolver?.();
+				this.terminalTurnResolver = null;
+				this.terminalTurnRejecter = null;
 				break;
 			}
 			case "turn.failed": {
-				// Prefer event.error.message; fallback to last standalone "error" event
 				const message =
 					event.error?.message ||
 					this.errorMessages.at(-1) ||
 					"Codex execution failed";
 				this.errorMessages.push(message);
 				this.pendingResultMessage = this.createErrorResultMessage(message);
+				this.terminalTurnRejecter?.(new Error(message));
+				this.terminalTurnResolver = null;
+				this.terminalTurnRejecter = null;
 				break;
 			}
 			case "error": {
@@ -864,42 +1290,36 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 	}
 
-	private projectItemToTool(item: ThreadItem): ToolProjection | null {
+	private projectItemToTool(item: CodexThreadItem): ToolProjection | null {
 		switch (item.type) {
 			case "command_execution": {
-				const commandItem = item as CommandExecutionItem;
 				const isError =
-					commandItem.status === "failed" ||
-					(typeof commandItem.exit_code === "number" &&
-						commandItem.exit_code !== 0);
+					item.status === "failed" ||
+					(typeof item.exit_code === "number" && item.exit_code !== 0);
 				const result =
-					commandItem.aggregated_output?.trim() ||
+					item.aggregated_output.trim() ||
 					(isError
-						? `Command failed (exit code ${commandItem.exit_code ?? "unknown"})`
+						? `Command failed (exit code ${item.exit_code ?? "unknown"})`
 						: "Command completed with no output");
 
 				return {
-					toolUseId: commandItem.id,
-					toolName: inferCommandToolName(commandItem.command),
-					toolInput: { command: commandItem.command },
+					toolUseId: item.id,
+					toolName: inferCommandToolName(item.command),
+					toolInput: { command: item.command },
 					result,
 					isError,
 				};
 			}
 			case "file_change": {
-				const fileChangeItem = item as FileChangeItem;
 				const primaryPath =
-					fileChangeItem.changes[0]?.path &&
-					normalizeFilePath(
-						fileChangeItem.changes[0].path,
-						this.config.workingDirectory,
-					);
+					item.changes[0]?.path &&
+					normalizeFilePath(item.changes[0].path, this.config.workingDirectory);
 				return {
-					toolUseId: fileChangeItem.id,
+					toolUseId: item.id,
 					toolName: "Edit",
 					toolInput: {
 						...(primaryPath ? { file_path: primaryPath } : {}),
-						changes: fileChangeItem.changes.map((change) => ({
+						changes: item.changes.map((change) => ({
 							kind: change.kind,
 							path: normalizeFilePath(
 								change.path,
@@ -907,73 +1327,61 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 							),
 						})),
 					},
-					result: summarizeFileChanges(
-						fileChangeItem,
-						this.config.workingDirectory,
-					),
-					isError: fileChangeItem.status === "failed",
+					result: summarizeFileChanges(item, this.config.workingDirectory),
+					isError: item.status === "failed",
 				};
 			}
 			case "web_search": {
-				const webSearchItem = item as WebSearchItem;
-				const extendedItem = item as unknown as Record<string, unknown>;
-				const action = asRecord(extendedItem.action);
+				const action = asRecord(item.action);
 				const actionType =
 					typeof action?.type === "string" ? action.type : undefined;
 				const isFetch = actionType === "open_page";
-				const url =
-					typeof action?.url === "string"
-						? action.url
-						: typeof extendedItem.url === "string"
-							? extendedItem.url
-							: undefined;
+				const url = typeof action?.url === "string" ? action.url : undefined;
 				const pattern =
-					typeof action?.pattern === "string"
-						? action.pattern
-						: typeof extendedItem.pattern === "string"
-							? extendedItem.pattern
-							: undefined;
+					typeof action?.pattern === "string" ? action.pattern : undefined;
 
 				return {
-					toolUseId: webSearchItem.id,
+					toolUseId: item.id,
 					toolName: isFetch ? "WebFetch" : "WebSearch",
 					toolInput: isFetch
 						? {
-								url: url || webSearchItem.query,
+								url: url || item.query,
 								...(pattern ? { pattern } : {}),
 							}
-						: { query: webSearchItem.query },
+						: { query: item.query },
 					result:
 						action && Object.keys(action).length > 0
 							? safeStringify(action)
-							: `Search completed for query: ${webSearchItem.query}`,
+							: `Search completed for query: ${item.query}`,
 					isError: false,
 				};
 			}
 			case "mcp_tool_call": {
-				const mcpItem = item as McpToolCallItem;
 				return {
-					toolUseId: mcpItem.id,
-					toolName: `mcp__${normalizeMcpIdentifier(mcpItem.server)}__${normalizeMcpIdentifier(mcpItem.tool)}`,
-					toolInput: asRecord(mcpItem.arguments) || {
-						arguments: mcpItem.arguments,
+					toolUseId: item.id,
+					toolName: `mcp__${normalizeMcpIdentifier(item.server)}__${normalizeMcpIdentifier(item.tool)}`,
+					toolInput: asRecord(item.arguments) || {
+						arguments: item.arguments,
 					},
-					result: toMcpResultString(mcpItem),
-					isError: mcpItem.status === "failed" || Boolean(mcpItem.error),
+					result: toMcpResultString(item),
+					isError: item.status === "failed" || Boolean(item.error),
 				};
 			}
 			case "todo_list": {
-				const todoItem = item as TodoListItem;
 				return {
-					toolUseId: todoItem.id,
+					toolUseId: item.id,
 					toolName: "TodoWrite",
 					toolInput: {
-						todos: todoItem.items.map((todo) => ({
+						todos: item.items.map((todo) => ({
 							content: todo.text,
-							status: todo.completed ? "completed" : "pending",
+							status: todo.completed
+								? "completed"
+								: todo.in_progress
+									? "in_progress"
+									: "pending",
 						})),
 					},
-					result: `Updated todo list (${todoItem.items.length} items)`,
+					result: `Updated todo list (${item.items.length} items)`,
 					isError: false,
 				};
 			}
@@ -983,7 +1391,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	private emitToolMessagesForItem(
-		item: ThreadItem,
+		item: CodexThreadItem,
 		includeResult: boolean,
 	): void {
 		const projection = this.projectItemToTool(item);
@@ -1037,7 +1445,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 
 		this.sessionInfo.isRunning = false;
 
-		// Ensure init is emitted even if stream fails before thread.started.
 		if (!this.hasInitMessage) {
 			this.emitSystemInitMessage(
 				this.sessionInfo.sessionId || this.config.resumeSessionId || "pending",
@@ -1068,7 +1475,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		this.emit("complete", [...this.messages]);
-
 		this.cleanupRuntimeState();
 	}
 
@@ -1101,7 +1507,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			subtype: "init",
 			agents: undefined,
 			apiKeySource: "user",
-			claude_code_version: "codex-cli",
+			claude_code_version: "codex-app-server",
 			cwd: this.config.workingDirectory || cwd(),
 			tools: [],
 			mcp_servers: [],
@@ -1160,15 +1566,31 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	private cleanupRuntimeState(): void {
-		this.abortController = null;
+		this.terminalTurnResolver = null;
+		this.terminalTurnRejecter = null;
+		this.appServerClient?.close();
+		this.appServerClient = null;
 	}
 
 	stop(): void {
 		if (!this.sessionInfo?.isRunning) {
 			return;
 		}
+
 		this.wasStopped = true;
-		this.abortController?.abort();
+		if (this.appServerClient && this.sessionInfo.sessionId) {
+			void this.appServerClient
+				.interruptTurn({ threadId: this.sessionInfo.sessionId })
+				.catch((error) => {
+					console.warn(
+						`[CodexRunner] Failed to interrupt app-server turn: ${normalizeError(error)}`,
+					);
+					this.appServerClient?.close();
+				});
+			return;
+		}
+
+		this.appServerClient?.close();
 	}
 
 	isRunning(): boolean {

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -578,7 +578,7 @@ export declare interface CodexRunner {
 }
 
 export class CodexRunner extends EventEmitter implements IAgentRunner {
-	readonly supportsStreamingInput = false;
+	readonly supportsStreamingInput = true;
 
 	private config: CodexRunnerConfig;
 	private sessionInfo: CodexSessionInfo | null = null;
@@ -600,6 +600,15 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private appServerClient: CodexAppServerClient | null = null;
 	private terminalTurnResolver: (() => void) | null = null;
 	private terminalTurnRejecter: ((error: Error) => void) | null = null;
+	private completedTurnCount = 0;
+	private pendingPrompts: string[] = [];
+	private sessionTask: Promise<void> | null = null;
+	private streamingMode = false;
+	private streamingCompleted = false;
+	private activeTurnId: string | null = null;
+	private turnStartedPromise: Promise<void> | null = null;
+	private turnStartedResolver: (() => void) | null = null;
+	private turnStartedRejecter: ((error: Error) => void) | null = null;
 
 	constructor(config: CodexRunnerConfig) {
 		super();
@@ -619,11 +628,71 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		return this.startWithPrompt(null, initialPrompt);
 	}
 
-	addStreamMessage(_content: string): void {
-		throw new Error("CodexRunner does not support streaming input messages");
+	addStreamMessage(content: string): void {
+		if (!this.streamingMode) {
+			throw new Error("Cannot add stream message when not in streaming mode");
+		}
+		if (this.streamingCompleted) {
+			throw new Error("Cannot add stream message after stream completion");
+		}
+		if (!this.sessionInfo?.isRunning) {
+			throw new Error(
+				"Cannot add stream message when Codex session is not running",
+			);
+		}
+
+		const prompt = content.trim();
+		if (!prompt) {
+			return;
+		}
+
+		if (
+			this.activeTurnId &&
+			this.appServerClient &&
+			this.sessionInfo?.sessionId
+		) {
+			void this.appServerClient
+				.steerTurn({
+					threadId: this.sessionInfo.sessionId,
+					expectedTurnId: this.activeTurnId,
+					input: [
+						{
+							type: "text",
+							text: prompt,
+							text_elements: [],
+						},
+					],
+				})
+				.catch((error) => {
+					const message = normalizeError(error);
+					this.errorMessages.push(message);
+					this.emit("error", new Error(message));
+				});
+			return;
+		}
+
+		this.pendingPrompts.push(prompt);
+		this.ensureSessionTaskRunning();
 	}
 
-	completeStream(): void {}
+	completeStream(): void {
+		this.streamingCompleted = true;
+		if (
+			this.sessionInfo?.isRunning &&
+			!this.sessionTask &&
+			this.pendingPrompts.length === 0
+		) {
+			this.finalizeSession();
+		}
+	}
+
+	isStreaming(): boolean {
+		return (
+			this.streamingMode &&
+			!this.streamingCompleted &&
+			(this.sessionInfo?.isRunning ?? false)
+		);
+	}
 
 	private async startWithPrompt(
 		stringPrompt?: string | null,
@@ -654,6 +723,15 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		this.startTimestampMs = Date.now();
 		this.emittedToolUseIds.clear();
 		this.tokenUsageByTurn.clear();
+		this.completedTurnCount = 0;
+		this.pendingPrompts = [];
+		this.sessionTask = null;
+		this.streamingMode = stringPrompt === null || stringPrompt === undefined;
+		this.streamingCompleted = false;
+		this.activeTurnId = null;
+		this.turnStartedPromise = null;
+		this.turnStartedResolver = null;
+		this.turnStartedRejecter = null;
 
 		await this.resolveModelWithFallback();
 
@@ -673,12 +751,26 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 					experimentalApi: false,
 				},
 			});
-			await this.runTurn(client, prompt);
+
+			await this.initializeThread(client);
+			if (prompt) {
+				this.pendingPrompts.push(prompt);
+			}
+
+			if (this.streamingMode) {
+				this.ensureSessionTaskRunning();
+				if (prompt) {
+					await this.waitForTurnToStart();
+				}
+				return this.sessionInfo!;
+			}
+
+			await this.drainPendingPrompts(client);
 		} catch (error) {
 			caughtError = error;
-		} finally {
-			this.finalizeSession(caughtError);
 		}
+
+		this.finalizeSession(caughtError);
 
 		return this.sessionInfo!;
 	}
@@ -885,8 +977,15 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 						},
 					};
 				}
-				if (turn.status === "interrupted" && this.wasStopped) {
-					return null;
+				if (turn.status === "interrupted") {
+					return {
+						type: "turn.interrupted",
+						message:
+							turn.error?.message ||
+							(this.wasStopped
+								? "Codex session interrupted"
+								: "Codex turn interrupted"),
+					};
 				}
 				const usage = this.tokenUsageByTurn.get(turn.id);
 				return {
@@ -918,6 +1017,76 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		client: CodexAppServerClient,
 		prompt: string,
 	): Promise<void> {
+		const threadId = this.sessionInfo?.sessionId;
+		if (!threadId) {
+			throw new Error("Codex app-server thread is not initialized");
+		}
+
+		const trimmedPrompt = prompt.trim();
+		if (!trimmedPrompt) {
+			return;
+		}
+
+		this.pendingResultMessage = null;
+		const turnParams: AppServerTurnStartParams = {
+			threadId,
+			input: [
+				{
+					type: "text",
+					text: trimmedPrompt,
+					text_elements: [],
+				},
+			],
+			cwd: this.config.workingDirectory,
+			approvalPolicy: this.buildApprovalPolicy(),
+			sandboxPolicy: this.buildSandboxPolicy(),
+			model: this.config.model,
+			effort:
+				this.config.modelReasoningEffort ??
+				getDefaultReasoningEffortForModel(this.config.model),
+			...(isJsonValue(this.config.outputSchema)
+				? { outputSchema: this.config.outputSchema }
+				: {}),
+		};
+
+		const completionPromise = new Promise<void>((resolve, reject) => {
+			this.terminalTurnResolver = resolve;
+			this.terminalTurnRejecter = reject;
+		});
+
+		try {
+			const startedTurn = await client.startTurn(turnParams);
+			this.activeTurnId = startedTurn.turn.id;
+			this.turnStartedResolver?.();
+			this.turnStartedPromise = null;
+			this.turnStartedResolver = null;
+			this.turnStartedRejecter = null;
+		} catch (error) {
+			this.turnStartedRejecter?.(
+				error instanceof Error ? error : new Error(normalizeError(error)),
+			);
+			this.turnStartedPromise = null;
+			this.turnStartedResolver = null;
+			this.turnStartedRejecter = null;
+			throw error;
+		}
+		await completionPromise;
+	}
+
+	private async waitForTurnToStart(): Promise<void> {
+		if (this.activeTurnId) {
+			return;
+		}
+		if (!this.turnStartedPromise) {
+			this.turnStartedPromise = new Promise<void>((resolve, reject) => {
+				this.turnStartedResolver = resolve;
+				this.turnStartedRejecter = reject;
+			});
+		}
+		await this.turnStartedPromise;
+	}
+
+	private async initializeThread(client: CodexAppServerClient): Promise<void> {
 		const threadConfig = this.buildThreadConfig();
 		const threadResponse = this.config.resumeSessionId
 			? await client.resumeThread({
@@ -936,35 +1105,55 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			this.sessionInfo.sessionId = threadResponse.thread.id;
 		}
 		this.emitSystemInitMessage(threadResponse.thread.id);
+	}
 
-		const turnParams: AppServerTurnStartParams = {
-			threadId: threadResponse.thread.id,
-			input: [
-				{
-					type: "text",
-					text: prompt,
-					text_elements: [],
-				},
-			],
-			cwd: this.config.workingDirectory,
-			approvalPolicy: this.buildApprovalPolicy(),
-			sandboxPolicy: this.buildSandboxPolicy(),
-			model: this.config.model,
-			effort:
-				this.config.modelReasoningEffort ??
-				getDefaultReasoningEffortForModel(this.config.model),
-			...(isJsonValue(threadConfig.outputSchema)
-				? { outputSchema: threadConfig.outputSchema }
-				: {}),
-		};
+	private ensureSessionTaskRunning(): void {
+		if (
+			!this.appServerClient ||
+			!this.sessionInfo?.isRunning ||
+			this.sessionTask
+		) {
+			return;
+		}
+		if (this.pendingPrompts.length === 0) {
+			if (this.streamingCompleted) {
+				this.finalizeSession();
+			}
+			return;
+		}
 
-		const completionPromise = new Promise<void>((resolve, reject) => {
-			this.terminalTurnResolver = resolve;
-			this.terminalTurnRejecter = reject;
-		});
+		this.sessionTask = this.drainPendingPrompts(this.appServerClient).finally(
+			() => {
+				this.sessionTask = null;
+			},
+		);
+	}
 
-		await client.startTurn(turnParams);
-		await completionPromise;
+	private async drainPendingPrompts(
+		client: CodexAppServerClient,
+	): Promise<void> {
+		let caughtError: unknown;
+
+		try {
+			while (this.sessionInfo?.isRunning) {
+				const nextPrompt = this.pendingPrompts.shift();
+				if (!nextPrompt) {
+					break;
+				}
+				await this.runTurn(client, nextPrompt);
+			}
+		} catch (error) {
+			caughtError = error;
+		}
+
+		if (this.streamingMode) {
+			this.finalizeSession(caughtError);
+			return;
+		}
+
+		if (caughtError) {
+			throw caughtError;
+		}
 	}
 
 	private buildApprovalPolicy(): AppServerApprovalPolicy {
@@ -1261,10 +1450,16 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			}
 			case "turn.completed": {
 				this.lastUsage = parseUsage(event.usage);
-				this.pendingResultMessage = this.createSuccessResultMessage(
-					this.lastAssistantText || "Codex session completed successfully",
-				);
+				this.completedTurnCount += 1;
+				this.activeTurnId = null;
 				this.terminalTurnResolver?.();
+				this.terminalTurnResolver = null;
+				this.terminalTurnRejecter = null;
+				break;
+			}
+			case "turn.interrupted": {
+				this.activeTurnId = null;
+				this.terminalTurnRejecter?.(new Error(event.message));
 				this.terminalTurnResolver = null;
 				this.terminalTurnRejecter = null;
 				break;
@@ -1275,6 +1470,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 					this.errorMessages.at(-1) ||
 					"Codex execution failed";
 				this.errorMessages.push(message);
+				this.activeTurnId = null;
 				this.pendingResultMessage = this.createErrorResultMessage(message);
 				this.terminalTurnRejecter?.(new Error(message));
 				this.terminalTurnResolver = null;
@@ -1442,6 +1638,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			this.cleanupRuntimeState();
 			return;
 		}
+		if (!this.sessionInfo.isRunning) {
+			this.cleanupRuntimeState();
+			return;
+		}
 
 		this.sessionInfo.isRunning = false;
 
@@ -1533,7 +1733,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			duration_ms: durationMs,
 			duration_api_ms: 0,
 			is_error: false,
-			num_turns: 1,
+			num_turns: Math.max(this.completedTurnCount, 1),
 			result,
 			stop_reason: null,
 			total_cost_usd: 0,
@@ -1553,7 +1753,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			duration_ms: durationMs,
 			duration_api_ms: 0,
 			is_error: true,
-			num_turns: 1,
+			num_turns: Math.max(this.completedTurnCount, 1),
 			stop_reason: null,
 			errors: [errorMessage],
 			total_cost_usd: 0,
@@ -1568,6 +1768,14 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private cleanupRuntimeState(): void {
 		this.terminalTurnResolver = null;
 		this.terminalTurnRejecter = null;
+		this.pendingPrompts = [];
+		this.sessionTask = null;
+		this.streamingMode = false;
+		this.streamingCompleted = false;
+		this.activeTurnId = null;
+		this.turnStartedResolver = null;
+		this.turnStartedRejecter = null;
+		this.turnStartedPromise = null;
 		this.appServerClient?.close();
 		this.appServerClient = null;
 	}
@@ -1578,6 +1786,8 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		this.wasStopped = true;
+		this.streamingCompleted = true;
+		this.pendingPrompts = [];
 		if (this.appServerClient && this.sessionInfo.sessionId) {
 			void this.appServerClient
 				.interruptTurn({ threadId: this.sessionInfo.sessionId })
@@ -1591,6 +1801,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		this.appServerClient?.close();
+		this.finalizeSession();
 	}
 
 	isRunning(): boolean {

--- a/packages/codex-runner/src/appServerProtocol.ts
+++ b/packages/codex-runner/src/appServerProtocol.ts
@@ -127,6 +127,16 @@ export interface AppServerTurnStartResponse {
 	turn: AppServerTurnSummary;
 }
 
+export interface AppServerTurnSteerParams {
+	threadId: string;
+	expectedTurnId: string;
+	input: AppServerUserInput[];
+}
+
+export interface AppServerTurnSteerResponse {
+	turnId: string;
+}
+
 export interface AppServerTurnInterruptParams {
 	threadId: string;
 }

--- a/packages/codex-runner/src/appServerProtocol.ts
+++ b/packages/codex-runner/src/appServerProtocol.ts
@@ -1,3 +1,23 @@
+/**
+ * Thin, hand-curated subset of the Codex app-server protocol used by Cyrus.
+ *
+ * Before editing this file, regenerate the official protocol artifacts from the
+ * package root and diff this shim against them:
+ *
+ *   codex app-server generate-ts --out ./schemas/ts
+ *   codex app-server generate-json-schema --out ./schemas/json
+ *
+ * Equivalent package scripts:
+ *
+ *   pnpm run generate:app-server:ts
+ *   pnpm run generate:app-server:json
+ *   pnpm run generate:app-server
+ *
+ * We keep this subset instead of importing the raw generated TS directly
+ * because Cyrus only uses a narrow slice of the protocol and intentionally
+ * relaxes some fields (for example, request fields that the generator marks as
+ * always present but that Cyrus omits in its minimal payloads).
+ */
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue =
 	| JsonPrimitive

--- a/packages/codex-runner/src/appServerProtocol.ts
+++ b/packages/codex-runner/src/appServerProtocol.ts
@@ -1,0 +1,312 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+	| JsonPrimitive
+	| JsonValue[]
+	| { [key: string]: JsonValue | undefined };
+
+export interface JsonRpcSuccessResponse<Result = unknown> {
+	id: number;
+	result: Result;
+}
+
+export interface JsonRpcErrorResponse {
+	id: number;
+	error: {
+		code: number;
+		message: string;
+		data?: unknown;
+	};
+}
+
+export type JsonRpcResponse<Result = unknown> =
+	| JsonRpcSuccessResponse<Result>
+	| JsonRpcErrorResponse;
+
+export interface AppServerInitializeParams {
+	clientInfo: {
+		name: string;
+		title: string;
+		version: string;
+	};
+	capabilities: {
+		experimentalApi: boolean;
+		optOutNotificationMethods?: string[];
+	} | null;
+}
+
+export type AppServerApprovalPolicy =
+	| "never"
+	| "on-request"
+	| "on-failure"
+	| "untrusted"
+	| {
+			reject: {
+				sandbox_approval: boolean;
+				rules: boolean;
+				mcp_elicitations: boolean;
+			};
+	  };
+
+export type AppServerReadOnlyAccess =
+	| { type: "fullAccess" }
+	| {
+			type: "restricted";
+			includePlatformDefaults: boolean;
+			readableRoots: string[];
+	  };
+
+export type AppServerSandboxPolicy =
+	| { type: "dangerFullAccess" }
+	| { type: "externalSandbox"; networkAccess: "restricted" | "enabled" }
+	| { type: "readOnly"; access: AppServerReadOnlyAccess }
+	| {
+			type: "workspaceWrite";
+			writableRoots: string[];
+			readOnlyAccess: AppServerReadOnlyAccess;
+			networkAccess: boolean;
+			excludeTmpdirEnvVar: boolean;
+			excludeSlashTmp: boolean;
+	  };
+
+export interface AppServerThreadSummary {
+	id: string;
+	source?: string | null;
+}
+
+export interface AppServerThreadStartParams {
+	model?: string | null;
+	cwd?: string | null;
+	approvalPolicy?: AppServerApprovalPolicy | null;
+	sandbox?: "read-only" | "workspace-write" | "danger-full-access" | null;
+	config?: { [key: string]: JsonValue | undefined } | null;
+	developerInstructions?: string | null;
+	ephemeral?: boolean | null;
+	experimentalRawEvents?: boolean;
+	persistExtendedHistory?: boolean;
+}
+
+export interface AppServerThreadStartResponse {
+	thread: AppServerThreadSummary;
+}
+
+export interface AppServerThreadResumeParams {
+	threadId: string;
+}
+
+export interface AppServerTextInput {
+	type: "text";
+	text: string;
+	text_elements: unknown[];
+}
+
+export interface AppServerLocalImageInput {
+	type: "localImage";
+	path: string;
+}
+
+export type AppServerUserInput = AppServerTextInput | AppServerLocalImageInput;
+
+export interface AppServerTurnStartParams {
+	threadId: string;
+	input: AppServerUserInput[];
+	cwd?: string | null;
+	approvalPolicy?: AppServerApprovalPolicy | null;
+	sandboxPolicy?: AppServerSandboxPolicy | null;
+	model?: string | null;
+	effort?: string | null;
+	outputSchema?: JsonValue | null;
+}
+
+export interface AppServerTurnSummary {
+	id: string;
+	status: "completed" | "failed" | "interrupted" | "inProgress";
+	error: { message: string } | null;
+}
+
+export interface AppServerTurnStartResponse {
+	turn: AppServerTurnSummary;
+}
+
+export interface AppServerTurnInterruptParams {
+	threadId: string;
+}
+
+export interface AppServerTokenUsage {
+	total: {
+		inputTokens: number;
+		cachedInputTokens: number;
+		outputTokens: number;
+	};
+	last: {
+		inputTokens: number;
+		cachedInputTokens: number;
+		outputTokens: number;
+	};
+}
+
+export interface AppServerCommandExecutionItem {
+	type: "commandExecution";
+	id: string;
+	command: string;
+	aggregatedOutput: string | null;
+	exitCode: number | null;
+	status: "in_progress" | "completed" | "failed" | "inProgress";
+}
+
+export interface AppServerFileChangeItem {
+	type: "fileChange";
+	id: string;
+	status: "completed" | "failed";
+	changes: Array<{ path: string; kind: "add" | "delete" | "update" }>;
+}
+
+export interface AppServerMcpToolCallItem {
+	type: "mcpToolCall";
+	id: string;
+	server: string;
+	tool: string;
+	arguments: unknown;
+	result: {
+		content?: unknown[];
+		structured_content?: unknown;
+		structuredContent?: unknown;
+	} | null;
+	error: { message: string } | null;
+	status: "in_progress" | "completed" | "failed" | "inProgress";
+}
+
+export interface AppServerAgentMessageItem {
+	type: "agentMessage";
+	id: string;
+	text: string;
+}
+
+export interface AppServerReasoningItem {
+	type: "reasoning";
+	id: string;
+	summary?: string[];
+	content?: string[];
+}
+
+export interface AppServerWebSearchItem {
+	type: "webSearch";
+	id: string;
+	query: string;
+	action: {
+		type?: string;
+		url?: string;
+		pattern?: string;
+		query?: string;
+		queries?: string[];
+	} | null;
+}
+
+export interface AppServerPlanItem {
+	type: "plan";
+	id: string;
+	text: string;
+}
+
+export type AppServerThreadItem =
+	| AppServerCommandExecutionItem
+	| AppServerFileChangeItem
+	| AppServerMcpToolCallItem
+	| AppServerAgentMessageItem
+	| AppServerReasoningItem
+	| AppServerWebSearchItem
+	| AppServerPlanItem;
+
+export type AppServerNotification =
+	| {
+			method: "thread/started";
+			params: { thread: AppServerThreadSummary };
+	  }
+	| {
+			method: "item/started";
+			params: { threadId: string; turnId: string; item: AppServerThreadItem };
+	  }
+	| {
+			method: "item/completed";
+			params: { threadId: string; turnId: string; item: AppServerThreadItem };
+	  }
+	| {
+			method: "turn/completed";
+			params: { threadId: string; turn: AppServerTurnSummary };
+	  }
+	| {
+			method: "turn/plan/updated";
+			params: {
+				threadId: string;
+				turnId: string;
+				explanation: string | null;
+				plan: Array<{
+					step: string;
+					status: "pending" | "inProgress" | "completed";
+				}>;
+			};
+	  }
+	| {
+			method: "thread/tokenUsage/updated";
+			params: {
+				threadId: string;
+				turnId: string;
+				tokenUsage: AppServerTokenUsage;
+			};
+	  }
+	| {
+			method: "error";
+			params: { message: string };
+	  }
+	| {
+			method: string;
+			params?: unknown;
+	  };
+
+export type AppServerRequest =
+	| {
+			method: "item/tool/requestUserInput";
+			id: number;
+			params: {
+				threadId: string;
+				turnId: string;
+				itemId: string;
+				questions: Array<{
+					id: string;
+					header: string;
+					question: string;
+					isOther: boolean;
+					isSecret: boolean;
+					options: Array<{ label: string; description: string }> | null;
+				}>;
+			};
+	  }
+	| {
+			method: "item/commandExecution/requestApproval";
+			id: number;
+			params: unknown;
+	  }
+	| {
+			method: "item/fileChange/requestApproval";
+			id: number;
+			params: unknown;
+	  }
+	| {
+			method: "item/tool/call";
+			id: number;
+			params: unknown;
+	  }
+	| {
+			method: "applyPatchApproval";
+			id: number;
+			params: unknown;
+	  }
+	| {
+			method: "execCommandApproval";
+			id: number;
+			params: unknown;
+	  }
+	| {
+			method: string;
+			id: number;
+			params?: unknown;
+	  };

--- a/packages/codex-runner/src/types.ts
+++ b/packages/codex-runner/src/types.ts
@@ -1,15 +1,102 @@
 import type {
-	ApprovalMode,
-	ModelReasoningEffort,
-	SandboxMode,
-	ThreadEvent,
-	WebSearchMode,
-} from "@openai/codex-sdk";
-import type {
 	AgentRunnerConfig,
 	AgentSessionInfo,
 	SDKMessage,
 } from "cyrus-core";
+
+export type SandboxMode =
+	| "read-only"
+	| "workspace-write"
+	| "danger-full-access";
+export type ApprovalMode = "never" | "on-request" | "on-failure" | "untrusted";
+export type ModelReasoningEffort =
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh";
+export type WebSearchMode = "disabled" | "cached" | "live";
+
+export interface CodexUsage {
+	input_tokens: number;
+	output_tokens: number;
+	cached_input_tokens: number;
+}
+
+export interface CodexCommandExecutionItem {
+	id: string;
+	type: "command_execution";
+	command: string;
+	aggregated_output: string;
+	exit_code?: number;
+	status: "in_progress" | "completed" | "failed";
+}
+
+export interface CodexFileChangeItem {
+	id: string;
+	type: "file_change";
+	changes: Array<{ path: string; kind: "add" | "delete" | "update" }>;
+	status: "completed" | "failed";
+}
+
+export interface CodexMcpToolCallItem {
+	id: string;
+	type: "mcp_tool_call";
+	server: string;
+	tool: string;
+	arguments: unknown;
+	result?: {
+		content?: unknown[];
+		structured_content?: unknown;
+	};
+	error?: { message: string };
+	status: "in_progress" | "completed" | "failed";
+}
+
+export interface CodexWebSearchItem {
+	id: string;
+	type: "web_search";
+	query: string;
+	action?: {
+		type?: string;
+		url?: string;
+		pattern?: string;
+		query?: string;
+		queries?: string[];
+	} | null;
+}
+
+export interface CodexTodoListItem {
+	id: string;
+	type: "todo_list";
+	items: Array<{
+		text: string;
+		completed: boolean;
+		in_progress?: boolean;
+	}>;
+}
+
+export interface CodexAgentMessageItem {
+	id: string;
+	type: "agent_message";
+	text: string;
+}
+
+export type CodexThreadItem =
+	| CodexCommandExecutionItem
+	| CodexFileChangeItem
+	| CodexMcpToolCallItem
+	| CodexWebSearchItem
+	| CodexTodoListItem
+	| CodexAgentMessageItem;
+
+export type CodexJsonEvent =
+	| { type: "thread.started"; thread_id: string }
+	| { type: "item.started"; item: CodexThreadItem }
+	| { type: "item.completed"; item: CodexThreadItem }
+	| { type: "turn.completed"; usage?: CodexUsage }
+	| { type: "turn.failed"; error?: { message: string } }
+	| { type: "error"; message: string };
 
 export type CodexConfigValue =
 	| string
@@ -20,14 +107,6 @@ export type CodexConfigValue =
 
 export type CodexConfigOverrides = { [key: string]: CodexConfigValue };
 
-/**
- * Typed event shape emitted by Codex SDK thread streams.
- */
-export type CodexJsonEvent = ThreadEvent;
-
-/**
- * Configuration for CodexRunner.
- */
 export interface CodexRunnerConfig extends AgentRunnerConfig {
 	/** Path to codex CLI binary (defaults to `codex` in PATH) */
 	codexPath?: string;
@@ -51,22 +130,16 @@ export interface CodexRunnerConfig extends AgentRunnerConfig {
 	webSearchMode?: WebSearchMode;
 	/** Allow execution outside git repo (defaults to true) */
 	skipGitRepoCheck?: boolean;
-	/** Additional global Codex config overrides passed through SDK `config` */
+	/** Additional global Codex config overrides passed through app-server thread config */
 	configOverrides?: CodexConfigOverrides;
-	/** JSON Schema for structured output (passed to thread.runStreamed as outputSchema) */
+	/** JSON Schema for structured output (passed to turn/start as outputSchema) */
 	outputSchema?: unknown;
 }
 
-/**
- * Session metadata for CodexRunner.
- */
 export interface CodexSessionInfo extends AgentSessionInfo {
 	sessionId: string | null;
 }
 
-/**
- * Event emitter interface for CodexRunner.
- */
 export interface CodexRunnerEvents {
 	message: (message: SDKMessage) => void;
 	error: (error: Error) => void;

--- a/packages/codex-runner/src/types.ts
+++ b/packages/codex-runner/src/types.ts
@@ -95,6 +95,7 @@ export type CodexJsonEvent =
 	| { type: "item.started"; item: CodexThreadItem }
 	| { type: "item.completed"; item: CodexThreadItem }
 	| { type: "turn.completed"; usage?: CodexUsage }
+	| { type: "turn.interrupted"; message: string }
 	| { type: "turn.failed"; error?: { message: string } }
 	| { type: "error"; message: string };
 

--- a/packages/codex-runner/test/CodexRunner.app-server.test.ts
+++ b/packages/codex-runner/test/CodexRunner.app-server.test.ts
@@ -1,0 +1,184 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+	const actual =
+		await vi.importActual<typeof import("node:child_process")>(
+			"node:child_process",
+		);
+	return {
+		...actual,
+		spawn: vi.fn(),
+	};
+});
+
+import { spawn } from "node:child_process";
+import { CodexRunner } from "../src/CodexRunner.js";
+
+class FakeChildProcess extends EventEmitter {
+	stdin = new PassThrough();
+	stdout = new PassThrough();
+	stderr = new PassThrough();
+	kill = vi.fn(() => true);
+}
+
+function attachJsonRpcResponder(child: FakeChildProcess): string[] {
+	const sentMethods: string[] = [];
+	let buffer = "";
+
+	child.stdin.on("data", (chunk: Buffer | string) => {
+		buffer += chunk.toString();
+		const lines = buffer.split("\n");
+		buffer = lines.pop() || "";
+
+		for (const line of lines) {
+			if (!line.trim()) continue;
+			const message = JSON.parse(line) as {
+				id?: number;
+				method?: string;
+				params?: any;
+			};
+			if (message.method) {
+				sentMethods.push(message.method);
+			}
+
+			switch (message.method) {
+				case "initialize":
+					child.stdout.write(
+						`${JSON.stringify({ id: message.id, result: {} })}\n`,
+					);
+					break;
+				case "thread/start":
+					child.stdout.write(
+						`${JSON.stringify({
+							id: message.id,
+							result: {
+								thread: { id: "thr_app_server_1" },
+							},
+						})}\n`,
+					);
+					child.stdout.write(
+						`${JSON.stringify({
+							method: "thread/started",
+							params: { thread: { id: "thr_app_server_1" } },
+						})}\n`,
+					);
+					break;
+				case "turn/start":
+					child.stdout.write(
+						`${JSON.stringify({
+							id: message.id,
+							result: {
+								turn: {
+									id: "turn_app_server_1",
+									status: "inProgress",
+									error: null,
+								},
+							},
+						})}\n`,
+					);
+					child.stdout.write(
+						`${JSON.stringify({
+							method: "item/completed",
+							params: {
+								threadId: "thr_app_server_1",
+								turnId: "turn_app_server_1",
+								item: {
+									type: "agentMessage",
+									id: "msg_1",
+									text: "App server response",
+								},
+							},
+						})}\n`,
+					);
+					child.stdout.write(
+						`${JSON.stringify({
+							method: "thread/tokenUsage/updated",
+							params: {
+								threadId: "thr_app_server_1",
+								turnId: "turn_app_server_1",
+								tokenUsage: {
+									total: {
+										inputTokens: 12,
+										cachedInputTokens: 3,
+										outputTokens: 7,
+									},
+									last: {
+										inputTokens: 12,
+										cachedInputTokens: 3,
+										outputTokens: 7,
+									},
+								},
+							},
+						})}\n`,
+					);
+					child.stdout.write(
+						`${JSON.stringify({
+							method: "turn/completed",
+							params: {
+								threadId: "thr_app_server_1",
+								turn: {
+									id: "turn_app_server_1",
+									status: "completed",
+									error: null,
+								},
+							},
+						})}\n`,
+					);
+					break;
+				default:
+					break;
+			}
+		}
+	});
+
+	return sentMethods;
+}
+
+describe("CodexRunner app-server transport", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("uses codex app-server JSON-RPC instead of codex exec", async () => {
+		const child = new FakeChildProcess();
+		const sentMethods = attachJsonRpcResponder(child);
+		vi.mocked(spawn).mockReturnValue(child as any);
+
+		const runner = new CodexRunner({
+			cyrusHome: "/tmp/cyrus-home",
+			workingDirectory: "/tmp/project",
+			model: "gpt-5.4",
+		});
+
+		const session = await runner.start("Inspect the repository");
+
+		expect(spawn).toHaveBeenCalledWith(
+			"codex",
+			["app-server", "--config", "sandbox_workspace_write.network_access=true"],
+			{
+				env: undefined,
+				stdio: ["pipe", "pipe", "pipe"],
+			},
+		);
+		expect(sentMethods).toEqual([
+			"initialize",
+			"initialized",
+			"thread/start",
+			"turn/start",
+		]);
+		expect(session.sessionId).toBe("thr_app_server_1");
+
+		const messages = runner.getMessages();
+		expect(messages.some((message) => message.type === "system")).toBe(true);
+		expect(messages.some((message) => message.type === "result")).toBe(true);
+		expect(
+			messages.some(
+				(message) =>
+					message.type === "assistant" &&
+					JSON.stringify(message.message).includes("App server response"),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/codex-runner/test/CodexRunner.app-server.test.ts
+++ b/packages/codex-runner/test/CodexRunner.app-server.test.ts
@@ -30,11 +30,13 @@ function attachJsonRpcResponder(
 	sentMethods: string[];
 	turnInputs: string[];
 	steerInputs: string[];
+	turnStartParams: any[];
 	completeTurn: (turnNumber: number, text?: string) => void;
 } {
 	const sentMethods: string[] = [];
 	const turnInputs: string[] = [];
 	const steerInputs: string[] = [];
+	const turnStartParams: any[] = [];
 	let buffer = "";
 	const autoCompleteTurns = options.autoCompleteTurns ?? true;
 
@@ -130,6 +132,7 @@ function attachJsonRpcResponder(
 					);
 					break;
 				case "turn/start": {
+					turnStartParams.push(message.params);
 					turnInputs.push(message.params?.input?.[0]?.text ?? "");
 					const turnNumber = turnInputs.length;
 					child.stdout.write(
@@ -170,6 +173,7 @@ function attachJsonRpcResponder(
 		sentMethods,
 		turnInputs,
 		steerInputs,
+		turnStartParams,
 		completeTurn,
 	};
 }
@@ -207,6 +211,18 @@ describe("CodexRunner app-server transport", () => {
 				"thread/start",
 				"turn/start",
 			]);
+		});
+		expect(responder.turnStartParams[0]?.sandboxPolicy).toEqual({
+			type: "workspaceWrite",
+			writableRoots: ["/tmp/project"],
+			readOnlyAccess: {
+				type: "restricted",
+				includePlatformDefaults: true,
+				readableRoots: ["/tmp/project"],
+			},
+			networkAccess: true,
+			excludeTmpdirEnvVar: false,
+			excludeSlashTmp: false,
 		});
 		expect(session.sessionId).toBe("thr_app_server_1");
 

--- a/packages/codex-runner/test/CodexRunner.app-server.test.ts
+++ b/packages/codex-runner/test/CodexRunner.app-server.test.ts
@@ -23,9 +23,73 @@ class FakeChildProcess extends EventEmitter {
 	kill = vi.fn(() => true);
 }
 
-function attachJsonRpcResponder(child: FakeChildProcess): string[] {
+function attachJsonRpcResponder(
+	child: FakeChildProcess,
+	options: { autoCompleteTurns?: boolean } = {},
+): {
+	sentMethods: string[];
+	turnInputs: string[];
+	steerInputs: string[];
+	completeTurn: (turnNumber: number, text?: string) => void;
+} {
 	const sentMethods: string[] = [];
+	const turnInputs: string[] = [];
+	const steerInputs: string[] = [];
 	let buffer = "";
+	const autoCompleteTurns = options.autoCompleteTurns ?? true;
+
+	function completeTurn(turnNumber: number, text?: string): void {
+		const threadId = "thr_app_server_1";
+		const turnId = `turn_app_server_${turnNumber}`;
+		child.stdout.write(
+			`${JSON.stringify({
+				method: "item/completed",
+				params: {
+					threadId,
+					turnId,
+					item: {
+						type: "agentMessage",
+						id: `msg_${turnNumber}`,
+						text: text || `App server response ${turnNumber}`,
+					},
+				},
+			})}\n`,
+		);
+		child.stdout.write(
+			`${JSON.stringify({
+				method: "thread/tokenUsage/updated",
+				params: {
+					threadId,
+					turnId,
+					tokenUsage: {
+						total: {
+							inputTokens: 12,
+							cachedInputTokens: 3,
+							outputTokens: 7,
+						},
+						last: {
+							inputTokens: 12,
+							cachedInputTokens: 3,
+							outputTokens: 7,
+						},
+					},
+				},
+			})}\n`,
+		);
+		child.stdout.write(
+			`${JSON.stringify({
+				method: "turn/completed",
+				params: {
+					threadId,
+					turn: {
+						id: turnId,
+						status: "completed",
+						error: null,
+					},
+				},
+			})}\n`,
+		);
+	}
 
 	child.stdin.on("data", (chunk: Buffer | string) => {
 		buffer += chunk.toString();
@@ -65,64 +129,33 @@ function attachJsonRpcResponder(child: FakeChildProcess): string[] {
 						})}\n`,
 					);
 					break;
-				case "turn/start":
+				case "turn/start": {
+					turnInputs.push(message.params?.input?.[0]?.text ?? "");
+					const turnNumber = turnInputs.length;
 					child.stdout.write(
 						`${JSON.stringify({
 							id: message.id,
 							result: {
 								turn: {
-									id: "turn_app_server_1",
+									id: `turn_app_server_${turnNumber}`,
 									status: "inProgress",
 									error: null,
 								},
 							},
 						})}\n`,
 					);
+					if (autoCompleteTurns) {
+						completeTurn(turnNumber, "App server response");
+					}
+					break;
+				}
+				case "turn/steer":
+					steerInputs.push(message.params?.input?.[0]?.text ?? "");
 					child.stdout.write(
 						`${JSON.stringify({
-							method: "item/completed",
-							params: {
-								threadId: "thr_app_server_1",
-								turnId: "turn_app_server_1",
-								item: {
-									type: "agentMessage",
-									id: "msg_1",
-									text: "App server response",
-								},
-							},
-						})}\n`,
-					);
-					child.stdout.write(
-						`${JSON.stringify({
-							method: "thread/tokenUsage/updated",
-							params: {
-								threadId: "thr_app_server_1",
-								turnId: "turn_app_server_1",
-								tokenUsage: {
-									total: {
-										inputTokens: 12,
-										cachedInputTokens: 3,
-										outputTokens: 7,
-									},
-									last: {
-										inputTokens: 12,
-										cachedInputTokens: 3,
-										outputTokens: 7,
-									},
-								},
-							},
-						})}\n`,
-					);
-					child.stdout.write(
-						`${JSON.stringify({
-							method: "turn/completed",
-							params: {
-								threadId: "thr_app_server_1",
-								turn: {
-									id: "turn_app_server_1",
-									status: "completed",
-									error: null,
-								},
+							id: message.id,
+							result: {
+								turnId: message.params?.expectedTurnId ?? "turn_app_server_1",
 							},
 						})}\n`,
 					);
@@ -133,7 +166,12 @@ function attachJsonRpcResponder(child: FakeChildProcess): string[] {
 		}
 	});
 
-	return sentMethods;
+	return {
+		sentMethods,
+		turnInputs,
+		steerInputs,
+		completeTurn,
+	};
 }
 
 describe("CodexRunner app-server transport", () => {
@@ -143,7 +181,7 @@ describe("CodexRunner app-server transport", () => {
 
 	it("uses codex app-server JSON-RPC instead of codex exec", async () => {
 		const child = new FakeChildProcess();
-		const sentMethods = attachJsonRpcResponder(child);
+		const responder = attachJsonRpcResponder(child);
 		vi.mocked(spawn).mockReturnValue(child as any);
 
 		const runner = new CodexRunner({
@@ -162,12 +200,14 @@ describe("CodexRunner app-server transport", () => {
 				stdio: ["pipe", "pipe", "pipe"],
 			},
 		);
-		expect(sentMethods).toEqual([
-			"initialize",
-			"initialized",
-			"thread/start",
-			"turn/start",
-		]);
+		await vi.waitFor(() => {
+			expect(responder.sentMethods).toEqual([
+				"initialize",
+				"initialized",
+				"thread/start",
+				"turn/start",
+			]);
+		});
 		expect(session.sessionId).toBe("thr_app_server_1");
 
 		const messages = runner.getMessages();
@@ -178,6 +218,62 @@ describe("CodexRunner app-server transport", () => {
 				(message) =>
 					message.type === "assistant" &&
 					JSON.stringify(message.message).includes("App server response"),
+			),
+		).toBe(true);
+	});
+
+	it("steers an active turn with follow-up prompts during streaming", async () => {
+		const child = new FakeChildProcess();
+		const responder = attachJsonRpcResponder(child, {
+			autoCompleteTurns: false,
+		});
+		vi.mocked(spawn).mockReturnValue(child as any);
+
+		const runner = new CodexRunner({
+			cyrusHome: "/tmp/cyrus-home",
+			workingDirectory: "/tmp/project",
+			model: "gpt-5.4",
+		});
+
+		const completionPromise = new Promise<void>((resolve) => {
+			runner.on("complete", () => resolve());
+		});
+
+		expect(runner.supportsStreamingInput).toBe(true);
+
+		const session = await runner.startStreaming("Initial prompt");
+		expect(session.sessionId).toBe("thr_app_server_1");
+
+		await vi.waitFor(() => {
+			expect(runner.isStreaming?.()).toBe(true);
+			expect(responder.turnInputs).toEqual(["Initial prompt"]);
+		});
+
+		runner.addStreamMessage("Follow-up prompt");
+
+		await vi.waitFor(() => {
+			expect(responder.steerInputs).toEqual(["Follow-up prompt"]);
+		});
+
+		responder.completeTurn(1, "Second response");
+		await completionPromise;
+
+		expect(runner.isRunning()).toBe(false);
+		expect(runner.isStreaming?.()).toBe(false);
+		expect(responder.sentMethods).toEqual([
+			"initialize",
+			"initialized",
+			"thread/start",
+			"turn/start",
+			"turn/steer",
+		]);
+
+		const messages = runner.getMessages();
+		expect(
+			messages.some(
+				(message) =>
+					message.type === "assistant" &&
+					JSON.stringify(message.message).includes("Second response"),
 			),
 		).toBe(true);
 	});

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -154,7 +154,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 
 		// Mock CodexRunner
 		mockCodexRunner = {
-			supportsStreamingInput: false,
+			supportsStreamingInput: true,
 			start: vi.fn().mockResolvedValue({ sessionId: "codex-session-123" }),
 			startStreaming: vi
 				.fn()


### PR DESCRIPTION
## Summary
- switch the Codex runner from the SDK exec path to `codex app-server`
- preserve Cyrus event/activity mapping on top of the app-server protocol
- add F1 coverage and document the validation run for `CYPACK-998`

## Testing
- pnpm --filter cyrus-codex-runner test:run
- pnpm build
- pnpm --filter cyrus-edge-worker exec vitest run test/AgentSessionManager.codex-runner-activity.test.ts test/EdgeWorker.runner-selection.test.ts
- F1 test drive: `apps/f1/test-drives/2026-03-19-codex-app-server-validation.md`

Closes CYPACK-998
