### PR TITLE
fix(deps): patch ip-address XSS and @anthropic-ai/sdk file-permission advisories (CYPACK-1182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Patched two Dependabot security advisories** — Resolved `GHSA-p7fg-763f-g4gf` (Anthropic TypeScript SDK insecure default file permissions in `BetaLocalFilesystemMemoryTool`, CVE-2026-41686) by forcing `@anthropic-ai/sdk >= 0.91.1` via root `pnpm.overrides`, and `GHSA-v2v4-37r5-5v8g` (XSS in `ip-address` `Address6` HTML-emitting methods, CVE-2026-42338) by forcing `ip-address >= 10.1.1`. Overrides were necessary because the vulnerable copies are pinned by transitive deps that have not yet released a fix. ([CYPACK-1182](https://linear.app/ceedar/issue/CYPACK-1182))
+
 ## [0.2.51] - 2026-04-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
 			"diff": ">=8.0.3",
 			"@tootallnate/once": ">=3.0.1",
 			"@isaacs/brace-expansion": ">=5.0.1",
-			"tar": ">=7.5.11"
+			"tar": ">=7.5.11",
+			"@anthropic-ai/sdk": ">=0.91.1",
+			"ip-address": ">=10.1.1"
 		}
 	},
 	"lint-staged": {

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -94,6 +94,7 @@ function createAssistantToolUseMessage(
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,
@@ -147,6 +148,7 @@ function createAssistantBetaMessage(
 		model: DEFAULT_CODEX_MODEL,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/packages/cursor-runner/src/CursorRunner.ts
+++ b/packages/cursor-runner/src/CursorRunner.ts
@@ -111,6 +111,7 @@ function createAssistantToolUseMessage(
 		model: "cursor-agent",
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,
@@ -139,6 +140,7 @@ function createAssistantTextMessage(
 		model: "cursor-agent",
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/packages/gemini-runner/src/adapters.ts
+++ b/packages/gemini-runner/src/adapters.ts
@@ -38,6 +38,7 @@ function createBetaMessage(
 		model: "gemini-3" as const,
 		stop_reason: null,
 		stop_sequence: null,
+		stop_details: null,
 		usage: {
 			input_tokens: 0,
 			output_tokens: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   '@tootallnate/once': '>=3.0.1'
   '@isaacs/brace-expansion': '>=5.0.1'
   tar: '>=7.5.11'
+  '@anthropic-ai/sdk': '>=0.91.1'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -149,7 +151,7 @@ importers:
         specifier: 0.2.123
         version: 0.2.123(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.91.0
+        specifier: '>=0.91.1'
         version: 0.91.1(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
@@ -617,15 +619,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: 4.3.6
-
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
-    hasBin: true
-    peerDependencies:
-      zod: 4.3.6
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -2870,10 +2863,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
   ip-address@10.1.1:
     resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
@@ -4318,7 +4307,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.123(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -4333,12 +4322,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
@@ -6361,7 +6344,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@5.2.1:
     dependencies:
@@ -6887,10 +6870,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  ip-address@10.1.0: {}
-
-  ip-address@10.1.1:
-    optional: true
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary
- Adds root `pnpm.overrides` for `@anthropic-ai/sdk >=0.91.1` (GHSA-p7fg-763f-g4gf, CVE-2026-41686 — insecure default file permissions in `BetaLocalFilesystemMemoryTool`) and `ip-address >=10.1.1` (GHSA-v2v4-37r5-5v8g, CVE-2026-42338 — XSS in `Address6` HTML-emitting methods).
- Overrides were necessary in both cases: the vulnerable `@anthropic-ai/sdk@0.81.0` is pinned by `@anthropic-ai/claude-agent-sdk@latest`, and the vulnerable `ip-address` is a 3-level transitive via `@modelcontextprotocol/sdk > express-rate-limit`. Per the team's mandated dependency security policy, a direct-dep bump cannot reach either.
- Bumping `@anthropic-ai/sdk` added a required `stop_details: BetaRefusalStopDetails | null` field to `BetaMessage`. Updated `cursor-runner`, `gemini-runner`, and `codex-runner` SDK message adapters accordingly.

`pnpm audit` reports zero advisories. Closes [CYPACK-1182](https://linear.app/ceedar/issue/CYPACK-1182).

## Test plan
- [x] `pnpm install` succeeds with new overrides
- [x] `pnpm audit` reports no known vulnerabilities
- [x] `pnpm build` succeeds across all packages
- [x] `pnpm typecheck` passes across the workspace
- [x] `pnpm test:packages:run` passes (one pre-existing flake in `claude-runner/test/debug-logging.test.ts` due to a leaky `DEBUG_CLAUDE_AGENT_SDK` env var in the local shell — unrelated; passes when env is clean)

<!-- generated-by-cyrus -->