### PR TITLE
fix: guard addStreamMessage with isStreaming() to avoid stream-completed race

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1512,7 +1512,8 @@ Your base branch \`${branchName}\` has received ${commitCount} new commit(s). Co
 			if (
 				isRunning &&
 				existingRunner?.supportsStreamingInput &&
-				existingRunner.addStreamMessage
+				existingRunner.addStreamMessage &&
+				existingRunner.isStreaming?.()
 			) {
 				existingRunner.addStreamMessage(notification);
 				this.logger.debug(
@@ -3521,7 +3522,8 @@ ${taskSection}`;
 			if (
 				isRunning &&
 				existingRunner?.supportsStreamingInput &&
-				existingRunner.addStreamMessage
+				existingRunner.addStreamMessage &&
+				existingRunner.isStreaming?.()
 			) {
 				existingRunner.addStreamMessage(fullPrompt);
 				delivered = true;
@@ -6616,7 +6618,8 @@ ${input.userComment}
 		if (
 			existingRunner?.isRunning() &&
 			existingRunner.supportsStreamingInput &&
-			existingRunner.addStreamMessage
+			existingRunner.addStreamMessage &&
+			existingRunner.isStreaming?.()
 		) {
 			log.debug(
 				`Adding prompt to existing stream for ${sessionId} (${logContext})`,
@@ -6703,7 +6706,8 @@ ${input.userComment}
 		if (
 			existingRunner?.isRunning() &&
 			existingRunner.supportsStreamingInput &&
-			existingRunner.addStreamMessage
+			existingRunner.addStreamMessage &&
+			existingRunner.isStreaming?.()
 		) {
 			let fullPrompt = promptBody;
 			if (attachmentManifest) {

--- a/packages/edge-worker/test/EdgeWorker.issue-update-multiple-sessions.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.issue-update-multiple-sessions.test.ts
@@ -83,6 +83,7 @@ describe("EdgeWorker - Issue Update Session Delivery (CYPACK-954)", () => {
 			agentRunner: hasRunner
 				? {
 						isRunning: vi.fn().mockReturnValue(isRunning),
+						isStreaming: vi.fn().mockReturnValue(isRunning),
 						supportsStreamingInput: supportsStreaming,
 						addStreamMessage: vi.fn(),
 						stop: vi.fn(),


### PR DESCRIPTION
## Bug

After #1141 began calling `streamingPrompt.complete()` on the SDK result message under non-warm mode, a brief window opens where:

- `ClaudeRunner.isRunning()` still returns `true` (because `sessionInfo.isRunning` is flipped *after* the for-await loop exits — see `ClaudeRunner.ts:806`)
- `streamingPrompt.completed` is already `true`

Webhook handlers that guarded `addStreamMessage(...)` with `isRunning()` alone passed the check, then `StreamingPrompt.addMessage()` threw `"Cannot add message to completed stream"`. The exception was logged but not caught, so the user's comment was silently dropped — *after* Cyrus had already posted `"I've queued up your message as guidance"` in the Linear UI. Confusing failure mode.

## Symptom from production logs

```
2026-05-13T11:53:01.920Z [ERROR] [EdgeWorker] Failed to handle prompted webhook:
Error: Cannot add message to completed stream
at ClaudeRunner.addStreamMessage (.../cyrus-claude-runner/dist/ClaudeRunner.js:299:30)
```

User's view: they replied to an agent session, saw "queued as guidance", waited 9 minutes for the agent to act on it, nothing happened. The comment had to be re-posted to take effect.

## Fix

`IAgentRunner.isStreaming?()` is already part of the interface — see `agent-runner-types.ts:296`:
> "Use this to guard calls to `addStreamMessage()`."
`ClaudeRunner.isStreaming()` correctly checks both `streamingPrompt !== null && !streamingPrompt.completed && isRunning()`. `ChatSessionHandler.ts:141-143` already gates on `isStreaming?.()`. The four EdgeWorker sites did not — this PR adds `&& existingRunner.isStreaming?.()` to each guard:
- `EdgeWorker.ts:1512` — base-branch change notification streaming
- `EdgeWorker.ts:3521` — issue-update streaming delivery (CYPACK-954 path)
- `EdgeWorker.ts:6619` — `handlePromptWithStreamingCheck` (main prompted-webhook entry)
- `EdgeWorker.ts:6706` — `resumeAgentSession` early-return when stream is alive
When the guard fails, callers fall through to the proper `query({ resume: ... })` path, preserving the user's message instead of dropping it.

## Test changes

`EdgeWorker.issue-update-multiple-sessions.test.ts` — the mock factory at line 84 was missing `isStreaming` on the agent runner mock. Other test files already mock both. Added `isStreaming: vi.fn().mockReturnValue(isRunning)` so the streaming branch is reachable in tests.
## Verification
- All 611 edge-worker tests pass (`pnpm --filter cyrus-edge-worker test:run`).
- `pnpm --filter cyrus-edge-worker typecheck` clean.
- `pnpm build` clean across the workspace.
- Deployed locally to a Cyrus production install for ~30 min before reverting; no regressions observed during the test window.

## Related

- #1141 (`c0495f3d`) — introduced the `streamingPrompt.complete()` on result behavior under non-warm mode. This PR is a follow-up to harden the call sites that the change exposed.
- #1109 — the warm-sessions PR that originally removed the close.