### PR TITLE
refactor: simplify parent session resume callback

### DIFF
--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -446,8 +446,6 @@ export class EdgeWorker extends EventEmitter {
 					parentSessionId,
 					prompt,
 					childSessionId,
-					repo,
-					this.agentSessionManager,
 				);
 			},
 		);
@@ -2647,8 +2645,6 @@ ${taskSection}`;
 		parentSessionId: string,
 		prompt: string,
 		childSessionId: string,
-		_childRepo: RepositoryConfig,
-		childAgentSessionManager: AgentSessionManager,
 	): Promise<void> {
 		const log = this.logger.withContext({ sessionId: parentSessionId });
 		log.info(
@@ -2679,8 +2675,7 @@ ${taskSection}`;
 		);
 
 		// Get the child session to access its workspace path
-		// Child session is in the child's manager (passed in from the callback)
-		const childSession = childAgentSessionManager.getSession(childSessionId);
+		const childSession = this.agentSessionManager.getSession(childSessionId);
 		const childWorkspaceDirs: string[] = [];
 		if (childSession) {
 			childWorkspaceDirs.push(childSession.workspace.path);


### PR DESCRIPTION
## Summary
- stop passing agentSessionManager into the parent-resume callback while it is being initialized
- have handleResumeParentSession read the shared session manager from the EdgeWorker instance

Fixes #322

## Tests
- pnpm exec biome check packages/edge-worker/src/EdgeWorker.ts
- pnpm --filter cyrus-edge-worker... build
- pnpm --filter cyrus-edge-worker typecheck
- commit hook also ran full monorepo build and typecheck