### PR TITLE
fix: diff changelog entries against base branch to prevent duplicates (CYPACK-1063)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- PR/MR and changelog-update skills now diff changelog entries against the base branch (not the last commit) to detect existing entries added by the current branch. Prevents duplicate entries and ensures existing entries are updated in-place. (CYPACK-1063)
+
 ## [0.2.44] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Changed
-- PR/MR and changelog-update skills now diff changelog entries against the base branch (not the last commit) to detect existing entries added by the current branch. Prevents duplicate entries and ensures existing entries are updated in-place. (CYPACK-1063)
+- PR/MR and changelog-update skills now diff changelog entries against the base branch (not the last commit) to detect existing entries added by the current branch. Prevents duplicate entries and ensures existing entries are updated in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))
 
 ## [0.2.44] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Changelog updates no longer create duplicate entries** — The PR/MR and changelog-update skills now diff entries against the base branch instead of only the last commit, correctly detecting entries already added by the current branch and updating them in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))
+
 ## [0.2.44] - 2026-04-10
 
 ### Fixed

--- a/packages/edge-worker/src/prompts/subroutines/changelog-update-gitlab.md
+++ b/packages/edge-worker/src/prompts/subroutines/changelog-update-gitlab.md
@@ -27,12 +27,19 @@ ls -la CHANGELOG.md CHANGELOG.internal.md 2>/dev/null || echo "NO_CHANGELOG"
 **If no changelog files exist, complete with:** `Draft MR created at [MR URL]. No changelog files found.`
 
 ### 3. Check for Existing Changelog Entry
-If changelog files exist, check if there's already a changelog entry for this issue:
-- Look in the `## [Unreleased]` section for entries mentioning the current Linear issue identifier
-- If an entry already exists for this issue, you may update it to add the MR link, but do NOT add duplicate entries
+If changelog files exist, diff against the base branch to detect entries already added by this branch:
+
+```bash
+# See what changelog lines this branch has added compared to the base branch
+# Replace <base_branch> with the actual target branch from the issue context
+git diff <base_branch> -- CHANGELOG.md CHANGELOG.internal.md 2>/dev/null
+```
+
+- If the diff shows this branch already added a changelog entry for the current issue (matching the issue identifier), **update that entry in-place** (e.g., to add the MR link or refine the description). Do NOT add a duplicate entry.
+- If the diff shows this branch added entries for a different issue or no entries at all, add a new entry in step 4.
 
 ### 4. Update Changelog with MR Link
-If changelog files exist and no entry exists (or entry needs MR link):
+If changelog files exist and no entry exists for this issue on this branch (or the existing entry needs the MR link):
 
 **For user-facing changes (CHANGELOG.md):**
 - Add entry under `## [Unreleased]` in the appropriate subsection (`### Added`, `### Changed`, `### Fixed`, `### Removed`)

--- a/skills/verify-and-ship/SKILL.md
+++ b/skills/verify-and-ship/SKILL.md
@@ -26,8 +26,20 @@ Check if the project has changelog files:
 ls -la CHANGELOG.md CHANGELOG.internal.md 2>/dev/null || echo "NO_CHANGELOG"
 ```
 
-If changelog files exist:
-- Add an entry under `## [Unreleased]` in the appropriate subsection (`### Added`, `### Changed`, `### Fixed`, `### Removed`)
+If changelog files exist, diff against the base branch to detect entries already added by this branch:
+
+```bash
+# See what changelog lines this branch has added compared to the base branch
+# Replace <base_branch> with the actual base branch from the issue context
+git diff <base_branch> -- CHANGELOG.md CHANGELOG.internal.md 2>/dev/null
+```
+
+**Handling existing entries:**
+- If the diff shows this branch already added a changelog entry for the current issue (matching the issue identifier), **update that entry in-place** (e.g., to add the PR/MR link or refine the description). Do NOT add a duplicate entry.
+- If the diff shows this branch added changelog entries for a different issue or no entries at all, add a new entry.
+
+**Adding or updating entries:**
+- Place entries under `## [Unreleased]` in the appropriate subsection (`### Added`, `### Changed`, `### Fixed`, `### Removed`)
 - Focus on end-user impact — be concise but descriptive
 - Include the Linear issue identifier and PR/MR link (format: `([ISSUE-ID](linear_url), [#NUMBER](PR_OR_MR_URL))`)
 - Follow [Keep a Changelog](https://keepachangelog.com/) format


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary
- Updated `verify-and-ship` skill and `changelog-update-gitlab` subroutine to diff changelog files against the base branch (`git diff <base_branch> -- CHANGELOG.md CHANGELOG.internal.md`) instead of only looking at the current file state
- When the branch already has a changelog entry for the current issue, agents are now instructed to **update it in-place** (e.g. to add a PR/MR link) rather than adding a duplicate entry
- This prevents changelog entry duplication across multiple commits on the same branch

## Test plan
- [x] All 550 edge-worker tests pass
- [x] All package tests pass
- [x] TypeScript type checking passes
- [x] Biome linting passes

[CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063/ensure-that-the-gh-prmr-prompt-skill-handles-changelog-entries-right)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->