### PR TITLE
feat: integrate Graphiti knowledge graph for agent memory

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4744,6 +4744,16 @@ ${taskSection}`;
 			};
 		}
 
+		// Conditionally inject the Graphiti memory MCP server
+		// https://github.com/getzep/graphiti
+		const graphitiUrl = process.env.GRAPHITI_MCP_URL?.trim();
+		if (graphitiUrl) {
+			mcpConfig.graphiti = {
+				type: "http",
+				url: graphitiUrl,
+			};
+		}
+
 		return mcpConfig;
 	}
 

--- a/packages/edge-worker/src/PromptBuilder.ts
+++ b/packages/edge-worker/src/PromptBuilder.ts
@@ -505,6 +505,9 @@ export class PromptBuilder {
 			// Append agent guidance if present
 			prompt += this.formatAgentGuidance(guidance);
 
+			// Append memory context instructions if Graphiti is configured
+			prompt += this.formatMemoryContext();
+
 			if (attachmentManifest) {
 				this.logger.debug(
 					`Adding attachment manifest to label-based prompt, length: ${attachmentManifest.length} characters`,
@@ -949,6 +952,9 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
 			// Append agent guidance if present
 			prompt += this.formatAgentGuidance(guidance);
 
+			// Append memory context instructions if Graphiti is configured
+			prompt += this.formatMemoryContext();
+
 			// Append attachment manifest if provided
 			if (attachmentManifest) {
 				this.logger.debug(
@@ -1215,6 +1221,23 @@ ${reply.body}
 	}
 
 	/**
+	 * Format memory context instructions for agents with access to Graphiti.
+	 * Only included when GRAPHITI_MCP_URL is configured.
+	 */
+	formatMemoryContext(): string {
+		if (!process.env.GRAPHITI_MCP_URL?.trim()) {
+			return "";
+		}
+		return `\n\n<memory_context>
+You have access to a team knowledge graph via Graphiti MCP tools. At the start of your work:
+1. Use \`search_memory_facts\` with keywords from the issue to recall relevant team patterns, preferences, and past decisions.
+2. Apply any recalled context to your work (coding standards, architectural patterns, user preferences).
+
+During your work, if you discover important patterns or receive corrections, note them for the memory-reflection phase.
+</memory_context>`;
+	}
+
+	/**
 	 * Extract version tag from template content
 	 * @param templateContent The template content to parse
 	 * @returns The version value if found, undefined otherwise
@@ -1289,6 +1312,14 @@ ${reply.body}
 		// Skip loading for "primary" - it's a placeholder that doesn't have a file
 		if (subroutine.promptPath === "primary") {
 			return null;
+		}
+
+		// Skip memory-reflection when Graphiti is not configured
+		if (
+			subroutine.name === "memory-reflection" &&
+			!process.env.GRAPHITI_MCP_URL?.trim()
+		) {
+			return "Memory reflection skipped — no knowledge graph configured. Reply: `Memory reflection complete.`";
 		}
 
 		const __filename = fileURLToPath(import.meta.url);

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -412,6 +412,9 @@ export class RunnerSelectionService {
 		if (process.env.SLACK_BOT_TOKEN?.trim()) {
 			tools.push("mcp__slack");
 		}
+		if (process.env.GRAPHITI_MCP_URL?.trim()) {
+			tools.push("mcp__graphiti");
+		}
 		return tools;
 	}
 

--- a/packages/edge-worker/src/procedures/registry.ts
+++ b/packages/edge-worker/src/procedures/registry.ts
@@ -129,6 +129,14 @@ export const SUBROUTINES = {
 		suppressThoughtPosting: true,
 		disallowAllTools: true,
 	},
+	memoryReflection: {
+		name: "memory-reflection",
+		promptPath: "subroutines/memory-reflection.md",
+		singleTurn: true,
+		description: "Reflecting on session and storing learnings to memory",
+		skipLinearPost: true,
+		suppressThoughtPosting: true,
+	},
 } as const;
 
 /**
@@ -166,6 +174,7 @@ export const PROCEDURES: Record<string, ProcedureDefinition> = {
 			SUBROUTINES.gitCommit,
 			SUBROUTINES.ghPr,
 			SUBROUTINES.conciseSummary,
+			SUBROUTINES.memoryReflection,
 		],
 	},
 
@@ -181,6 +190,7 @@ export const PROCEDURES: Record<string, ProcedureDefinition> = {
 			SUBROUTINES.gitCommit,
 			SUBROUTINES.ghPr,
 			SUBROUTINES.conciseSummary,
+			SUBROUTINES.memoryReflection,
 		],
 	},
 

--- a/packages/edge-worker/src/prompts/subroutines/memory-reflection.md
+++ b/packages/edge-worker/src/prompts/subroutines/memory-reflection.md
@@ -1,0 +1,26 @@
+# Memory Reflection Phase
+
+Review the work completed in this session and store important learnings to the team knowledge graph.
+
+## What to Store
+
+Use `add_memory` for each distinct learning. Focus on:
+
+- **Coding patterns**: conventions, file organization, naming standards observed in the codebase
+- **User preferences**: explicit corrections or preferences expressed by the assignee
+- **Architectural decisions**: technology choices, design patterns, dependency decisions
+- **Business context**: domain terms, workflow rules, team processes
+
+## Guidelines
+
+- Only store facts that would be useful in future sessions
+- Be specific — "uses Tailwind v4" is better than "uses CSS framework"
+- Include the entity involved — "cyrus-hosted uses barrel exports in components/" not just "uses barrel exports"
+- Do NOT store session-specific details (issue numbers, branch names, PR URLs)
+- Do NOT store information that's already in the codebase's README or CLAUDE.md
+
+## Constraints
+
+- You have exactly 1 turn
+- Store 0-5 learnings (0 is fine if nothing new was learned)
+- Complete with: `Memory reflection complete.`


### PR DESCRIPTION
## Summary

- Add Graphiti MCP server integration for persistent team memory, gated behind `GRAPHITI_MCP_URL` env var
- Agents recall relevant context at session start via `search_memory_facts` and store learnings post-session via `add_memory`
- Zero behavior change when env var is not set

## Changes

- **EdgeWorker.ts** — Add conditional Graphiti MCP server to `buildMcpConfig()` (same pattern as Slack)
- **RunnerSelectionService.ts** — Add `mcp__graphiti` to workspace MCP tool allowlist
- **PromptBuilder.ts** — Add `formatMemoryContext()` for recall instructions in `<memory_context>` block; skip memory-reflection subroutine when Graphiti not configured
- **registry.ts** — Add `memoryReflection` subroutine definition; append to `full-development` and `debugger-full` procedures
- **memory-reflection.md** — New subroutine prompt for post-session learning capture (0-5 facts per session)

## Test plan

- [ ] Set `GRAPHITI_MCP_URL=http://localhost:8000/mcp/` and run `docker compose up` with Graphiti container
- [ ] Trigger a `full-development` session — verify agent calls `search_memory_facts` at start
- [ ] Verify `memory-reflection` subroutine runs after `concise-summary` and stores learnings via `add_memory`
- [ ] Unset `GRAPHITI_MCP_URL` — verify no Graphiti references in prompts or MCP config
- [ ] Verify `memory-reflection` auto-skips when Graphiti is not configured

Resolves CYPACK-1001