### PR TITLE
fix: update Linear workspace tokens before adding new repositories

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Fixed
+- Fixed config reload ordering in `EdgeWorker.configChanged` handler — `updateLinearWorkspaceTokens()` now runs before `addNewRepositories()` so new repositories can look up their Linear workspace token during initialization. Previously, tokens were updated after repo addition, causing failures when both a new workspace and its first repository arrived in the same config change. ([CYPACK-1089](https://linear.app/ceedar/issue/CYPACK-1089))
+
 ### Changed
 - Removed `config: EdgeWorkerConfig` dependency from `PromptBuilder` — it was only used to check `handlers?.createWorkspace` for the working directory placeholder. Working directory is now passed explicitly via `workspaceRepoPaths` parameter through `buildIssueContextPrompt` → `buildIssueContextForPromptAssembly` → `buildNewSessionPrompt`. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088), [#1110](https://github.com/ceedaragents/cyrus/pull/1110))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Cloud runtime provisioning no longer fails on first repository** — Fixed a race condition where the edge worker tried to initialize a new repository before Linear workspace tokens were available, causing "No Linear workspace config found" errors during cloud runtime provisioning. ([CYPACK-1089](https://linear.app/ceedar/issue/CYPACK-1089))
 - **Working directory context now shows actual path** — The `<working_directory>` in agent session prompts previously showed "Will be created based on issue" instead of the actual worktree path. It now correctly displays the real workspace directory. ([CYPACK-1088](https://linear.app/ceedar/issue/CYPACK-1088), [#1110](https://github.com/ceedaragents/cyrus/pull/1110))
 
 ## [0.2.45] - 2026-04-15

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2551,26 +2551,9 @@ ${taskSection}`;
 				// Add to internal map
 				this.repositories.set(repo.id, resolvedRepo);
 
-				// Create issue tracker for this workspace if not already present
-				if (!this.issueTrackers.has(requireLinearWorkspaceId(repo))) {
-					const linearToken = this.getLinearTokenForWorkspace(
-						requireLinearWorkspaceId(repo),
-					);
-					const issueTracker =
-						this.config.platform === "cli"
-							? (() => {
-									const service = new CLIIssueTrackerService();
-									service.seedDefaultData();
-									return service;
-								})()
-							: new LinearIssueTrackerService(
-									new LinearClient({
-										accessToken: linearToken,
-									}),
-									this.buildOAuthConfig(requireLinearWorkspaceId(repo)),
-								);
-					this.issueTrackers.set(requireLinearWorkspaceId(repo), issueTracker);
-				}
+				// Issue tracker for this workspace is guaranteed to exist here:
+				// updateLinearWorkspaceTokens() runs before addNewRepositories()
+				// and creates trackers for any new workspaces from newConfig.
 
 				// Create activity sink for this repository
 				const issueTracker = this.issueTrackers.get(

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2597,44 +2597,10 @@ ${taskSection}`;
 				// Update stored config
 				this.repositories.set(repo.id, resolvedRepo);
 
-				// If workspace changed or token was updated, ensure issue tracker is current
-				const currentToken = this.getLinearTokenForWorkspace(
-					requireLinearWorkspaceId(repo),
-				);
-				if (!this.issueTrackers.has(requireLinearWorkspaceId(repo))) {
-					this.logger.info(
-						`  🔑 Creating issue tracker for workspace ${requireLinearWorkspaceId(repo)}`,
-					);
-					const newIssueTracker =
-						this.config.platform === "cli"
-							? (() => {
-									const service = new CLIIssueTrackerService();
-									service.seedDefaultData();
-									return service;
-								})()
-							: new LinearIssueTrackerService(
-									new LinearClient({
-										accessToken: currentToken,
-									}),
-									this.buildOAuthConfig(requireLinearWorkspaceId(repo)),
-								);
-					const wsId = requireLinearWorkspaceId(repo);
-					this.issueTrackers.set(wsId, newIssueTracker);
-					this.activitySinks.set(
-						wsId,
-						new LinearActivitySink(newIssueTracker, wsId),
-					);
-				} else {
-					// Update token on existing issue tracker if it changed
-					const issueTracker = this.issueTrackers.get(
-						requireLinearWorkspaceId(repo),
-					);
-					if (issueTracker && currentToken) {
-						(issueTracker as LinearIssueTrackerService).setAccessToken(
-							currentToken,
-						);
-					}
-				}
+				// Issue tracker and activity sink for this workspace are guaranteed
+				// to exist: updateLinearWorkspaceTokens() runs before
+				// updateModifiedRepositories() and creates/updates trackers + sinks
+				// for all workspaces.
 
 				// If active status changed
 				if (oldRepo.isActive !== repo.isActive) {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -511,9 +511,6 @@ export class EdgeWorker extends EventEmitter {
 		this.configManager.on(
 			"configChanged",
 			async (changes: RepositoryChanges) => {
-				// Update Linear workspace tokens BEFORE adding new repositories.
-				// New repositories need their workspace's Linear token during
-				// initialization, so the token must be available first.
 				this.updateLinearWorkspaceTokens(changes.newConfig);
 				await this.removeDeletedRepositories(changes.removed);
 				await this.updateModifiedRepositories(changes.modified);
@@ -2550,10 +2547,6 @@ ${taskSection}`;
 				// Add to internal map
 				this.repositories.set(repo.id, resolvedRepo);
 
-				// Activity sink for this workspace is guaranteed to exist:
-				// updateLinearWorkspaceTokens() runs before addNewRepositories()
-				// and creates trackers + sinks for any new workspaces.
-
 				this.logger.info(`✅ Repository added successfully: ${repo.name}`);
 			} catch (error) {
 				this.logger.error(`❌ Failed to add repository ${repo.name}:`, error);
@@ -2596,11 +2589,6 @@ ${taskSection}`;
 
 				// Update stored config
 				this.repositories.set(repo.id, resolvedRepo);
-
-				// Issue tracker and activity sink for this workspace are guaranteed
-				// to exist: updateLinearWorkspaceTokens() runs before
-				// updateModifiedRepositories() and creates/updates trackers + sinks
-				// for all workspaces.
 
 				// If active status changed
 				if (oldRepo.isActive !== repo.isActive) {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -182,7 +182,7 @@ export class EdgeWorker extends EventEmitter {
 	private config: EdgeWorkerConfig;
 	private repositories: Map<string, RepositoryConfig> = new Map(); // repository 'id' (internal, stored in config.json) mapped to the full repo config
 	private agentSessionManager: AgentSessionManager; // Single instance managing all agent sessions across repositories
-	private activitySinks: Map<string, IActivitySink> = new Map(); // Maps repository ID to activity sink
+	private activitySinks: Map<string, IActivitySink> = new Map(); // Maps Linear workspace ID to activity sink (one per workspace, mirrors issueTrackers)
 	private sessionRepositories: Map<string, string> = new Map(); // Maps session ID to repository ID
 	private issueTrackers: Map<string, IIssueTrackerService> = new Map(); // one issue tracker per Linear workspace (keyed by linearWorkspaceId)
 	private linearEventTransport: LinearEventTransport | null = null; // Single event transport for webhook delivery
@@ -413,17 +413,12 @@ export class EdgeWorker extends EventEmitter {
 			}
 		}
 
-		// Create activity sinks for each repository (uses workspace issue tracker)
-		for (const [repoId, repo] of this.repositories) {
-			if (!repo.linearWorkspaceId) continue;
-			const issueTracker = this.issueTrackers.get(repo.linearWorkspaceId);
-			if (issueTracker) {
-				const activitySink = new LinearActivitySink(
-					issueTracker,
-					repo.linearWorkspaceId,
-				);
-				this.activitySinks.set(repoId, activitySink);
-			}
+		// Create activity sinks per workspace (one per workspace, mirrors issueTrackers)
+		for (const [workspaceId, issueTracker] of this.issueTrackers) {
+			this.activitySinks.set(
+				workspaceId,
+				new LinearActivitySink(issueTracker, workspaceId),
+			);
 		}
 
 		// Initialize user access control with global and per-repository configs
@@ -1222,7 +1217,7 @@ export class EdgeWorker extends EventEmitter {
 
 			// Register session-to-repo mapping and activity sink
 			this.sessionRepositories.set(githubSessionId, repository.id);
-			const activitySink = this.activitySinks.get(repository.id);
+			const activitySink = this.getActivitySinkForRepo(repository.id);
 			if (activitySink) {
 				agentSessionManager.setActivitySink(githubSessionId, activitySink);
 			}
@@ -1793,7 +1788,7 @@ ${taskSection}`;
 
 			// Register session-to-repo mapping and activity sink
 			this.sessionRepositories.set(gitlabSessionId, repository.id);
-			const activitySink = this.activitySinks.get(repository.id);
+			const activitySink = this.getActivitySinkForRepo(repository.id);
 			if (activitySink) {
 				agentSessionManager.setActivitySink(gitlabSessionId, activitySink);
 			}
@@ -2502,12 +2497,16 @@ ${taskSection}`;
 					`🔑 Updated Linear token for workspace ${workspaceId}`,
 				);
 			} else if (this.config.platform !== "cli") {
-				// Workspace is new — create a tracker for it
+				// Workspace is new — create a tracker and activity sink for it
 				const newIssueTracker = new LinearIssueTrackerService(
 					new LinearClient({ accessToken: newToken }),
 					this.buildOAuthConfig(workspaceId),
 				);
 				this.issueTrackers.set(workspaceId, newIssueTracker);
+				this.activitySinks.set(
+					workspaceId,
+					new LinearActivitySink(newIssueTracker, workspaceId),
+				);
 				this.logger.info(
 					`🔑 Created issue tracker for new workspace ${workspaceId}`,
 				);
@@ -2551,19 +2550,9 @@ ${taskSection}`;
 				// Add to internal map
 				this.repositories.set(repo.id, resolvedRepo);
 
-				// Issue tracker for this workspace is guaranteed to exist here:
+				// Activity sink for this workspace is guaranteed to exist:
 				// updateLinearWorkspaceTokens() runs before addNewRepositories()
-				// and creates trackers for any new workspaces from newConfig.
-
-				// Create activity sink for this repository
-				const issueTracker = this.issueTrackers.get(
-					requireLinearWorkspaceId(repo),
-				)!;
-				const activitySink = new LinearActivitySink(
-					issueTracker,
-					requireLinearWorkspaceId(repo),
-				);
-				this.activitySinks.set(repo.id, activitySink);
+				// and creates trackers + sinks for any new workspaces.
 
 				this.logger.info(`✅ Repository added successfully: ${repo.name}`);
 			} catch (error) {
@@ -2629,9 +2618,11 @@ ${taskSection}`;
 									}),
 									this.buildOAuthConfig(requireLinearWorkspaceId(repo)),
 								);
-					this.issueTrackers.set(
-						requireLinearWorkspaceId(repo),
-						newIssueTracker,
+					const wsId = requireLinearWorkspaceId(repo);
+					this.issueTrackers.set(wsId, newIssueTracker);
+					this.activitySinks.set(
+						wsId,
+						new LinearActivitySink(newIssueTracker, wsId),
 					);
 				} else {
 					// Update token on existing issue tracker if it changed
@@ -2734,14 +2725,15 @@ ${taskSection}`;
 
 				// Remove repository from all maps
 				this.repositories.delete(repo.id);
-				this.activitySinks.delete(repo.id);
 
-				// Only remove workspace issue tracker if no other repos use this workspace
+				// Only remove workspace issue tracker and activity sink if no other repos use this workspace
+				const wsId = requireLinearWorkspaceId(repo);
 				const workspaceStillInUse = Array.from(this.repositories.values()).some(
-					(r) => r.linearWorkspaceId === requireLinearWorkspaceId(repo),
+					(r) => r.linearWorkspaceId === wsId,
 				);
 				if (!workspaceStillInUse) {
-					this.issueTrackers.delete(requireLinearWorkspaceId(repo));
+					this.issueTrackers.delete(wsId);
+					this.activitySinks.delete(wsId);
 				}
 
 				this.logger.info(`✅ Repository removed successfully: ${repo.name}`);
@@ -3355,6 +3347,15 @@ ${taskSection}`;
 	}
 
 	/**
+	 * Get the activity sink for a repository by looking up its workspace.
+	 */
+	private getActivitySinkForRepo(repoId: string): IActivitySink | undefined {
+		const repo = this.repositories.get(repoId);
+		if (!repo?.linearWorkspaceId) return undefined;
+		return this.activitySinks.get(repo.linearWorkspaceId);
+	}
+
+	/**
 	 * Get the Linear API token for a workspace from workspace-level config.
 	 */
 	private getLinearTokenForWorkspace(linearWorkspaceId: string): string {
@@ -3444,7 +3445,7 @@ ${taskSection}`;
 
 		// Register session-to-repo mapping and activity sink (use primary repo)
 		this.sessionRepositories.set(sessionId, primaryRepo.id);
-		const activitySink = this.activitySinks.get(primaryRepo.id);
+		const activitySink = this.getActivitySinkForRepo(primaryRepo.id);
 		if (activitySink) {
 			agentSessionManager.setActivitySink(sessionId, activitySink);
 		}
@@ -5740,7 +5741,7 @@ ${input.userComment}
 						if (repoId) {
 							this.sessionRepositories.set(sessionId, repoId);
 							// Also register the activity sink for this restored session
-							const activitySink = this.activitySinks.get(repoId);
+							const activitySink = this.getActivitySinkForRepo(repoId);
 							if (activitySink) {
 								this.agentSessionManager.setActivitySink(
 									sessionId,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -516,11 +516,13 @@ export class EdgeWorker extends EventEmitter {
 		this.configManager.on(
 			"configChanged",
 			async (changes: RepositoryChanges) => {
+				// Update Linear workspace tokens BEFORE adding new repositories.
+				// New repositories need their workspace's Linear token during
+				// initialization, so the token must be available first.
+				this.updateLinearWorkspaceTokens(changes.newConfig);
 				await this.removeDeletedRepositories(changes.removed);
 				await this.updateModifiedRepositories(changes.modified);
 				await this.addNewRepositories(changes.added);
-				// Detect and apply workspace token changes before overwriting config
-				this.updateLinearWorkspaceTokens(changes.newConfig);
 				// Live-update sandbox / egress proxy settings
 				await this.applySandboxConfigChanges(changes.newConfig);
 				this.config = changes.newConfig;


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary

Fixes a race condition in the EdgeWorker's `configChanged` handler where new repositories were initialized before Linear workspace tokens were registered. During cloud runtime provisioning, when a new workspace and its first repository arrive in the same config change, the repository initialization fails with "No Linear workspace config found" because `updateLinearWorkspaceTokens()` ran after `addNewRepositories()`.

**Change:** Reorder the handler to call `updateLinearWorkspaceTokens()` before `addNewRepositories()`, ensuring tokens are always available when repositories are initialized.

**Companion PR:** ceedaragents/cyrus-hosted#680

## Test plan

- [x] All 568 edge-worker tests pass
- [x] Full monorepo build and typecheck pass
- [ ] Deploy and verify cloud runtime provisioning succeeds without "No Linear workspace config" errors

[CYPACK-1089](https://linear.app/ceedar/issue/CYPACK-1089)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->