### PR TITLE
Release v0.2.38

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.38] - 2026-03-25
+
 ### Added
 - Created `cyrus-gitlab-event-transport` package mirroring `cyrus-github-event-transport`: `GitLabEventTransport` (webhook endpoint with proxy/signature verification), `GitLabCommentService` (post MR notes, discussion replies, award emoji), `GitLabMessageTranslator` (translate GitLab events to `InternalMessage`), and `gitlab-webhook-utils` (payload extractors).
 - Added `GitLabPlatformRef`, `GitLabSessionStartPlatformData`, `GitLabUserPromptPlatformData` types to `cyrus-core` messages. Updated `MessageSource` to include `"gitlab"`. Added type guards `isGitLabMessage`, `hasGitLabSessionStartPlatformData`, `hasGitLabUserPromptPlatformData`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.38] - 2026-03-25
+
 ### Added
 - **GitLab integration with `glab` CLI support** - Cyrus now supports GitLab repositories alongside GitHub. Create merge requests, respond to MR comments, and handle review feedback using the `glab` CLI. Includes webhook support for receiving GitLab events, a dedicated setup skill (`/cyrus-setup-gitlab`), and platform-aware subroutines that automatically use `glab` commands for GitLab-hosted repos.
 - **Cyrus docs MCP available in all sessions** - Cyrus now has access to its own documentation via the Mintlify docs MCP server, enabling better self-reference and user guidance. ([CYPACK-995](https://linear.app/ceedar/issue/CYPACK-995), [#1016](https://github.com/ceedaragents/cyrus/pull/1016))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.38
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.38
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.38
+
+#### cyrus-core
+- cyrus-core@0.2.38
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.38
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.38
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.38
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.38
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.38
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.38
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.38
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.38
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.38
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.38
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.38
 
 ## [0.2.37] - 2026-03-18
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.1.0",
+	"version": "0.2.38",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.37",
+	"version": "0.2.38",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all packages to v0.2.38
- Move Unreleased changelog entries to v0.2.38 in both CHANGELOG.md and CHANGELOG.internal.md
- Includes GitLab integration and Cyrus docs MCP features

## Changes
- CHANGELOG.md updated with v0.2.38 release notes (GitLab integration, Cyrus docs MCP)
- CHANGELOG.internal.md updated with v0.2.38 internal notes (new cyrus-gitlab-event-transport package)
- All package versions bumped from 0.2.37 to 0.2.38 (cyrus-gitlab-event-transport bumped from 0.1.0 to 0.2.38)

## Key Features in this Release
- **GitLab integration** - Full `glab` CLI support for GitLab repos
- **Cyrus docs MCP** - Self-reference via Mintlify docs MCP server in all sessions

## Note
npm publish requires authentication credentials that are not currently configured on this machine. Once this PR is merged, packages need to be published with: `cd packages/<pkg> && pnpm publish --access public --no-git-checks` in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)