### PR TITLE
fix: don't delete issue trackers and activity sinks when removing repositories

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Stopped deleting workspace-level issue trackers and activity sinks when removing repositories — they are keyed by workspace ID and may be needed by other repos in the same workspace or by repos about to be added in the same `configChanged` cycle. They are naturally replaced when workspace tokens are updated. ([CYPACK-1089](https://linear.app/ceedar/issue/CYPACK-1089))
+
 ## [0.2.46] - 2026-04-16
 
 ### Fixed

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2677,18 +2677,13 @@ ${taskSection}`;
 					}
 				}
 
-				// Remove repository from all maps
+				// Remove repository from the repositories map.
+				// Note: we intentionally do NOT remove workspace-level issue trackers
+				// or activity sinks here. They are keyed by workspace ID and may be
+				// needed by other repositories in the same workspace, or by new
+				// repositories about to be added in the same configChanged cycle.
+				// They will be naturally replaced when workspace tokens are updated.
 				this.repositories.delete(repo.id);
-
-				// Only remove workspace issue tracker and activity sink if no other repos use this workspace
-				const wsId = requireLinearWorkspaceId(repo);
-				const workspaceStillInUse = Array.from(this.repositories.values()).some(
-					(r) => r.linearWorkspaceId === wsId,
-				);
-				if (!workspaceStillInUse) {
-					this.issueTrackers.delete(wsId);
-					this.activitySinks.delete(wsId);
-				}
 
 				this.logger.info(`✅ Repository removed successfully: ${repo.name}`);
 			} catch (error) {


### PR DESCRIPTION
## Summary
- Stops deleting workspace-level issue trackers and activity sinks when a repository is removed from config
- These resources are keyed by workspace ID and may be needed by other repositories in the same workspace, or by new repositories about to be added in the same `configChanged` cycle
- They are naturally replaced when workspace tokens are updated via `updateLinearWorkspaceTokens()`

Follow-up to #1112 (CYPACK-1089).

## Test plan
- [x] All 568 edge-worker tests pass
- [x] Typecheck passes
- [x] Build succeeds