### PR TITLE
feat: Add global_teardown_script to run during worktree cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Global teardown script support** - Added `global_teardown_script` config option that runs before worktree deletion when an issue reaches a terminal state (Done, Canceled, deleted). Mirrors the existing `global_setup_script` pattern. Useful for cleaning up per-worktree resources like databases or registered ports. Non-blocking on failure. ([#1065](https://github.com/ceedaragents/cyrus/issues/1065))
+
 ## [0.2.40] - 2026-04-02
 
 ### Fixed

--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -237,7 +237,13 @@ Sets default allowed tools for each prompt type across all repositories. Reposit
 
 ### `global_setup_script` (string)
 
-Path to a script that runs for all repositories when creating new worktrees. See the main README for details on setup scripts.
+Path to a script that runs for all repositories when creating new worktrees. See [SETUP_SCRIPTS.md](SETUP_SCRIPTS.md) for details.
+
+---
+
+### `global_teardown_script` (string)
+
+Path to a script that runs for all repositories before a worktree is deleted (when an issue reaches a terminal state). Runs in the worktree directory so it can read configuration files like `.env.local`. Non-blocking on failure — worktree deletion proceeds regardless. See [SETUP_SCRIPTS.md](SETUP_SCRIPTS.md) for details.
 
 ---
 

--- a/docs/SETUP_SCRIPTS.md
+++ b/docs/SETUP_SCRIPTS.md
@@ -1,6 +1,6 @@
-# Setup Scripts
+# Setup & Teardown Scripts
 
-Cyrus supports optional setup scripts that run automatically when creating new git worktrees for issues. This allows you to perform repository-specific or global initialization tasks.
+Cyrus supports optional scripts that run automatically during the worktree lifecycle — setup scripts when creating worktrees, and teardown scripts before deleting them.
 
 ---
 
@@ -74,3 +74,54 @@ Make sure the script is executable: `chmod +x /opt/cyrus/bin/global-setup.sh`
 - If the global script fails, Cyrus logs the error but continues with repository script execution
 - Both scripts have a 5-minute timeout to prevent hanging
 - Script failures don't prevent worktree creation
+
+---
+
+## Global Teardown Script
+
+When an issue reaches a terminal state (Done, Canceled, or deleted), Cyrus deletes the worktree. A global teardown script runs **before** the worktree directory is removed, allowing you to clean up resources that were provisioned by the setup script.
+
+### Configuration
+
+Add `global_teardown_script` to your `~/.cyrus/config.json`:
+
+```json
+{
+  "repositories": [...],
+  "global_setup_script": "~/.cyrus/scripts/setup.sh",
+  "global_teardown_script": "~/.cyrus/scripts/teardown.sh"
+}
+```
+
+### Environment Variables
+
+The teardown script receives:
+
+- `LINEAR_ISSUE_IDENTIFIER` - The issue identifier (e.g., "CEA-123")
+
+The script runs in the worktree directory, so it can read files like `.env.local` that were written by the setup script.
+
+### Example Usage
+
+```bash
+#!/bin/bash
+# teardown.sh - Clean up per-worktree databases
+
+if [ -f "bin/worktree-teardown" ]; then
+  bin/worktree-teardown
+fi
+
+echo "Teardown complete for issue: $LINEAR_ISSUE_IDENTIFIER"
+```
+
+### Use Cases
+
+- **Drop per-worktree databases** provisioned during setup
+- **Deregister services** or ports claimed by the worktree
+- **Clean up temporary credentials** or tokens
+
+### Error Handling
+
+- The teardown script has a 2-minute timeout
+- Script failures are logged but do **not** prevent worktree deletion
+- The worktree directory is always removed after the script runs (or fails)

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -546,6 +546,9 @@
 		"global_setup_script": {
 			"type": "string"
 		},
+		"global_teardown_script": {
+			"type": "string"
+		},
 		"defaultAllowedTools": {
 			"type": "array",
 			"items": {

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -540,6 +540,9 @@
 		"global_setup_script": {
 			"type": "string"
 		},
+		"global_teardown_script": {
+			"type": "string"
+		},
 		"defaultAllowedTools": {
 			"type": "array",
 			"items": {

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -246,6 +246,9 @@ export const EdgeConfigSchema = z.object({
 	/** Optional path to global setup script that runs for all repositories */
 	global_setup_script: z.string().optional(),
 
+	/** Optional path to global teardown script that runs before worktree deletion */
+	global_teardown_script: z.string().optional(),
+
 	/** Default tools to allow across all repositories */
 	defaultAllowedTools: z.array(z.string()).optional(),
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -3064,7 +3064,9 @@ ${taskSection}`;
 		}
 
 		// Delete worktrees for this issue, keyed by the Linear issue identifier.
-		this.gitService.deleteWorktree(message.workItemIdentifier);
+		this.gitService.deleteWorktree(message.workItemIdentifier, {
+			globalTeardownScript: this.config.global_teardown_script,
+		});
 
 		this.logger.info(
 			`Completed cleanup for ${message.workItemIdentifier}: stopped ${sessions.length} session(s)`,

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -228,6 +228,92 @@ export class GitService {
 	}
 
 	/**
+	 * Run a teardown script before worktree deletion.
+	 * Mirrors runSetupScript but runs during cleanup. Non-blocking on failure
+	 * so worktree deletion always proceeds.
+	 */
+	private runTeardownScript(
+		scriptPath: string,
+		scriptType: "global" | "repository",
+		workspacePath: string,
+		issueIdentifier: string,
+	): void {
+		const expandedPath = scriptPath.replace(/^~/, homedir());
+
+		if (!existsSync(expandedPath)) {
+			this.logger.warn(
+				`⚠️  ${scriptType === "global" ? "Global" : "Repository"} teardown script not found: ${scriptPath}`,
+			);
+			return;
+		}
+
+		if (process.platform !== "win32") {
+			try {
+				const stats = statSync(expandedPath);
+				if (!(stats.mode & 0o100)) {
+					this.logger.warn(
+						`⚠️  ${scriptType === "global" ? "Global" : "Repository"} teardown script is not executable: ${scriptPath}`,
+					);
+					this.logger.warn(`   Run: chmod +x "${expandedPath}"`);
+					return;
+				}
+			} catch (error) {
+				this.logger.warn(
+					`⚠️  Cannot check permissions for ${scriptType} teardown script: ${(error as Error).message}`,
+				);
+				return;
+			}
+		}
+
+		const scriptName = basename(expandedPath);
+		this.logger.info(`ℹ️  Running ${scriptType} teardown script: ${scriptName}`);
+
+		try {
+			let command: string;
+			const isWindows = process.platform === "win32";
+
+			if (scriptPath.endsWith(".ps1")) {
+				command = `powershell -ExecutionPolicy Bypass -File "${expandedPath}"`;
+			} else if (scriptPath.endsWith(".cmd") || scriptPath.endsWith(".bat")) {
+				command = `"${expandedPath}"`;
+			} else if (isWindows) {
+				command = `bash "${expandedPath}"`;
+			} else {
+				command = `bash "${expandedPath}"`;
+			}
+
+			execSync(command, {
+				cwd: workspacePath,
+				stdio: "inherit",
+				env: {
+					...process.env,
+					LINEAR_ISSUE_IDENTIFIER: issueIdentifier,
+				},
+				timeout: 2 * 60 * 1000, // 2 minute timeout (teardown should be fast)
+			});
+
+			this.logger.info(
+				`✅ ${scriptType === "global" ? "Global" : "Repository"} teardown script completed successfully`,
+			);
+		} catch (error) {
+			const errorMessage =
+				(error as any).signal === "SIGTERM"
+					? "Script execution timed out (exceeded 2 minutes)"
+					: (error as Error).message;
+
+			this.logger.error(
+				`❌ ${scriptType === "global" ? "Global" : "Repository"} teardown script failed: ${errorMessage}`,
+			);
+
+			if ((error as any).stderr) {
+				this.logger.error("   stderr:", (error as any).stderr.toString());
+			}
+
+			this.logger.info(`   Continuing with worktree deletion...`);
+		}
+	}
+
+	/**
 	 * Find an existing worktree by its checked-out branch name.
 	 * Parses `git worktree list --porcelain` output and returns the worktree path
 	 * if a worktree is found with the given branch checked out, or null otherwise.
@@ -880,7 +966,10 @@ export class GitService {
 	 *
 	 * @param issueIdentifier - The issue identifier (e.g., "DEF-123")
 	 */
-	deleteWorktree(issueIdentifier: string): void {
+	deleteWorktree(
+		issueIdentifier: string,
+		options?: { globalTeardownScript?: string },
+	): void {
 		const workspacePath = join(this.workspaceBaseDir, issueIdentifier);
 
 		if (!existsSync(workspacePath)) {
@@ -893,6 +982,16 @@ export class GitService {
 		this.logger.info(
 			`Deleting worktree directory for ${issueIdentifier} at ${workspacePath}`,
 		);
+
+		// Run teardown script before deletion so it can read worktree files (e.g. .env.local)
+		if (options?.globalTeardownScript) {
+			this.runTeardownScript(
+				options.globalTeardownScript,
+				"global",
+				workspacePath,
+				issueIdentifier,
+			);
+		}
 
 		// Find all git worktrees that are within this workspace path.
 		// In multi-repo layouts, there may be subdirectories that are each worktrees.

--- a/packages/edge-worker/test/GitService.test.ts
+++ b/packages/edge-worker/test/GitService.test.ts
@@ -683,6 +683,105 @@ describe("GitService", () => {
 				{ recursive: true, force: true },
 			);
 		});
+
+		it("runs global teardown script before deleting worktree", () => {
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
+				// Teardown script exists and is executable
+				if (p === "/home/user/scripts/teardown.sh") return true;
+				return false;
+			});
+
+			mockStatSync.mockImplementation(() => {
+				return { isFile: () => true, mode: 0o755 } as any;
+			});
+
+			mockReaddirSync.mockReturnValue([] as any);
+			mockExecSync.mockReturnValue(Buffer.from(""));
+
+			gitService.deleteWorktree("DEF-123", {
+				globalTeardownScript: "/home/user/scripts/teardown.sh",
+			});
+
+			// Teardown script should run before deletion, in the worktree directory
+			expect(mockExecSync).toHaveBeenCalledWith(
+				'bash "/home/user/scripts/teardown.sh"',
+				expect.objectContaining({
+					cwd: "/home/user/.cyrus/worktrees/DEF-123",
+					env: expect.objectContaining({
+						LINEAR_ISSUE_IDENTIFIER: "DEF-123",
+					}),
+				}),
+			);
+
+			// Should still delete the directory
+			expect(mockRmSync).toHaveBeenCalledWith(
+				"/home/user/.cyrus/worktrees/DEF-123",
+				{ recursive: true, force: true },
+			);
+		});
+
+		it("continues with deletion when teardown script fails", () => {
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
+				if (p === "/home/user/scripts/teardown.sh") return true;
+				return false;
+			});
+
+			mockStatSync.mockImplementation(() => {
+				return { isFile: () => true, mode: 0o755 } as any;
+			});
+
+			mockReaddirSync.mockReturnValue([] as any);
+
+			// First call (teardown script) fails, subsequent calls succeed
+			let callCount = 0;
+			mockExecSync.mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					throw new Error("teardown script failed");
+				}
+				return Buffer.from("");
+			});
+
+			gitService.deleteWorktree("DEF-123", {
+				globalTeardownScript: "/home/user/scripts/teardown.sh",
+			});
+
+			// Should log the failure
+			expect(mockLogger.error).toHaveBeenCalledWith(
+				expect.stringContaining("teardown script failed"),
+			);
+
+			// Should still delete the directory despite teardown failure
+			expect(mockRmSync).toHaveBeenCalledWith(
+				"/home/user/.cyrus/worktrees/DEF-123",
+				{ recursive: true, force: true },
+			);
+		});
+
+		it("skips teardown when no script is configured", () => {
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
+				return false;
+			});
+
+			mockReaddirSync.mockReturnValue([] as any);
+
+			gitService.deleteWorktree("DEF-123");
+
+			// No teardown-related exec calls
+			expect(mockExecSync).not.toHaveBeenCalled();
+
+			// Should still delete
+			expect(mockRmSync).toHaveBeenCalledWith(
+				"/home/user/.cyrus/worktrees/DEF-123",
+				{ recursive: true, force: true },
+			);
+		});
 	});
 
 	describe("createGitWorktree - 0 repos", () => {


### PR DESCRIPTION
## Summary

Adds `global_teardown_script` config option that runs before worktree deletion when an issue reaches a terminal state (Done, Canceled, or deleted). Mirrors the existing `global_setup_script` pattern.

The teardown script:
- Runs in the worktree directory (can read `.env.local` and other config files written by the setup script)
- Receives `LINEAR_ISSUE_IDENTIFIER` as an environment variable
- Has a 2-minute timeout
- Is non-blocking on failure — worktree deletion always proceeds

## Use Case

Our Rails app's `global_setup_script` creates 8 isolated Postgres databases per worktree (primary, queue, cache, cable × dev + test). When Cyrus deletes the worktree, those databases are orphaned. The teardown script runs `bin/worktree-teardown` to drop them before the directory is removed.

## Config Example

```json
{
  "global_setup_script": "~/.cyrus/scripts/setup.sh",
  "global_teardown_script": "~/.cyrus/scripts/teardown.sh"
}
```

## Changes

- **`packages/core/src/config-schemas.ts`** — Added `global_teardown_script` to `EdgeConfigSchema`
- **`packages/core/schemas/`** — Updated JSON schema snapshots (auto-regenerated by pre-commit hook)
- **`packages/edge-worker/src/GitService.ts`** — Added `runTeardownScript` method, called in `deleteWorktree` before directory removal
- **`packages/edge-worker/src/EdgeWorker.ts`** — Pass `global_teardown_script` from config to `deleteWorktree`
- **`packages/edge-worker/test/GitService.test.ts`** — 3 new tests: runs teardown before deletion, continues on failure, skips when unconfigured
- **`docs/CONFIG_FILE.md`** — Documented the new option
- **`docs/SETUP_SCRIPTS.md`** — Added teardown section with examples and error handling docs
- **`CHANGELOG.md`** — Added entry under `[Unreleased]`

## Testing

All existing tests pass (1,259 total). 3 new tests added:
- Runs global teardown script in worktree directory with correct env vars
- Continues with deletion when teardown script fails
- Skips teardown when no script is configured

Closes #1065