### PR TITLE
chore: update @anthropic-ai/claude-agent-sdk to v0.2.91 (CYPACK-1033)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Bumped `@anthropic-ai/claude-agent-sdk` from `^0.2.90` to `^0.2.91` in `cyrus-claude-runner`, `cyrus-core`, and `cyrus-simple-agent-runner`. `@anthropic-ai/sdk` was already at latest (`^0.82.0`). ([CYPACK-1033](https://linear.app/ceedar/issue/CYPACK-1033), [#1067](https://github.com/ceedaragents/cyrus/pull/1067))
+
 ## [0.2.40] - 2026-04-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.91** - Upgrade from v0.2.90. v0.2.91 adds an optional `terminal_reason` field to result messages (exposed why the query loop ended: `"completed"`, `"aborted_tools"`, `"max_turns"`, or `"blocking_limit"`), adds `'auto'` to the public `PermissionMode` type, and changes sandbox behavior so `enabled: true` now defaults `failIfUnavailable` to `true` (set `failIfUnavailable: false` to restore previous graceful degradation). `@anthropic-ai/sdk` already at latest (v0.82.0). See changelog: [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#v0291). ([CYPACK-1033](https://linear.app/ceedar/issue/CYPACK-1033), [#1067](https://github.com/ceedaragents/cyrus/pull/1067))
+
 ## [0.2.40] - 2026-04-02
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.91",
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.91",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.91",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.91
+        version: 0.2.91(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: ^0.82.0
         version: 0.82.0(zod@4.3.6)
@@ -245,8 +245,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.91
+        version: 0.2.91(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -508,8 +508,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.91
+        version: 0.2.91(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -552,14 +552,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.90':
-    resolution: {integrity: sha512-up5bK0pUbthKIZtNE18WDrIYi0KNpZUhdgjGbkfH/mFQJxI6W/uE3mTiLrCX3UF0SqNl0fMtojBTZPJr2b3O4g==}
+  '@anthropic-ai/claude-agent-sdk@0.2.91':
+    resolution: {integrity: sha512-DCd5Ad5XKBbIIOMZ73L+c+e9azM6NtZzOtdKQAzykzRG/KxSCMraMAsMMQrJrIUMH3oTtHY7QuQimAiElVVVpA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.74.0':
-    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
     hasBin: true
     peerDependencies:
       zod: 4.3.6
@@ -3731,9 +3731,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.90(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.91(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.80.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -3750,7 +3750,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- Updated `@anthropic-ai/claude-agent-sdk` from `v0.2.90` to `v0.2.91` across all packages that depend on it (`cyrus-claude-runner`, `cyrus-core`, `cyrus-simple-agent-runner`)
- `@anthropic-ai/sdk` was already at the latest version (`v0.82.0`) — no change needed

## What's new in v0.2.91

- **`terminal_reason` field** — Result messages now expose why the query loop ended (`"completed"`, `"aborted_tools"`, `"max_turns"`, `"blocking_limit"`)
- **`'auto'` added to `PermissionMode` type** — The public type now includes `'auto'` as a supported permission mode value
- **Sandbox `failIfUnavailable` default change** — When `enabled: true` is passed to the sandbox option, `failIfUnavailable` now defaults to `true`. The SDK will emit an error and exit if sandbox dependencies are missing rather than silently degrading. Set `failIfUnavailable: false` to restore previous behavior
- **Version alignment** — Synced with Claude Code v2.1.91

See upstream changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md

## Testing

- All 642 package tests pass
- TypeScript type checking passes across all packages

## Linear Issue

[CYPACK-1033](https://linear.app/ceedar/issue/CYPACK-1033/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest)

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->