### PR TITLE
fix: scope .env loading per-session in ClaudeRunner (CYPACK-1057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Repository `.env` variables are now scoped per session** — Previously, `.env` values were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now isolated per session, always reflect the latest `.env` contents, and no longer leak between repos. ([CYPACK-1057](https://linear.app/ceedar/issue/CYPACK-1057))
+- **Repository `.env` variables are now scoped per session** — Previously, `.env` values were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now isolated per session, always reflect the latest `.env` contents, and no longer leak between repos. ([CYPACK-1057](https://linear.app/ceedar/issue/CYPACK-1057), [#1085](https://github.com/ceedaragents/cyrus/pull/1085))
 - **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Repository `.env` variables are now scoped per session** — Previously, `.env` values were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now isolated per session, always reflect the latest `.env` contents, and no longer leak between repos. ([CYPACK-1057](https://linear.app/ceedar/issue/CYPACK-1057))
 - **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -71,6 +71,7 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	private formatter: IMessageFormatter;
 	private pendingResultMessage: SDKMessage | null = null;
 	private canUseToolCallback: CanUseTool | undefined;
+	private repositoryEnv: Record<string, string> = {};
 
 	constructor(config: ClaudeRunnerConfig) {
 		super();
@@ -436,6 +437,7 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					// see: https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default
 					settingSources: ["user", "project", "local"],
 					env: {
+						...this.repositoryEnv,
 						...process.env,
 						CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1",
 						CLAUDE_CODE_ENABLE_TASKS: "true",
@@ -753,25 +755,26 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	/**
-	 * Load environment variables from repository .env file
-	 * Does not override existing process.env values
+	 * Load environment variables from repository .env file into an isolated object.
+	 * Variables are merged only into the child subprocess env, never into process.env.
+	 * Each call re-reads the file so updated/removed values are always reflected.
 	 */
 	private loadRepositoryEnv(workingDirectory: string): void {
 		try {
 			const envPath = join(workingDirectory, ".env");
 
 			if (existsSync(envPath)) {
-				// Load but don't override existing env vars
-				const result = dotenv.config({
-					path: envPath,
-					override: false, // Existing process.env takes precedence
-				});
+				const fileContent = readFileSync(envPath, "utf-8");
+				const parsed = dotenv.parse(fileContent);
 
-				if (result.error) {
-					this.logger.warn("Failed to parse .env file:", result.error);
-				} else if (result.parsed && Object.keys(result.parsed).length > 0) {
+				if (Object.keys(parsed).length > 0) {
 					this.logger.debug("Loaded environment variables from .env");
 				}
+
+				// Replace entirely so removed vars don't carry forward
+				this.repositoryEnv = parsed;
+			} else {
+				this.repositoryEnv = {};
 			}
 		} catch (error) {
 			this.logger.warn("Error loading repository .env:", error);

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -23,6 +23,7 @@ vi.mock("os", () => ({
 	homedir: vi.fn(() => "/mock/home"),
 }));
 
+import { existsSync, readFileSync } from "node:fs";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { AbortError, ClaudeRunner } from "../src/ClaudeRunner";
 import type { ClaudeRunnerConfig, SDKMessage } from "../src/types";
@@ -841,6 +842,126 @@ describe("ClaudeRunner", () => {
 
 			// Readable log logic would filter out TodoWrite but keep Read
 			// (This tests the filtering logic in writeReadableLogEntry)
+		});
+	});
+
+	describe("loadRepositoryEnv - per-session .env isolation", () => {
+		const mockExistsSync = vi.mocked(existsSync);
+		const mockReadFileSync = vi.mocked(readFileSync);
+
+		const mockMessages: SDKMessage[] = [
+			{
+				type: "assistant",
+				message: { content: [{ type: "text", text: "Hello!" }] },
+				parent_tool_use_id: null,
+				session_id: "test-session",
+			} as any,
+		];
+
+		function setupQueryMock() {
+			vi.mocked(query).mockImplementation(async function* () {
+				for (const message of mockMessages) {
+					yield message;
+				}
+			});
+		}
+
+		function getEnvPassedToQuery(): Record<string, string> {
+			const calls = vi.mocked(query).mock.calls;
+			const lastCall = calls[calls.length - 1];
+			return (lastCall[0] as any).options.env;
+		}
+
+		it("should pass .env vars to subprocess env without polluting process.env", async () => {
+			mockExistsSync.mockImplementation((p: any) => String(p).endsWith(".env"));
+			mockReadFileSync.mockImplementation((p: any) => {
+				if (String(p).endsWith(".env"))
+					return "DOCKER_HOST=unix:///run/podman/podman.sock\nCUSTOM_VAR=hello";
+				return "";
+			});
+			setupQueryMock();
+
+			const envRunner = new ClaudeRunner({ ...defaultConfig });
+			await envRunner.start("test");
+
+			const env = getEnvPassedToQuery();
+			expect(env.DOCKER_HOST).toBe("unix:///run/podman/podman.sock");
+			expect(env.CUSTOM_VAR).toBe("hello");
+
+			// process.env must NOT be polluted
+			expect(process.env.DOCKER_HOST).toBeUndefined();
+			expect(process.env.CUSTOM_VAR).toBeUndefined();
+		});
+
+		it("should pick up updated .env values and drop removed vars on new session", async () => {
+			// First session: .env has VAR_A and VAR_B
+			mockExistsSync.mockImplementation((p: any) => String(p).endsWith(".env"));
+			mockReadFileSync.mockImplementation((p: any) => {
+				if (String(p).endsWith(".env")) return "VAR_A=1\nVAR_B=2";
+				return "";
+			});
+			setupQueryMock();
+
+			const runner1 = new ClaudeRunner({ ...defaultConfig });
+			await runner1.start("test");
+
+			const env1 = getEnvPassedToQuery();
+			expect(env1.VAR_A).toBe("1");
+			expect(env1.VAR_B).toBe("2");
+
+			// Second session: .env updated — VAR_A changed, VAR_B removed, VAR_C added
+			mockReadFileSync.mockImplementation((p: any) => {
+				if (String(p).endsWith(".env")) return "VAR_A=updated\nVAR_C=3";
+				return "";
+			});
+
+			const runner2 = new ClaudeRunner({ ...defaultConfig });
+			await runner2.start("test");
+
+			const env2 = getEnvPassedToQuery();
+			expect(env2.VAR_A).toBe("updated");
+			expect(env2.VAR_C).toBe("3");
+			// VAR_B was removed from .env — must not appear
+			expect(env2.VAR_B).toBeUndefined();
+		});
+
+		it("should let process.env take precedence over .env values", async () => {
+			// Set a process.env value that also appears in .env
+			const originalValue = process.env.TEST_PRECEDENCE;
+			process.env.TEST_PRECEDENCE = "from-process";
+
+			mockExistsSync.mockImplementation((p: any) => String(p).endsWith(".env"));
+			mockReadFileSync.mockImplementation((p: any) => {
+				if (String(p).endsWith(".env")) return "TEST_PRECEDENCE=from-dotenv";
+				return "";
+			});
+			setupQueryMock();
+
+			const envRunner = new ClaudeRunner({ ...defaultConfig });
+			await envRunner.start("test");
+
+			const env = getEnvPassedToQuery();
+			// process.env should win
+			expect(env.TEST_PRECEDENCE).toBe("from-process");
+
+			// Clean up
+			if (originalValue === undefined) {
+				delete process.env.TEST_PRECEDENCE;
+			} else {
+				process.env.TEST_PRECEDENCE = originalValue;
+			}
+		});
+
+		it("should handle missing .env file gracefully", async () => {
+			mockExistsSync.mockReturnValue(false);
+			setupQueryMock();
+
+			const envRunner = new ClaudeRunner({ ...defaultConfig });
+			await envRunner.start("test");
+
+			const env = getEnvPassedToQuery();
+			// Should still have the standard Cyrus env vars
+			expect(env.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
 		});
 	});
 });


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

- **Replaced `dotenv.config()` with `dotenv.parse()`** in `ClaudeRunner.loadRepositoryEnv()` so `.env` variables are stored in an isolated `repositoryEnv` object per instance, never written to `process.env`
- **Merged `.env` vars only into subprocess env** via spread order (`...this.repositoryEnv, ...process.env`) preserving existing precedence where `process.env` always wins
- **Each call re-reads the `.env` file** and fully replaces the stored object, so updated/removed variables are always reflected

## Test plan

- [x] Added 4 tests covering:
  - `.env` vars passed to subprocess without polluting `process.env`
  - Updated `.env` picks up changes and drops removed vars on new session
  - `process.env` takes precedence over `.env` values
  - Missing `.env` file handled gracefully
- [x] All 67 claude-runner tests pass
- [x] Full monorepo test suite passes (550+ tests)
- [x] TypeScript typecheck passes across all packages
- [x] Biome lint passes

Resolves [CYPACK-1057](https://linear.app/ceedar/issue/CYPACK-1057/fix-env-loading-in-clauderunner-to-scope-env-vars-per-session)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->