### PR TITLE
feat: add centralized secret redaction for all outbound messages (CYPACK-1061)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Secret redaction for all outbound messages** — Environment variable values (API keys, tokens, secrets) are now automatically scrubbed from all outbound content before it reaches Linear, Slack, GitHub, or GitLab. A centralized `SecretRedactor` catches both explicitly registered secrets and well-known token patterns (e.g., `sk-ant-*`, `ghp_*`, `xoxb-*`). ([CYPACK-1061](https://linear.app/ceedar/issue/CYPACK-1061))
+
 ## [0.2.44] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **Secret redaction for all outbound messages** — Environment variable values (API keys, tokens, secrets) are now automatically scrubbed from all outbound content before it reaches Linear, Slack, GitHub, or GitLab. A centralized `SecretRedactor` catches both explicitly registered secrets and well-known token patterns (e.g., `sk-ant-*`, `ghp_*`, `xoxb-*`). ([CYPACK-1061](https://linear.app/ceedar/issue/CYPACK-1061))
+- **Secret redaction for all outbound messages** — Environment variable values (API keys, tokens, secrets) are now automatically scrubbed from all outbound content before it reaches Linear, Slack, GitHub, or GitLab. A centralized `SecretRedactor` catches both explicitly registered secrets and well-known token patterns (e.g., `sk-ant-*`, `ghp_*`, `xoxb-*`). ([CYPACK-1061](https://linear.app/ceedar/issue/CYPACK-1061), [#1089](https://github.com/ceedaragents/cyrus/pull/1089))
 
 ## [0.2.44] - 2026-04-10
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -153,6 +153,10 @@ import { LinearActivitySink } from "./sinks/LinearActivitySink.js";
 import { ToolPermissionResolver } from "./ToolPermissionResolver.js";
 import type { AgentSessionData, EdgeWorkerEvents } from "./types.js";
 import { UserAccessControl } from "./UserAccessControl.js";
+import {
+	type ISecretRedactor,
+	SecretRedactor,
+} from "./utils/SecretRedactor.js";
 
 export declare interface EdgeWorker {
 	on<K extends keyof EdgeWorkerEvents>(
@@ -229,6 +233,7 @@ export class EdgeWorker extends EventEmitter {
 	 * Key format: `${createdAt}:${issueId}`
 	 */
 	private processedIssueUpdateKeys = new Set<string>();
+	private secretRedactor: ISecretRedactor;
 
 	constructor(config: EdgeWorkerConfig) {
 		super();
@@ -239,11 +244,18 @@ export class EdgeWorker extends EventEmitter {
 			join(this.cyrusHome, "state"),
 		);
 
+		// Initialize centralized secret redactor for all outbound messages
+		this.secretRedactor = this.buildSecretRedactor(config);
+
 		// Initialize GitHub comment service for posting replies to GitHub PRs
-		this.gitHubCommentService = new GitHubCommentService();
+		this.gitHubCommentService = new GitHubCommentService({
+			scrubContent: (text) => this.secretRedactor.redact(text),
+		});
 
 		// Initialize GitLab comment service for posting replies to GitLab MRs
-		this.gitLabCommentService = new GitLabCommentService();
+		this.gitLabCommentService = new GitLabCommentService({
+			scrubContent: (text) => this.secretRedactor.redact(text),
+		});
 
 		// Initialize global session registry (centralized session storage)
 		this.globalSessionRegistry = new GlobalSessionRegistry();
@@ -391,6 +403,7 @@ export class EdgeWorker extends EventEmitter {
 				const activitySink = new LinearActivitySink(
 					issueTracker,
 					repo.linearWorkspaceId,
+					this.secretRedactor,
 				);
 				this.activitySinks.set(repoId, activitySink);
 			}
@@ -806,7 +819,10 @@ export class EdgeWorker extends EventEmitter {
 		const slackAdapter = new SlackChatAdapter(
 			chatRepositoryProvider,
 			this.logger,
-			{ repositoryRoutingContext: routingContext },
+			{
+				repositoryRoutingContext: routingContext,
+				scrubContent: (text) => this.secretRedactor.redact(text),
+			},
 		);
 
 		if (
@@ -2338,6 +2354,7 @@ ${taskSection}`;
 				const activitySink = new LinearActivitySink(
 					issueTracker,
 					requireLinearWorkspaceId(repo),
+					this.secretRedactor,
 				);
 				this.activitySinks.set(repo.id, activitySink);
 
@@ -5947,6 +5964,49 @@ ${input.userComment}
 	 * Uses workspace-level token storage.
 	 * Returns undefined if OAuth credentials are not available.
 	 */
+
+	/**
+	 * Build and populate the secret redactor with all known secret values.
+	 * Collects API keys, tokens, and other sensitive env vars plus workspace tokens.
+	 */
+	private buildSecretRedactor(config: EdgeWorkerConfig): ISecretRedactor {
+		const redactor = new SecretRedactor();
+
+		// Collect well-known secret env vars
+		const secretEnvVars = [
+			"ANTHROPIC_API_KEY",
+			"CLAUDE_CODE_OAUTH_TOKEN",
+			"OPENAI_API_KEY",
+			"GEMINI_API_KEY",
+			"GITHUB_TOKEN",
+			"SLACK_BOT_TOKEN",
+			"CURSOR_API_KEY",
+			"LINEAR_CLIENT_SECRET",
+			"LINEAR_WEBHOOK_SECRET",
+			"GITHUB_WEBHOOK_SECRET",
+			"GITLAB_WEBHOOK_SECRET",
+			"GITLAB_ACCESS_TOKEN",
+			"SLACK_SIGNING_SECRET",
+			"CYRUS_API_KEY",
+			"CLOUDFLARE_TOKEN",
+		];
+
+		const envSecrets = secretEnvVars
+			.map((key) => process.env[key])
+			.filter((v): v is string => v != null && v.length > 0);
+		redactor.addSecrets(envSecrets);
+
+		// Collect Linear workspace tokens from config
+		if (config.linearWorkspaces) {
+			const workspaceTokens = Object.values(config.linearWorkspaces)
+				.map((ws) => (ws as { linearToken?: string }).linearToken)
+				.filter((v): v is string => v != null && v.length > 0);
+			redactor.addSecrets(workspaceTokens);
+		}
+
+		return redactor;
+	}
+
 	private buildOAuthConfig(
 		linearWorkspaceId: string,
 	): LinearOAuthConfig | undefined {

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -26,17 +26,21 @@ export class SlackChatAdapter
 	private logger: ILogger;
 	private selfBotId: string | undefined;
 
+	private scrubContent: ((text: string) => string) | undefined;
+
 	constructor(
 		repositoryProvider: ChatRepositoryProvider,
 		logger?: ILogger,
 		options?: {
 			repositoryRoutingContext?: string;
+			scrubContent?: (text: string) => string;
 		},
 	) {
 		this.repositoryProvider = repositoryProvider;
 		this.repositoryRoutingContext =
 			options?.repositoryRoutingContext?.trim() || "";
 		this.logger = logger ?? createLogger({ component: "SlackChatAdapter" });
+		this.scrubContent = options?.scrubContent;
 	}
 
 	/**
@@ -233,7 +237,9 @@ Supported mrkdwn syntax:
 			// Thread the reply under the original message
 			const threadTs = event.payload.thread_ts || event.payload.ts;
 
-			await new SlackMessageService().postMessage({
+			await new SlackMessageService({
+				scrubContent: this.scrubContent,
+			}).postMessage({
 				token,
 				channel: event.payload.channel,
 				text: summary,
@@ -276,7 +282,9 @@ Supported mrkdwn syntax:
 
 		const threadTs = event.payload.thread_ts || event.payload.ts;
 
-		await new SlackMessageService().postMessage({
+		await new SlackMessageService({
+			scrubContent: this.scrubContent,
+		}).postMessage({
 			token,
 			channel: event.payload.channel,
 			text: "I'm still working on the previous request in this thread. I'll pick up your new message once I'm done.",

--- a/packages/edge-worker/src/index.ts
+++ b/packages/edge-worker/src/index.ts
@@ -60,5 +60,10 @@ export {
 	DEFAULT_BLOCK_MESSAGE,
 	UserAccessControl,
 } from "./UserAccessControl.js";
+export type { ISecretRedactor } from "./utils/SecretRedactor.js";
+export {
+	redactActivityContent,
+	SecretRedactor,
+} from "./utils/SecretRedactor.js";
 
 export { WorktreeIncludeService } from "./WorktreeIncludeService.js";

--- a/packages/edge-worker/src/sinks/LinearActivitySink.ts
+++ b/packages/edge-worker/src/sinks/LinearActivitySink.ts
@@ -3,6 +3,8 @@ import {
 	AgentActivitySignal,
 	type IIssueTrackerService,
 } from "cyrus-core";
+import type { ISecretRedactor } from "../utils/SecretRedactor.js";
+import { redactActivityContent } from "../utils/SecretRedactor.js";
 import type {
 	ActivityPostOptions,
 	ActivityPostResult,
@@ -43,16 +45,23 @@ export class LinearActivitySink implements IActivitySink {
 	public readonly id: string;
 
 	private readonly issueTracker: IIssueTrackerService;
+	private readonly redactor: ISecretRedactor | undefined;
 
 	/**
 	 * Create a new LinearActivitySink.
 	 *
 	 * @param issueTracker - The IIssueTrackerService instance to delegate to
 	 * @param workspaceId - The Linear workspace ID (used as sink ID)
+	 * @param redactor - Optional secret redactor to scrub outbound content
 	 */
-	constructor(issueTracker: IIssueTrackerService, workspaceId: string) {
+	constructor(
+		issueTracker: IIssueTrackerService,
+		workspaceId: string,
+		redactor?: ISecretRedactor,
+	) {
 		this.issueTracker = issueTracker;
 		this.id = workspaceId;
+		this.redactor = redactor;
 	}
 
 	/**
@@ -87,9 +96,13 @@ export class LinearActivitySink implements IActivitySink {
 		activity: AgentActivityContent,
 		options?: ActivityPostOptions,
 	): Promise<ActivityPostResult> {
+		const content = this.redactor
+			? redactActivityContent(this.redactor, activity)
+			: activity;
+
 		const result = await this.issueTracker.createAgentActivity({
 			agentSessionId: sessionId,
-			content: activity,
+			content,
 			...(options?.ephemeral !== undefined && { ephemeral: options.ephemeral }),
 			...(options?.signal && { signal: this.mapSignal(options.signal) }),
 			...(options?.signalMetadata && {

--- a/packages/edge-worker/src/utils/SecretRedactor.ts
+++ b/packages/edge-worker/src/utils/SecretRedactor.ts
@@ -1,0 +1,137 @@
+/**
+ * Centralized secret redaction for all outbound messages.
+ *
+ * Scrubs known secret values and common token patterns from arbitrary text
+ * before it reaches any external service (Linear, Slack, GitHub, GitLab).
+ */
+
+import type { AgentActivityContent } from "cyrus-core";
+
+/** Replacement string used for redacted values. */
+const REDACTED = "[REDACTED]";
+
+/** Minimum length for a secret value to be registered (avoids false positives on short strings). */
+const MIN_SECRET_LENGTH = 8;
+
+/**
+ * Interface for secret redaction. Consumers depend on this abstraction,
+ * not the concrete SecretRedactor class.
+ */
+export interface ISecretRedactor {
+	/** Scrub all known secrets and token patterns from the given text. */
+	redact(text: string): string;
+
+	/** Register additional secret values to be redacted. */
+	addSecrets(values: string[]): void;
+}
+
+/**
+ * Well-known token prefixes that should be caught even if not explicitly registered.
+ *
+ * Each pattern matches the prefix and a reasonable suffix length to avoid
+ * false positives while still catching tokens that weren't registered.
+ */
+const TOKEN_PATTERNS: RegExp[] = [
+	// Anthropic API keys
+	/sk-ant-[\w-]{20,}/g,
+	// OpenAI API keys (project-scoped and legacy)
+	/sk-proj-[\w-]{20,}/g,
+	/sk-[\w]{20,}/g,
+	// Slack bot tokens
+	/xoxb-[\w-]{20,}/g,
+	// Slack user tokens
+	/xoxp-[\w-]{20,}/g,
+	// Slack app-level tokens
+	/xapp-[\w-]{20,}/g,
+	// GitHub personal access tokens (classic and fine-grained)
+	/ghp_[A-Za-z0-9]{36,}/g,
+	// GitHub server-to-server tokens
+	/ghs_[A-Za-z0-9]{36,}/g,
+	// GitHub user-to-server tokens
+	/ghu_[A-Za-z0-9]{36,}/g,
+	// GitHub OAuth access tokens
+	/gho_[A-Za-z0-9]{36,}/g,
+	// GitHub App refresh tokens
+	/ghr_[A-Za-z0-9]{36,}/g,
+	// GitLab personal/project/group access tokens
+	/glpat-[\w-]{20,}/g,
+	// Google API keys
+	/AIza[A-Za-z0-9_-]{35}/g,
+	// AWS access key IDs
+	/AKIA[A-Z0-9]{16}/g,
+	// Generic Bearer tokens in markdown/text (catches leaked auth headers)
+	/Bearer\s+[A-Za-z0-9._~+/=-]{20,}/g,
+];
+
+export class SecretRedactor implements ISecretRedactor {
+	private readonly secrets: Set<string> = new Set();
+
+	/**
+	 * Register secret values to redact.
+	 * Values shorter than MIN_SECRET_LENGTH are ignored to avoid false positives.
+	 */
+	addSecrets(values: string[]): void {
+		for (const value of values) {
+			const trimmed = value.trim();
+			if (trimmed.length >= MIN_SECRET_LENGTH) {
+				this.secrets.add(trimmed);
+			}
+		}
+	}
+
+	/**
+	 * Scrub all registered secrets and well-known token patterns from text.
+	 *
+	 * Exact-value replacement runs first (longer values replaced first to avoid
+	 * partial matches), then pattern-based replacement catches unregistered tokens.
+	 */
+	redact(text: string): string {
+		if (!text) {
+			return text;
+		}
+
+		let result = text;
+
+		// Replace exact secret values, longest first to avoid partial replacements
+		const sortedSecrets = [...this.secrets].sort((a, b) => b.length - a.length);
+		for (const secret of sortedSecrets) {
+			result = result.replaceAll(secret, REDACTED);
+		}
+
+		// Apply well-known token patterns
+		for (const pattern of TOKEN_PATTERNS) {
+			// Reset lastIndex since these are global regexes that may be reused
+			pattern.lastIndex = 0;
+			result = result.replace(pattern, REDACTED);
+		}
+
+		return result;
+	}
+}
+
+/**
+ * Deep-scrub all string fields of an AgentActivityContent object.
+ *
+ * Returns a shallow copy with redacted string values; the original is not mutated.
+ */
+export function redactActivityContent(
+	redactor: ISecretRedactor,
+	content: AgentActivityContent,
+): AgentActivityContent {
+	if ("body" in content && typeof content.body === "string") {
+		return { ...content, body: redactor.redact(content.body) };
+	}
+
+	if ("action" in content) {
+		return {
+			...content,
+			action: redactor.redact(content.action),
+			parameter: redactor.redact(content.parameter),
+			...(content.result != null && {
+				result: redactor.redact(content.result),
+			}),
+		};
+	}
+
+	return content;
+}

--- a/packages/edge-worker/test/SecretRedactor.test.ts
+++ b/packages/edge-worker/test/SecretRedactor.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Unit tests for SecretRedactor, redactActivityContent, and sink integration.
+ */
+
+import type { AgentActivityContent } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type ISecretRedactor,
+	redactActivityContent,
+	SecretRedactor,
+} from "../src/utils/SecretRedactor.js";
+
+/**
+ * Build fake tokens at runtime so GitHub push protection doesn't flag test strings.
+ */
+function fakeToken(prefix: string, suffix: string): string {
+	return `${prefix}${suffix}`;
+}
+
+describe("SecretRedactor", () => {
+	let redactor: SecretRedactor;
+
+	beforeEach(() => {
+		redactor = new SecretRedactor();
+	});
+
+	describe("addSecrets() and redact()", () => {
+		it("should redact a registered secret value", () => {
+			redactor.addSecrets(["my-super-secret-api-key-12345"]);
+			const result = redactor.redact(
+				"The key is my-super-secret-api-key-12345 here",
+			);
+			expect(result).toBe("The key is [REDACTED] here");
+		});
+
+		it("should redact multiple registered secrets", () => {
+			redactor.addSecrets([
+				"secret-value-one-abcdef",
+				"secret-value-two-ghijkl",
+			]);
+			const result = redactor.redact(
+				"First: secret-value-one-abcdef, Second: secret-value-two-ghijkl",
+			);
+			expect(result).toBe("First: [REDACTED], Second: [REDACTED]");
+		});
+
+		it("should ignore short secrets (less than 8 chars)", () => {
+			redactor.addSecrets(["short"]);
+			const result = redactor.redact("The value is short here");
+			expect(result).toBe("The value is short here");
+		});
+
+		it("should handle empty string input", () => {
+			redactor.addSecrets(["my-secret-value-xyz"]);
+			expect(redactor.redact("")).toBe("");
+		});
+
+		it("should handle null/undefined-like empty input", () => {
+			expect(redactor.redact("")).toBe("");
+		});
+
+		it("should replace all occurrences of a secret", () => {
+			redactor.addSecrets(["repeated-secret-value"]);
+			const result = redactor.redact(
+				"repeated-secret-value and repeated-secret-value",
+			);
+			expect(result).toBe("[REDACTED] and [REDACTED]");
+		});
+
+		it("should replace longest secret first to avoid partial matches", () => {
+			redactor.addSecrets(["sk-ant-api-key", "sk-ant-api-key-extended-value"]);
+			const result = redactor.redact(
+				"Token: sk-ant-api-key-extended-value end",
+			);
+			expect(result).toBe("Token: [REDACTED] end");
+		});
+
+		it("should trim whitespace from secrets before registering", () => {
+			redactor.addSecrets(["  my-padded-secret-value  "]);
+			const result = redactor.redact("Using my-padded-secret-value in text");
+			expect(result).toBe("Using [REDACTED] in text");
+		});
+	});
+
+	describe("well-known token patterns", () => {
+		it("should redact Anthropic API keys (sk-ant-*)", () => {
+			const result = redactor.redact("Key: sk-ant-api03-abcdefghijklmnopqrst");
+			expect(result).toBe("Key: [REDACTED]");
+		});
+
+		it("should redact OpenAI project-scoped keys (sk-proj-*)", () => {
+			const result = redactor.redact("Key: sk-proj-abcdefghijklmnopqrstuvwxyz");
+			expect(result).toBe("Key: [REDACTED]");
+		});
+
+		it("should redact generic OpenAI keys (sk-*)", () => {
+			const result = redactor.redact("Key: sk-abcdefghijklmnopqrstuvwxyz");
+			expect(result).toBe("Key: [REDACTED]");
+		});
+
+		it("should redact Slack bot tokens (xoxb-*)", () => {
+			const token = fakeToken("xoxb-", "123456789-abcdefghijklmnopqrstuvwxyz");
+			const result = redactor.redact(`Token: ${token}`);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact Slack user tokens (xoxp-*)", () => {
+			const token = fakeToken("xoxp-", "123456789-abcdefghijklmnopqrstuvwxyz");
+			const result = redactor.redact(`Token: ${token}`);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact Slack app tokens (xapp-*)", () => {
+			const token = fakeToken("xapp-", "123456789-abcdefghijklmnopqrstuvwxyz");
+			const result = redactor.redact(`Token: ${token}`);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact GitHub personal access tokens (ghp_*)", () => {
+			const result = redactor.redact(
+				"Token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn",
+			);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact GitHub server tokens (ghs_*)", () => {
+			const result = redactor.redact(
+				"Token: ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn",
+			);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact GitHub user tokens (ghu_*)", () => {
+			const result = redactor.redact(
+				"Token: ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn",
+			);
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact GitLab tokens (glpat-*)", () => {
+			const result = redactor.redact("Token: glpat-abcdefghijklmnopqrstuvwx");
+			expect(result).toBe("Token: [REDACTED]");
+		});
+
+		it("should redact Google API keys (AIza*)", () => {
+			const result = redactor.redact(
+				"Key: AIzaSyA1234567890abcdefghijklmnopqrstuv",
+			);
+			expect(result).toBe("Key: [REDACTED]");
+		});
+
+		it("should redact AWS access key IDs (AKIA*)", () => {
+			const result = redactor.redact("Key: AKIAIOSFODNN7EXAMPLE");
+			expect(result).toBe("Key: [REDACTED]");
+		});
+
+		it("should redact Bearer tokens", () => {
+			const result = redactor.redact(
+				"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature",
+			);
+			expect(result).toBe("Authorization: [REDACTED]");
+		});
+
+		it("should redact multiple token patterns in one string", () => {
+			const slackToken = fakeToken(
+				"xoxb-",
+				"123456789-abcdefghijklmnopqrstuvwxyz",
+			);
+			const result = redactor.redact(
+				`GitHub: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn, Slack: ${slackToken}`,
+			);
+			expect(result).toBe("GitHub: [REDACTED], Slack: [REDACTED]");
+		});
+
+		it("should not redact non-matching strings", () => {
+			const safe = "This is a normal message with no secrets";
+			expect(redactor.redact(safe)).toBe(safe);
+		});
+	});
+
+	describe("combined exact + pattern redaction", () => {
+		it("should redact both registered secrets and pattern-matched tokens", () => {
+			redactor.addSecrets(["my-custom-secret-value-xyz"]);
+			const result = redactor.redact(
+				"Custom: my-custom-secret-value-xyz, GitHub: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn",
+			);
+			expect(result).toBe("Custom: [REDACTED], GitHub: [REDACTED]");
+		});
+	});
+});
+
+describe("redactActivityContent()", () => {
+	let redactor: ISecretRedactor;
+
+	beforeEach(() => {
+		const r = new SecretRedactor();
+		r.addSecrets(["super-secret-api-key-value"]);
+		redactor = r;
+	});
+
+	it("should redact body in thought activities", () => {
+		const content: AgentActivityContent = {
+			type: "thought" as any,
+			body: "Found super-secret-api-key-value in env",
+		};
+		const result = redactActivityContent(redactor, content);
+		expect((result as any).body).toBe("Found [REDACTED] in env");
+	});
+
+	it("should redact body in response activities", () => {
+		const content: AgentActivityContent = {
+			type: "response" as any,
+			body: "The key super-secret-api-key-value was used",
+		};
+		const result = redactActivityContent(redactor, content);
+		expect((result as any).body).toBe("The key [REDACTED] was used");
+	});
+
+	it("should redact body in error activities", () => {
+		const content: AgentActivityContent = {
+			type: "error" as any,
+			body: "Error: invalid key super-secret-api-key-value",
+		};
+		const result = redactActivityContent(redactor, content);
+		expect((result as any).body).toBe("Error: invalid key [REDACTED]");
+	});
+
+	it("should redact body in elicitation activities", () => {
+		const content: AgentActivityContent = {
+			type: "elicitation" as any,
+			body: "Should I use super-secret-api-key-value?",
+		};
+		const result = redactActivityContent(redactor, content);
+		expect((result as any).body).toBe("Should I use [REDACTED]?");
+	});
+
+	it("should redact action, parameter, and result in action activities", () => {
+		const content: AgentActivityContent = {
+			type: "action" as any,
+			action: "run super-secret-api-key-value",
+			parameter: "super-secret-api-key-value.json",
+			result: "output: super-secret-api-key-value",
+		};
+		const result = redactActivityContent(redactor, content) as any;
+		expect(result.action).toBe("run [REDACTED]");
+		expect(result.parameter).toBe("[REDACTED].json");
+		expect(result.result).toBe("output: [REDACTED]");
+	});
+
+	it("should handle action activities with no result", () => {
+		const content: AgentActivityContent = {
+			type: "action" as any,
+			action: "test_action",
+			parameter: "super-secret-api-key-value",
+		};
+		const result = redactActivityContent(redactor, content) as any;
+		expect(result.action).toBe("test_action");
+		expect(result.parameter).toBe("[REDACTED]");
+		expect(result.result).toBeUndefined();
+	});
+
+	it("should not mutate the original content object", () => {
+		const content: AgentActivityContent = {
+			type: "thought" as any,
+			body: "secret: super-secret-api-key-value",
+		};
+		const original = { ...content };
+		redactActivityContent(redactor, content);
+		expect(content).toEqual(original);
+	});
+
+	it("should also catch pattern-matched tokens in activity content", () => {
+		const content: AgentActivityContent = {
+			type: "thought" as any,
+			body: "Found token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn in output",
+		};
+		const result = redactActivityContent(redactor, content);
+		expect((result as any).body).toBe("Found token [REDACTED] in output");
+	});
+});
+
+describe("LinearActivitySink with redactor", () => {
+	it("should redact activity content before posting to Linear", async () => {
+		const { LinearActivitySink } = await import(
+			"../src/sinks/LinearActivitySink.js"
+		);
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["my-anthropic-api-key-secret"]);
+
+		const mockIssueTracker = {
+			createAgentActivity: vi.fn().mockResolvedValue({
+				success: true,
+				agentActivity: Promise.resolve({ id: "activity-1" }),
+			}),
+			createAgentSessionOnIssue: vi.fn(),
+		};
+
+		const sink = new LinearActivitySink(
+			mockIssueTracker as any,
+			"workspace-123",
+			redactor,
+		);
+
+		await sink.postActivity("session-1", {
+			type: "thought" as any,
+			body: "Found my-anthropic-api-key-secret in the environment",
+		});
+
+		expect(mockIssueTracker.createAgentActivity).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: expect.objectContaining({
+					body: "Found [REDACTED] in the environment",
+				}),
+			}),
+		);
+	});
+
+	it("should pass through unmodified when no redactor is provided", async () => {
+		const { LinearActivitySink } = await import(
+			"../src/sinks/LinearActivitySink.js"
+		);
+
+		const mockIssueTracker = {
+			createAgentActivity: vi.fn().mockResolvedValue({
+				success: true,
+				agentActivity: Promise.resolve({ id: "activity-1" }),
+			}),
+			createAgentSessionOnIssue: vi.fn(),
+		};
+
+		const sink = new LinearActivitySink(
+			mockIssueTracker as any,
+			"workspace-123",
+		);
+
+		const activity = {
+			type: "thought" as any,
+			body: "This has no secrets to redact",
+		};
+		await sink.postActivity("session-1", activity);
+
+		expect(mockIssueTracker.createAgentActivity).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: activity,
+			}),
+		);
+	});
+});
+
+describe("GitHubCommentService with scrubContent", () => {
+	it("should scrub body before posting issue comment", async () => {
+		const { GitHubCommentService } = await import(
+			"cyrus-github-event-transport"
+		);
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["github-secret-token-value"]);
+
+		const service = new GitHubCommentService({
+			apiBaseUrl: "https://api.github.com",
+			scrubContent: (text: string) => redactor.redact(text),
+		});
+
+		const mockResponse = {
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					id: 1,
+					html_url: "https://github.com/test/pr/1#comment-1",
+					body: "[REDACTED]",
+				}),
+		};
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockResponse as any);
+
+		await service.postIssueComment({
+			token: "test-token",
+			owner: "test",
+			repo: "repo",
+			issueNumber: 1,
+			body: "Found github-secret-token-value in logs",
+		});
+
+		const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+		expect(fetchBody.body).toBe("Found [REDACTED] in logs");
+
+		fetchSpy.mockRestore();
+	});
+
+	it("should scrub body before posting review comment reply", async () => {
+		const { GitHubCommentService } = await import(
+			"cyrus-github-event-transport"
+		);
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["github-secret-token-value"]);
+
+		const service = new GitHubCommentService({
+			scrubContent: (text: string) => redactor.redact(text),
+		});
+
+		const mockResponse = {
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					id: 2,
+					html_url: "https://github.com/test/pr/1#comment-2",
+					body: "[REDACTED]",
+				}),
+		};
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockResponse as any);
+
+		await service.postReviewCommentReply({
+			token: "test-token",
+			owner: "test",
+			repo: "repo",
+			pullNumber: 1,
+			commentId: 100,
+			body: "Here is github-secret-token-value leaked",
+		});
+
+		const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+		expect(fetchBody.body).toBe("Here is [REDACTED] leaked");
+
+		fetchSpy.mockRestore();
+	});
+});
+
+describe("GitLabCommentService with scrubContent", () => {
+	it("should scrub body before posting MR note", async () => {
+		const { GitLabCommentService } = await import(
+			"cyrus-gitlab-event-transport"
+		);
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["gitlab-secret-token-value"]);
+
+		const service = new GitLabCommentService({
+			apiBaseUrl: "https://gitlab.com",
+			scrubContent: (text: string) => redactor.redact(text),
+		});
+
+		const mockResponse = {
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					id: 1,
+					body: "[REDACTED]",
+					created_at: "2025-01-01",
+					author: { id: 1, username: "bot", name: "Bot" },
+				}),
+		};
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockResponse as any);
+
+		await service.postMRNote({
+			token: "test-token",
+			projectId: 123,
+			mrIid: 1,
+			body: "Found gitlab-secret-token-value in MR",
+		});
+
+		const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+		expect(fetchBody.body).toBe("Found [REDACTED] in MR");
+
+		fetchSpy.mockRestore();
+	});
+
+	it("should scrub body before posting discussion reply", async () => {
+		const { GitLabCommentService } = await import(
+			"cyrus-gitlab-event-transport"
+		);
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["gitlab-secret-token-value"]);
+
+		const service = new GitLabCommentService({
+			scrubContent: (text: string) => redactor.redact(text),
+		});
+
+		const mockResponse = {
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					id: 2,
+					body: "[REDACTED]",
+					created_at: "2025-01-01",
+					author: { id: 1, username: "bot", name: "Bot" },
+				}),
+		};
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockResponse as any);
+
+		await service.postDiscussionReply({
+			token: "test-token",
+			projectId: 123,
+			mrIid: 1,
+			discussionId: "disc-1",
+			body: "Reply with gitlab-secret-token-value",
+		});
+
+		const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+		expect(fetchBody.body).toBe("Reply with [REDACTED]");
+
+		fetchSpy.mockRestore();
+	});
+});
+
+describe("SlackMessageService with scrubContent", () => {
+	it("should scrub text before posting message", async () => {
+		const { SlackMessageService } = await import("cyrus-slack-event-transport");
+
+		const redactor = new SecretRedactor();
+		redactor.addSecrets(["slack-secret-token-value"]);
+
+		const service = new SlackMessageService({
+			apiBaseUrl: "https://slack.com/api",
+			scrubContent: (text: string) => redactor.redact(text),
+		});
+
+		const mockResponse = {
+			ok: true,
+			json: () => Promise.resolve({ ok: true }),
+		};
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockResponse as any);
+
+		await service.postMessage({
+			token: "xoxb-test",
+			channel: "C123",
+			text: "Message with slack-secret-token-value",
+			thread_ts: "1234567890.123456",
+		});
+
+		const fetchBody = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+		expect(fetchBody.text).toBe("Message with [REDACTED]");
+
+		fetchSpy.mockRestore();
+	});
+});

--- a/packages/github-event-transport/src/GitHubCommentService.ts
+++ b/packages/github-event-transport/src/GitHubCommentService.ts
@@ -8,6 +8,8 @@
 export interface GitHubCommentServiceConfig {
 	/** GitHub API base URL (default: https://api.github.com) */
 	apiBaseUrl?: string;
+	/** Optional function to scrub sensitive content before posting. */
+	scrubContent?: (text: string) => string;
 }
 
 /**
@@ -73,9 +75,11 @@ export interface AddReactionParams {
 
 export class GitHubCommentService {
 	private apiBaseUrl: string;
+	private scrubContent: ((text: string) => string) | undefined;
 
 	constructor(config?: GitHubCommentServiceConfig) {
 		this.apiBaseUrl = config?.apiBaseUrl ?? "https://api.github.com";
+		this.scrubContent = config?.scrubContent;
 	}
 
 	/**
@@ -88,6 +92,7 @@ export class GitHubCommentService {
 		params: PostCommentParams,
 	): Promise<GitHubCommentResponse> {
 		const { token, owner, repo, issueNumber, body } = params;
+		const scrubbedBody = this.scrubContent ? this.scrubContent(body) : body;
 		const url = `${this.apiBaseUrl}/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
 
 		const response = await fetch(url, {
@@ -98,7 +103,7 @@ export class GitHubCommentService {
 				"Content-Type": "application/json",
 				"X-GitHub-Api-Version": "2022-11-28",
 			},
-			body: JSON.stringify({ body }),
+			body: JSON.stringify({ body: scrubbedBody }),
 		});
 
 		if (!response.ok) {
@@ -121,6 +126,7 @@ export class GitHubCommentService {
 		params: PostReviewCommentReplyParams,
 	): Promise<GitHubCommentResponse> {
 		const { token, owner, repo, pullNumber, commentId, body } = params;
+		const scrubbedBody = this.scrubContent ? this.scrubContent(body) : body;
 		const url = `${this.apiBaseUrl}/repos/${owner}/${repo}/pulls/${pullNumber}/comments/${commentId}/replies`;
 
 		const response = await fetch(url, {
@@ -131,7 +137,7 @@ export class GitHubCommentService {
 				"Content-Type": "application/json",
 				"X-GitHub-Api-Version": "2022-11-28",
 			},
-			body: JSON.stringify({ body }),
+			body: JSON.stringify({ body: scrubbedBody }),
 		});
 
 		if (!response.ok) {

--- a/packages/gitlab-event-transport/src/GitLabCommentService.ts
+++ b/packages/gitlab-event-transport/src/GitLabCommentService.ts
@@ -8,6 +8,8 @@
 export interface GitLabCommentServiceConfig {
 	/** GitLab API base URL (default: https://gitlab.com) */
 	apiBaseUrl?: string;
+	/** Optional function to scrub sensitive content before posting. */
+	scrubContent?: (text: string) => string;
 }
 
 /**
@@ -72,9 +74,11 @@ export interface GitLabNoteResponse {
 
 export class GitLabCommentService {
 	private apiBaseUrl: string;
+	private scrubContent: ((text: string) => string) | undefined;
 
 	constructor(config?: GitLabCommentServiceConfig) {
 		this.apiBaseUrl = config?.apiBaseUrl ?? "https://gitlab.com";
+		this.scrubContent = config?.scrubContent;
 	}
 
 	/**
@@ -84,6 +88,7 @@ export class GitLabCommentService {
 	 */
 	async postMRNote(params: PostMRNoteParams): Promise<GitLabNoteResponse> {
 		const { token, projectId, mrIid, body } = params;
+		const scrubbedBody = this.scrubContent ? this.scrubContent(body) : body;
 		const url = `${this.apiBaseUrl}/api/v4/projects/${projectId}/merge_requests/${mrIid}/notes`;
 
 		const response = await fetch(url, {
@@ -92,7 +97,7 @@ export class GitLabCommentService {
 				"PRIVATE-TOKEN": token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ body }),
+			body: JSON.stringify({ body: scrubbedBody }),
 		});
 
 		if (!response.ok) {
@@ -114,6 +119,7 @@ export class GitLabCommentService {
 		params: PostDiscussionReplyParams,
 	): Promise<GitLabNoteResponse> {
 		const { token, projectId, mrIid, discussionId, body } = params;
+		const scrubbedBody = this.scrubContent ? this.scrubContent(body) : body;
 		const url = `${this.apiBaseUrl}/api/v4/projects/${projectId}/merge_requests/${mrIid}/discussions/${discussionId}/notes`;
 
 		const response = await fetch(url, {
@@ -122,7 +128,7 @@ export class GitLabCommentService {
 				"PRIVATE-TOKEN": token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ body }),
+			body: JSON.stringify({ body: scrubbedBody }),
 		});
 
 		if (!response.ok) {

--- a/packages/slack-event-transport/src/SlackMessageService.ts
+++ b/packages/slack-event-transport/src/SlackMessageService.ts
@@ -49,11 +49,27 @@ export interface SlackPostMessageParams {
 	thread_ts?: string;
 }
 
+/**
+ * Optional configuration for SlackMessageService.
+ */
+export interface SlackMessageServiceConfig {
+	/** Slack API base URL (default: https://slack.com/api) */
+	apiBaseUrl?: string;
+	/** Optional function to scrub sensitive content before posting. */
+	scrubContent?: (text: string) => string;
+}
+
 export class SlackMessageService {
 	private apiBaseUrl: string;
+	private scrubContent: ((text: string) => string) | undefined;
 
-	constructor(apiBaseUrl?: string) {
-		this.apiBaseUrl = apiBaseUrl ?? "https://slack.com/api";
+	constructor(config?: string | SlackMessageServiceConfig) {
+		if (typeof config === "string" || config === undefined) {
+			this.apiBaseUrl = config ?? "https://slack.com/api";
+		} else {
+			this.apiBaseUrl = config.apiBaseUrl ?? "https://slack.com/api";
+			this.scrubContent = config.scrubContent;
+		}
 	}
 
 	/**
@@ -65,8 +81,9 @@ export class SlackMessageService {
 		const { token, channel, text, thread_ts } = params;
 
 		const url = `${this.apiBaseUrl}/chat.postMessage`;
+		const scrubbedText = this.scrubContent ? this.scrubContent(text) : text;
 
-		const body: Record<string, string> = { channel, text };
+		const body: Record<string, string> = { channel, text: scrubbedText };
 		if (thread_ts) {
 			body.thread_ts = thread_ts;
 		}

--- a/packages/slack-event-transport/src/index.ts
+++ b/packages/slack-event-transport/src/index.ts
@@ -1,6 +1,7 @@
 export { SlackEventTransport } from "./SlackEventTransport.js";
 export type {
 	SlackFetchThreadParams,
+	SlackMessageServiceConfig,
 	SlackPostMessageParams,
 	SlackThreadMessage,
 } from "./SlackMessageService.js";


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

Implements a centralized `SecretRedactor` utility that scrubs API keys, tokens, and sensitive environment variable values from all outbound content before it reaches any external service.

- **New `SecretRedactor` class** (`packages/edge-worker/src/utils/SecretRedactor.ts`) — maintains a set of registered secret values and 14 regex patterns for well-known token formats (`sk-ant-*`, `ghp_*`, `xoxb-*`, `glpat-*`, `AIza*`, `AKIA*`, `Bearer`, etc.)
- **Populated at EdgeWorker startup** with 15 secret env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GITHUB_TOKEN, SLACK_BOT_TOKEN, etc.) plus all Linear workspace tokens from config
- **Hooked into all outbound sinks** via constructor injection:
  - `LinearActivitySink` — scrubs `AgentActivityContent` fields (body, action, parameter, result)
  - `GitHubCommentService` — scrubs comment and review reply bodies
  - `GitLabCommentService` — scrubs MR note and discussion reply bodies
  - `SlackMessageService` — scrubs message text
  - `SlackChatAdapter` — passes scrubber to `SlackMessageService` instances
- **39 unit tests** covering exact-value redaction, pattern matching, all sink integrations, and edge cases

## Design

Follows SOLID principles:
- **S**: `SecretRedactor` has single responsibility (redaction)
- **O**: Services are open for extension via `scrubContent` config without modifying core logic
- **L**: All sinks accept the optional redactor without breaking existing behavior
- **I**: `ISecretRedactor` interface keeps consumers decoupled from implementation
- **D**: All sinks depend on abstractions (`ISecretRedactor` / `scrubContent` function), not the concrete class

## Test plan

- [x] `SecretRedactor.redact()` replaces registered secrets (longest-first)
- [x] Well-known token patterns caught even when not explicitly registered
- [x] `redactActivityContent()` scrubs all `AgentActivityContent` variant fields
- [x] `LinearActivitySink` passes redacted content to issue tracker
- [x] `GitHubCommentService` sends scrubbed body in POST requests
- [x] `GitLabCommentService` sends scrubbed body in POST requests
- [x] `SlackMessageService` sends scrubbed text in POST requests
- [x] Short secrets (< 8 chars) ignored to avoid false positives
- [x] Original content objects not mutated
- [x] Build, typecheck, and all 589 tests pass

Resolves [CYPACK-1061](https://linear.app/ceedar/issue/CYPACK-1061/add-secret-redactionscrubbing-for-all-outbound-messages)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->