### PR TITLE
feat: add /linear-webhook endpoint with deprecated /webhook alias (CYPACK-1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **New `/linear-webhook` endpoint for Linear webhooks** — The Linear webhook URL in your OAuth application can now be set to `<CYRUS_BASE_URL>/linear-webhook`. The legacy `/webhook` path continues to work for backward compatibility but is deprecated and will log a warning on first use. ([CYPACK-1119](https://linear.app/ceedar/issue/CYPACK-1119))
+- **New `/linear-webhook` endpoint for Linear webhooks** — The Linear webhook URL in your OAuth application can now be set to `<CYRUS_BASE_URL>/linear-webhook`. The legacy `/webhook` path continues to work for backward compatibility but is deprecated and will log a warning on first use. ([CYPACK-1119](https://linear.app/ceedar/issue/CYPACK-1119), [#1142](https://github.com/ceedaragents/cyrus/pull/1142))
 - **Base branch update notifications** - When your base branch receives new commits while Cyrus is working, the active session is automatically notified to rebase, helping avoid merge conflicts. ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))
 - **Blocked-by dependency deferral** - Issues with unresolved `blocked_by` relationships are now automatically deferred instead of starting immediately. Cyrus posts an acknowledgment and starts work automatically when all blocking issues are resolved. User re-prompts also re-check blocking status. ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **New `/linear-webhook` endpoint for Linear webhooks** — The Linear webhook URL in your OAuth application can now be set to `<CYRUS_BASE_URL>/linear-webhook`. The legacy `/webhook` path continues to work for backward compatibility but is deprecated and will log a warning on first use. ([CYPACK-1119](https://linear.app/ceedar/issue/CYPACK-1119))
 - **Base branch update notifications** - When your base branch receives new commits while Cyrus is working, the active session is automatically notified to rebase, helping avoid merge conflicts. ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))
 - **Blocked-by dependency deferral** - Issues with unresolved `blocked_by` relationships are now automatically deferred instead of starting immediately. Cyrus posts an acknowledgment and starts work automatically when all blocking issues are resolved. User re-prompts also re-check blocking status. ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -134,7 +134,7 @@ For Vertex AI, Azure, AWS Bedrock, and other providers, see the [Third-Party Int
 4. **Enable Webhooks** toggle
 
 5. **Configure Webhook Settings:**
-   - **Webhook URL:** `https://your-public-url.com/webhook`
+   - **Webhook URL:** `https://your-public-url.com/linear-webhook`
    - **App events** - Check these boxes:
      - **Agent session events** (REQUIRED - makes Cyrus appear as agent)
      - **Inbox notifications** (recommended)
@@ -315,7 +315,7 @@ For detailed options, see the [Configuration File Reference](./CONFIG_FILE.md).
 
 ### Webhooks Not Received
 
-- Verify Linear webhook URL matches `CYRUS_BASE_URL/webhook`
+- Verify Linear webhook URL matches `CYRUS_BASE_URL/linear-webhook` (the legacy `/webhook` path still works but is deprecated)
 - Check Cyrus logs for incoming webhook attempts
 - Ensure your public URL is accessible
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -722,7 +722,7 @@ export class EdgeWorker extends EventEmitter {
 				this.handleError(error);
 			});
 
-			// Register the /webhook endpoint
+			// Register the /linear-webhook endpoint (with /webhook retained as a deprecated alias)
 			this.linearEventTransport.register();
 
 			this.logger.info(

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -335,7 +335,7 @@ export class SharedApplicationServer {
 	 * Get the webhook URL
 	 */
 	getWebhookUrl(): string {
-		return `http://${this.host}:${this.port}/webhook`;
+		return `http://${this.host}:${this.port}/linear-webhook`;
 	}
 
 	/**

--- a/packages/linear-event-transport/src/LinearEventTransport.ts
+++ b/packages/linear-event-transport/src/LinearEventTransport.ts
@@ -29,8 +29,9 @@ export declare interface LinearEventTransport {
  * This class implements IAgentEventTransport to provide a platform-agnostic
  * interface for handling Linear webhooks with Linear-specific verification.
  *
- * It registers a POST /webhook endpoint with a Fastify server
- * and verifies incoming webhooks using either:
+ * It registers a POST /linear-webhook endpoint with a Fastify server, plus
+ * a POST /webhook alias retained for backward compatibility (deprecated).
+ * Incoming webhooks are verified using either:
  * 1. "direct" mode: Verifies Linear's webhook signature
  * 2. "proxy" mode: Verifies Bearer token authentication
  *
@@ -72,33 +73,52 @@ export class LinearEventTransport
 	}
 
 	/**
-	 * Register the /webhook endpoint with the Fastify server
+	 * Register the /linear-webhook endpoint (plus the deprecated /webhook alias)
+	 * with the Fastify server.
 	 */
 	register(): void {
+		const handler = async (
+			request: FastifyRequest,
+			reply: FastifyReply,
+		): Promise<void> => {
+			try {
+				// Verify based on mode
+				if (this.config.verificationMode === "direct") {
+					await this.handleDirectWebhook(request, reply);
+				} else {
+					await this.handleProxyWebhook(request, reply);
+				}
+			} catch (error) {
+				const err = new Error("Webhook error");
+				if (error instanceof Error) {
+					err.cause = error;
+				}
+				this.logger.error("Webhook error", err);
+				this.emit("error", err);
+				reply.code(500).send({ error: "Internal server error" });
+			}
+		};
+
+		this.config.fastifyServer.post("/linear-webhook", handler);
+
+		// Deprecated alias — retained so existing Linear webhook configurations
+		// continue to deliver while users migrate to /linear-webhook.
+		let deprecationWarned = false;
 		this.config.fastifyServer.post(
 			"/webhook",
 			async (request: FastifyRequest, reply: FastifyReply) => {
-				try {
-					// Verify based on mode
-					if (this.config.verificationMode === "direct") {
-						await this.handleDirectWebhook(request, reply);
-					} else {
-						await this.handleProxyWebhook(request, reply);
-					}
-				} catch (error) {
-					const err = new Error("Webhook error");
-					if (error instanceof Error) {
-						err.cause = error;
-					}
-					this.logger.error("Webhook error", err);
-					this.emit("error", err);
-					reply.code(500).send({ error: "Internal server error" });
+				if (!deprecationWarned) {
+					deprecationWarned = true;
+					this.logger.warn(
+						"POST /webhook is deprecated; update your Linear webhook URL to use /linear-webhook",
+					);
 				}
+				await handler(request, reply);
 			},
 		);
 
 		this.logger.info(
-			`Registered POST /webhook endpoint (${this.config.verificationMode} mode)`,
+			`Registered POST /linear-webhook endpoint (${this.config.verificationMode} mode); POST /webhook retained as deprecated alias`,
 		);
 	}
 

--- a/packages/linear-event-transport/test/LinearEventTransport.test.ts
+++ b/packages/linear-event-transport/test/LinearEventTransport.test.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { LinearEventTransport } from "../src/LinearEventTransport.js";
+
+describe("LinearEventTransport", () => {
+	describe("register", () => {
+		it("registers POST /linear-webhook and a deprecated /webhook alias", () => {
+			const post = vi.fn();
+			const fastifyServer = { post } as unknown as FastifyInstance;
+
+			const transport = new LinearEventTransport({
+				fastifyServer,
+				verificationMode: "proxy",
+				secret: "test-secret",
+			});
+
+			transport.register();
+
+			const registeredPaths = post.mock.calls.map((call: unknown[]) => call[0]);
+			expect(registeredPaths).toEqual(
+				expect.arrayContaining(["/linear-webhook", "/webhook"]),
+			);
+			expect(post).toHaveBeenCalledTimes(2);
+		});
+
+		it("deprecated /webhook alias delegates to the same handler as /linear-webhook", async () => {
+			const post = vi.fn();
+			const fastifyServer = { post } as unknown as FastifyInstance;
+
+			const transport = new LinearEventTransport({
+				fastifyServer,
+				verificationMode: "proxy",
+				secret: "test-secret",
+			});
+
+			transport.register();
+
+			const calls = post.mock.calls as Array<
+				[string, (request: unknown, reply: unknown) => Promise<void>]
+			>;
+			const primary = calls.find(([path]) => path === "/linear-webhook");
+			const deprecated = calls.find(([path]) => path === "/webhook");
+			expect(primary).toBeDefined();
+			expect(deprecated).toBeDefined();
+
+			const makeReply = () => ({
+				code: vi.fn().mockReturnThis(),
+				send: vi.fn().mockReturnThis(),
+			});
+
+			const unauthorizedRequest = {
+				headers: {},
+			};
+
+			const primaryReply = makeReply();
+			await primary![1](unauthorizedRequest, primaryReply);
+			expect(primaryReply.code).toHaveBeenCalledWith(401);
+
+			const deprecatedReply = makeReply();
+			await deprecated![1](unauthorizedRequest, deprecatedReply);
+			expect(deprecatedReply.code).toHaveBeenCalledWith(401);
+		});
+	});
+});

--- a/skills/cyrus-setup-linear/SKILL.md
+++ b/skills/cyrus-setup-linear/SKILL.md
@@ -79,7 +79,7 @@ agent-browser fill "input[name='redirectUrls']" "<CYRUS_BASE_URL>/callback"
 
 Enable webhooks and fill webhook URL:
 ```bash
-agent-browser fill "input[name='webhookUrl']" "<CYRUS_BASE_URL>/webhook"
+agent-browser fill "input[name='webhookUrl']" "<CYRUS_BASE_URL>/linear-webhook"
 ```
 
 Check the required event types:
@@ -114,7 +114,7 @@ Guide the user through manual creation:
 >    - **Developer name:** Your name or org
 >    - **Developer URL:** `https://github.com/ceedaragents/cyrus`
 >    - **Redirect callback URLs:** `<CYRUS_BASE_URL>/callback`
->    - **Webhook URL:** `<CYRUS_BASE_URL>/webhook`
+>    - **Webhook URL:** `<CYRUS_BASE_URL>/linear-webhook`
 >    - **Webhook:** ✓ enabled
 >    - **Event types:** ✓ Agent session events, ✓ Inbox notifications, ✓ Permission changes, ✓ Issues
 >    - **Public:** ✗ leave disabled (this is a private self-hosted app)


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- `LinearEventTransport` now registers `POST /linear-webhook` as the primary Linear webhook endpoint and retains `POST /webhook` as a deprecated alias that logs a one-time warning on first use, so existing OAuth webhook configurations keep delivering.
- `SharedApplicationServer.getWebhookUrl()` returns the new `/linear-webhook` path so logs and setup flows advertise the new URL.
- Updated `docs/SELF_HOSTING.md`, the Linear setup skill, and the changelog to point users at `/linear-webhook`.

## Test plan

- [x] `pnpm test:packages:run` — all suites green (linear-event-transport 24/24 including the new dual-route registration test; edge-worker 586/586)
- [x] `pnpm typecheck`
- [x] `pnpm biome check`

Linked issue: [CYPACK-1119](https://linear.app/ceedar/issue/CYPACK-1119/add-linear-webhook-as-an-equivalent-of-webhook)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->