### PR TITLE
feat: gate warm Claude sessions behind CYRUS_ENABLE_WARM_SESSIONS (CYPACK-1116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Warm Claude sessions are now opt-in** — On startup, Cyrus no longer pre-spawns Claude Code subprocesses for the 30 most recent sessions by default. To restore the previous near-zero cold-start latency on the first message after a restart, set `CYRUS_ENABLE_WARM_SESSIONS=1` in the environment. ([CYPACK-1116](https://linear.app/ceedar/issue/CYPACK-1116))
 - **Improved `ToolSearch` presentation in Linear activities** — `ToolSearch` calls now post as a regular action entry (with an expandable result) instead of a bare thought. The parameter reads like "Loading tool schemas: `TaskCreate`, `TaskUpdate`" or "Searching tools for: `+linear get_issue`", and the expanded result shows the tools that were loaded (e.g. "Loaded tools: `TaskCreate`, `TaskUpdate`"). ([CYPACK-1112](https://linear.app/ceedar/issue/CYPACK-1112), [#1134](https://github.com/ceedaragents/cyrus/pull/1134))
 
 ### Fixed

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -519,10 +519,13 @@ export class EdgeWorker extends EventEmitter {
 		await this.loadPersistedState();
 
 		// Pre-warm the 30 most recent Claude sessions in the background
-		// so their first query after restart has near-zero cold-start latency
-		this.warmupRecentSessions(30).catch((err) => {
-			this.logger.warn("Session warmup failed (non-fatal):", err);
-		});
+		// so their first query after restart has near-zero cold-start latency.
+		// Disabled by default; opt in with CYRUS_ENABLE_WARM_SESSIONS=1.
+		if (this.isWarmSessionsEnabled()) {
+			this.warmupRecentSessions(30).catch((err) => {
+				this.logger.warn("Session warmup failed (non-fatal):", err);
+			});
+		}
 
 		// Start config file watcher via ConfigManager
 		this.configManager.on(
@@ -5501,8 +5504,9 @@ ${input.userComment}
 			requireLinearWorkspaceId,
 		});
 
-		// Attach pre-warmed session if available (only for Claude runner)
-		if (result.runnerType === "claude") {
+		// Attach pre-warmed session if available (only for Claude runner).
+		// Skipped entirely when warm sessions are not enabled.
+		if (result.runnerType === "claude" && this.isWarmSessionsEnabled()) {
 			const warmSession = this.warmInstances.get(sessionId);
 			if (warmSession) {
 				this.warmInstances.delete(sessionId);
@@ -5686,6 +5690,21 @@ ${input.userComment}
 	}
 
 	/**
+	 * Whether the warm-session feature is enabled.
+	 *
+	 * Warm sessions are an opt-in optimization that pre-spawns Claude Code
+	 * subprocesses on startup so the first query after a restart skips the
+	 * cold-start cost. Disabled by default; opt in by setting
+	 * `CYRUS_ENABLE_WARM_SESSIONS=1` (or `=true`).
+	 */
+	private isWarmSessionsEnabled(): boolean {
+		const raw = process.env.CYRUS_ENABLE_WARM_SESSIONS;
+		if (!raw) return false;
+		const v = raw.toLowerCase().trim();
+		return v === "1" || v === "true";
+	}
+
+	/**
 	 * Pre-warm the N most recently updated Claude sessions so the first query
 	 * after a CLI restart has near-zero cold-start latency (~20x faster).
 	 *
@@ -5693,6 +5712,8 @@ ${input.userComment}
 	 * so the warm instances are ready in ~500ms rather than ~4s.
 	 * Warm instances are stored in this.warmInstances keyed by agentSessionId and
 	 * consumed by buildAgentRunnerConfig() when the first message arrives.
+	 *
+	 * Gated by `isWarmSessionsEnabled()` — callers should check before invoking.
 	 */
 	private async warmupRecentSessions(count = 30): Promise<void> {
 		const allSessions = this.agentSessionManager.getAllSessions();


### PR DESCRIPTION
## Summary
- Pre-warming the 30 most recent Claude sessions on EdgeWorker startup is now opt-in. Set `CYRUS_ENABLE_WARM_SESSIONS=1` (or `=true`) to enable; without it, no warm subprocesses are spawned and no `warmInstances` are attached when the first message arrives.
- Adds a private `isWarmSessionsEnabled()` helper on `EdgeWorker` and gates both call sites: the startup `warmupRecentSessions(30)` invocation and the warm-instance attach in `buildAgentRunnerConfig()`.
- Linear: [CYPACK-1116](https://linear.app/ceedar/issue/CYPACK-1116)

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test:packages:run` (all 574 edge-worker tests pass; full monorepo green)
- [ ] Smoke: start CLI without the env var and confirm logs do not show "Pre-warming … Claude sessions"
- [ ] Smoke: start CLI with `CYRUS_ENABLE_WARM_SESSIONS=1` and confirm pre-warm logs appear and the first message after restart attaches a warm session