### PR TITLE
fix(security): patch open Dependabot advisories (CYPACK-1170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Patched two open Dependabot advisories** — Bumped `@anthropic-ai/sdk` to `^0.91.1` in `cyrus-claude-runner` to address [GHSA-p7fg-763f-g4gf](https://github.com/anthropics/anthropic-sdk-typescript/security/advisories/GHSA-p7fg-763f-g4gf) (insecure default file permissions in the local filesystem memory tool) and added a root `pnpm.overrides` entry for `>=0.91.1` to force the transitive copy bundled inside `@anthropic-ai/claude-agent-sdk` onto the patched version. Added a root `pnpm.overrides` entry `uuid: '>=14.0.0'` to address [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in v3/v5/v6) pulled in transitively via `@google/gemini-cli-core`. ([CYPACK-1170](https://linear.app/ceedar/issue/CYPACK-1170))
+
 ## [0.2.51] - 2026-04-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
 			"diff": ">=8.0.3",
 			"@tootallnate/once": ">=3.0.1",
 			"@isaacs/brace-expansion": ">=5.0.1",
-			"tar": ">=7.5.11"
+			"tar": ">=7.5.11",
+			"@anthropic-ai/sdk": ">=0.91.1",
+			"uuid": ">=14.0.0"
 		}
 	},
 	"lint-staged": {

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "0.2.123",
-		"@anthropic-ai/sdk": "^0.91.0",
+		"@anthropic-ai/sdk": "^0.91.1",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -94,6 +94,7 @@ function createAssistantToolUseMessage(
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,
@@ -147,6 +148,7 @@ function createAssistantBetaMessage(
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/packages/cursor-runner/src/CursorRunner.ts
+++ b/packages/cursor-runner/src/CursorRunner.ts
@@ -111,6 +111,7 @@ function createAssistantToolUseMessage(
 		model: "cursor-agent",
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,
@@ -139,6 +140,7 @@ function createAssistantTextMessage(
 		model: "cursor-agent",
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/packages/gemini-runner/src/adapters.ts
+++ b/packages/gemini-runner/src/adapters.ts
@@ -38,6 +38,7 @@ function createBetaMessage(
 		model: "gemini-3" as const,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   '@tootallnate/once': '>=3.0.1'
   '@isaacs/brace-expansion': '>=5.0.1'
   tar: '>=7.5.11'
+  '@anthropic-ai/sdk': '>=0.91.1'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -149,7 +151,7 @@ importers:
         specifier: 0.2.123
         version: 0.2.123(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.91.0
+        specifier: '>=0.91.1'
         version: 0.91.1(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
@@ -617,15 +619,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
-
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
-    hasBin: true
-    peerDependencies:
-      zod: 4.3.6
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -4081,14 +4074,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -4318,7 +4305,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.123(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -4333,12 +4320,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
@@ -4603,7 +4584,7 @@ snapshots:
       on-finished: 2.4.1
       pumpify: 2.0.1
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6331,7 +6312,7 @@ snapshots:
 
   eventid@2.0.1:
     dependencies:
-      uuid: 8.3.2
+      uuid: 14.0.0
 
   eventsource-parser@3.0.8: {}
 
@@ -6583,7 +6564,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6691,7 +6672,7 @@ snapshots:
       proto3-json-serializer: 2.0.2
       protobufjs: 7.5.6
       retry-request: 7.0.2(encoding@0.1.13)
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6705,7 +6686,7 @@ snapshots:
       google-auth-library: 9.15.1(encoding@0.1.13)
       qs: 6.15.1
       url-template: 2.0.8
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7999,7 +7980,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8118,9 +8099,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
## Summary

Closes the two open Dependabot advisories on the repo:

- **`@anthropic-ai/sdk` <0.91.1** ([GHSA-p7fg-763f-g4gf](https://github.com/anthropics/anthropic-sdk-typescript/security/advisories/GHSA-p7fg-763f-g4gf), medium) — insecure default file permissions in the local filesystem memory tool. Fixed by bumping the direct dep in `cyrus-claude-runner` to `^0.91.1` and adding a root `pnpm.overrides` entry of `>=0.91.1` so the transitive copy bundled inside `@anthropic-ai/claude-agent-sdk` (still pinned to `0.2.123` → `@anthropic-ai/sdk@^0.81.0`) is also forced onto the patched version.
- **`uuid` <14.0.0** ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), medium) — missing buffer bounds check in v3/v5/v6. Pulled in transitively only via the pinned `cyrus-gemini-runner > @google/gemini-cli-core@0.17.0` devDependency. Upstream pins prevent reaching v14 through normal resolution, so addressed via a root `pnpm.overrides` entry `uuid: '>=14.0.0'`.

The `@anthropic-ai/sdk` 0.91.x release added a required `stop_details: BetaRefusalStopDetails | null` field to `BetaMessage`. Updated the locally-constructed assistant messages in `codex-runner`, `cursor-runner`, and `gemini-runner` to set `stop_details: null`.

`pnpm audit` now reports `No known vulnerabilities found`.

Per `CLAUDE.md`'s dependency security policy: prefer direct-dep bumps, fall back to root `pnpm.overrides` only when a direct bump can't reach the vulnerable transitive (both apply here for different reasons).

## Supersedes

This PR supersedes:
- #1181 — fix(security): patch open Dependabot advisories (CYPACK-1168)

Closes [CYPACK-1170](https://linear.app/ceedar/issue/CYPACK-1170/address-open-security-patches-for-cyrus-cli).

## Test plan

- [x] `pnpm install` succeeds with new lockfile
- [x] `pnpm audit` reports zero advisories
- [x] `pnpm build` (all packages + apps) green
- [x] `pnpm typecheck` green
- [x] `pnpm test:packages:run` green (one pre-existing flake in `packages/claude-runner/test/debug-logging.test.ts` when `DEBUG_CLAUDE_AGENT_SDK` env var leaks from parent shell; passes when env var is unset — unrelated to this change)

<!-- generated-by-cyrus -->