### PR TITLE
fix: resolve stale Slack chat repository allowlist after runtime config changes (CYPACK-1051)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Changed
-- Introduced `ChatRepositoryProvider` interface and `LiveChatRepositoryProvider` implementation to decouple `SlackChatAdapter` and `ChatSessionHandler` from frozen boot-time repository snapshots. Both now read live repository state on demand at session-build time via the provider abstraction. Removed `chatRepositoryPaths`, `repository`, and `linearWorkspaceId` from `ChatSessionHandlerDeps` in favor of a single `chatRepositoryProvider` field. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051))
+- Introduced `ChatRepositoryProvider` interface and `LiveChatRepositoryProvider` implementation to decouple `SlackChatAdapter` and `ChatSessionHandler` from frozen boot-time repository snapshots. Both now read live repository state on demand at session-build time via the provider abstraction. Removed `chatRepositoryPaths`, `repository`, and `linearWorkspaceId` from `ChatSessionHandlerDeps` in favor of a single `chatRepositoryProvider` field. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051), [#1078](https://github.com/ceedaragents/cyrus/pull/1078))
 
 ## [0.2.42] - 2026-04-06
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Introduced `ChatRepositoryProvider` interface and `LiveChatRepositoryProvider` implementation to decouple `SlackChatAdapter` and `ChatSessionHandler` from frozen boot-time repository snapshots. Both now read live repository state on demand at session-build time via the provider abstraction. Removed `chatRepositoryPaths`, `repository`, and `linearWorkspaceId` from `ChatSessionHandlerDeps` in favor of a single `chatRepositoryProvider` field. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051))
+
 ## [0.2.42] - 2026-04-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Slack chat sessions now see repositories added or removed at runtime** — Previously, Slack sessions used a stale snapshot of configured repositories from boot time, causing Cyrus to report missing access to repos that were actually configured. New sessions now always reflect the current repository configuration. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051))
+- **Slack chat sessions now see repositories added or removed at runtime** — Previously, Slack sessions used a stale snapshot of configured repositories from boot time, causing Cyrus to report missing access to repos that were actually configured. New sessions now always reflect the current repository configuration. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051), [#1078](https://github.com/ceedaragents/cyrus/pull/1078))
 
 ## [0.2.42] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Slack chat sessions now see repositories added or removed at runtime** — Previously, Slack sessions used a stale snapshot of configured repositories from boot time, causing Cyrus to report missing access to repos that were actually configured. New sessions now always reflect the current repository configuration. ([CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051))
+
 ## [0.2.42] - 2026-04-06
 
 ### Fixed

--- a/packages/edge-worker/src/ChatRepositoryProvider.ts
+++ b/packages/edge-worker/src/ChatRepositoryProvider.ts
@@ -1,0 +1,45 @@
+import type { RepositoryConfig } from "cyrus-core";
+
+/**
+ * Abstraction for accessing the current set of chat-accessible repositories.
+ *
+ * SlackChatAdapter and ChatSessionHandler depend on this interface rather than
+ * a frozen array, so they always read the live repository state at the moment
+ * a session is built — no refresh/notification wiring needed.
+ */
+export interface ChatRepositoryProvider {
+	/** Current repository paths available for chat sessions */
+	getRepositoryPaths(): string[];
+	/** Default repository for MCP config sourcing (V1: first available) */
+	getDefaultRepository(): RepositoryConfig | undefined;
+	/** Default Linear workspace ID for MCP config (V1: first configured) */
+	getDefaultLinearWorkspaceId(): string | undefined;
+}
+
+/**
+ * Live implementation backed by EdgeWorker's repository map and config.
+ *
+ * Reads are computed on demand from the underlying collections, so any
+ * runtime config changes (add/update/remove) are automatically visible
+ * to the next chat session without explicit notification.
+ */
+export class LiveChatRepositoryProvider implements ChatRepositoryProvider {
+	constructor(
+		private readonly repositories: Map<string, RepositoryConfig>,
+		private readonly getLinearWorkspaces: () => Record<string, unknown>,
+	) {}
+
+	getRepositoryPaths(): string[] {
+		return Array.from(this.repositories.values()).map(
+			(repo) => repo.repositoryPath,
+		);
+	}
+
+	getDefaultRepository(): RepositoryConfig | undefined {
+		return Array.from(this.repositories.values())[0];
+	}
+
+	getDefaultLinearWorkspaceId(): string | undefined {
+		return Object.keys(this.getLinearWorkspaces())[0];
+	}
+}

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -7,10 +7,10 @@ import type {
 	CyrusAgentSession,
 	IAgentRunner,
 	ILogger,
-	RepositoryConfig,
 } from "cyrus-core";
 import { createLogger } from "cyrus-core";
 import { AgentSessionManager } from "./AgentSessionManager.js";
+import type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import type { RunnerConfigBuilder } from "./RunnerConfigBuilder.js";
 
 /**
@@ -55,11 +55,8 @@ export interface ChatPlatformAdapter<TEvent> {
  */
 export interface ChatSessionHandlerDeps {
 	cyrusHome: string;
-	/** Linear workspace ID for building fresh MCP config per session */
-	linearWorkspaceId?: string;
-	/** Repository to source user-configured MCP paths from (V1: first available repo) */
-	repository?: RepositoryConfig;
-	chatRepositoryPaths?: string[];
+	/** Provider for live repository paths, default repo, and workspace ID */
+	chatRepositoryProvider: ChatRepositoryProvider;
 	/** Shared RunnerConfigBuilder for constructing runner configs */
 	runnerConfigBuilder: RunnerConfigBuilder;
 	/** Factory function that creates the appropriate runner based on config.defaultRunner */
@@ -397,6 +394,9 @@ export class ChatSessionHandler<TEvent> {
 			platform: this.adapter.platformName,
 		});
 
+		// Read live values from the provider at session-build time
+		const provider = this.deps.chatRepositoryProvider;
+
 		return this.deps.runnerConfigBuilder.buildChatConfig({
 			workspacePath,
 			workspaceName,
@@ -404,9 +404,9 @@ export class ChatSessionHandler<TEvent> {
 			sessionId,
 			resumeSessionId,
 			cyrusHome: this.deps.cyrusHome,
-			linearWorkspaceId: this.deps.linearWorkspaceId,
-			repository: this.deps.repository,
-			repositoryPaths: this.deps.chatRepositoryPaths,
+			linearWorkspaceId: provider.getDefaultLinearWorkspaceId(),
+			repository: provider.getDefaultRepository(),
+			repositoryPaths: provider.getRepositoryPaths(),
 			logger: sessionLogger,
 			onMessage: (message: SDKMessage) =>
 				this.handleAgentMessage(sessionId, message),

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -124,6 +124,7 @@ import { ActivityPoster } from "./ActivityPoster.js";
 import { AgentSessionManager } from "./AgentSessionManager.js";
 import { AskUserQuestionHandler } from "./AskUserQuestionHandler.js";
 import { AttachmentService } from "./AttachmentService.js";
+import { LiveChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import { ChatSessionHandler } from "./ChatSessionHandler.js";
 import { ConfigManager, type RepositoryChanges } from "./ConfigManager.js";
 import { DefaultSkillsDeployer } from "./DefaultSkillsDeployer.js";
@@ -794,23 +795,24 @@ export class EdgeWorker extends EventEmitter {
 	 * This creates a /slack-webhook endpoint that handles @mention events from Slack.
 	 */
 	private registerSlackEventTransport(): void {
-		const allRepos = Array.from(this.repositories.values());
-		const chatRepositoryPaths = allRepos.map((repo) => repo.repositoryPath);
+		// Live provider reads from the repository map on demand — no snapshot needed
+		const chatRepositoryProvider = new LiveChatRepositoryProvider(
+			this.repositories,
+			() => this.config.linearWorkspaces || {},
+		);
+
 		const routingContext =
 			this.promptBuilder.generateRoutingContextForAllWorkspaces();
 		const slackAdapter = new SlackChatAdapter(
-			chatRepositoryPaths,
+			chatRepositoryProvider,
 			this.logger,
 			{ repositoryRoutingContext: routingContext },
 		);
 
-		// V1: Source workspace/repo from first available (all repos share the same MCPs today)
-		const firstLinearWorkspaceId = Object.keys(
-			this.config.linearWorkspaces || {},
-		)[0];
-		const firstRepo = allRepos[0];
-
-		if (!firstLinearWorkspaceId || !firstRepo) {
+		if (
+			!chatRepositoryProvider.getDefaultLinearWorkspaceId() ||
+			!chatRepositoryProvider.getDefaultRepository()
+		) {
 			this.logger.warn(
 				"No repositories or workspaces configured — Slack sessions will not have access to MCP tools",
 			);
@@ -820,9 +822,7 @@ export class EdgeWorker extends EventEmitter {
 			slackAdapter,
 			{
 				cyrusHome: this.cyrusHome,
-				chatRepositoryPaths,
-				linearWorkspaceId: firstLinearWorkspaceId,
-				repository: firstRepo,
+				chatRepositoryProvider,
 				runnerConfigBuilder: this.runnerConfigBuilder,
 				createRunner: (config) => {
 					const runnerType = this.runnerSelectionService.getDefaultRunner();

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -7,6 +7,7 @@ import {
 	type SlackWebhookEvent,
 	stripMention as stripSlackMention,
 } from "cyrus-slack-event-transport";
+import type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import type { ChatPlatformAdapter } from "./ChatSessionHandler.js";
 
 /**
@@ -20,21 +21,19 @@ export class SlackChatAdapter
 	implements ChatPlatformAdapter<SlackWebhookEvent>
 {
 	readonly platformName = "slack" as const;
-	private repositoryPaths: string[];
+	private repositoryProvider: ChatRepositoryProvider;
 	private repositoryRoutingContext: string;
 	private logger: ILogger;
 	private selfBotId: string | undefined;
 
 	constructor(
-		repositoryPaths: string[] = [],
+		repositoryProvider: ChatRepositoryProvider,
 		logger?: ILogger,
 		options?: {
 			repositoryRoutingContext?: string;
 		},
 	) {
-		this.repositoryPaths = Array.from(
-			new Set(repositoryPaths.filter(Boolean)),
-		).sort();
+		this.repositoryProvider = repositoryProvider;
 		this.repositoryRoutingContext =
 			options?.repositoryRoutingContext?.trim() || "";
 		this.logger = logger ?? createLogger({ component: "SlackChatAdapter" });
@@ -85,12 +84,15 @@ export class SlackChatAdapter
 	}
 
 	buildSystemPrompt(event: SlackWebhookEvent): string {
+		const repositoryPaths = Array.from(
+			new Set(this.repositoryProvider.getRepositoryPaths().filter(Boolean)),
+		).sort();
 		const repositoryAccessSection =
-			this.repositoryPaths.length > 0
+			repositoryPaths.length > 0
 				? `
 ## Repository Access
 - You have read-only access to the following configured repositories:
-${this.repositoryPaths.map((path) => `- ${path}`).join("\n")}
+${repositoryPaths.map((path) => `- ${path}`).join("\n")}
 
 - If you need to inspect source code in one of these repositories, use:
   - Bash(git -C * pull)

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -16,6 +16,8 @@ export type {
 	AskUserQuestionHandlerDeps,
 } from "./AskUserQuestionHandler.js";
 export { AskUserQuestionHandler } from "./AskUserQuestionHandler.js";
+export type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
+export { LiveChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 export type {
 	ChatPlatformAdapter,
 	ChatPlatformName,

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -1,6 +1,9 @@
 import { join } from "node:path";
 import { getReadOnlyTools } from "cyrus-claude-runner";
+import type { RepositoryConfig } from "cyrus-core";
 import { describe, expect, it, vi } from "vitest";
+import type { ChatRepositoryProvider } from "../src/ChatRepositoryProvider.js";
+import { LiveChatRepositoryProvider } from "../src/ChatRepositoryProvider.js";
 import type { ChatPlatformAdapter } from "../src/ChatSessionHandler.js";
 import { ChatSessionHandler } from "../src/ChatSessionHandler.js";
 import type { RunnerConfigBuilder } from "../src/RunnerConfigBuilder.js";
@@ -34,6 +37,19 @@ function createMockRunnerConfigBuilder(): RunnerConfigBuilder {
 		},
 		buildIssueConfig: vi.fn(),
 	} as unknown as RunnerConfigBuilder;
+}
+
+/** Minimal ChatRepositoryProvider backed by a plain array (for tests) */
+function createStaticProvider(
+	paths: string[],
+	defaultRepo?: RepositoryConfig,
+	linearWorkspaceId?: string,
+): ChatRepositoryProvider {
+	return {
+		getRepositoryPaths: () => paths,
+		getDefaultRepository: () => defaultRepo,
+		getDefaultLinearWorkspaceId: () => linearWorkspaceId,
+	};
 }
 
 interface TestEvent {
@@ -109,7 +125,7 @@ describe("ChatSessionHandler chat session permissions", () => {
 
 		const handler = new ChatSessionHandler(adapter, {
 			cyrusHome,
-			chatRepositoryPaths,
+			chatRepositoryProvider: createStaticProvider(chatRepositoryPaths),
 			runnerConfigBuilder: createMockRunnerConfigBuilder(),
 			createRunner: createRunner,
 			onWebhookStart,
@@ -137,7 +153,7 @@ describe("ChatSessionHandler chat session permissions", () => {
 describe("SlackChatAdapter system prompt", () => {
 	it("includes configured repository context and git pull instructions", () => {
 		const repositoryPaths = ["/repo/chat-one", "/repo/chat-two"];
-		const adapter = new SlackChatAdapter(repositoryPaths);
+		const adapter = new SlackChatAdapter(createStaticProvider(repositoryPaths));
 		const systemPrompt = adapter.buildSystemPrompt({
 			payload: {
 				user: "U1",
@@ -159,9 +175,11 @@ describe("SlackChatAdapter system prompt", () => {
 		const repositoryPaths = ["/repo/chat-one", "/repo/chat-two"];
 		const repositoryRoutingContext =
 			"<repository_routing_context>\n  <description>Use repo routing tags.</description>\n</repository_routing_context>";
-		const adapter = new SlackChatAdapter(repositoryPaths, undefined, {
-			repositoryRoutingContext,
-		});
+		const adapter = new SlackChatAdapter(
+			createStaticProvider(repositoryPaths),
+			undefined,
+			{ repositoryRoutingContext },
+		);
 		const systemPrompt = adapter.buildSystemPrompt({
 			payload: {
 				user: "U1",
@@ -177,5 +195,212 @@ describe("SlackChatAdapter system prompt", () => {
 		expect(systemPrompt).toContain("mcp__linear__get_user");
 		expect(systemPrompt).toContain('query: "me"');
 		expect(systemPrompt).toContain("linear_get_agent_sessions");
+	});
+});
+
+describe("ChatRepositoryProvider runtime updates", () => {
+	const slackEvent = {
+		payload: {
+			user: "U1",
+			channel: "C1",
+			text: "<@cyrus> test",
+			ts: "1700000000.000100",
+			event_ts: "1700000000.000100",
+			type: "app_mention",
+		},
+	} as any;
+
+	it("SlackChatAdapter.buildSystemPrompt reflects repos added at runtime", () => {
+		const paths = ["/repo/A"];
+		const provider: ChatRepositoryProvider = {
+			getRepositoryPaths: () => paths,
+			getDefaultRepository: () => undefined,
+			getDefaultLinearWorkspaceId: () => undefined,
+		};
+		const adapter = new SlackChatAdapter(provider);
+
+		// Initial state: only repo A
+		let prompt = adapter.buildSystemPrompt(slackEvent);
+		expect(prompt).toContain("- /repo/A");
+		expect(prompt).not.toContain("- /repo/B");
+
+		// Simulate runtime config change: add repo B
+		paths.push("/repo/B");
+
+		prompt = adapter.buildSystemPrompt(slackEvent);
+		expect(prompt).toContain("- /repo/A");
+		expect(prompt).toContain("- /repo/B");
+	});
+
+	it("SlackChatAdapter.buildSystemPrompt reflects repos removed at runtime", () => {
+		const paths = ["/repo/A", "/repo/B"];
+		const provider: ChatRepositoryProvider = {
+			getRepositoryPaths: () => paths,
+			getDefaultRepository: () => undefined,
+			getDefaultLinearWorkspaceId: () => undefined,
+		};
+		const adapter = new SlackChatAdapter(provider);
+
+		// Initial state: both repos
+		let prompt = adapter.buildSystemPrompt(slackEvent);
+		expect(prompt).toContain("- /repo/A");
+		expect(prompt).toContain("- /repo/B");
+
+		// Simulate runtime config change: remove repo A
+		paths.splice(0, 1);
+
+		prompt = adapter.buildSystemPrompt(slackEvent);
+		expect(prompt).not.toContain("- /repo/A");
+		expect(prompt).toContain("- /repo/B");
+	});
+
+	it("ChatSessionHandler reads live repository paths from provider at session build time", async () => {
+		const cyrusHome = TEST_CYRUS_CHAT;
+		const paths = ["/repo/A"];
+		const provider: ChatRepositoryProvider = {
+			getRepositoryPaths: () => [...paths],
+			getDefaultRepository: () => undefined,
+			getDefaultLinearWorkspaceId: () => undefined,
+		};
+
+		let capturedConfig: any;
+		const createRunner = vi.fn((config: any) => {
+			capturedConfig = config;
+			return {
+				supportsStreamingInput: false,
+				start: vi.fn().mockResolvedValue({ sessionId: "session-1" }),
+				stop: vi.fn(),
+				isRunning: vi.fn().mockReturnValue(false),
+				isStreaming: vi.fn().mockReturnValue(false),
+				addStreamMessage: vi.fn(),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+
+		const adapter = new TestChatAdapter("runtime-thread");
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome,
+			chatRepositoryProvider: provider,
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		// Add repo B at "runtime" before creating a session
+		paths.push("/repo/B");
+
+		await handler.handleEvent({
+			eventId: "runtime-event",
+			threadKey: "runtime-thread",
+		} as any);
+
+		expect(capturedConfig.allowedDirectories).toContain("/repo/A");
+		expect(capturedConfig.allowedDirectories).toContain("/repo/B");
+	});
+
+	it("ChatSessionHandler excludes removed repos from allowedDirectories", async () => {
+		const cyrusHome = TEST_CYRUS_CHAT;
+		const paths = ["/repo/A", "/repo/B"];
+		const provider: ChatRepositoryProvider = {
+			getRepositoryPaths: () => [...paths],
+			getDefaultRepository: () => undefined,
+			getDefaultLinearWorkspaceId: () => undefined,
+		};
+
+		let capturedConfig: any;
+		const createRunner = vi.fn((config: any) => {
+			capturedConfig = config;
+			return {
+				supportsStreamingInput: false,
+				start: vi.fn().mockResolvedValue({ sessionId: "session-1" }),
+				stop: vi.fn(),
+				isRunning: vi.fn().mockReturnValue(false),
+				isStreaming: vi.fn().mockReturnValue(false),
+				addStreamMessage: vi.fn(),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+
+		const adapter = new TestChatAdapter("remove-thread");
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome,
+			chatRepositoryProvider: provider,
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		// Remove repo A at "runtime" before creating a session
+		paths.splice(0, 1);
+
+		await handler.handleEvent({
+			eventId: "remove-event",
+			threadKey: "remove-thread",
+		} as any);
+
+		expect(capturedConfig.allowedDirectories).not.toContain("/repo/A");
+		expect(capturedConfig.allowedDirectories).toContain("/repo/B");
+	});
+});
+
+describe("LiveChatRepositoryProvider", () => {
+	function makeRepo(id: string, path: string): RepositoryConfig {
+		return {
+			id,
+			name: id,
+			repositoryPath: path,
+			baseBranch: "main",
+			workspaceBaseDir: "/tmp",
+		} as RepositoryConfig;
+	}
+
+	it("returns current repository paths from the live map", () => {
+		const repos = new Map<string, RepositoryConfig>();
+		repos.set("r1", makeRepo("r1", "/repo/alpha"));
+
+		const provider = new LiveChatRepositoryProvider(repos, () => ({ ws1: {} }));
+
+		expect(provider.getRepositoryPaths()).toEqual(["/repo/alpha"]);
+
+		// Add a repo at "runtime"
+		repos.set("r2", makeRepo("r2", "/repo/beta"));
+		expect(provider.getRepositoryPaths()).toEqual([
+			"/repo/alpha",
+			"/repo/beta",
+		]);
+
+		// Remove a repo at "runtime"
+		repos.delete("r1");
+		expect(provider.getRepositoryPaths()).toEqual(["/repo/beta"]);
+	});
+
+	it("returns the first repo as default", () => {
+		const repos = new Map<string, RepositoryConfig>();
+		const repo1 = makeRepo("r1", "/repo/alpha");
+		repos.set("r1", repo1);
+
+		const provider = new LiveChatRepositoryProvider(repos, () => ({}));
+		expect(provider.getDefaultRepository()).toBe(repo1);
+	});
+
+	it("returns undefined when no repos are configured", () => {
+		const repos = new Map<string, RepositoryConfig>();
+		const provider = new LiveChatRepositoryProvider(repos, () => ({}));
+		expect(provider.getDefaultRepository()).toBeUndefined();
+		expect(provider.getRepositoryPaths()).toEqual([]);
+	});
+
+	it("returns first linear workspace ID from live config", () => {
+		const repos = new Map<string, RepositoryConfig>();
+		const workspaces = { ws1: {}, ws2: {} };
+		const provider = new LiveChatRepositoryProvider(repos, () => workspaces);
+
+		expect(provider.getDefaultLinearWorkspaceId()).toBe("ws1");
 	});
 });


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

- Introduced `ChatRepositoryProvider` interface and `LiveChatRepositoryProvider` implementation so Slack chat sessions always read the **live** repository state at session-build time, instead of a frozen boot-time snapshot
- Refactored `SlackChatAdapter` to accept the provider and read paths dynamically inside `buildSystemPrompt()`
- Refactored `ChatSessionHandler` to read `repositoryPaths`, `defaultRepository`, and `linearWorkspaceId` from the provider when building runner configs
- Replaced snapshot-copy code in `EdgeWorker.registerSlackEventTransport()` with provider injection backed by the live `this.repositories` map

## Test plan

- [x] All 550 existing edge-worker tests pass
- [x] Added 7 new regression tests covering:
  - Adding a repo at runtime is reflected in `SlackChatAdapter.buildSystemPrompt()`
  - Removing a repo at runtime is reflected in `SlackChatAdapter.buildSystemPrompt()`
  - `ChatSessionHandler` reads live paths from provider into `allowedDirectories`
  - `ChatSessionHandler` excludes removed repos from `allowedDirectories`
  - `LiveChatRepositoryProvider` correctly reads from live map and config
- [x] TypeScript typecheck passes across all packages
- [x] Biome lint passes

Resolves [CYPACK-1051](https://linear.app/ceedar/issue/CYPACK-1051)

---
> **Tip:** I will respond to comments that @ mention @cyrus-the-ai on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->