### PR TITLE
fix: scope .env loading per-session to prevent cross-repo env poisoning (CYPACK-1059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Repository `.env` variables are now scoped per-session** — Previously, `.env` files were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now parsed into an isolated object and merged only into the child subprocess env, so updated or removed values take effect immediately and one repo's `.env` cannot leak into another. ([CYPACK-1059](https://linear.app/ceedar/issue/CYPACK-1059))
 - **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Repository `.env` variables are now scoped per-session** — Previously, `.env` files were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now parsed into an isolated object and merged only into the child subprocess env, so updated or removed values take effect immediately and one repo's `.env` cannot leak into another. ([CYPACK-1059](https://linear.app/ceedar/issue/CYPACK-1059))
+- **Repository `.env` variables are now scoped per-session** — Previously, `.env` files were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now parsed into an isolated object and merged only into the child subprocess env, so updated or removed values take effect immediately and one repo's `.env` cannot leak into another. ([CYPACK-1059](https://linear.app/ceedar/issue/CYPACK-1059), [#1086](https://github.com/ceedaragents/cyrus/pull/1086))
 - **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 
 ## [0.2.43] - 2026-04-08

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -71,6 +71,7 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	private formatter: IMessageFormatter;
 	private pendingResultMessage: SDKMessage | null = null;
 	private canUseToolCallback: CanUseTool | undefined;
+	private repositoryEnv: Record<string, string> = {};
 
 	constructor(config: ClaudeRunnerConfig) {
 		super();
@@ -436,6 +437,7 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					// see: https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default
 					settingSources: ["user", "project", "local"],
 					env: {
+						...this.repositoryEnv,
 						...process.env,
 						CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1",
 						CLAUDE_CODE_ENABLE_TASKS: "true",
@@ -753,29 +755,34 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	/**
-	 * Load environment variables from repository .env file
-	 * Does not override existing process.env values
+	 * Load environment variables from repository .env file into an isolated
+	 * object. The parsed vars are merged only into the child subprocess env,
+	 * never into the EdgeWorker's own process.env, so different sessions
+	 * (potentially across different repositories) cannot poison each other.
+	 * Re-reads the file on every call so updated/removed vars take effect.
 	 */
 	private loadRepositoryEnv(workingDirectory: string): void {
 		try {
 			const envPath = join(workingDirectory, ".env");
 
 			if (existsSync(envPath)) {
-				// Load but don't override existing env vars
-				const result = dotenv.config({
-					path: envPath,
-					override: false, // Existing process.env takes precedence
-				});
+				const content = readFileSync(envPath, "utf8");
+				const parsed = dotenv.parse(content);
 
-				if (result.error) {
-					this.logger.warn("Failed to parse .env file:", result.error);
-				} else if (result.parsed && Object.keys(result.parsed).length > 0) {
+				// Store as isolated per-session env — replaces any previous load
+				this.repositoryEnv = parsed;
+
+				if (Object.keys(parsed).length > 0) {
 					this.logger.debug("Loaded environment variables from .env");
 				}
+			} else {
+				// No .env file — clear any previously loaded vars
+				this.repositoryEnv = {};
 			}
 		} catch (error) {
 			this.logger.warn("Error loading repository .env:", error);
 			// Don't fail the session, just warn
+			this.repositoryEnv = {};
 		}
 	}
 

--- a/packages/claude-runner/test/env-isolation.test.ts
+++ b/packages/claude-runner/test/env-isolation.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: vi.fn(),
+}));
+
+// Track readFileSync calls per path so we can change .env contents between sessions
+const envFileContents = new Map<string, string>();
+
+// Mock file system operations
+vi.mock("fs", () => ({
+	mkdirSync: vi.fn(),
+	existsSync: vi.fn((path: string) => {
+		if (typeof path === "string" && path.endsWith(".env")) {
+			return envFileContents.has(path);
+		}
+		return false;
+	}),
+	readFileSync: vi.fn((path: string) => {
+		if (typeof path === "string" && envFileContents.has(path)) {
+			return envFileContents.get(path);
+		}
+		return "";
+	}),
+	createWriteStream: vi.fn(() => ({
+		write: vi.fn(),
+		end: vi.fn(),
+		on: vi.fn(),
+	})),
+	writeFileSync: vi.fn(),
+}));
+
+// Mock os module
+vi.mock("os", () => ({
+	homedir: vi.fn(() => "/mock/home"),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeRunner } from "../src/ClaudeRunner";
+import type { ClaudeRunnerConfig } from "../src/types";
+
+describe("Environment variable isolation", () => {
+	let mockQuery: any;
+
+	const makeConfig = (workingDirectory: string): ClaudeRunnerConfig => ({
+		workingDirectory,
+		cyrusHome: "/tmp/test-cyrus-home",
+	});
+
+	function mockSuccessfulQuery() {
+		mockQuery.mockImplementation(async function* () {
+			yield {
+				type: "assistant",
+				message: { content: [{ type: "text", text: "Done" }] },
+				parent_tool_use_id: null,
+				session_id: "test-session",
+			} as any;
+		});
+	}
+
+	function getQueryEnv(): Record<string, string> {
+		const call = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
+		return call[0].options.env;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		envFileContents.clear();
+		mockQuery = vi.mocked(query);
+	});
+
+	afterEach(() => {
+		envFileContents.clear();
+	});
+
+	it("should load .env vars into the child env without polluting process.env", async () => {
+		envFileContents.set(
+			"/repo-a/.env",
+			"DOCKER_HOST=unix:///run/podman/podman.sock\nMY_VAR=hello",
+		);
+
+		// Ensure process.env doesn't have these before
+		const hadDockerHost = "DOCKER_HOST" in process.env;
+		const hadMyVar = "MY_VAR" in process.env;
+		const origDockerHost = process.env.DOCKER_HOST;
+		const origMyVar = process.env.MY_VAR;
+
+		mockSuccessfulQuery();
+		const runner = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner.start("test");
+
+		const env = getQueryEnv();
+		expect(env.DOCKER_HOST).toBe("unix:///run/podman/podman.sock");
+		expect(env.MY_VAR).toBe("hello");
+
+		// Verify process.env was NOT mutated
+		if (!hadDockerHost) {
+			expect(process.env.DOCKER_HOST).toBeUndefined();
+		} else {
+			expect(process.env.DOCKER_HOST).toBe(origDockerHost);
+		}
+		if (!hadMyVar) {
+			expect(process.env.MY_VAR).toBeUndefined();
+		} else {
+			expect(process.env.MY_VAR).toBe(origMyVar);
+		}
+	});
+
+	it("should pick up updated .env values on subsequent sessions", async () => {
+		// First session: DOCKER_HOST is set
+		envFileContents.set(
+			"/repo-a/.env",
+			"DOCKER_HOST=unix:///run/podman/podman.sock",
+		);
+
+		mockSuccessfulQuery();
+		const runner1 = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner1.start("test");
+
+		const env1 = getQueryEnv();
+		expect(env1.DOCKER_HOST).toBe("unix:///run/podman/podman.sock");
+
+		// Second session: DOCKER_HOST is changed
+		envFileContents.set("/repo-a/.env", "DOCKER_HOST=tcp://localhost:2375");
+
+		mockSuccessfulQuery();
+		const runner2 = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner2.start("test");
+
+		const env2 = getQueryEnv();
+		expect(env2.DOCKER_HOST).toBe("tcp://localhost:2375");
+	});
+
+	it("should not carry removed .env vars into subsequent sessions", async () => {
+		// First session: two vars
+		envFileContents.set("/repo-a/.env", "VAR_A=one\nVAR_B=two");
+
+		mockSuccessfulQuery();
+		const runner1 = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner1.start("test");
+
+		const env1 = getQueryEnv();
+		expect(env1.VAR_A).toBe("one");
+		expect(env1.VAR_B).toBe("two");
+
+		// Second session: VAR_B removed
+		envFileContents.set("/repo-a/.env", "VAR_A=updated");
+
+		mockSuccessfulQuery();
+		const runner2 = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner2.start("test");
+
+		const env2 = getQueryEnv();
+		expect(env2.VAR_A).toBe("updated");
+		// VAR_B should NOT be present (it was removed from .env)
+		// It would only be present if it exists in process.env
+		if (!("VAR_B" in process.env)) {
+			expect(env2.VAR_B).toBeUndefined();
+		}
+	});
+
+	it("should isolate env vars between different repositories", async () => {
+		envFileContents.set("/repo-a/.env", "REPO_VAR=from-repo-a");
+		envFileContents.set(
+			"/repo-b/.env",
+			"REPO_VAR=from-repo-b\nOTHER=only-in-b",
+		);
+
+		// Start session for repo-a
+		mockSuccessfulQuery();
+		const runnerA = new ClaudeRunner(makeConfig("/repo-a"));
+		await runnerA.start("test");
+
+		const envA = getQueryEnv();
+		expect(envA.REPO_VAR).toBe("from-repo-a");
+		if (!("OTHER" in process.env)) {
+			expect(envA.OTHER).toBeUndefined();
+		}
+
+		// Start session for repo-b
+		mockSuccessfulQuery();
+		const runnerB = new ClaudeRunner(makeConfig("/repo-b"));
+		await runnerB.start("test");
+
+		const envB = getQueryEnv();
+		expect(envB.REPO_VAR).toBe("from-repo-b");
+		expect(envB.OTHER).toBe("only-in-b");
+	});
+
+	it("should let process.env take precedence over .env values", async () => {
+		// Set a value in process.env
+		const originalPath = process.env.PATH;
+		envFileContents.set("/repo-a/.env", `PATH=/should-not-override`);
+
+		mockSuccessfulQuery();
+		const runner = new ClaudeRunner(makeConfig("/repo-a"));
+		await runner.start("test");
+
+		const env = getQueryEnv();
+		// process.env.PATH should win over .env's PATH
+		expect(env.PATH).toBe(originalPath);
+	});
+});


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

- Replaced `dotenv.config()` with `dotenv.parse()` in `ClaudeRunner.loadRepositoryEnv()` so `.env` variables are loaded into an isolated per-instance object (`this.repositoryEnv`) instead of the EdgeWorker's `process.env`
- The parsed vars are spread into the child subprocess env **before** `process.env`, preserving the existing precedence (system/platform env vars always win)
- Re-reads the `.env` file on every session start, so updated or removed values take effect immediately without stale carryover
- Added 5 tests covering: process.env isolation, value updates between sessions, removed var cleanup, cross-repo isolation, and env var precedence

## Test plan

- [x] Existing ClaudeRunner tests pass (32 tests)
- [x] New env isolation tests pass (5 tests)
- [x] Full monorepo typecheck passes
- [x] Build succeeds

Resolves [CYPACK-1059](https://linear.app/ceedar/issue/CYPACK-1059/fix-env-loading-in-clauderunner-to-scope-env-vars-per-session)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->