### PR TITLE
fix: spread process.env in claude-agent-sdk invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Claude sessions inherit the parent process environment again** — `@anthropic-ai/claude-agent-sdk` v0.2.113 reverted to no longer overlaying `process.env` onto the env passed to spawned sessions, which left Cyrus-launched Claude processes without `HOME` (and other inherited vars). That broke GPG-signed commits, `gh` CLI authentication, and any other tool that relies on a real home directory or the user's shell environment. Cyrus now spreads `process.env` explicitly when invoking the SDK so these tools work as expected. ([#1150](https://github.com/cyrusagents/cyrus/pull/1150))
+
 ## [0.2.48] - 2026-04-20
 
 ### Changed

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -496,6 +496,8 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					// see: https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default
 					settingSources: ["user", "project", "local"],
 					env: {
+						// we continue, for now, to overlay the entirely of process.env since claude-agent-sdk stopped overlaying it again (reverted)
+						...process.env,
 						...(process.env.PATH && { PATH: process.env.PATH }),
 						// Forward auth credentials from parent process — the SDK needs
 						// these for API calls.


### PR DESCRIPTION
## Summary
Re-spread `process.env` into the env passed to `@anthropic-ai/claude-agent-sdk` invocations. Fixes a regression introduced by SDK [v0.2.113](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#02113), which reverted to no longer overlaying the parent process env onto spawned sessions.

Without this, Cyrus-launched Claude sessions started without `HOME` (and other inherited env vars), which broke major workflows:
- GPG-signed commits (no `HOME` → no GPG keyring)
- `gh` CLI authentication (no `HOME` → no `~/.config/gh`)
- Any other tool that relies on the user's shell environment or a real home directory

## Test plan
- [ ] Manually verify a Claude session inherits expected env vars (`HOME`, `NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`) when running through Cyrus
- [ ] Confirm GPG-signed commits succeed from a Cyrus-driven session
- [ ] Confirm `gh` CLI commands authenticate from a Cyrus-driven session
- [ ] `pnpm test:packages:run`
- [ ] `pnpm typecheck`