### PR TITLE
fix: use actual workspace path in working directory context (CYPACK-1088)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Removed `config: EdgeWorkerConfig` dependency from `PromptBuilder` — it was only used to check `handlers?.createWorkspace` for the working directory placeholder. Working directory is now passed explicitly via `workspaceRepoPaths` parameter through `buildIssueContextPrompt` → `buildIssueContextForPromptAssembly` → `buildNewSessionPrompt`. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088))
+
 ## [0.2.45] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Changed
-- Removed `config: EdgeWorkerConfig` dependency from `PromptBuilder` — it was only used to check `handlers?.createWorkspace` for the working directory placeholder. Working directory is now passed explicitly via `workspaceRepoPaths` parameter through `buildIssueContextPrompt` → `buildIssueContextForPromptAssembly` → `buildNewSessionPrompt`. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088))
+- Removed `config: EdgeWorkerConfig` dependency from `PromptBuilder` — it was only used to check `handlers?.createWorkspace` for the working directory placeholder. Working directory is now passed explicitly via `workspaceRepoPaths` parameter through `buildIssueContextPrompt` → `buildIssueContextForPromptAssembly` → `buildNewSessionPrompt`. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088), [#1110](https://github.com/ceedaragents/cyrus/pull/1110))
 
 ## [0.2.45] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Working directory context now shows actual path** — The `<working_directory>` in agent session prompts previously showed "Will be created based on issue" instead of the actual worktree path. It now correctly displays the real workspace directory. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088))
+
 ## [0.2.45] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Working directory context now shows actual path** — The `<working_directory>` in agent session prompts previously showed "Will be created based on issue" instead of the actual worktree path. It now correctly displays the real workspace directory. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088))
+- **Working directory context now shows actual path** — The `<working_directory>` in agent session prompts previously showed "Will be created based on issue" instead of the actual worktree path. It now correctly displays the real workspace directory. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088), [#1110](https://github.com/ceedaragents/cyrus/pull/1110))
 
 ## [0.2.45] - 2026-04-15
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -486,7 +486,6 @@ export class EdgeWorker extends EventEmitter {
 			repositories: this.repositories,
 			issueTrackers: this.issueTrackers,
 			gitService: this.gitService,
-			config: this.config,
 		});
 		this.defaultSkillsDeployer = new DefaultSkillsDeployer(
 			this.cyrusHome,
@@ -5258,6 +5257,14 @@ ${taskSection}`;
 			input,
 			!!labelBasedSystemPrompt,
 		);
+		// Build workspace repo paths map for prompt context.
+		// For multi-repo sessions, workspace.repoPaths maps each repo ID to its worktree.
+		// For single-repo sessions, use workspace.path as the worktree for the primary repo.
+		const workspaceRepoPaths =
+			input.session.workspace.repoPaths ??
+			(repositories.length === 1
+				? { [repositories[0]!.id]: input.session.workspace.path }
+				: undefined);
 		const issueContext = await this.buildIssueContextForPromptAssembly(
 			input.fullIssue,
 			repositories,
@@ -5266,6 +5273,7 @@ ${taskSection}`;
 			input.guidance,
 			input.agentSession,
 			input.resolvedBaseBranches,
+			workspaceRepoPaths,
 		);
 
 		parts.push(issueContext.prompt);
@@ -5410,6 +5418,7 @@ ${input.userComment}
 		guidance?: GuidanceRule[],
 		agentSession?: WebhookAgentSession,
 		resolvedBaseBranches?: Record<string, BaseBranchResolution>,
+		workspaceRepoPaths?: Record<string, string>,
 	): Promise<IssueContextResult> {
 		// Delegate to appropriate builder based on promptType
 		if (promptType === "mention") {
@@ -5445,6 +5454,7 @@ ${input.userComment}
 			attachmentManifest,
 			guidance,
 			resolvedBaseBranches,
+			workspaceRepoPaths,
 		);
 	}
 

--- a/packages/edge-worker/src/PromptBuilder.ts
+++ b/packages/edge-worker/src/PromptBuilder.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 import {
 	type BaseBranchResolution,
 	type Comment,
-	type EdgeWorkerConfig,
 	type GuidanceRule,
 	type IIssueTrackerService,
 	type ILogger,
@@ -25,7 +24,6 @@ export interface PromptBuilderDeps {
 	repositories: Map<string, RepositoryConfig>;
 	issueTrackers: Map<string, IIssueTrackerService>;
 	gitService: GitService;
-	config: EdgeWorkerConfig;
 }
 
 /**
@@ -62,14 +60,12 @@ export class PromptBuilder {
 	private readonly repositories: Map<string, RepositoryConfig>;
 	private readonly issueTrackers: Map<string, IIssueTrackerService>;
 	private readonly gitService: GitService;
-	private readonly config: EdgeWorkerConfig;
 
 	constructor(deps: PromptBuilderDeps) {
 		this.logger = deps.logger;
 		this.repositories = deps.repositories;
 		this.issueTrackers = deps.issueTrackers;
 		this.gitService = deps.gitService;
-		this.config = deps.config;
 	}
 
 	// ========================================================================
@@ -758,6 +754,7 @@ Focus on addressing the specific request in the mention. You can use the Linear 
 		attachmentManifest: string = "",
 		guidance?: GuidanceRule[],
 		resolvedBaseBranches?: Record<string, BaseBranchResolution>,
+		workspaceRepoPaths?: Record<string, string>,
 	): Promise<PromptResult> {
 		const repository = repositories[0]!;
 		this.logger.debug(
@@ -871,9 +868,7 @@ Focus on addressing the specific request in the mention. You can use the Linear 
 				.replace(/{{comment_threads}}/g, commentThreads)
 				.replace(
 					/{{working_directory}}/g,
-					this.config.handlers?.createWorkspace
-						? "Will be created based on issue"
-						: repository.repositoryPath,
+					workspaceRepoPaths?.[repository.id] ?? repository.repositoryPath,
 				)
 				.replace(/{{base_branch}}/g, baseBranch)
 				.replace(
@@ -894,9 +889,8 @@ Focus on addressing the specific request in the mention. You can use the Linear 
 				const repoSections = repositories
 					.map((repo) => {
 						const repoBranch = baseBranchMap.get(repo.id) ?? repo.baseBranch;
-						const workingDir = this.config.handlers?.createWorkspace
-							? "Will be created based on issue"
-							: repo.repositoryPath;
+						const workingDir =
+							workspaceRepoPaths?.[repo.id] ?? repo.repositoryPath;
 						return `  <repository name="${repo.name}">\n    <working_directory>${workingDir}</working_directory>\n    <base_branch>${repoBranch}</base_branch>\n  </repository>`;
 					})
 					.join("\n");

--- a/packages/edge-worker/test/prompt-assembly.component-order.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.component-order.test.ts
@@ -13,7 +13,7 @@ describe("Prompt Assembly - Component Order", () => {
 
 		const session = {
 			issueId: "c3d4e5f6-a7b8-9012-cdef-123456789012",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 

--- a/packages/edge-worker/test/prompt-assembly.multi-repo.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.multi-repo.test.ts
@@ -106,7 +106,7 @@ No comments yet.
 
 			const session = {
 				issueId: "solo-issue-uuid",
-				workspace: { path: "/test" },
+				workspace: { path: "/test/solo" },
 				metadata: {},
 			};
 

--- a/packages/edge-worker/test/prompt-assembly.multi-repo.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.multi-repo.test.ts
@@ -91,6 +91,161 @@ No comments yet.
 		});
 	});
 
+	describe("workspace repoPaths overrides repositoryPath", () => {
+		it("should use worktree paths from session workspace instead of repository source paths", async () => {
+			const repoA = {
+				id: "repo-a-uuid",
+				name: "frontend-app",
+				repositoryPath: "/repos/frontend",
+				baseBranch: "main",
+				linearWorkspaceId: "ws-1",
+				workspaceBaseDir: "/test/workspaces",
+			};
+			const repoB = {
+				id: "repo-b-uuid",
+				name: "backend-api",
+				repositoryPath: "/repos/backend",
+				baseBranch: "develop",
+				linearWorkspaceId: "ws-1",
+				workspaceBaseDir: "/test/workspaces",
+			};
+
+			const worker = createTestWorker([repoA, repoB]);
+
+			// Session with repoPaths set — simulates real multi-repo worktree creation
+			const session = {
+				issueId: "worktree-issue-uuid",
+				workspace: {
+					path: "/worktrees/CEE-300",
+					repoPaths: {
+						"repo-a-uuid": "/worktrees/CEE-300/frontend-app",
+						"repo-b-uuid": "/worktrees/CEE-300/backend-api",
+					},
+				},
+				metadata: {},
+			};
+
+			const issue = {
+				id: "worktree-issue-uuid",
+				identifier: "CEE-300",
+				title: "Multi-repo worktree test",
+				description: "Tests worktree paths",
+			};
+
+			await scenario(worker)
+				.newSession()
+				.assignmentBased()
+				.withSession(session)
+				.withIssue(issue)
+				.withRepositories([repoA, repoB])
+				.withUserComment("")
+				.withLabels()
+				.expectUserPrompt(`<repositories>
+  <repository name="frontend-app">
+    <working_directory>/worktrees/CEE-300/frontend-app</working_directory>
+    <base_branch>main</base_branch>
+  </repository>
+  <repository name="backend-api">
+    <working_directory>/worktrees/CEE-300/backend-api</working_directory>
+    <base_branch>develop</base_branch>
+  </repository>
+</repositories>
+
+<linear_issue>
+  <id>worktree-issue-uuid</id>
+  <identifier>CEE-300</identifier>
+  <title>Multi-repo worktree test</title>
+  <description>
+Tests worktree paths
+  </description>
+  <state>Unknown</state>
+  <priority>None</priority>
+  <url></url>
+  <assignee>
+    <linear_display_name></linear_display_name>
+    <linear_profile_url></linear_profile_url>
+    <github_username></github_username>
+    <github_user_id></github_user_id>
+    <github_noreply_email></github_noreply_email>
+  </assignee>
+</linear_issue>
+
+<linear_comments>
+No comments yet.
+</linear_comments>`)
+				.expectPromptType("fallback")
+				.expectComponents("issue-context")
+				.verify();
+		});
+
+		it("single repo should use workspace.path as working directory", async () => {
+			const repo = {
+				id: "single-repo-uuid",
+				name: "my-app",
+				repositoryPath: "/repos/my-app",
+				baseBranch: "main",
+				linearWorkspaceId: "ws-1",
+				workspaceBaseDir: "/test/workspaces",
+			};
+
+			const worker = createTestWorker([repo]);
+
+			// Single repo: workspace.path is the worktree, no repoPaths
+			const session = {
+				issueId: "single-wt-uuid",
+				workspace: { path: "/worktrees/CEE-400" },
+				metadata: {},
+			};
+
+			const issue = {
+				id: "single-wt-uuid",
+				identifier: "CEE-400",
+				title: "Single repo worktree test",
+				description: "Tests single-repo worktree path",
+			};
+
+			await scenario(worker)
+				.newSession()
+				.assignmentBased()
+				.withSession(session)
+				.withIssue(issue)
+				.withRepositories([repo])
+				.withUserComment("")
+				.withLabels()
+				.expectUserPrompt(`<context>
+  <repository>my-app</repository>
+  <working_directory>/worktrees/CEE-400</working_directory>
+  <base_branch>main</base_branch>
+</context>
+
+<linear_issue>
+  <id>single-wt-uuid</id>
+  <identifier>CEE-400</identifier>
+  <title>Single repo worktree test</title>
+  <description>
+Tests single-repo worktree path
+  </description>
+  <state>Unknown</state>
+  <priority>None</priority>
+  <url></url>
+  <assignee>
+    <linear_display_name></linear_display_name>
+    <linear_profile_url></linear_profile_url>
+    <github_username></github_username>
+    <github_user_id></github_user_id>
+    <github_noreply_email></github_noreply_email>
+  </assignee>
+</linear_issue>
+
+<linear_comments>
+No comments yet.
+</linear_comments>`)
+				.expectPromptType("fallback")
+				.expectComponents("issue-context")
+				.verify();
+		});
+	});
+
 	describe("single repo backward compat", () => {
 		it("should produce single-repo context section when only 1 repo in array", async () => {
 			const repo = {

--- a/packages/edge-worker/test/prompt-assembly.new-comment-metadata.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.new-comment-metadata.test.ts
@@ -18,7 +18,7 @@ describe("Prompt Assembly - New Comment Metadata in Agent Sessions", () => {
 		// Create test data for an agent session with comment metadata
 		const session = {
 			issueId: "test-issue-123",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 
@@ -112,7 +112,7 @@ Focus on addressing the specific request in the mention. You can use the Linear 
 
 		const session = {
 			issueId: "test-issue-456",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 

--- a/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
@@ -14,7 +14,7 @@ describe("Prompt Assembly - New Sessions", () => {
 		// Create minimal test data
 		const session = {
 			issueId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 
@@ -105,7 +105,7 @@ Analyze the issue description, labels, and any user comments to determine which 
 		// Create minimal test data
 		const session = {
 			issueId: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 

--- a/packages/edge-worker/test/prompt-assembly.system-prompt-behavior.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.system-prompt-behavior.test.ts
@@ -13,7 +13,7 @@ describe("Prompt Assembly - System Prompt Behavior", () => {
 
 		const session = {
 			issueId: "d4e5f6a7-b8c9-0123-def1-234567890123",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 
@@ -96,7 +96,7 @@ No comments yet.
 
 		const session = {
 			issueId: "e5f6a7b8-c9d0-1234-ef12-345678901234",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 
@@ -187,7 +187,7 @@ Build the payment integration
 
 		const session = {
 			issueId: "f6a7b8c9-d0e1-2345-f012-345678901234",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 
@@ -279,7 +279,7 @@ Orchestrate this task
 
 		const session = {
 			issueId: "a7b8c9d0-e1f2-3456-0123-456789abcdef",
-			workspace: { path: "/test" },
+			workspace: { path: "/test/repo" },
 			metadata: {},
 		};
 


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- The `<working_directory>` in agent session prompts previously showed the placeholder text "Will be created based on issue" instead of the real worktree path, because `PromptBuilder` checked for the existence of a `createWorkspace` handler rather than using the actual workspace path
- Now passes workspace repo paths from the session through `buildIssueContextForPromptAssembly` → `buildIssueContextPrompt`, so the prompt always contains the real directory
- Removes the now-unused `EdgeWorkerConfig` dependency from `PromptBuilder`

## Test plan

- [x] All 566 edge-worker tests pass (updated 5 prompt-assembly test files to use correct workspace paths)
- [x] Build passes clean
- [x] TypeScript typecheck passes
- [x] Lint passes (biome)

Closes [CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->