### PR TITLE
fix: clear refreshPromise after successful token refresh

### DIFF
--- a/packages/linear-event-transport/src/LinearIssueTrackerService.ts
+++ b/packages/linear-event-transport/src/LinearIssueTrackerService.ts
@@ -143,9 +143,7 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 					// or if it's not a token expiration error
 					if (isRetry || !this.isTokenExpiredError(error)) throw error;
 
-					// Coalesce ALL concurrent refresh attempts - everyone shares the same promise.
-					// The promise persists after resolution so late-arriving 401s still get
-					// the same token without triggering a new refresh.
+					// Coalesce concurrent refresh attempts - everyone shares the same promise.
 					if (!this.refreshPromise) {
 						this.refreshPromise = this.doTokenRefresh().catch(
 							(refreshError) => {
@@ -159,6 +157,9 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 
 					try {
 						const newToken = await this.refreshPromise;
+						// Clear cached promise so future token expirations trigger a fresh refresh.
+						// Workspace-level coalescing via pendingRefreshes still deduplicates concurrent calls.
+						this.refreshPromise = null;
 						client.setHeader("Authorization", `Bearer ${newToken}`);
 
 						// Retry the request with the new token (marked as retry to prevent loops)


### PR DESCRIPTION
## Summary

- Fix auto token refresh only working once per service lifetime
- Clear `refreshPromise` after successful refresh so subsequent expirations trigger a new refresh
- Workspace-level coalescing via `pendingRefreshes` still correctly deduplicates concurrent calls

Fixes #1070

## Problem

`refreshPromise` is only cleared on failure (in the `.catch()` handler). After a successful refresh, it remains as a resolved Promise. When the token expires again days later:

1. `!this.refreshPromise` → `false` (stale resolved Promise)
2. `await this.refreshPromise` → returns the old (now expired) token
3. Retry with `isRetry=true` → 401 → throws without attempting refresh

This causes self-hosted deployments to stop responding to Linear after ~48 hours (two token expiration cycles), requiring a manual service restart.

## Fix

Add `this.refreshPromise = null` after `await this.refreshPromise` resolves, before retrying the request. This is safe because the workspace-level static `pendingRefreshes` Map in `doTokenRefresh()` still handles concurrent deduplication.

## Test plan

- [ ] Deploy to a self-hosted instance and verify token auto-refreshes across multiple expiration cycles without restart
- [ ] Verify concurrent 401s during the same expiration window still coalesce into a single refresh call