### PR TITLE
Prepare release v0.2.44

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.44] - 2026-04-10
+
 ### Fixed
 - `buildAgentContextBlock()` now always emits `<agent_context>` with default bot usernames (`cyrusagent`) instead of returning empty string when `GITHUB_BOT_USERNAME`/`GITLAB_BOT_USERNAME` env vars are unset. Updated `verify-and-ship` skill to also include an explicit fallback instruction. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.44] - 2026-04-10
+
 ### Fixed
 - **Repository `.env` variables are now scoped per-session** — Previously, `.env` files were loaded into the EdgeWorker's `process.env`, causing environment poisoning across sessions and repositories. Variables are now parsed into an isolated object and merged only into the child subprocess env, so updated or removed values take effect immediately and one repo's `.env` cannot leak into another. ([CYPACK-1059](https://linear.app/ceedar/issue/CYPACK-1059), [#1086](https://github.com/ceedaragents/cyrus/pull/1086))
 - **PR/MR interaction tips now correctly reference `@cyrusagent`** — Previously, when `GITHUB_BOT_USERNAME` or `GITLAB_BOT_USERNAME` environment variables were not set, PR/MR descriptions could show an incorrect bot username. The system now defaults to `cyrusagent`. ([CYPACK-1054](https://linear.app/ceedar/issue/CYPACK-1054), [#1082](https://github.com/ceedaragents/cyrus/pull/1082))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.44
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.44
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.44
+
+#### cyrus-core
+- cyrus-core@0.2.44
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.44
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.44
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.44
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.44
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.44
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.44
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.44
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.44
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.44
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.44
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.44
 
 ## [0.2.43] - 2026-04-08
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,67 +1,67 @@
 {
-  "name": "cyrus-ai",
-  "version": "0.2.44",
-  "description": "AI-powered Linear issue automation using Claude",
-  "main": "dist/src/app.js",
-  "types": "dist/src/app.d.ts",
-  "bin": {
-    "cyrus": "./dist/src/app.js"
-  },
-  "type": "module",
-  "scripts": {
-    "build": "tsc",
-    "start": "node dist/src/app.js",
-    "dev": "tsc --watch",
-    "test": "vitest run",
-    "test:run": "vitest run --passWithNoTests",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "cd ../.. && pnpm build"
-  },
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ceedaragents/cyrus.git",
-    "directory": "apps/cli"
-  },
-  "keywords": [
-    "linear",
-    "claude",
-    "ai",
-    "automation",
-    "cli"
-  ],
-  "author": "",
-  "license": "MIT",
-  "dependencies": {
-    "@linear/sdk": "^64.0.0",
-    "commander": "^14.0.2",
-    "cyrus-claude-runner": "workspace:*",
-    "cyrus-cloudflare-tunnel-client": "workspace:*",
-    "cyrus-config-updater": "workspace:*",
-    "cyrus-core": "workspace:*",
-    "cyrus-edge-worker": "workspace:*",
-    "cyrus-slack-event-transport": "workspace:*",
-    "dotenv": "^16.5.0",
-    "express": "^5.2.0",
-    "fastify": "^5.8.3",
-    "file-type": "^21.0.0",
-    "fs-extra": "^11.3.0",
-    "node-fetch": "^2.7.0",
-    "open": "^10.0.0",
-    "zod": "^4.3.5"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "@vitest/ui": "^3.1.4",
-    "nodemon": "^2.0.22",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  }
+	"name": "cyrus-ai",
+	"version": "0.2.44",
+	"description": "AI-powered Linear issue automation using Claude",
+	"main": "dist/src/app.js",
+	"types": "dist/src/app.d.ts",
+	"bin": {
+		"cyrus": "./dist/src/app.js"
+	},
+	"type": "module",
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/src/app.js",
+		"dev": "tsc --watch",
+		"test": "vitest run",
+		"test:run": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"typecheck": "tsc --noEmit",
+		"prepublishOnly": "cd ../.. && pnpm build"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ceedaragents/cyrus.git",
+		"directory": "apps/cli"
+	},
+	"keywords": [
+		"linear",
+		"claude",
+		"ai",
+		"automation",
+		"cli"
+	],
+	"author": "",
+	"license": "MIT",
+	"dependencies": {
+		"@linear/sdk": "^64.0.0",
+		"commander": "^14.0.2",
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-cloudflare-tunnel-client": "workspace:*",
+		"cyrus-config-updater": "workspace:*",
+		"cyrus-core": "workspace:*",
+		"cyrus-edge-worker": "workspace:*",
+		"cyrus-slack-event-transport": "workspace:*",
+		"dotenv": "^16.5.0",
+		"express": "^5.2.0",
+		"fastify": "^5.8.3",
+		"file-type": "^21.0.0",
+		"fs-extra": "^11.3.0",
+		"node-fetch": "^2.7.0",
+		"open": "^10.0.0",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"@vitest/ui": "^3.1.4",
+		"nodemon": "^2.0.22",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	}
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,67 +1,67 @@
 {
-	"name": "cyrus-ai",
-	"version": "0.2.43",
-	"description": "AI-powered Linear issue automation using Claude",
-	"main": "dist/src/app.js",
-	"types": "dist/src/app.d.ts",
-	"bin": {
-		"cyrus": "./dist/src/app.js"
-	},
-	"type": "module",
-	"scripts": {
-		"build": "tsc",
-		"start": "node dist/src/app.js",
-		"dev": "tsc --watch",
-		"test": "vitest run",
-		"test:run": "vitest run --passWithNoTests",
-		"test:watch": "vitest",
-		"typecheck": "tsc --noEmit",
-		"prepublishOnly": "cd ../.. && pnpm build"
-	},
-	"files": [
-		"dist",
-		"README.md"
-	],
-	"publishConfig": {
-		"access": "public"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ceedaragents/cyrus.git",
-		"directory": "apps/cli"
-	},
-	"keywords": [
-		"linear",
-		"claude",
-		"ai",
-		"automation",
-		"cli"
-	],
-	"author": "",
-	"license": "MIT",
-	"dependencies": {
-		"@linear/sdk": "^64.0.0",
-		"commander": "^14.0.2",
-		"cyrus-claude-runner": "workspace:*",
-		"cyrus-cloudflare-tunnel-client": "workspace:*",
-		"cyrus-config-updater": "workspace:*",
-		"cyrus-core": "workspace:*",
-		"cyrus-edge-worker": "workspace:*",
-		"cyrus-slack-event-transport": "workspace:*",
-		"dotenv": "^16.5.0",
-		"express": "^5.2.0",
-		"fastify": "^5.8.3",
-		"file-type": "^21.0.0",
-		"fs-extra": "^11.3.0",
-		"node-fetch": "^2.7.0",
-		"open": "^10.0.0",
-		"zod": "^4.3.5"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"@vitest/ui": "^3.1.4",
-		"nodemon": "^2.0.22",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	}
+  "name": "cyrus-ai",
+  "version": "0.2.44",
+  "description": "AI-powered Linear issue automation using Claude",
+  "main": "dist/src/app.js",
+  "types": "dist/src/app.d.ts",
+  "bin": {
+    "cyrus": "./dist/src/app.js"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/app.js",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:run": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "cd ../.. && pnpm build"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ceedaragents/cyrus.git",
+    "directory": "apps/cli"
+  },
+  "keywords": [
+    "linear",
+    "claude",
+    "ai",
+    "automation",
+    "cli"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@linear/sdk": "^64.0.0",
+    "commander": "^14.0.2",
+    "cyrus-claude-runner": "workspace:*",
+    "cyrus-cloudflare-tunnel-client": "workspace:*",
+    "cyrus-config-updater": "workspace:*",
+    "cyrus-core": "workspace:*",
+    "cyrus-edge-worker": "workspace:*",
+    "cyrus-slack-event-transport": "workspace:*",
+    "dotenv": "^16.5.0",
+    "express": "^5.2.0",
+    "fastify": "^5.8.3",
+    "file-type": "^21.0.0",
+    "fs-extra": "^11.3.0",
+    "node-fetch": "^2.7.0",
+    "open": "^10.0.0",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/ui": "^3.1.4",
+    "nodemon": "^2.0.22",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  }
 }

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,37 +1,37 @@
 {
-  "name": "cyrus-claude-runner",
-  "version": "0.2.44",
-  "description": "Claude CLI execution wrapper for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
-    "@anthropic-ai/sdk": "^0.82.0",
-    "@linear/sdk": "^64.0.0",
-    "cyrus-core": "workspace:*",
-    "dotenv": "^16.4.5",
-    "fs-extra": "^11.3.2",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.0.0",
-    "tsx": "^4.19.2",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-claude-runner",
+	"version": "0.2.44",
+	"description": "Claude CLI execution wrapper for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@anthropic-ai/sdk": "^0.82.0",
+		"@linear/sdk": "^64.0.0",
+		"cyrus-core": "workspace:*",
+		"dotenv": "^16.4.5",
+		"fs-extra": "^11.3.2",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.4",
+		"@types/node": "^20.0.0",
+		"tsx": "^4.19.2",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "cyrus-claude-runner",
-	"version": "0.2.43",
-	"description": "Claude CLI execution wrapper for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
-		"@anthropic-ai/sdk": "^0.82.0",
-		"@linear/sdk": "^64.0.0",
-		"cyrus-core": "workspace:*",
-		"dotenv": "^16.4.5",
-		"fs-extra": "^11.3.2",
-		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@types/fs-extra": "^11.0.4",
-		"@types/node": "^20.0.0",
-		"tsx": "^4.19.2",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-claude-runner",
+  "version": "0.2.44",
+  "description": "Claude CLI execution wrapper for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+    "@anthropic-ai/sdk": "^0.82.0",
+    "@linear/sdk": "^64.0.0",
+    "cyrus-core": "workspace:*",
+    "dotenv": "^16.4.5",
+    "fs-extra": "^11.3.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "cyrus-cloudflare-tunnel-client",
-  "version": "0.2.44",
-  "description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests"
-  },
-  "dependencies": {
-    "cloudflared": "^0.7.1"
-  },
-  "devDependencies": {
-    "@types/node": "^20.12.7",
-    "typescript": "^5.4.5",
-    "vitest": "^3.1.4"
-  },
-  "keywords": [
-    "cloudflare",
-    "tunnel",
-    "webhook",
-    "linear",
-    "cyrus"
-  ],
-  "author": "Cyrus Team",
-  "license": "MIT"
+	"name": "cyrus-cloudflare-tunnel-client",
+	"version": "0.2.44",
+	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests"
+	},
+	"dependencies": {
+		"cloudflared": "^0.7.1"
+	},
+	"devDependencies": {
+		"@types/node": "^20.12.7",
+		"typescript": "^5.4.5",
+		"vitest": "^3.1.4"
+	},
+	"keywords": [
+		"cloudflare",
+		"tunnel",
+		"webhook",
+		"linear",
+		"cyrus"
+	],
+	"author": "Cyrus Team",
+	"license": "MIT"
 }

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.43",
-	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
-	"type": "module",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		}
-	},
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"typecheck": "tsc --noEmit",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests"
-	},
-	"dependencies": {
-		"cloudflared": "^0.7.1"
-	},
-	"devDependencies": {
-		"@types/node": "^20.12.7",
-		"typescript": "^5.4.5",
-		"vitest": "^3.1.4"
-	},
-	"keywords": [
-		"cloudflare",
-		"tunnel",
-		"webhook",
-		"linear",
-		"cyrus"
-	],
-	"author": "Cyrus Team",
-	"license": "MIT"
+  "name": "cyrus-cloudflare-tunnel-client",
+  "version": "0.2.44",
+  "description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "cloudflared": "^0.7.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.4"
+  },
+  "keywords": [
+    "cloudflare",
+    "tunnel",
+    "webhook",
+    "linear",
+    "cyrus"
+  ],
+  "author": "Cyrus Team",
+  "license": "MIT"
 }

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "cyrus-codex-runner",
-  "version": "0.2.44",
-  "description": "Codex CLI process wrapper for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@openai/codex-sdk": "^0.107.0",
-    "cyrus-core": "workspace:*",
-    "cyrus-simple-agent-runner": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-codex-runner",
+	"version": "0.2.44",
+	"description": "Codex CLI process wrapper for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@openai/codex-sdk": "^0.107.0",
+		"cyrus-core": "workspace:*",
+		"cyrus-simple-agent-runner": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,31 +1,31 @@
 {
-	"name": "cyrus-codex-runner",
-	"version": "0.2.43",
-	"description": "Codex CLI process wrapper for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@openai/codex-sdk": "^0.107.0",
-		"cyrus-core": "workspace:*",
-		"cyrus-simple-agent-runner": "workspace:*"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-codex-runner",
+  "version": "0.2.44",
+  "description": "Codex CLI process wrapper for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openai/codex-sdk": "^0.107.0",
+    "cyrus-core": "workspace:*",
+    "cyrus-simple-agent-runner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,43 +1,43 @@
 {
-	"name": "cyrus-config-updater",
-	"version": "0.2.43",
-	"description": "Configuration update handlers for Cyrus agent",
-	"type": "module",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		}
-	},
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"typecheck": "tsc --noEmit",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests"
-	},
-	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.25.2",
-		"cyrus-core": "workspace:*",
-		"fastify": "^5.8.3",
-		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@types/node": "^20.12.7",
-		"typescript": "^5.4.5",
-		"vitest": "^3.1.4"
-	},
-	"keywords": [
-		"config",
-		"update",
-		"handler",
-		"cyrus"
-	],
-	"author": "Cyrus Team",
-	"license": "MIT"
+  "name": "cyrus-config-updater",
+  "version": "0.2.44",
+  "description": "Configuration update handlers for Cyrus agent",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.2",
+    "cyrus-core": "workspace:*",
+    "fastify": "^5.8.3",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "typescript": "^5.4.5",
+    "vitest": "^3.1.4"
+  },
+  "keywords": [
+    "config",
+    "update",
+    "handler",
+    "cyrus"
+  ],
+  "author": "Cyrus Team",
+  "license": "MIT"
 }

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,43 +1,43 @@
 {
-  "name": "cyrus-config-updater",
-  "version": "0.2.44",
-  "description": "Configuration update handlers for Cyrus agent",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests"
-  },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
-    "cyrus-core": "workspace:*",
-    "fastify": "^5.8.3",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@types/node": "^20.12.7",
-    "typescript": "^5.4.5",
-    "vitest": "^3.1.4"
-  },
-  "keywords": [
-    "config",
-    "update",
-    "handler",
-    "cyrus"
-  ],
-  "author": "Cyrus Team",
-  "license": "MIT"
+	"name": "cyrus-config-updater",
+	"version": "0.2.44",
+	"description": "Configuration update handlers for Cyrus agent",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.25.2",
+		"cyrus-core": "workspace:*",
+		"fastify": "^5.8.3",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@types/node": "^20.12.7",
+		"typescript": "^5.4.5",
+		"vitest": "^3.1.4"
+	},
+	"keywords": [
+		"config",
+		"update",
+		"handler",
+		"cyrus"
+	],
+	"author": "Cyrus Team",
+	"license": "MIT"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "cyrus-core",
-	"version": "0.2.43",
-	"description": "Core business logic for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist",
-		"schemas"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"generate:json-schema": "tsx scripts/export-json-schema.ts && biome format --write schemas/",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
-		"@linear/sdk": "^64.0.0",
-		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"fastify": "^5.8.3",
-		"tsx": "^4.20.6",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-core",
+  "version": "0.2.44",
+  "description": "Core business logic for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "schemas"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "generate:json-schema": "tsx scripts/export-json-schema.ts && biome format --write schemas/",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+    "@linear/sdk": "^64.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "fastify": "^5.8.3",
+    "tsx": "^4.20.6",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "cyrus-core",
-  "version": "0.2.44",
-  "description": "Core business logic for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "schemas"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "generate:json-schema": "tsx scripts/export-json-schema.ts && biome format --write schemas/",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
-    "@linear/sdk": "^64.0.0",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "fastify": "^5.8.3",
-    "tsx": "^4.20.6",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-core",
+	"version": "0.2.44",
+	"description": "Core business logic for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist",
+		"schemas"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"generate:json-schema": "tsx scripts/export-json-schema.ts && biome format --write schemas/",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"@linear/sdk": "^64.0.0",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"fastify": "^5.8.3",
+		"tsx": "^4.20.6",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "cyrus-cursor-runner",
-  "version": "0.2.44",
-  "description": "Cursor Agent CLI process wrapper for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs",
-    "test:run": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "cyrus-core": "workspace:*",
-    "cyrus-simple-agent-runner": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-cursor-runner",
+	"version": "0.2.44",
+	"description": "Cursor Agent CLI process wrapper for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs",
+		"test:run": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs run --passWithNoTests",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"cyrus-core": "workspace:*",
+		"cyrus-simple-agent-runner": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "cyrus-cursor-runner",
-	"version": "0.2.43",
-	"description": "Cursor Agent CLI process wrapper for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs",
-		"test:run": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs run --passWithNoTests",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"cyrus-core": "workspace:*",
-		"cyrus-simple-agent-runner": "workspace:*"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-cursor-runner",
+  "version": "0.2.44",
+  "description": "Cursor Agent CLI process wrapper for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs",
+    "test:run": "node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "cyrus-core": "workspace:*",
+    "cyrus-simple-agent-runner": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "cyrus-edge-worker",
-  "version": "0.2.44",
-  "description": "Unified edge worker for processing Linear issues with Claude",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "prompt-template-v2.md",
-    "prompt-template.md",
-    "label-prompt-template.md",
-    "prompts"
-  ],
-  "scripts": {
-    "build": "tsc && npm run copy-prompts",
-    "copy-prompts": "cp label-prompt-template.md dist/ && cp -r prompts dist/ && rm -rf dist/cyrus-skills-plugin && cp -rL cyrus-skills-plugin dist/cyrus-skills-plugin",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@linear/sdk": "^64.0.0",
-    "@ngrok/ngrok": "^1.5.1",
-    "chokidar": "^4.0.3",
-    "cyrus-claude-runner": "workspace:*",
-    "cyrus-cloudflare-tunnel-client": "workspace:*",
-    "cyrus-codex-runner": "workspace:*",
-    "cyrus-config-updater": "workspace:*",
-    "cyrus-core": "workspace:*",
-    "cyrus-cursor-runner": "workspace:*",
-    "cyrus-gemini-runner": "workspace:*",
-    "cyrus-github-event-transport": "workspace:*",
-    "cyrus-gitlab-event-transport": "workspace:*",
-    "cyrus-linear-event-transport": "workspace:*",
-    "cyrus-mcp-tools": "workspace:*",
-    "cyrus-slack-event-transport": "workspace:*",
-    "cyrus-simple-agent-runner": "workspace:*",
-    "fastify": "^5.8.3",
-    "fastify-mcp": "^2.1.0",
-    "file-type": "^21.3.2",
-    "ignore": "^7.0.5",
-    "zod": "4.3.6"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "@vitest/coverage-v8": "^3.1.4",
-    "axios": "^1.13.5",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4",
-    "vitest-mock-extended": "^3.1.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-edge-worker",
+	"version": "0.2.44",
+	"description": "Unified edge worker for processing Linear issues with Claude",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist",
+		"prompt-template-v2.md",
+		"prompt-template.md",
+		"label-prompt-template.md",
+		"prompts"
+	],
+	"scripts": {
+		"build": "tsc && npm run copy-prompts",
+		"copy-prompts": "cp label-prompt-template.md dist/ && cp -r prompts dist/ && rm -rf dist/cyrus-skills-plugin && cp -rL cyrus-skills-plugin dist/cyrus-skills-plugin",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"test:watch": "vitest --watch",
+		"test:coverage": "vitest --coverage",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@linear/sdk": "^64.0.0",
+		"@ngrok/ngrok": "^1.5.1",
+		"chokidar": "^4.0.3",
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-cloudflare-tunnel-client": "workspace:*",
+		"cyrus-codex-runner": "workspace:*",
+		"cyrus-config-updater": "workspace:*",
+		"cyrus-core": "workspace:*",
+		"cyrus-cursor-runner": "workspace:*",
+		"cyrus-gemini-runner": "workspace:*",
+		"cyrus-github-event-transport": "workspace:*",
+		"cyrus-gitlab-event-transport": "workspace:*",
+		"cyrus-linear-event-transport": "workspace:*",
+		"cyrus-mcp-tools": "workspace:*",
+		"cyrus-slack-event-transport": "workspace:*",
+		"cyrus-simple-agent-runner": "workspace:*",
+		"fastify": "^5.8.3",
+		"fastify-mcp": "^2.1.0",
+		"file-type": "^21.3.2",
+		"ignore": "^7.0.5",
+		"zod": "4.3.6"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"@vitest/coverage-v8": "^3.1.4",
+		"axios": "^1.13.5",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4",
+		"vitest-mock-extended": "^3.1.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,59 +1,59 @@
 {
-	"name": "cyrus-edge-worker",
-	"version": "0.2.43",
-	"description": "Unified edge worker for processing Linear issues with Claude",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist",
-		"prompt-template-v2.md",
-		"prompt-template.md",
-		"label-prompt-template.md",
-		"prompts"
-	],
-	"scripts": {
-		"build": "tsc && npm run copy-prompts",
-		"copy-prompts": "cp label-prompt-template.md dist/ && cp -r prompts dist/ && rm -rf dist/cyrus-skills-plugin && cp -rL cyrus-skills-plugin dist/cyrus-skills-plugin",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run",
-		"test:watch": "vitest --watch",
-		"test:coverage": "vitest --coverage",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@linear/sdk": "^64.0.0",
-		"@ngrok/ngrok": "^1.5.1",
-		"chokidar": "^4.0.3",
-		"cyrus-claude-runner": "workspace:*",
-		"cyrus-cloudflare-tunnel-client": "workspace:*",
-		"cyrus-codex-runner": "workspace:*",
-		"cyrus-config-updater": "workspace:*",
-		"cyrus-core": "workspace:*",
-		"cyrus-cursor-runner": "workspace:*",
-		"cyrus-gemini-runner": "workspace:*",
-		"cyrus-github-event-transport": "workspace:*",
-		"cyrus-gitlab-event-transport": "workspace:*",
-		"cyrus-linear-event-transport": "workspace:*",
-		"cyrus-mcp-tools": "workspace:*",
-		"cyrus-slack-event-transport": "workspace:*",
-		"cyrus-simple-agent-runner": "workspace:*",
-		"fastify": "^5.8.3",
-		"fastify-mcp": "^2.1.0",
-		"file-type": "^21.3.2",
-		"ignore": "^7.0.5",
-		"zod": "4.3.6"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"@vitest/coverage-v8": "^3.1.4",
-		"axios": "^1.13.5",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4",
-		"vitest-mock-extended": "^3.1.0"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-edge-worker",
+  "version": "0.2.44",
+  "description": "Unified edge worker for processing Linear issues with Claude",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "prompt-template-v2.md",
+    "prompt-template.md",
+    "label-prompt-template.md",
+    "prompts"
+  ],
+  "scripts": {
+    "build": "tsc && npm run copy-prompts",
+    "copy-prompts": "cp label-prompt-template.md dist/ && cp -r prompts dist/ && rm -rf dist/cyrus-skills-plugin && cp -rL cyrus-skills-plugin dist/cyrus-skills-plugin",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@linear/sdk": "^64.0.0",
+    "@ngrok/ngrok": "^1.5.1",
+    "chokidar": "^4.0.3",
+    "cyrus-claude-runner": "workspace:*",
+    "cyrus-cloudflare-tunnel-client": "workspace:*",
+    "cyrus-codex-runner": "workspace:*",
+    "cyrus-config-updater": "workspace:*",
+    "cyrus-core": "workspace:*",
+    "cyrus-cursor-runner": "workspace:*",
+    "cyrus-gemini-runner": "workspace:*",
+    "cyrus-github-event-transport": "workspace:*",
+    "cyrus-gitlab-event-transport": "workspace:*",
+    "cyrus-linear-event-transport": "workspace:*",
+    "cyrus-mcp-tools": "workspace:*",
+    "cyrus-slack-event-transport": "workspace:*",
+    "cyrus-simple-agent-runner": "workspace:*",
+    "fastify": "^5.8.3",
+    "fastify-mcp": "^2.1.0",
+    "file-type": "^21.3.2",
+    "ignore": "^7.0.5",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^3.1.4",
+    "axios": "^1.13.5",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4",
+    "vitest-mock-extended": "^3.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,37 +1,37 @@
 {
-  "name": "cyrus-gemini-runner",
-  "version": "0.2.44",
-  "description": "Gemini CLI process spawning and management for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc && cp -r src/prompts dist/prompts",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@linear/sdk": "^60.0.0",
-    "cyrus-claude-runner": "workspace:*",
-    "cyrus-core": "workspace:*",
-    "cyrus-simple-agent-runner": "workspace:*",
-    "dotenv": "^16.6.1",
-    "fs-extra": "^11.3.0",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@google/gemini-cli-core": "0.17.0",
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-gemini-runner",
+	"version": "0.2.44",
+	"description": "Gemini CLI process spawning and management for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc && cp -r src/prompts dist/prompts",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@linear/sdk": "^60.0.0",
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-core": "workspace:*",
+		"cyrus-simple-agent-runner": "workspace:*",
+		"dotenv": "^16.6.1",
+		"fs-extra": "^11.3.0",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@google/gemini-cli-core": "0.17.0",
+		"@types/fs-extra": "^11.0.4",
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "cyrus-gemini-runner",
-	"version": "0.2.43",
-	"description": "Gemini CLI process spawning and management for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc && cp -r src/prompts dist/prompts",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@linear/sdk": "^60.0.0",
-		"cyrus-claude-runner": "workspace:*",
-		"cyrus-core": "workspace:*",
-		"cyrus-simple-agent-runner": "workspace:*",
-		"dotenv": "^16.6.1",
-		"fs-extra": "^11.3.0",
-		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@google/gemini-cli-core": "0.17.0",
-		"@types/fs-extra": "^11.0.4",
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-gemini-runner",
+  "version": "0.2.44",
+  "description": "Gemini CLI process spawning and management for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && cp -r src/prompts dist/prompts",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@linear/sdk": "^60.0.0",
+    "cyrus-claude-runner": "workspace:*",
+    "cyrus-core": "workspace:*",
+    "cyrus-simple-agent-runner": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fs-extra": "^11.3.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@google/gemini-cli-core": "0.17.0",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "cyrus-github-event-transport",
-	"version": "0.2.43",
-	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"typecheck": "tsc --noEmit",
-		"test": "vitest",
-		"test:run": "vitest run"
-	},
-	"dependencies": {
-		"cyrus-core": "workspace:*",
-		"fastify": "^5.8.3"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-github-event-transport",
+  "version": "0.2.44",
+  "description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "cyrus-core": "workspace:*",
+    "fastify": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "cyrus-github-event-transport",
-  "version": "0.2.44",
-  "description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:run": "vitest run"
-  },
-  "dependencies": {
-    "cyrus-core": "workspace:*",
-    "fastify": "^5.8.3"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-github-event-transport",
+	"version": "0.2.44",
+	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run"
+	},
+	"dependencies": {
+		"cyrus-core": "workspace:*",
+		"fastify": "^5.8.3"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.43",
-	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"typecheck": "tsc --noEmit",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests"
-	},
-	"dependencies": {
-		"cyrus-core": "workspace:*",
-		"fastify": "^5.8.3"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-gitlab-event-transport",
+  "version": "0.2.44",
+  "description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "cyrus-core": "workspace:*",
+    "fastify": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "cyrus-gitlab-event-transport",
-  "version": "0.2.44",
-  "description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests"
-  },
-  "dependencies": {
-    "cyrus-core": "workspace:*",
-    "fastify": "^5.8.3"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-gitlab-event-transport",
+	"version": "0.2.44",
+	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests"
+	},
+	"dependencies": {
+		"cyrus-core": "workspace:*",
+		"fastify": "^5.8.3"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,31 +1,31 @@
 {
-	"name": "cyrus-linear-event-transport",
-	"version": "0.2.43",
-	"description": "Linear event transport for receiving and verifying Linear webhooks",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@linear/sdk": "^64.0.0",
-		"cyrus-core": "workspace:*",
-		"fastify": "^5.8.3"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.2.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-linear-event-transport",
+  "version": "0.2.44",
+  "description": "Linear event transport for receiving and verifying Linear webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@linear/sdk": "^64.0.0",
+    "cyrus-core": "workspace:*",
+    "fastify": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "cyrus-linear-event-transport",
-  "version": "0.2.44",
-  "description": "Linear event transport for receiving and verifying Linear webhooks",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@linear/sdk": "^64.0.0",
-    "cyrus-core": "workspace:*",
-    "fastify": "^5.8.3"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.2.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-linear-event-transport",
+	"version": "0.2.44",
+	"description": "Linear event transport for receiving and verifying Linear webhooks",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@linear/sdk": "^64.0.0",
+		"cyrus-core": "workspace:*",
+		"fastify": "^5.8.3"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "cyrus-mcp-tools",
-  "version": "0.2.44",
-  "description": "Runner-neutral MCP tool servers for Cyrus",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@linear/sdk": "^64.0.0",
-    "@modelcontextprotocol/sdk": "^1.25.2",
-    "fs-extra": "^11.3.2",
-    "openai": "^6.9.1",
-    "zod": "^4.3.5"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-mcp-tools",
+	"version": "0.2.44",
+	"description": "Runner-neutral MCP tool servers for Cyrus",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@linear/sdk": "^64.0.0",
+		"@modelcontextprotocol/sdk": "^1.25.2",
+		"fs-extra": "^11.3.2",
+		"openai": "^6.9.1",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.4",
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "cyrus-mcp-tools",
-	"version": "0.2.43",
-	"description": "Runner-neutral MCP tool servers for Cyrus",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@linear/sdk": "^64.0.0",
-		"@modelcontextprotocol/sdk": "^1.25.2",
-		"fs-extra": "^11.3.2",
-		"openai": "^6.9.1",
-		"zod": "^4.3.5"
-	},
-	"devDependencies": {
-		"@types/fs-extra": "^11.0.4",
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-mcp-tools",
+  "version": "0.2.44",
+  "description": "Runner-neutral MCP tool servers for Cyrus",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@linear/sdk": "^64.0.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
+    "fs-extra": "^11.3.2",
+    "openai": "^6.9.1",
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "cyrus-simple-agent-runner",
-  "version": "0.2.44",
-  "description": "Simple agent runner for enumerated responses",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:run": "vitest run --passWithNoTests",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
-    "cyrus-claude-runner": "workspace:*",
-    "cyrus-core": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-simple-agent-runner",
+	"version": "0.2.44",
+	"description": "Simple agent runner for enumerated responses",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"test": "vitest",
+		"test:run": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
+		"cyrus-claude-runner": "workspace:*",
+		"cyrus-core": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,31 +1,31 @@
 {
-	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.43",
-	"description": "Simple agent runner for enumerated responses",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"test": "vitest",
-		"test:run": "vitest run --passWithNoTests",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.90",
-		"cyrus-claude-runner": "workspace:*",
-		"cyrus-core": "workspace:*"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-simple-agent-runner",
+  "version": "0.2.44",
+  "description": "Simple agent runner for enumerated responses",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:run": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.90",
+    "cyrus-claude-runner": "workspace:*",
+    "cyrus-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "cyrus-slack-event-transport",
-	"version": "0.2.43",
-	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
-	"type": "module",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"build": "tsc",
-		"dev": "tsc --watch",
-		"typecheck": "tsc --noEmit",
-		"test": "vitest",
-		"test:run": "vitest run"
-	},
-	"dependencies": {
-		"cyrus-core": "workspace:*",
-		"fastify": "^5.8.3"
-	},
-	"devDependencies": {
-		"@types/node": "^20.0.0",
-		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
-	},
-	"publishConfig": {
-		"access": "public"
-	}
+  "name": "cyrus-slack-event-transport",
+  "version": "0.2.44",
+  "description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "cyrus-core": "workspace:*",
+    "fastify": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "cyrus-slack-event-transport",
-  "version": "0.2.44",
-  "description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:run": "vitest run"
-  },
-  "dependencies": {
-    "cyrus-core": "workspace:*",
-    "fastify": "^5.8.3"
-  },
-  "devDependencies": {
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.3",
-    "vitest": "^3.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "cyrus-slack-event-transport",
+	"version": "0.2.44",
+	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest",
+		"test:run": "vitest run"
+	},
+	"dependencies": {
+		"cyrus-core": "workspace:*",
+		"fastify": "^5.8.3"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.3.3",
+		"vitest": "^3.1.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }


### PR DESCRIPTION
## Summary
- Release v0.2.44 to npm
- Update changelogs with release notes
- Bump all package versions to 0.2.44

## Changes
- **Fixed**: Repository `.env` variables scoped per-session (CYPACK-1059)
- **Fixed**: PR/MR interaction tips default to `@cyrusagent` (CYPACK-1054)

## Links
- [GitHub Release](https://github.com/ceedaragents/cyrus/releases/tag/v0.2.44)
- [CYPACK-1060](https://linear.app/ceedar/issue/CYPACK-1060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)