### PR TITLE
docs: add Gemini and Codex credits to README (CYPACK-1076)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ This project is licensed under the Apache 2.0 license - see the [LICENSE](LICENS
 
 ## Credits
 
-This project builds on the technologies built by the awesome teams at Linear, and Claude by Anthropic:
+This project builds on the technologies built by the awesome teams at Linear, Anthropic, Google, and OpenAI:
 
 - [Linear API](https://linear.app/developers)
 - [Anthropic Claude Code](https://www.claude.com/product/claude-code)
+- [Google Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [OpenAI Codex CLI](https://github.com/openai/codex)


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

- Updated the credits section in the README to acknowledge Google Gemini CLI and OpenAI Codex CLI, which are now supported agent runtimes alongside Claude Code.

## Test plan

- [x] Verify README renders correctly with the new credit links

Resolves [CYPACK-1076](https://linear.app/ceedar/issue/CYPACK-1076/test-copy)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->