### PR TITLE
fix(security): patch open Dependabot advisories (CYPACK-1174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Patched open Dependabot advisories** — Updates `@anthropic-ai/claude-agent-sdk` to `0.2.129` and `@anthropic-ai/sdk` to `^0.94.0` (in `cyrus-claude-runner`, `cyrus-core`, `cyrus-edge-worker`, `cyrus-simple-agent-runner`) to resolve [GHSA-p7fg-763f-g4gf](https://github.com/advisories/GHSA-p7fg-763f-g4gf) (insecure default file permissions in `BetaLocalFilesystemMemoryTool`). Bumps `@modelcontextprotocol/sdk` to `^1.29.0` in `cyrus-config-updater` and adds an `ip-address >= 10.1.1` override to resolve [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS in `Address6` HTML-emitting methods). `pnpm audit` now reports zero advisories. ([CYPACK-1174](https://linear.app/ceedar/issue/CYPACK-1174), [#1187](https://github.com/ceedaragents/cyrus/pull/1187))
+
 ## [0.2.51] - 2026-04-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
 		],
 		"overrides": {
 			"jws": ">=4.0.1",
-			"@modelcontextprotocol/sdk": ">=1.26.0",
+			"@anthropic-ai/sdk": ">=0.91.1",
+			"@modelcontextprotocol/sdk": ">=1.29.0",
+			"ip-address": ">=10.1.1",
 			"semver": ">=7.5.2",
 			"qs": ">=6.14.2",
 			"vite": ">=7.1.11",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.123",
-		"@anthropic-ai/sdk": "^0.91.0",
+		"@anthropic-ai/claude-agent-sdk": "0.2.129",
+		"@anthropic-ai/sdk": "^0.94.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -93,6 +93,7 @@ function createAssistantToolUseMessage(
 		content: contentBlocks,
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
+		stop_details: null,
 		stop_sequence: null,
 		usage: {
 			input_tokens: 0,
@@ -146,6 +147,7 @@ function createAssistantBetaMessage(
 		content: contentBlocks,
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
+		stop_details: null,
 		stop_sequence: null,
 		usage: {
 			input_tokens: 0,

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -22,7 +22,7 @@
 		"test:run": "vitest run --passWithNoTests"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.25.2",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"cyrus-core": "workspace:*",
 		"fastify": "^5.8.5",
 		"zod": "^4.3.6"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.123",
+		"@anthropic-ai/claude-agent-sdk": "0.2.129",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/cursor-runner/src/CursorRunner.ts
+++ b/packages/cursor-runner/src/CursorRunner.ts
@@ -110,6 +110,7 @@ function createAssistantToolUseMessage(
 		content: contentBlocks,
 		model: "cursor-agent",
 		stop_reason: null,
+		stop_details: null,
 		stop_sequence: null,
 		usage: {
 			input_tokens: 0,
@@ -138,6 +139,7 @@ function createAssistantTextMessage(
 		content: contentBlocks,
 		model: "cursor-agent",
 		stop_reason: null,
+		stop_details: null,
 		stop_sequence: null,
 		usage: {
 			input_tokens: 0,

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.123",
+		"@anthropic-ai/claude-agent-sdk": "0.2.129",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/gemini-runner/src/adapters.ts
+++ b/packages/gemini-runner/src/adapters.ts
@@ -37,6 +37,7 @@ function createBetaMessage(
 		content: contentBlocks,
 		model: "gemini-3" as const,
 		stop_reason: null,
+		stop_details: null,
 		stop_sequence: null,
 		usage: {
 			input_tokens: 0,

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.123",
+		"@anthropic-ai/claude-agent-sdk": "0.2.129",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   jws: '>=4.0.1'
-  '@modelcontextprotocol/sdk': '>=1.26.0'
+  '@anthropic-ai/sdk': '>=0.91.1'
+  '@modelcontextprotocol/sdk': '>=1.29.0'
+  ip-address: '>=10.1.1'
   semver: '>=7.5.2'
   qs: '>=6.14.2'
   vite: '>=7.1.11'
@@ -146,10 +148,10 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.123
-        version: 0.2.123(zod@4.3.6)
+        specifier: 0.2.129
+        version: 0.2.129(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.91.0
+        specifier: '>=0.91.1'
         version: 0.91.1(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
@@ -224,7 +226,7 @@ importers:
   packages/config-updater:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: '>=1.26.0'
+        specifier: '>=1.29.0'
         version: 1.29.0(zod@4.3.6)
       cyrus-core:
         specifier: workspace:*
@@ -249,8 +251,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.123
-        version: 0.2.123(zod@4.3.6)
+        specifier: 0.2.129
+        version: 0.2.129(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -299,8 +301,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.123
-        version: 0.2.123(zod@4.3.6)
+        specifier: 0.2.129
+        version: 0.2.129(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -496,7 +498,7 @@ importers:
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
       '@modelcontextprotocol/sdk':
-        specifier: '>=1.26.0'
+        specifier: '>=1.29.0'
         version: 1.29.0(zod@4.3.6)
       fs-extra:
         specifier: ^11.3.2
@@ -524,8 +526,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.2.123
-        version: 0.2.123(zod@4.3.6)
+        specifier: 0.2.129
+        version: 0.2.129(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -568,64 +570,55 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.123':
-    resolution: {integrity: sha512-tYAXCjlXZQklsUs0J//gip3fZQRzhlH5OCgvNXV70qe7A1iiwHqO2KPGvEHV1L+deEKQoMZmTaCOrQpN6zju3w==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.129':
+    resolution: {integrity: sha512-+YUdFu6f84SidfZUx14eq9pR634d1vP0GKVWElrvptqYGhQoLcYbvNJ4A0jCFO8ncX+fvseSkxtzZ3fHwkEIVg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.123':
-    resolution: {integrity: sha512-AcUC6sTon6z6HculP87KsAOeTMRLBwpovdhcXUTjXUpo/8nplJ7lBEzWjZCHt8FF1KuN/WBy1Z4bDg/59TQDmA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.129':
+    resolution: {integrity: sha512-zzhdIK7lbUyDzOokXrb9Qk/Gw9/m3iktnQaxyw+rD3f5xILpQO8V3Ffoj7ACOnDMCbiSHLqSLURELlwtrBahpg==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.123':
-    resolution: {integrity: sha512-bYgRiaf2q+yVbGAoUluuhqrEW1zexL34+3HDmK9DneKXa2K2EJpw4M6Sq4XoBD/JezGaemoAP78Xv/M/QUS1OQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.129':
+    resolution: {integrity: sha512-itt/0eZ1jC9gXJfb2i4PksHqter6+u+S5xR/NYjpnbYUSij08PoNhKOtca3bm63siVG5DJM6EhZw8qv2HXyc9w==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.123':
-    resolution: {integrity: sha512-7+GnbcF3/aZ8RJ1WmU/ogtPsOpknBAoUPer90MvZuFYBLPT9iI/U7f24gjrOHuYdcbDA5n7jFlhcfIO26F5DJQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.129':
+    resolution: {integrity: sha512-I2snRvxXx9orypJ+0KWM5C5RAOgL1KukHiEHWvBqlMlig4feuLRay839DEubdHw8rQUMl4Ug4Znt0dfybXNJ/g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.123':
-    resolution: {integrity: sha512-IX95lFKhmmndY/YPfWPsVV+C3rLYJmuuq5wCS53p6jYIkCMxH1iGfhBGF1EUWcXO4Uc8yqXFmQ3aaxMzOOPrwA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.129':
+    resolution: {integrity: sha512-27RUDIrI2FxkKBeAbB7qDmuqj3ndFRzlpCt5Qx9/qTm4UZdB1T3qViqI4WYdvOz/zCWJct8SRUugKB4u3tOG0w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.123':
-    resolution: {integrity: sha512-Xi+Rwk8uP5vWEnawJOlsk179fr0ATLl5J90MlbLj+puKaX5svEq8ljS+P3zq6zHTJeKh9GKLzPf7bc5YJKwcew==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.129':
+    resolution: {integrity: sha512-VXQp1yqM2nc9L2fSZXrgWlYOtyOvhCP9wFN+4h1znIfm7hFNtRAtQXimmTLuXmyK3RdKw4o2ReKSd2sh0QMIhw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.123':
-    resolution: {integrity: sha512-WDZmAQG1rOiqNLZlSXaCjSWmqJvLk2io+vFQWWqSy2b5HCk9pa3PadLiaLztiihyk81wPhH9Q/44kOxdyfEGMw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.129':
+    resolution: {integrity: sha512-iGqmOmCNEIrcINJ4zwK5acC1dfZFqes0SwwF1IqsibmPqmUDJvjcbCTq5HyF6VvbEZRKKGgkAKTTiBW/zloBeA==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.123':
-    resolution: {integrity: sha512-588xrd1i6d4kXQ6FqwL+cgBiN4evRQSi5DCtPa02CZ3VEbuVQBeFlyPlD8tfWtNNeGZ4NM8kjPNNzZz5omezPA==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.129':
+    resolution: {integrity: sha512-fruJBHSrg82o0gIC0gUQOBltD9fZ1UfHKxc1fEdNuxP5/paWUmMlR54j88wN5Oh0e9QzP0pAr9qzmr6zSxG+Cw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.123':
-    resolution: {integrity: sha512-a4TysYoR9DBdkM9Uwh4J5ub7TwKmRPe5hFiWh4En+IKC+qkk5UFkxFM22c//cZjYZKynHX0ah2t6LUqb+najYA==}
+  '@anthropic-ai/claude-agent-sdk@0.2.129':
+    resolution: {integrity: sha512-tcrjAVNI4x+5n4BKJqfJDiuUhAjOs1nFA7oT3xQjXf29S/41vEvswfQmTiTsdQOhn8gebc342AHtnxfCjPsAiA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
-
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
-    hasBin: true
-    peerDependencies:
-      zod: 4.3.6
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -1012,7 +1005,7 @@ packages:
     resolution: {integrity: sha512-hdTYu39QgDFxv+FB6BK2zi4UIJGWhx2iPc0pHQ0C5Q/RCi+m+4gsryIzTGO+riqWcUA8/WGYp6hpqckdOBNysw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.26.0'
+      '@modelcontextprotocol/sdk': '>=1.29.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -2870,10 +2863,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
   ip-address@10.1.1:
     resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
@@ -4292,53 +4281,47 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.123':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.129':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.123(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.129(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.123
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.123
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.129
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.129
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
@@ -6361,7 +6344,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@5.2.1:
     dependencies:
@@ -6887,10 +6870,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ip-address@10.1.0: {}
-
-  ip-address@10.1.1:
-    optional: true
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

Closes the two currently-open Dependabot advisories on the repo:

- **`@anthropic-ai/sdk` <0.91.1** ([GHSA-p7fg-763f-g4gf](https://github.com/advisories/GHSA-p7fg-763f-g4gf), moderate) — insecure default file permissions in `BetaLocalFilesystemMemoryTool`. Fixed by bumping the direct dep in `cyrus-claude-runner` to `^0.94.0` and adding a root `pnpm.overrides` entry of `>=0.91.1` so the transitive copy bundled inside `@anthropic-ai/claude-agent-sdk` (which still pins `@anthropic-ai/sdk@^0.81.0`) is also forced onto the patched version. Also bumps `@anthropic-ai/claude-agent-sdk` from `0.2.123` → `0.2.129` everywhere.
- **`ip-address` <=10.1.0** ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g), moderate) — XSS in `Address6` HTML-emitting methods. Pulled in transitively via `cyrus-config-updater > @modelcontextprotocol/sdk > express-rate-limit > ip-address`. Fixed by bumping `@modelcontextprotocol/sdk` to `^1.29.0` in `cyrus-config-updater` (and updating the matching root override) and adding an `ip-address: >=10.1.1` override as belt-and-braces.

The `@anthropic-ai/sdk` 0.91.x release added a required `stop_details: BetaRefusalStopDetails | null` field to `BetaMessage`. Updated the locally-constructed assistant messages in `codex-runner`, `cursor-runner`, and `gemini-runner` to set `stop_details: null`.

`pnpm audit` reports `No known vulnerabilities found`.

Per `CLAUDE.md`'s dependency security policy: prefer direct-dep bumps in the owning `package.json`, fall back to root `pnpm.overrides` only when a direct bump can't reach the vulnerable transitive (the SDK case requires both, since `@anthropic-ai/claude-agent-sdk` still pins `@anthropic-ai/sdk@^0.81.0`).

## Supersedes

This PR supersedes:
- #1183 — fix(security): patch open Dependabot advisories (CYPACK-1170)
- #1185 — chore(deps): update @anthropic-ai/claude-agent-sdk to v0.2.128 and @anthropic-ai/sdk to ^0.93.0 (CYPACK-1172)

Closes [CYPACK-1174](https://linear.app/ceedar/issue/CYPACK-1174).

## Test plan

- [x] `pnpm install` succeeds with new lockfile
- [x] `pnpm audit` reports zero advisories
- [x] `pnpm build` (all packages + apps) green
- [x] `pnpm typecheck` green
- [x] `pnpm test:packages:run` green (one pre-existing flake in `packages/claude-runner/test/debug-logging.test.ts` when `DEBUG_CLAUDE_AGENT_SDK` env var leaks from parent shell; passes when env var is unset — unrelated to this change)
- [x] `./scripts/extract-claude-tools.sh` shows the same 33 tools already in `availableTools`; no config changes needed

<!-- generated-by-cyrus -->