### PR TITLE
docs: normalize GitHub capitalization in README (CYPACK-1072)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Discord](https://img.shields.io/discord/1443747721910685792?label=Discord&logo=discord&logoColor=white)](https://discord.gg/prrtADHYTt)
 
-Your (Claude Code|Codex|Cursor|Gemini) powered (Linear|Github|Gitlab|Slack) agent. Cyrus monitors (Linear|Github|GitLab|Slack) issues assigned to it, creates isolated Git worktrees for each issue, runs (Claude Code|Codex|Cursor|Gemini) sessions to process them, and streams detailed agent activity updates back to (Linear|Github), along with rich interactions like dropdown selects and approvals.
+Your (Claude Code|Codex|Cursor|Gemini) powered (Linear|GitHub|GitLab|Slack) agent. Cyrus monitors (Linear|GitHub|GitLab|Slack) issues assigned to it, creates isolated Git worktrees for each issue, runs (Claude Code|Codex|Cursor|Gemini) sessions to process them, and streams detailed agent activity updates back to (Linear|GitHub), along with rich interactions like dropdown selects and approvals.
 
 **Note:** Cyrus is a BYOK platform (bring your keys / subscriptions) for tokens.
 


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

- Normalized "Github" to "GitHub" (capital H) in the README description to match GitHub's official branding

## Linear Issue

[CYPACK-1072](https://linear.app/ceedar/issue/CYPACK-1072/test)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->