### PR TITLE
fix: default bot username to 'cyrusagent' in PR/MR tips (CYPACK-1054)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Fixed
+- `buildAgentContextBlock()` now always emits `<agent_context>` with default bot usernames (`cyrusagent`) instead of returning empty string when `GITHUB_BOT_USERNAME`/`GITLAB_BOT_USERNAME` env vars are unset. Updated `verify-and-ship` skill to also include an explicit fallback instruction. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054))
+
 ## [0.2.43] - 2026-04-08
 
 ### Changed

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Fixed
-- `buildAgentContextBlock()` now always emits `<agent_context>` with default bot usernames (`cyrusagent`) instead of returning empty string when `GITHUB_BOT_USERNAME`/`GITLAB_BOT_USERNAME` env vars are unset. Updated `verify-and-ship` skill to also include an explicit fallback instruction. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054))
+- `buildAgentContextBlock()` now always emits `<agent_context>` with default bot usernames (`cyrusagent`) instead of returning empty string when `GITHUB_BOT_USERNAME`/`GITLAB_BOT_USERNAME` env vars are unset. Updated `verify-and-ship` skill to also include an explicit fallback instruction. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054))
+
 ## [0.2.43] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054))
+- **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5076,20 +5076,12 @@ ${input.userComment}
 	 * correct bot account without hardcoding.
 	 */
 	private buildAgentContextBlock(): string {
-		const githubBot = process.env.GITHUB_BOT_USERNAME || "";
-		const gitlabBot = process.env.GITLAB_BOT_USERNAME || "";
-
-		if (!githubBot && !gitlabBot) {
-			return "";
-		}
+		const githubBot = process.env.GITHUB_BOT_USERNAME || "cyrusagent";
+		const gitlabBot = process.env.GITLAB_BOT_USERNAME || "cyrusagent";
 
 		const lines: string[] = ["\n\n<agent_context>"];
-		if (githubBot) {
-			lines.push(`  <github_bot_username>${githubBot}</github_bot_username>`);
-		}
-		if (gitlabBot) {
-			lines.push(`  <gitlab_bot_username>${gitlabBot}</gitlab_bot_username>`);
-		}
+		lines.push(`  <github_bot_username>${githubBot}</github_bot_username>`);
+		lines.push(`  <gitlab_bot_username>${gitlabBot}</gitlab_bot_username>`);
 		lines.push("</agent_context>");
 
 		return lines.join("\n");

--- a/packages/edge-worker/test/prompt-assembly.component-order.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.component-order.test.ts
@@ -65,7 +65,12 @@ Choose the appropriate skill based on the context:
 - **Question or research request**: Use \`investigate\` to search the codebase and provide an answer, then \`summarize\`.
 - **PR review feedback** (changes requested): Use \`implementation\` to address review comments, then \`verify-and-ship\`.
 
-Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.`)
+Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.
+
+<agent_context>
+  <github_bot_username>cyrusagent</github_bot_username>
+  <gitlab_bot_username>cyrusagent</gitlab_bot_username>
+</agent_context>`)
 			.expectUserPrompt(`<context>
   <repository>undefined</repository>
   <working_directory>/test/repo</working_directory>

--- a/packages/edge-worker/test/prompt-assembly.new-comment-metadata.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.new-comment-metadata.test.ts
@@ -201,7 +201,12 @@ Choose the appropriate skill based on the context:
 - **Question or research request**: Use \`investigate\` to search the codebase and provide an answer, then \`summarize\`.
 - **PR review feedback** (changes requested): Use \`implementation\` to address review comments, then \`verify-and-ship\`.
 
-Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.`)
+Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.
+
+<agent_context>
+  <github_bot_username>cyrusagent</github_bot_username>
+  <gitlab_bot_username>cyrusagent</gitlab_bot_username>
+</agent_context>`)
 			.expectPromptType("fallback")
 			.expectComponents("issue-context", "user-comment")
 			.verify();

--- a/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
@@ -93,7 +93,12 @@ Choose the appropriate skill based on the context:
 - **Question or research request**: Use \`investigate\` to search the codebase and provide an answer, then \`summarize\`.
 - **PR review feedback** (changes requested): Use \`implementation\` to address review comments, then \`verify-and-ship\`.
 
-Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.`)
+Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.
+
+<agent_context>
+  <github_bot_username>cyrusagent</github_bot_username>
+  <gitlab_bot_username>cyrusagent</gitlab_bot_username>
+</agent_context>`)
 			.expectPromptType("fallback")
 			.expectComponents("issue-context")
 			.verify();
@@ -188,7 +193,12 @@ Choose the appropriate skill based on the context:
 - **Question or research request**: Use \`investigate\` to search the codebase and provide an answer, then \`summarize\`.
 - **PR review feedback** (changes requested): Use \`implementation\` to address review comments, then \`verify-and-ship\`.
 
-Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.`)
+Analyze the issue description, labels, and any user comments to determine which workflow fits. Do NOT skip the verify-and-ship step if you made code changes — it ensures quality checks pass and a PR is created.
+
+<agent_context>
+  <github_bot_username>cyrusagent</github_bot_username>
+  <gitlab_bot_username>cyrusagent</gitlab_bot_username>
+</agent_context>`)
 			.expectPromptType("fallback")
 			.expectComponents("issue-context", "user-comment")
 			.verify();

--- a/skills/verify-and-ship/SKILL.md
+++ b/skills/verify-and-ship/SKILL.md
@@ -63,7 +63,7 @@ Update the PR/MR with a comprehensive description:
 - **Summary** of changes, implementation approach, and testing performed
 - **Link** to the Linear issue
 - **Cyrus marker**: Include `<!-- generated-by-cyrus -->` as a hidden HTML comment at the end of the body
-- **Interaction tip**: Add this at the end (before the marker), using the bot username from `<github_bot_username>` or `<gitlab_bot_username>` in the `<agent_context>` block of the system prompt:
+- **Interaction tip**: Add this at the end (before the marker), using the bot username from `<github_bot_username>` or `<gitlab_bot_username>` in the `<agent_context>` block of the system prompt. If `<agent_context>` is not present, default to `cyrusagent`:
   ```
   ---
   > **Tip:** I will respond to comments that @ mention @<bot_username> on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- `buildAgentContextBlock()` now always emits an `<agent_context>` XML block with `cyrusagent` as the default bot username when `GITHUB_BOT_USERNAME`/`GITLAB_BOT_USERNAME` env vars are not set (previously returned empty string, causing the LLM to hallucinate "cyrusbot")
- Updated `verify-and-ship` skill to include an explicit fallback instruction to use `cyrusagent` when `<agent_context>` is absent
- Updated prompt assembly tests to match the new always-present `<agent_context>` block

## Linear Issue

[CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054/fix-that-prmr-creation-skill-file-is-falling-back-to-cyrusbot-instead)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->