### PR TITLE
fix: programmatically ensure Cyrus PR marker on GitHub PRs (CYPACK-1082)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Added
+- Added `ensureCyrusMarker()`, `findPullRequestByBranch()`, and `updatePullRequestBody()` methods to `GitHubCommentService` for programmatic PR marker enforcement. Exported `CYRUS_PR_MARKER` constant. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
+- Added `ensurePrCyrusMarker()`, `resolveGitHubTokenForApi()`, and `parseGitHubUrl()` private methods to `EdgeWorker`. Registered `sessionCompleted` listener on `GlobalSessionRegistry` to automatically verify and append the Cyrus attribution marker to PRs after session completion. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
+
 ### Changed
 - PR/MR and changelog-update skills now diff changelog entries against the base branch (not the last commit) to detect existing entries added by the current branch. Prevents duplicate entries and ensures existing entries are updated in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,8 +5,8 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Added
-- Added `ensureCyrusMarker()`, `findPullRequestByBranch()`, and `updatePullRequestBody()` methods to `GitHubCommentService` for programmatic PR marker enforcement. Exported `CYRUS_PR_MARKER` constant. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
-- Added `ensurePrCyrusMarker()`, `resolveGitHubTokenForApi()`, and `parseGitHubUrl()` private methods to `EdgeWorker`. Registered `sessionCompleted` listener on `GlobalSessionRegistry` to automatically verify and append the Cyrus attribution marker to PRs after session completion. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
+- Added `ensureCyrusMarker()`, `findPullRequestByBranch()`, and `updatePullRequestBody()` methods to `GitHubCommentService` for programmatic PR marker enforcement. Exported `CYRUS_PR_MARKER` constant. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082), [#1106](https://github.com/ceedaragents/cyrus/pull/1106))
+- Added `ensurePrCyrusMarker()`, `resolveGitHubTokenForApi()`, and `parseGitHubUrl()` private methods to `EdgeWorker`. Registered `sessionCompleted` listener on `GlobalSessionRegistry` to automatically verify and append the Cyrus attribution marker to PRs after session completion. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082), [#1106](https://github.com/ceedaragents/cyrus/pull/1106))
 
 ### Changed
 - PR/MR and changelog-update skills now diff changelog entries against the base branch (not the last commit) to detect existing entries added by the current branch. Prevents duplicate entries and ensures existing entries are updated in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Cyrus PR marker is now guaranteed on GitHub PRs** — After a session completes, Cyrus programmatically verifies that the `<!-- generated-by-cyrus -->` attribution marker is present in any open PR on the session's branch. If missing (e.g., the agent didn't follow the prompt instruction), the marker is automatically appended via the GitHub API. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
+- **Cyrus PR marker is now guaranteed on GitHub PRs** — After a session completes, Cyrus programmatically verifies that the `<!-- generated-by-cyrus -->` attribution marker is present in any open PR on the session's branch. If missing (e.g., the agent didn't follow the prompt instruction), the marker is automatically appended via the GitHub API. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082), [#1106](https://github.com/ceedaragents/cyrus/pull/1106))
 - **Changelog updates no longer create duplicate entries** — The PR/MR and changelog-update skills now diff entries against the base branch instead of only the last commit, correctly detecting entries already added by the current branch and updating them in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Cyrus PR marker is now guaranteed on GitHub PRs** — After a session completes, Cyrus programmatically verifies that the `<!-- generated-by-cyrus -->` attribution marker is present in any open PR on the session's branch. If missing (e.g., the agent didn't follow the prompt instruction), the marker is automatically appended via the GitHub API. ([CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082))
 - **Changelog updates no longer create duplicate entries** — The PR/MR and changelog-update skills now diff entries against the base branch instead of only the last commit, correctly detecting entries already added by the current branch and updating them in-place. ([CYPACK-1063](https://linear.app/ceedar/issue/CYPACK-1063), [#1091](https://github.com/ceedaragents/cyrus/pull/1091))
 
 ### Added

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -497,6 +497,15 @@ export class EdgeWorker extends EventEmitter {
 			this.logger,
 		);
 
+		// Ensure Cyrus PR marker is present after sessions complete
+		this.globalSessionRegistry.on("sessionCompleted", (_sessionId, session) => {
+			this.ensurePrCyrusMarker(session).catch((err) => {
+				this.logger.warn(
+					`Failed to ensure Cyrus PR marker: ${err instanceof Error ? err.message : err}`,
+				);
+			});
+		});
+
 		// Components will be initialized and registered in start() method before server starts
 	}
 
@@ -1008,6 +1017,88 @@ export class EdgeWorker extends EventEmitter {
 			}
 		}
 		return process.env.GITHUB_TOKEN;
+	}
+
+	/**
+	 * Resolve a GitHub token for API calls that aren't triggered by a webhook event.
+	 * Uses GitHub App token provider or falls back to GITHUB_TOKEN env var.
+	 */
+	private async resolveGitHubTokenForApi(): Promise<string | undefined> {
+		if (this.gitHubAppTokenProvider) {
+			try {
+				return await this.gitHubAppTokenProvider.getToken();
+			} catch (error) {
+				this.logger.warn(
+					"Failed to mint GitHub App installation token, falling back to GITHUB_TOKEN",
+					error instanceof Error ? error : new Error(String(error)),
+				);
+			}
+		}
+		return process.env.GITHUB_TOKEN;
+	}
+
+	/**
+	 * Parse a GitHub URL (e.g. "https://github.com/owner/repo") into owner and repo.
+	 */
+	private parseGitHubUrl(
+		githubUrl: string,
+	): { owner: string; repo: string } | null {
+		// Strip protocol and host prefix, then extract owner/repo
+		const cleaned = githubUrl
+			.replace(/^https?:\/\/[^/]+\//, "")
+			.replace(/\.git$/, "")
+			.replace(/\/$/, "");
+		const parts = cleaned.split("/");
+		const owner = parts[0];
+		const repo = parts[1];
+		if (owner && repo) {
+			return { owner, repo };
+		}
+		return null;
+	}
+
+	/**
+	 * After a session completes, ensure the Cyrus PR marker is present
+	 * in any open PR created on the session's branch.
+	 */
+	private async ensurePrCyrusMarker(
+		session: import("cyrus-core").CyrusAgentSession,
+	): Promise<void> {
+		if (session.status !== "complete") return;
+
+		for (const repoCtx of session.repositories) {
+			if (!repoCtx.branchName) continue;
+
+			const repo = this.repositories.get(repoCtx.repositoryId);
+			if (!repo?.githubUrl) continue;
+
+			const parsed = this.parseGitHubUrl(repo.githubUrl);
+			if (!parsed) continue;
+
+			const token = await this.resolveGitHubTokenForApi();
+			if (!token) {
+				this.logger.debug("No GitHub token available to check PR marker");
+				return;
+			}
+
+			try {
+				const added = await this.gitHubCommentService.ensureCyrusMarker({
+					token,
+					owner: parsed.owner,
+					repo: parsed.repo,
+					branch: repoCtx.branchName,
+				});
+				if (added) {
+					this.logger.info(
+						`Added Cyrus PR marker to ${parsed.owner}/${parsed.repo} branch ${repoCtx.branchName}`,
+					);
+				}
+			} catch (err) {
+				this.logger.warn(
+					`Failed to ensure Cyrus PR marker on ${parsed.owner}/${parsed.repo}: ${err instanceof Error ? err.message : err}`,
+				);
+			}
+		}
 	}
 
 	private async handleGitHubWebhook(event: GitHubWebhookEvent): Promise<void> {

--- a/packages/github-event-transport/src/GitHubCommentService.ts
+++ b/packages/github-event-transport/src/GitHubCommentService.ts
@@ -71,6 +71,9 @@ export interface AddReactionParams {
 	content: string;
 }
 
+/** The hidden HTML comment used to identify Cyrus-authored PRs */
+export const CYRUS_PR_MARKER = "<!-- generated-by-cyrus -->";
+
 export class GitHubCommentService {
 	private apiBaseUrl: string;
 
@@ -180,5 +183,109 @@ export class GitHubCommentService {
 				`[GitHubCommentService] Failed to add reaction: ${response.status} ${response.statusText} - ${errorBody}`,
 			);
 		}
+	}
+
+	/**
+	 * Find an open pull request for a given head branch.
+	 *
+	 * @see https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
+	 */
+	async findPullRequestByBranch(params: {
+		token: string;
+		owner: string;
+		repo: string;
+		branch: string;
+	}): Promise<{ number: number; body: string | null } | null> {
+		const { token, owner, repo, branch } = params;
+		const url = `${this.apiBaseUrl}/repos/${owner}/${repo}/pulls?head=${encodeURIComponent(`${owner}:${branch}`)}&state=open&per_page=1`;
+
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+
+		if (!response.ok) {
+			const errorBody = await response.text();
+			throw new Error(
+				`[GitHubCommentService] Failed to list PRs: ${response.status} ${response.statusText} - ${errorBody}`,
+			);
+		}
+
+		const prs = (await response.json()) as Array<{
+			number: number;
+			body: string | null;
+		}>;
+		return prs[0] ?? null;
+	}
+
+	/**
+	 * Update a pull request body.
+	 *
+	 * @see https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request
+	 */
+	async updatePullRequestBody(params: {
+		token: string;
+		owner: string;
+		repo: string;
+		pullNumber: number;
+		body: string;
+	}): Promise<void> {
+		const { token, owner, repo, pullNumber, body } = params;
+		const url = `${this.apiBaseUrl}/repos/${owner}/${repo}/pulls/${pullNumber}`;
+
+		const response = await fetch(url, {
+			method: "PATCH",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"Content-Type": "application/json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			body: JSON.stringify({ body }),
+		});
+
+		if (!response.ok) {
+			const errorBody = await response.text();
+			throw new Error(
+				`[GitHubCommentService] Failed to update PR body: ${response.status} ${response.statusText} - ${errorBody}`,
+			);
+		}
+	}
+
+	/**
+	 * Ensure the Cyrus attribution marker is present in a PR body.
+	 * If the PR exists and the marker is missing, appends it.
+	 *
+	 * @returns true if the marker was added, false if already present or no PR found
+	 */
+	async ensureCyrusMarker(params: {
+		token: string;
+		owner: string;
+		repo: string;
+		branch: string;
+	}): Promise<boolean> {
+		const pr = await this.findPullRequestByBranch(params);
+		if (!pr) return false;
+
+		const body = pr.body ?? "";
+		if (body.includes(CYRUS_PR_MARKER)) return false;
+
+		const updatedBody = body.trim()
+			? `${body}\n\n${CYRUS_PR_MARKER}`
+			: CYRUS_PR_MARKER;
+
+		await this.updatePullRequestBody({
+			token: params.token,
+			owner: params.owner,
+			repo: params.repo,
+			pullNumber: pr.number,
+			body: updatedBody,
+		});
+
+		return true;
 	}
 }

--- a/packages/github-event-transport/src/index.ts
+++ b/packages/github-event-transport/src/index.ts
@@ -10,7 +10,10 @@ export type {
 	PostCommentParams,
 	PostReviewCommentReplyParams,
 } from "./GitHubCommentService.js";
-export { GitHubCommentService } from "./GitHubCommentService.js";
+export {
+	CYRUS_PR_MARKER,
+	GitHubCommentService,
+} from "./GitHubCommentService.js";
 export { GitHubEventTransport } from "./GitHubEventTransport.js";
 export { GitHubMessageTranslator } from "./GitHubMessageTranslator.js";
 export {

--- a/packages/github-event-transport/test/GitHubCommentService.test.ts
+++ b/packages/github-event-transport/test/GitHubCommentService.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GitHubCommentService } from "../src/GitHubCommentService.js";
+import {
+	CYRUS_PR_MARKER,
+	GitHubCommentService,
+} from "../src/GitHubCommentService.js";
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -295,6 +298,197 @@ describe("GitHubCommentService", () => {
 			).rejects.toThrow(
 				"[GitHubCommentService] Failed to post review comment reply: 404 Not Found",
 			);
+		});
+	});
+
+	describe("findPullRequestByBranch", () => {
+		it("returns the first open PR for the branch", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [
+					{ number: 42, body: "PR description" },
+					{ number: 43, body: "Another PR" },
+				],
+			});
+
+			const result = await service.findPullRequestByBranch({
+				token: "ghp_test123",
+				owner: "testorg",
+				repo: "my-repo",
+				branch: "feature/test",
+			});
+
+			expect(result).toEqual({ number: 42, body: "PR description" });
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://api.github.com/repos/testorg/my-repo/pulls?head=testorg%3Afeature%2Ftest&state=open&per_page=1",
+				{
+					method: "GET",
+					headers: {
+						Authorization: "Bearer ghp_test123",
+						Accept: "application/vnd.github+json",
+						"X-GitHub-Api-Version": "2022-11-28",
+					},
+				},
+			);
+		});
+
+		it("returns null when no PR exists", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [],
+			});
+
+			const result = await service.findPullRequestByBranch({
+				token: "ghp_test123",
+				owner: "testorg",
+				repo: "my-repo",
+				branch: "no-pr-branch",
+			});
+
+			expect(result).toBeNull();
+		});
+
+		it("throws on API error", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				statusText: "Unauthorized",
+				text: async () => '{"message":"Bad credentials"}',
+			});
+
+			await expect(
+				service.findPullRequestByBranch({
+					token: "bad-token",
+					owner: "testorg",
+					repo: "my-repo",
+					branch: "feature/test",
+				}),
+			).rejects.toThrow(
+				"[GitHubCommentService] Failed to list PRs: 401 Unauthorized",
+			);
+		});
+	});
+
+	describe("updatePullRequestBody", () => {
+		it("updates the PR body via PATCH", async () => {
+			mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+			await service.updatePullRequestBody({
+				token: "ghp_test123",
+				owner: "testorg",
+				repo: "my-repo",
+				pullNumber: 42,
+				body: "Updated body",
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://api.github.com/repos/testorg/my-repo/pulls/42",
+				{
+					method: "PATCH",
+					headers: {
+						Authorization: "Bearer ghp_test123",
+						Accept: "application/vnd.github+json",
+						"Content-Type": "application/json",
+						"X-GitHub-Api-Version": "2022-11-28",
+					},
+					body: JSON.stringify({ body: "Updated body" }),
+				},
+			);
+		});
+
+		it("throws on API error", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 422,
+				statusText: "Unprocessable Entity",
+				text: async () => '{"message":"Validation failed"}',
+			});
+
+			await expect(
+				service.updatePullRequestBody({
+					token: "ghp_test123",
+					owner: "testorg",
+					repo: "my-repo",
+					pullNumber: 42,
+					body: "body",
+				}),
+			).rejects.toThrow(
+				"[GitHubCommentService] Failed to update PR body: 422 Unprocessable Entity",
+			);
+		});
+	});
+
+	describe("ensureCyrusMarker", () => {
+		const baseParams = {
+			token: "ghp_test123",
+			owner: "testorg",
+			repo: "my-repo",
+			branch: "feature/test",
+		};
+
+		it("adds marker when PR exists and marker is missing", async () => {
+			// findPullRequestByBranch
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [{ number: 42, body: "Some PR description" }],
+			});
+			// updatePullRequestBody
+			mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+			const result = await service.ensureCyrusMarker(baseParams);
+
+			expect(result).toBe(true);
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+			// Verify the update call includes the marker
+			const updateCall = mockFetch.mock.calls[1];
+			const updateBody = JSON.parse(updateCall[1].body);
+			expect(updateBody.body).toContain(CYRUS_PR_MARKER);
+			expect(updateBody.body).toContain("Some PR description");
+		});
+
+		it("returns false when marker already present", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [
+					{
+						number: 42,
+						body: `Description\n\n${CYRUS_PR_MARKER}`,
+					},
+				],
+			});
+
+			const result = await service.ensureCyrusMarker(baseParams);
+
+			expect(result).toBe(false);
+			// Should only call findPullRequestByBranch, not updatePullRequestBody
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns false when no PR exists", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [],
+			});
+
+			const result = await service.ensureCyrusMarker(baseParams);
+
+			expect(result).toBe(false);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("handles PR with null body", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => [{ number: 42, body: null }],
+			});
+			mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+			const result = await service.ensureCyrusMarker(baseParams);
+
+			expect(result).toBe(true);
+			const updateCall = mockFetch.mock.calls[1];
+			const updateBody = JSON.parse(updateCall[1].body);
+			expect(updateBody.body).toBe(CYRUS_PR_MARKER);
 		});
 	});
 });


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

The `<!-- generated-by-cyrus -->` hidden HTML comment is supposed to appear in every PR created by Cyrus, but it was previously enforced only by prompt instructions in the `verify-and-ship` skill. When Claude didn't follow the instruction (as happened in ceedaragents/cyrus-hosted#638), the marker was missing entirely.

This PR adds a programmatic fallback:

- **`GitHubCommentService`** — New methods: `findPullRequestByBranch()`, `updatePullRequestBody()`, and `ensureCyrusMarker()` for checking and appending the marker via the GitHub API
- **`EdgeWorker`** — Listens for `sessionCompleted` events on the `GlobalSessionRegistry`. After any session completes, checks if an open PR exists on the session's branch and appends the marker if missing
- **9 new tests** covering the PR marker API methods (`findPullRequestByBranch`, `updatePullRequestBody`, `ensureCyrusMarker`)

The prompt-based instruction remains in `verify-and-ship/SKILL.md` as the primary mechanism. The new code acts as a safety net that fires after every session completion.

## Test plan

- [x] All 126 github-event-transport tests pass (was 98, added 9 for new methods + pre-existing GitHubEventTransport suite now resolves)
- [x] All 566 edge-worker tests pass
- [x] Full monorepo build succeeds
- [x] Biome lint/format clean
- [x] TypeScript typecheck passes

Resolves [CYPACK-1082](https://linear.app/ceedar/issue/CYPACK-1082/fix-the-github-pr-id-ing-issue)

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->