### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,3 +567,26 @@ For detailed information about Gemini CLI configuration options (settings.json s
 - **Official Documentation**: https://github.com/google-gemini/gemini-cli/blob/main/docs/get-started/configuration.md
 
 The GeminiRunner automatically generates a `~/.gemini/settings.json` file with single-turn model aliases and preview features enabled if one doesn't already exist.
+
+## Cursor Cloud specific instructions
+
+### Environment setup
+
+- **Package manager**: pnpm (v10.33.x). Installed globally via `npm install -g pnpm`. After installing, you must create the bin symlink manually: `ln -sf $(npm root -g)/pnpm/bin/pnpm.cjs $(dirname $(which node))/pnpm`.
+- **Managed versions**: pnpm's `manage-package-manager-versions` must be set to `false` globally (`pnpm config set manage-package-manager-versions false --global`) since the exact version specified in `packageManager` may not be downloadable from the Cloud VM's network.
+- **System dependency**: `jq` is required by the claude-parser package.
+- **Node.js**: v22.x (matches CI matrix).
+
+### Running services
+
+- **Dev mode**: `pnpm dev` from the monorepo root starts all packages in watch mode.
+- **Lint**: `pnpm lint` (runs Biome).
+- **Typecheck**: `pnpm typecheck` (runs `tsc --noEmit` across all packages).
+- **Tests**: `pnpm test:packages:run` runs all package tests once (recommended for CI-like validation).
+- **Build**: `pnpm build` builds all packages (excludes Electron app).
+
+### Gotchas
+
+- The `pnpm install` step requires network access to `registry.npmjs.org`. If that domain is blocked by egress restrictions, dependency installation will fail with `ECONNRESET` errors during TLS handshake.
+- The pre-commit hook runs `lint-staged`, `pnpm build`, and `pnpm typecheck` — use `--no-verify` to bypass if needed.
+- There is no Docker dependency for the cyrus repo itself.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `CLAUDE.md` (which `AGENTS.md` symlinks to) documenting:

- Environment setup requirements (pnpm, managed versions workaround, jq, Node.js version)
- Common service commands (dev, lint, typecheck, tests, build)
- Gotchas for Cloud Agent environments (egress restrictions, pre-commit hook bypass)

This enables future Cursor Cloud agents to set up the development environment correctly without re-discovering these details.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f42e068-5de3-4051-bba8-ff071685da0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f42e068-5de3-4051-bba8-ff071685da0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

