### PR TITLE
Release v0.2.51

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.50] - 2026-04-30
+
 ### Added
 - Added `push` event support to `GitHubEventTransport` (new `GitHubPushPayload`, `GitHubPushCommit` types, `GitHubCommentWebhookEvent` narrowing type). Push events are emitted without action filtering. Updated `extractComment*` utility functions and `GitHubMessageTranslator` to use `GitHubCommentWebhookEvent` instead of `GitHubWebhookEvent` for type safety. Added `getSessionsByBaseBranch(branchName, repositoryId)` query to `AgentSessionManager`. Added `handleGitHubPushWebhook` to `EdgeWorker` — extracts branch from `refs/heads/*`, finds repo config, looks up active sessions, streams XML rebase notification via `addStreamMessage`. ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))
 - Added blocked-by dependency deferral to `EdgeWorker`: `checkBlockedByDependencies` fetches issue relations via `fetchBlockingIssues` and filters to unresolved blockers. Blocked sessions are parked in a `parkedSessions` Map (keyed by issue ID). Added `isIssueStateChangeWebhook` type guard to cyrus-core for detecting `stateId` changes in `updatedFrom`. Added `handleIssueStateChange` handler — when blocking issues complete, removes them from parked sessions and replays `initializeAgentRunner`. Added `handleParkedSessionReprompt` (Branch 1.5 in prompted handler) for re-checking blockers on user re-prompt. Added `postThoughtActivity` to `ActivityPoster`. 12 new tests (5 for `getSessionsByBaseBranch`, 7 for `isIssueStateChangeWebhook`). ([CYPACK-978](https://linear.app/ceedar/issue/CYPACK-978), [#1004](https://github.com/ceedaragents/cyrus/pull/1004))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.51] - 2026-04-30
+
+### Changed
+- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.123 and `@anthropic-ai/sdk` to `^0.91.0`** — Bumps the bundled Claude Code binary to v2.1.123 and the Anthropic TypeScript SDK to `^0.91.0`. This resolves a session-breaking bug where, after a parallel `Bash` tool call was cancelled following a non-zero exit on a sibling call, every subsequent `Bash` invocation in the same session would fail with `/bin/bash: line 4: /proc/self/fd/3: Permission denied` (exit 126) until the session was restarted. Other tools (`Read`, `Edit`, `Glob`, `Grep`, MCP) were unaffected. Also removes `LSP` from the `availableTools` list in `config.ts` — `LSP` is no longer shipped in Claude Code SDK v0.2.123. See [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1152](https://linear.app/ceedar/issue/CYPACK-1152), [#1172](https://github.com/cyrusagents/cyrus/pull/1172))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.51
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.51
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.51
+
+#### cyrus-core
+- cyrus-core@0.2.51
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.51
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.51
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.51
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.51
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.51
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.51
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.51
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.51
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.51
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.51
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.51
+
+## [0.2.50] - 2026-04-30
+
 ### Added
 - **Cyrus-authored PRs and MRs are now reliably tagged** — After every `gh pr create`/`gh pr edit`, `glab mr create`/`glab mr update`/`glab mr edit`, or `gt submit` command, Cyrus automatically appends a hidden `<!-- generated-by-cyrus -->` marker to the live PR/MR description if it isn't already there. This ensures the GitHub/GitLab webhook handlers can recognize Cyrus-authored PRs (so "Changes requested" events get forwarded back) even when the agent forgets to include the marker in the body it submits. ([CYPACK-1141](https://linear.app/ceedar/issue/CYPACK-1141), [#1162](https://github.com/cyrusagents/cyrus/pull/1162))
 - **PR guardrail when sessions try to stop with unshipped work** — When the agent attempts to end a session, Cyrus now inspects the worktree and blocks the first stop attempt if there are uncommitted changes or commits ahead of the upstream branch, prompting the agent to commit, push, and open a pull request. Sessions with no code changes (e.g. questions, research) stop normally. ([CYPACK-1140](https://linear.app/ceedar/issue/CYPACK-1140), [#1161](https://github.com/cyrusagents/cyrus/pull/1161))
@@ -35,9 +89,55 @@ All notable changes to this project will be documented in this file.
 - **Addressed open security advisories** — Refreshed `pnpm-lock.yaml` so vulnerable transitive dependencies resolve to their patched versions (`protobufjs`, `path-to-regexp`, `picomatch`, `flatted`, `brace-expansion`, `yaml`, `follow-redirects`, `vite`, `hono`, `@hono/node-server`) through their existing direct-dep paths, without introducing new `pnpm.overrides` entries. ([CYPACK-1101](https://linear.app/ceedar/issue/CYPACK-1101), [#1128](https://github.com/ceedaragents/cyrus/pull/1128))
 
 ### Changed
-- **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.123 and `@anthropic-ai/sdk` to `^0.91.0`** — Bumps the bundled Claude Code binary to v2.1.123 and the Anthropic TypeScript SDK to `^0.91.0`. Removes `LSP` from the `availableTools` list in `config.ts` — `LSP` is no longer shipped in Claude Code SDK v0.2.123. See [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1152](https://linear.app/ceedar/issue/CYPACK-1152), [#1172](https://github.com/cyrusagents/cyrus/pull/1172))
 - **Updated `@anthropic-ai/claude-agent-sdk` to v0.2.117** — Bumps the bundled Claude Code binary from v2.1.116 to v2.1.117 (parity release with no tool-list changes). Also fixes `scripts/extract-claude-tools.sh` to work with the new native binary structure introduced in SDK v0.2.113 (now resolves the platform-specific optional dependency instead of the removed `cli.js`). See [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1120](https://linear.app/ceedar/issue/CYPACK-1120), [#1143](https://github.com/ceedaragents/cyrus/pull/1143))
 - **Update `@anthropic-ai/claude-agent-sdk` to v0.2.116** — Bumps the bundled Claude Code binary from v2.1.114 to v2.1.116 (parity releases with no tool-list changes). See [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1111](https://linear.app/ceedar/issue/CYPACK-1111), [#1133](https://github.com/ceedaragents/cyrus/pull/1133))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.50
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.50
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.50
+
+#### cyrus-core
+- cyrus-core@0.2.50
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.50
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.50
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.50
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.50
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.50
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.50
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.50
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.50
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.50
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.50
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.50
 
 ## [0.2.49] - 2026-04-22
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.50",
+	"version": "0.2.51",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.49",
+	"version": "0.2.51",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.51 to npm — bumps `@anthropic-ai/claude-agent-sdk` to v0.2.123 (Claude Code v2.1.123) and `@anthropic-ai/sdk` to ^0.91.0
- Resolves the session-breaking bug where, after a parallel `Bash` tool call was cancelled, every subsequent `Bash` call in the same session failed with `/proc/self/fd/3: Permission denied` (exit 126) until session restart
- Updates CHANGELOG.md / CHANGELOG.internal.md and bumps all package versions to 0.2.51

## Notes
- v0.2.50 was released earlier today on a parallel branch; this PR's changelog reflects the v0.2.50 section that was finalized at the v0.2.50 tag, plus the new v0.2.51 entry.

## Links
- [GitHub Release v0.2.51](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.51)
- [CYPACK-1163](https://linear.app/ceedar/issue/CYPACK-1163)
- [CYPACK-1152](https://linear.app/ceedar/issue/CYPACK-1152)

<!-- generated-by-cyrus -->