### PR TITLE
chore: update @anthropic-ai/claude-agent-sdk to v0.2.92 (CYPACK-1039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.92** - Upgrades from v0.2.90. v0.2.91 adds an optional `terminal_reason` field to result messages (values: `completed`, `aborted_tools`, `max_turns`, `blocking_limit`), expands the public `PermissionMode` type to include `'auto'`, and changes `sandbox: { enabled: true }` to default `failIfUnavailable: true`. v0.2.92 syncs with Claude Code v2.1.92. See changelog: [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md). ([CYPACK-1039](https://linear.app/ceedar/issue/CYPACK-1039))
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.92** - Upgrades from v0.2.90. v0.2.91 adds an optional `terminal_reason` field to result messages (values: `completed`, `aborted_tools`, `max_turns`, `blocking_limit`), expands the public `PermissionMode` type to include `'auto'`, and changes `sandbox: { enabled: true }` to default `failIfUnavailable: true`. v0.2.92 syncs with Claude Code v2.1.92. See changelog: [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md). ([CYPACK-1039](https://linear.app/ceedar/issue/CYPACK-1039), [#1068](https://github.com/ceedaragents/cyrus/pull/1068))
 
 ## [0.2.40] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.92** - Upgrades from v0.2.90. v0.2.91 adds an optional `terminal_reason` field to result messages (values: `completed`, `aborted_tools`, `max_turns`, `blocking_limit`), expands the public `PermissionMode` type to include `'auto'`, and changes `sandbox: { enabled: true }` to default `failIfUnavailable: true`. v0.2.92 syncs with Claude Code v2.1.92. See changelog: [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md). ([CYPACK-1039](https://linear.app/ceedar/issue/CYPACK-1039))
+
 ## [0.2.40] - 2026-04-02
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.92",
 		"@anthropic-ai/sdk": "^0.82.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.92",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/claude-agent-sdk": "^0.2.92",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.92
+        version: 0.2.92(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: ^0.82.0
         version: 0.82.0(zod@4.3.6)
@@ -245,8 +245,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.92
+        version: 0.2.92(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -508,8 +508,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.90
-        version: 0.2.90(zod@4.3.6)
+        specifier: ^0.2.92
+        version: 0.2.92(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -552,14 +552,14 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.90':
-    resolution: {integrity: sha512-up5bK0pUbthKIZtNE18WDrIYi0KNpZUhdgjGbkfH/mFQJxI6W/uE3mTiLrCX3UF0SqNl0fMtojBTZPJr2b3O4g==}
+  '@anthropic-ai/claude-agent-sdk@0.2.92':
+    resolution: {integrity: sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.74.0':
-    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
     hasBin: true
     peerDependencies:
       zod: 4.3.6
@@ -3731,9 +3731,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.90(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.92(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.80.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -3750,7 +3750,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
Assignee: @Connoropolous ([Connor](https://linear.app/ceedar/profiles/connor))

## Summary

- Updates `@anthropic-ai/claude-agent-sdk` from `^0.2.90` → `^0.2.92` across `packages/core`, `packages/claude-runner`, and `packages/simple-agent-runner`
- `@anthropic-ai/sdk` remains at `^0.82.0` (already at latest)
- Closed superseded PR #1067 (CYPACK-1033 update to v0.2.91) and canceled associated Linear issue CYPACK-1033

**What's new in v0.2.91–v0.2.92** ([changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md)):
- `terminal_reason` field added to result messages (`completed`, `aborted_tools`, `max_turns`, `blocking_limit`)
- `PermissionMode` type expanded to include `'auto'`
- `sandbox: { enabled: true }` now defaults `failIfUnavailable: true`
- v0.2.92 syncs with Claude Code v2.1.92

## Test plan
- [x] All package tests pass (`pnpm test:packages:run`)
- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)

Linear: [CYPACK-1039](https://linear.app/ceedar/issue/CYPACK-1039)

---
> **Tip:** I will respond to comments that @ mention @cyrusbot on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->