### PR TITLE
fix: prevent config watcher feedback loop during OAuth token refresh

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -6625,6 +6625,18 @@ ${input.userComment}
 		}
 
 		try {
+			// Update in-memory config FIRST, then write to disk.
+			// When the file watcher fires, it will see no diff between
+			// in-memory and on-disk config, preventing a feedback loop.
+			const wsConfig = this.config.linearWorkspaces?.[tokens.linearWorkspaceId];
+			if (wsConfig) {
+				wsConfig.linearToken = tokens.linearToken;
+				if (tokens.linearRefreshToken) {
+					wsConfig.linearRefreshToken = tokens.linearRefreshToken;
+				}
+			}
+			this.configManager.setConfig(this.config);
+
 			const configContent = await readFile(this.configPath, "utf-8");
 			const config = JSON.parse(configContent);
 
@@ -6659,6 +6671,7 @@ ${input.userComment}
 			};
 
 			await writeFile(this.configPath, JSON.stringify(config, null, "\t"));
+
 			this.logger.debug(
 				`OAuth tokens saved to config for workspace ${tokens.linearWorkspaceId}`,
 			);

--- a/packages/linear-event-transport/src/LinearIssueTrackerService.ts
+++ b/packages/linear-event-transport/src/LinearIssueTrackerService.ts
@@ -169,7 +169,13 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 							true, // isRetry flag
 						)) as Data;
 					} catch (_refreshError) {
-						// If refresh failed, throw the original 401 error for clarity
+						// If the retry also hit 401, the refreshed token has expired
+						// or is invalid. Clear the stale promise so the next request
+						// can trigger a fresh refresh instead of reusing this one.
+						if (this.isTokenExpiredError(_refreshError)) {
+							this.refreshPromise = null;
+						}
+						// Throw the original 401 error for clarity
 						throw error;
 					}
 				}
@@ -202,10 +208,24 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 		LinearIssueTrackerService.pendingRefreshes.set(workspaceId, refreshPromise);
 
 		try {
-			return await refreshPromise;
-		} finally {
-			// One of the key guarantees of finally — it runs regardless of how the try block exits (return, throw, or normal completion).
+			const result = await refreshPromise;
+			// On success, keep the resolved promise in the map briefly so that
+			// late-arriving 401s coalesce onto it instead of triggering redundant
+			// HTTP refresh calls (which would fail because the refresh token is
+			// single-use and already consumed).
+			setTimeout(() => {
+				if (
+					LinearIssueTrackerService.pendingRefreshes.get(workspaceId) ===
+					refreshPromise
+				) {
+					LinearIssueTrackerService.pendingRefreshes.delete(workspaceId);
+				}
+			}, 5000);
+			return result;
+		} catch (error) {
+			// On failure, clear immediately so the next 401 can retry fresh.
 			LinearIssueTrackerService.pendingRefreshes.delete(workspaceId);
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the OAuth token refresh feedback loop and concurrent token exhaustion that forces users to repeatedly re-authenticate.

Three changes across two files:

### 1. Update in-memory config before writing to disk (`EdgeWorker.saveOAuthTokens`)
When the file watcher fires after `config.json` is updated, it compares in-memory vs on-disk state. By updating in-memory first, no diff is detected, preventing the feedback loop.

### 2. Cooldown on static refresh coalescing (`LinearIssueTrackerService.doTokenRefresh`)
Keep the resolved `pendingRefreshes` promise for 5 seconds instead of clearing immediately in `finally`. Late-arriving 401s coalesce onto the resolved promise instead of triggering redundant HTTP refresh calls that fail because the OAuth refresh token is single-use.

### 3. Clear stale instance promise on retry failure (`LinearIssueTrackerService`)
If the retry with a refreshed token also returns 401, clear the stale `refreshPromise` so the next request can trigger a fresh refresh. Without this, the instance-level coalesce holds a stale promise forever and the token can never be refreshed again after natural expiration (~1 hour).

## Problem

When OAuth tokens are refreshed, `saveOAuthTokens` writes to `config.json` → chokidar detects the change → `handleConfigChange` fires → `detectGlobalConfigChanges` sees `linearWorkspaces` changed → `updateLinearWorkspaceTokens` calls `setAccessToken()` which clears instance-level coalescing → concurrent 401s trigger new refreshes → refresh token already consumed → 400 → token exhaustion → user must re-auth.

## Test Plan

- [x] All 642 existing tests pass (edge-worker)
- [x] `pnpm biome check` passes
- [x] Full monorepo `typecheck` passes
- [x] Tested locally: OAuth token refresh no longer triggers config watcher loop
- [x] Tested locally: ran for hours without needing to re-authenticate (previously required re-auth every ~1 hour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)