### PR TITLE
chore: bump pnpm to 10.33.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.1",
 	"private": true,
 	"description": "Monorepo for Cyrus - Linear Claude Agent integration",
-	"packageManager": "pnpm@10.13.1",
+	"packageManager": "pnpm@10.33.1",
 	"type": "module",
 	"scripts": {
 		"build": "pnpm -r --filter='!@cyrus/electron' build",


### PR DESCRIPTION
## Summary
- Bumps the `packageManager` field from `pnpm@10.13.1` to `pnpm@10.33.1` (current latest in the 10.x line).
- CI picks up the version dynamically from `package.json` (see `.github/actions/install-dependencies/action.yml`), so no workflow changes are needed.

## Test plan
- [x] `pnpm install` clean with v10.33.1
- [x] `pnpm build` succeeds (ran via husky pre-commit)
- [x] `pnpm typecheck` succeeds (ran via husky pre-commit)
- [ ] CI green