### PR TITLE
chore: update @anthropic-ai/claude-agent-sdk to v0.2.112 (CYPACK-1093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.112** — Bumps the Claude Agent SDK to the latest version. See the [claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details. ([CYPACK-1093](https://linear.app/ceedar/issue/CYPACK-1093))
+
 ## [0.2.46] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.112** — Bumps the Claude Agent SDK to the latest version. See the [claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details. ([CYPACK-1093](https://linear.app/ceedar/issue/CYPACK-1093))
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.112** — Bumps the Claude Agent SDK to the latest version. See the [claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details. ([CYPACK-1093](https://linear.app/ceedar/issue/CYPACK-1093), [#1121](https://github.com/ceedaragents/cyrus/pull/1121))
 
 ## [0.2.46] - 2026-04-16
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.111",
+		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@anthropic-ai/sdk": "^0.90.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.111",
+		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.111",
+		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.111
-        version: 0.2.111(zod@4.3.6)
+        specifier: 0.2.112
+        version: 0.2.112(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: ^0.90.0
         version: 0.90.0(zod@4.3.6)
@@ -245,8 +245,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.111
-        version: 0.2.111(zod@4.3.6)
+        specifier: 0.2.112
+        version: 0.2.112(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0
@@ -514,8 +514,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.111
-        version: 0.2.111(zod@4.3.6)
+        specifier: 0.2.112
+        version: 0.2.112(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -558,8 +558,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.111':
-    resolution: {integrity: sha512-DwXyJpVL8JXB8L2toSw1by7uIt1p8hPGi0P+hqr5tL+Ae7DcK9O3tUd6XcGown3LZ49zNCUAIpqX3wDmOhqp0Q==}
+  '@anthropic-ai/claude-agent-sdk@0.2.112':
+    resolution: {integrity: sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
@@ -3745,7 +3745,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.111(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.112(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/claude-agent-sdk` from `0.2.111` to `0.2.112` in `packages/core`, `packages/claude-runner`, and `packages/simple-agent-runner`
- `@anthropic-ai/sdk` is already at `^0.90.0` (latest) — no change needed
- Tool allowance lists in `packages/claude-runner/src/config.ts` are already up to date (refreshed in CYPACK-1090 with LSP, ToolSearch, PushNotification)

See the [claude-agent-sdk changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full details on v0.2.112.

Closes [CYPACK-1093](https://linear.app/ceedar/issue/CYPACK-1093)

## Test plan
- [x] `pnpm install` succeeds and lockfile updated
- [x] Full monorepo build passes (`pnpm build`)
- [x] TypeScript typecheck passes (`pnpm typecheck`)