### PR TITLE
fix(edge-worker): guard PR review auto-responses to Cyrus-owned PRs (CYPACK-1173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Self-hosted: only auto-respond to PR change-requests on PRs Cyrus owns** — `pull_request_review` events with state `changes_requested` now trigger Cyrus only when the PR was opened by the configured Cyrus bot account or its description contains the hidden Cyrus marker. Other PRs are ignored (with a debug log). Explicit `@cyrusagent` mentions on any PR continue to work. ([CYPACK-1173](https://linear.app/ceedar/issue/CYPACK-1173))
+- **Self-hosted: only auto-respond to PR change-requests on PRs Cyrus owns** — `pull_request_review` events with state `changes_requested` now trigger Cyrus only when the PR was opened by the configured Cyrus bot account or its description contains the hidden Cyrus marker. Other PRs are ignored (with a debug log). Explicit `@cyrusagent` mentions on any PR continue to work. ([CYPACK-1173](https://linear.app/ceedar/issue/CYPACK-1173), [#1186](https://github.com/cyrusagents/cyrus/pull/1186))
 
 ## [0.2.57] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Self-hosted: only auto-respond to PR change-requests on PRs Cyrus owns** — `pull_request_review` events with state `changes_requested` now trigger Cyrus only when the PR was opened by the configured Cyrus bot account or its description contains the hidden Cyrus marker. Other PRs are ignored (with a debug log). Explicit `@cyrusagent` mentions on any PR continue to work. ([CYPACK-1173](https://linear.app/ceedar/issue/CYPACK-1173))
+
 ## [0.2.57] - 2026-05-22
 
 ### Fixed

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -102,6 +102,7 @@ import {
 	isIssueCommentPayload,
 	isPullRequestReviewCommentPayload,
 	isPullRequestReviewPayload,
+	PullRequestReviewAuthorizer,
 	stripMention,
 } from "cyrus-github-event-transport";
 import type { GitLabWebhookEvent } from "cyrus-gitlab-event-transport";
@@ -1191,6 +1192,20 @@ export class EdgeWorker extends EventEmitter {
 				if (event.payload.review.state !== "changes_requested") {
 					this.logger.debug(
 						`Ignoring pull_request_review with state: ${event.payload.review.state}`,
+					);
+					return;
+				}
+
+				// Only auto-respond to change requests on PRs Cyrus owns —
+				// either authored by the Cyrus bot or carrying the hidden
+				// Cyrus marker in the description. Explicit @mentions are
+				// handled separately and remain allowed on any PR.
+				const authorization = new PullRequestReviewAuthorizer({
+					botUsername,
+				}).authorize(event.payload);
+				if (!authorization.authorized) {
+					this.logger.debug(
+						`Ignoring pull_request_review on ${repoFullName}#${prNumber}: ${authorization.reason}`,
 					);
 					return;
 				}

--- a/packages/edge-worker/src/hooks/PrMarkerHook.ts
+++ b/packages/edge-worker/src/hooks/PrMarkerHook.ts
@@ -5,13 +5,15 @@ import type {
 	PostToolUseHookInput,
 } from "cyrus-claude-runner";
 import type { ILogger } from "cyrus-core";
+import { CYRUS_PR_MARKER } from "cyrus-github-event-transport";
 
 /**
  * The hidden HTML marker that identifies a PR/MR description as Cyrus-authored.
- * Its presence is what tells our GitHub/GitLab webhook handlers that a
- * "Changes requested" or comment event should be forwarded back to Cyrus.
+ * Re-exported from cyrus-github-event-transport so that the marker-injection
+ * hook (here) and the PR review authorization policy (there) share a single
+ * source of truth.
  */
-export const CYRUS_PR_MARKER = "<!-- generated-by-cyrus -->";
+export { CYRUS_PR_MARKER };
 
 /**
  * Provider-specific knowledge about how to detect PR/MR mutating commands and

--- a/packages/github-event-transport/src/PullRequestReviewAuthorizer.ts
+++ b/packages/github-event-transport/src/PullRequestReviewAuthorizer.ts
@@ -1,0 +1,97 @@
+import type { GitHubPullRequestReviewPayload, GitHubUser } from "./types.js";
+
+/**
+ * Hidden HTML marker that identifies a PR description as Cyrus-authored.
+ *
+ * Canonical location for the marker — both the marker-injection hook (in
+ * cyrus-edge-worker) and the review authorization policy (here) read from
+ * this constant so the two sides cannot drift.
+ */
+export const CYRUS_PR_MARKER = "<!-- generated-by-cyrus -->";
+
+/**
+ * Configuration for {@link PullRequestReviewAuthorizer}.
+ */
+export interface PullRequestReviewAuthorizerConfig {
+	/**
+	 * Configured Cyrus GitHub bot login (e.g. `cyrusagent` or
+	 * `cyrusagent[bot]`). Used to recognise PRs opened by Cyrus.
+	 *
+	 * When undefined, only the hidden-marker check is performed.
+	 */
+	botUsername?: string;
+}
+
+/**
+ * Outcome of a PR-review authorization check.
+ */
+export interface PullRequestReviewAuthorization {
+	authorized: boolean;
+	/** Human-readable reason, suitable for debug logging. */
+	reason: string;
+}
+
+/**
+ * Decides whether a `pull_request_review` event from GitHub is allowed to
+ * trigger Cyrus.
+ *
+ * Mirrors the policy enforced by the hosted webhook handler in
+ * `cyrus-hosted/apps/app/src/app/api/github/webhook/route.ts`: a review
+ * counts as actionable only when either
+ *   1. the PR author is the Cyrus bot account, or
+ *   2. the PR body contains {@link CYRUS_PR_MARKER}.
+ *
+ * Loop prevention (ignoring reviews authored *by* the bot) is the caller's
+ * responsibility — this policy is purely about PR ownership.
+ */
+export class PullRequestReviewAuthorizer {
+	constructor(
+		private readonly config: PullRequestReviewAuthorizerConfig = {},
+	) {}
+
+	authorize(
+		payload: GitHubPullRequestReviewPayload,
+	): PullRequestReviewAuthorization {
+		const prUser = payload.pull_request.user;
+		const prBody = payload.pull_request.body ?? "";
+
+		if (this.isCyrusBotAuthor(prUser)) {
+			return {
+				authorized: true,
+				reason: `PR author @${prUser.login} matches the configured Cyrus bot account`,
+			};
+		}
+
+		if (prBody.includes(CYRUS_PR_MARKER)) {
+			return {
+				authorized: true,
+				reason: "PR body contains the hidden Cyrus marker",
+			};
+		}
+
+		return {
+			authorized: false,
+			reason: `PR author @${prUser.login} is not the Cyrus bot and PR body lacks the Cyrus marker`,
+		};
+	}
+
+	/**
+	 * True when the PR's author looks like the configured Cyrus bot account.
+	 *
+	 * GitHub Apps surface as a user whose `type === "Bot"` and whose login is
+	 * the App slug with a `[bot]` suffix (e.g. `cyrusagent[bot]`). Self-hosted
+	 * deployments using a PAT under a regular user account surface as
+	 * `type === "User"` with a plain login. We accept either shape, comparing
+	 * logins case-insensitively against the configured bot username (with or
+	 * without the `[bot]` suffix).
+	 */
+	private isCyrusBotAuthor(prUser: GitHubUser): boolean {
+		const { botUsername } = this.config;
+		if (!botUsername) return false;
+
+		const normalize = (login: string): string =>
+			login.toLowerCase().replace(/\[bot\]$/, "");
+
+		return normalize(prUser.login) === normalize(botUsername);
+	}
+}

--- a/packages/github-event-transport/src/index.ts
+++ b/packages/github-event-transport/src/index.ts
@@ -34,6 +34,14 @@ export {
 	stripMention,
 } from "./github-webhook-utils.js";
 export type {
+	PullRequestReviewAuthorization,
+	PullRequestReviewAuthorizerConfig,
+} from "./PullRequestReviewAuthorizer.js";
+export {
+	CYRUS_PR_MARKER,
+	PullRequestReviewAuthorizer,
+} from "./PullRequestReviewAuthorizer.js";
+export type {
 	GitHubComment,
 	GitHubCommentEventType,
 	GitHubCommentWebhookEvent,

--- a/packages/github-event-transport/test/PullRequestReviewAuthorizer.test.ts
+++ b/packages/github-event-transport/test/PullRequestReviewAuthorizer.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+	CYRUS_PR_MARKER,
+	PullRequestReviewAuthorizer,
+} from "../src/PullRequestReviewAuthorizer.js";
+import type { GitHubPullRequestReviewPayload } from "../src/types.js";
+import { prReviewPayload, testPullRequest, testUser } from "./fixtures.js";
+
+function payloadWith(
+	overrides: Partial<{
+		body: string | null;
+		userLogin: string;
+		userType: string;
+	}>,
+): GitHubPullRequestReviewPayload {
+	return {
+		...prReviewPayload,
+		pull_request: {
+			...testPullRequest,
+			body:
+				"body" in overrides ? (overrides.body ?? null) : testPullRequest.body,
+			user: {
+				...testUser,
+				login: overrides.userLogin ?? testUser.login,
+				type: overrides.userType ?? testUser.type,
+			},
+		},
+	};
+}
+
+describe("PullRequestReviewAuthorizer", () => {
+	it("authorizes when the PR author matches the configured bot username", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "cyrusagent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({ userLogin: "cyrusagent", userType: "User", body: "" }),
+		);
+
+		expect(result.authorized).toBe(true);
+		expect(result.reason).toContain("Cyrus bot");
+	});
+
+	it("authorizes when PR author is the GitHub App bot variant (login[bot])", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "cyrusagent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({
+				userLogin: "cyrusagent[bot]",
+				userType: "Bot",
+				body: "",
+			}),
+		);
+
+		expect(result.authorized).toBe(true);
+	});
+
+	it("authorizes a PR by a human author when the body contains the marker", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "cyrusagent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({
+				userLogin: "alice",
+				userType: "User",
+				body: `Some description\n\n${CYRUS_PR_MARKER}\n`,
+			}),
+		);
+
+		expect(result.authorized).toBe(true);
+		expect(result.reason).toContain("marker");
+	});
+
+	it("rejects a PR by a human author with no marker", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "cyrusagent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({
+				userLogin: "alice",
+				userType: "User",
+				body: "Plain human PR",
+			}),
+		);
+
+		expect(result.authorized).toBe(false);
+		expect(result.reason).toContain("not the Cyrus bot");
+	});
+
+	it("rejects a PR by a human author when the PR body is null", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "cyrusagent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({
+				userLogin: "alice",
+				userType: "User",
+				body: null,
+			}),
+		);
+
+		expect(result.authorized).toBe(false);
+	});
+
+	it("falls back to marker-only when no botUsername is configured", () => {
+		const authorizer = new PullRequestReviewAuthorizer();
+
+		const withMarker = authorizer.authorize(
+			payloadWith({
+				userLogin: "anyone",
+				userType: "User",
+				body: CYRUS_PR_MARKER,
+			}),
+		);
+		const withoutMarker = authorizer.authorize(
+			payloadWith({
+				userLogin: "anyone",
+				userType: "User",
+				body: "no marker here",
+			}),
+		);
+
+		expect(withMarker.authorized).toBe(true);
+		expect(withoutMarker.authorized).toBe(false);
+	});
+
+	it("matches bot username case-insensitively", () => {
+		const authorizer = new PullRequestReviewAuthorizer({
+			botUsername: "CyrusAgent",
+		});
+
+		const result = authorizer.authorize(
+			payloadWith({
+				userLogin: "cyrusagent[bot]",
+				userType: "Bot",
+				body: "",
+			}),
+		);
+
+		expect(result.authorized).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes [CYPACK-1173](https://linear.app/ceedar/issue/CYPACK-1173).

Community Cyrus was auto-responding to every `pull_request_review` with state `changes_requested` regardless of who opened the PR. A community user reported Cyrus reacting to change-requests on PRs it did not author.

This change brings the self-hosted handler in line with the hosted policy: only act on a `changes_requested` review when either

1. the PR author is the configured Cyrus bot account, **or**
2. the PR description contains the hidden Cyrus marker (`<!-- generated-by-cyrus -->`).

Otherwise the event is ignored with a debug log explaining why. Explicit `@cyrusagent` mentions in PR/issue comments are unaffected.

## Implementation

- Added `PullRequestReviewAuthorizer` (single-responsibility policy) plus the canonical `CYRUS_PR_MARKER` constant in `cyrus-github-event-transport`. The hosted handler can now consume the same module instead of re-implementing the rule.
- The existing marker-injection hook in `cyrus-edge-worker` re-exports `CYRUS_PR_MARKER` from the new canonical location so the marker definition lives in exactly one place.
- `EdgeWorker.handleGitHubWebhook` instantiates the authorizer per request (using `GITHUB_BOT_USERNAME`) and gates the review path on its result. Existing bot-loop guard is unchanged.
- Bot-author detection accepts both `cyrusagent` and `cyrusagent[bot]` shapes (case-insensitive), so it works for both PAT and GitHub App deployments.

## Test plan

- [x] 7 new unit tests in `PullRequestReviewAuthorizer.test.ts` cover: bot author acts, GitHub App `[bot]` variant acts, human + marker acts, human without marker ignored, null body ignored, marker-only fallback when no bot username configured, case-insensitive matching.
- [x] All 124 `cyrus-github-event-transport` tests pass.
- [x] All 611 `cyrus-edge-worker` tests pass (no regressions).
- [x] `pnpm build`, `pnpm typecheck`, and `pnpm lint` all pass.

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->