### PR TITLE
feat(edge-worker): forward per-runner custom binary paths to spawned runners

### DIFF
--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -70,6 +70,28 @@ Routes Linear issues with specific labels to this repository. This is useful whe
 
 Example: `["backend", "api"]` - Only process issues that have the "backend" or "api" label
 
+### Custom runner-binary paths
+
+Per spawned runner type, you can override the binary cyrus dispatches with. Useful when operators wrap the runner binary for sandboxed / containerized dispatch, credential brokering, telemetry header injection, or other per-invocation transforms. The wrapper must accept the same CLI surface as the upstream binary and be directly executable (shebang). Each field is only honored for its matching runner type; the `cursor` runner is in-process (no spawned binary) and has no analogous knob.
+
+#### `pathToClaudeCodeExecutable` (string)
+
+Used by the `claude` runner. Forwarded to the Claude Agent SDK as the `pathToClaudeCodeExecutable` option, causing the SDK to spawn this binary instead of its bundled CLI.
+
+Example: `"pathToClaudeCodeExecutable": "/usr/local/bin/claude-docker.sh"`
+
+#### `codexPath` (string)
+
+Used by the `codex` runner. Forwarded to the codex runner as `codexPath`, replacing the default `codex` lookup on `PATH`.
+
+Example: `"codexPath": "/usr/local/bin/codex-docker.sh"`
+
+#### `geminiPath` (string)
+
+Used by the `gemini` runner. Forwarded to the gemini runner as `geminiPath`, replacing the default `gemini` lookup on `PATH`.
+
+Example: `"geminiPath": "/usr/local/bin/gemini-docker.sh"`
+
 ---
 
 ## Routing Priority Order

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -99,6 +99,15 @@
 					"fallbackModel": {
 						"type": "string"
 					},
+					"pathToClaudeCodeExecutable": {
+						"type": "string"
+					},
+					"codexPath": {
+						"type": "string"
+					},
+					"geminiPath": {
+						"type": "string"
+					},
 					"labelPrompts": {
 						"type": "object",
 						"properties": {

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -99,6 +99,15 @@
 					"fallbackModel": {
 						"type": "string"
 					},
+					"pathToClaudeCodeExecutable": {
+						"type": "string"
+					},
+					"codexPath": {
+						"type": "string"
+					},
+					"geminiPath": {
+						"type": "string"
+					},
 					"labelPrompts": {
 						"type": "object",
 						"properties": {

--- a/packages/core/schemas/RepositoryConfig.json
+++ b/packages/core/schemas/RepositoryConfig.json
@@ -94,6 +94,15 @@
 		"fallbackModel": {
 			"type": "string"
 		},
+		"pathToClaudeCodeExecutable": {
+			"type": "string"
+		},
+		"codexPath": {
+			"type": "string"
+		},
+		"geminiPath": {
+			"type": "string"
+		},
 		"labelPrompts": {
 			"type": "object",
 			"properties": {

--- a/packages/core/schemas/RepositoryConfigPayload.json
+++ b/packages/core/schemas/RepositoryConfigPayload.json
@@ -94,6 +94,15 @@
 		"fallbackModel": {
 			"type": "string"
 		},
+		"pathToClaudeCodeExecutable": {
+			"type": "string"
+		},
+		"codexPath": {
+			"type": "string"
+		},
+		"geminiPath": {
+			"type": "string"
+		},
 		"labelPrompts": {
 			"type": "object",
 			"properties": {

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -306,6 +306,42 @@ export const RepositoryConfigSchema = z.object({
 	model: z.string().optional(),
 	fallbackModel: z.string().optional(),
 
+	/**
+	 * Path to a custom Claude Code executable to dispatch this repository's
+	 * sessions with. When set, cyrus forwards this to the Claude Agent SDK
+	 * as `pathToClaudeCodeExecutable`, causing the SDK to spawn that binary
+	 * instead of its bundled CLI.
+	 *
+	 * Useful when operators wrap the Claude binary for sandboxed/containerized
+	 * dispatch, credential brokering, telemetry header injection, or other
+	 * per-invocation transforms. The wrapper must accept the same CLI surface
+	 * as `@anthropic-ai/claude-code` and be directly executable (shebang).
+	 *
+	 * Only honored for the `claude` runner type; ignored for codex/gemini/cursor.
+	 */
+	pathToClaudeCodeExecutable: z.string().optional(),
+
+	/**
+	 * Path to a custom Codex CLI binary to dispatch this repository's sessions
+	 * with. When set, cyrus forwards this to the codex runner as `codexPath`,
+	 * causing the runner to spawn that binary instead of the default `codex`
+	 * on PATH. Same wrapper use cases as `pathToClaudeCodeExecutable`.
+	 *
+	 * Only honored for the `codex` runner type; ignored for claude/gemini/cursor.
+	 */
+	codexPath: z.string().optional(),
+
+	/**
+	 * Path to a custom Gemini CLI binary to dispatch this repository's
+	 * sessions with. When set, cyrus forwards this to the gemini runner as
+	 * `geminiPath`, causing the runner to spawn that binary instead of the
+	 * default `gemini` on PATH. Same wrapper use cases as
+	 * `pathToClaudeCodeExecutable`.
+	 *
+	 * Only honored for the `gemini` runner type; ignored for claude/codex/cursor.
+	 */
+	geminiPath: z.string().optional(),
+
 	// Label-based system prompt configuration
 	labelPrompts: LabelPromptsSchema.optional(),
 

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -386,6 +386,25 @@ export class RunnerConfigBuilder {
 			...(runnerType === "claude" &&
 				input.sandboxSettings &&
 				this.buildSandboxConfig(input)),
+			// Custom runner-binary paths (per spawned runner type). When set in
+			// the repository config, the corresponding runner spawns this binary
+			// instead of its default — useful for sandbox/wrapper dispatch,
+			// credential brokering, or telemetry header injection. Each is
+			// honored only for its matching runner type; the cursor runner is
+			// in-process (no spawned binary) and has no analogous knob.
+			...(runnerType === "claude" &&
+				input.repository.pathToClaudeCodeExecutable && {
+					pathToClaudeCodeExecutable:
+						input.repository.pathToClaudeCodeExecutable,
+				}),
+			...(runnerType === "codex" &&
+				input.repository.codexPath && {
+					codexPath: input.repository.codexPath,
+				}),
+			...(runnerType === "gemini" &&
+				input.repository.geminiPath && {
+					geminiPath: input.repository.geminiPath,
+				}),
 			// AskUserQuestion callback - only for Claude runner
 			...(runnerType === "claude" &&
 				input.createAskUserQuestionCallback && {

--- a/packages/edge-worker/test/RunnerConfigBuilder.runner-binary-paths.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.runner-binary-paths.test.ts
@@ -1,0 +1,208 @@
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	type IssueRunnerConfigInput,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(
+	runnerType: "claude" | "codex" | "gemini" | "cursor" = "claude",
+): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType }),
+		getDefaultModelForRunner: () => "",
+		getDefaultFallbackModelForRunner: () => "",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(
+	overrides: Partial<RepositoryConfig> = {},
+): RepositoryConfig {
+	return {
+		id: "repo-1",
+		name: "repo-1",
+		repositoryPath: "/tmp/repo",
+		baseBranch: "main",
+		workspaceBaseDir: "/tmp/repo/.worktrees",
+		linearWorkspaceId: "ws-1",
+		...overrides,
+	} as RepositoryConfig;
+}
+
+function makeSession(): CyrusAgentSession {
+	return {
+		id: "session-1",
+		issueId: "issue-1",
+		workspace: { path: "/tmp/repo/.worktrees/issue-1" },
+		issue: { identifier: "TST-1" },
+	} as unknown as CyrusAgentSession;
+}
+
+function makeInput(
+	overrides: Partial<IssueRunnerConfigInput> = {},
+): IssueRunnerConfigInput {
+	return {
+		session: makeSession(),
+		repository: makeRepository(),
+		sessionId: "session-1",
+		systemPrompt: "",
+		allowedTools: [],
+		allowedDirectories: [],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home-test",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+		...overrides,
+	} as IssueRunnerConfigInput;
+}
+
+describe("RunnerConfigBuilder.buildIssueConfig — custom runner-binary paths", () => {
+	describe("pathToClaudeCodeExecutable (claude runner)", () => {
+		it("forwards repository.pathToClaudeCodeExecutable into the claude runner config when set", () => {
+			const builder = makeBuilder("claude");
+			const wrapperPath = "/usr/local/bin/claude-docker.sh";
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({
+						pathToClaudeCodeExecutable: wrapperPath,
+					}),
+				}),
+			);
+
+			expect(runnerType).toBe("claude");
+			expect(
+				(config as { pathToClaudeCodeExecutable?: string })
+					.pathToClaudeCodeExecutable,
+			).toBe(wrapperPath);
+		});
+
+		it("omits pathToClaudeCodeExecutable from the config when the repository field is unset", () => {
+			const builder = makeBuilder("claude");
+
+			const { config, runnerType } = builder.buildIssueConfig(makeInput());
+
+			expect(runnerType).toBe("claude");
+			expect(config).not.toHaveProperty("pathToClaudeCodeExecutable");
+		});
+
+		it("ignores repository.pathToClaudeCodeExecutable for non-claude runner types", () => {
+			const builder = makeBuilder("codex");
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({
+						pathToClaudeCodeExecutable: "/usr/local/bin/claude-docker.sh",
+					}),
+				}),
+			);
+
+			expect(runnerType).toBe("codex");
+			expect(config).not.toHaveProperty("pathToClaudeCodeExecutable");
+		});
+	});
+
+	describe("codexPath (codex runner)", () => {
+		it("forwards repository.codexPath into the codex runner config when set", () => {
+			const builder = makeBuilder("codex");
+			const wrapperPath = "/usr/local/bin/codex-docker.sh";
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({ codexPath: wrapperPath }),
+				}),
+			);
+
+			expect(runnerType).toBe("codex");
+			expect((config as { codexPath?: string }).codexPath).toBe(wrapperPath);
+		});
+
+		it("omits codexPath from the config when the repository field is unset", () => {
+			const builder = makeBuilder("codex");
+
+			const { config, runnerType } = builder.buildIssueConfig(makeInput());
+
+			expect(runnerType).toBe("codex");
+			expect(config).not.toHaveProperty("codexPath");
+		});
+
+		it("ignores repository.codexPath for non-codex runner types", () => {
+			const builder = makeBuilder("claude");
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({
+						codexPath: "/usr/local/bin/codex-docker.sh",
+					}),
+				}),
+			);
+
+			expect(runnerType).toBe("claude");
+			expect(config).not.toHaveProperty("codexPath");
+		});
+	});
+
+	describe("geminiPath (gemini runner)", () => {
+		it("forwards repository.geminiPath into the gemini runner config when set", () => {
+			const builder = makeBuilder("gemini");
+			const wrapperPath = "/usr/local/bin/gemini-docker.sh";
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({ geminiPath: wrapperPath }),
+				}),
+			);
+
+			expect(runnerType).toBe("gemini");
+			expect((config as { geminiPath?: string }).geminiPath).toBe(wrapperPath);
+		});
+
+		it("omits geminiPath from the config when the repository field is unset", () => {
+			const builder = makeBuilder("gemini");
+
+			const { config, runnerType } = builder.buildIssueConfig(makeInput());
+
+			expect(runnerType).toBe("gemini");
+			expect(config).not.toHaveProperty("geminiPath");
+		});
+
+		it("ignores repository.geminiPath for non-gemini runner types", () => {
+			const builder = makeBuilder("claude");
+
+			const { config, runnerType } = builder.buildIssueConfig(
+				makeInput({
+					repository: makeRepository({
+						geminiPath: "/usr/local/bin/gemini-docker.sh",
+					}),
+				}),
+			);
+
+			expect(runnerType).toBe("claude");
+			expect(config).not.toHaveProperty("geminiPath");
+		});
+	});
+});


### PR DESCRIPTION
## Motivation

Cyrus's three spawned-binary runners — `claude`, `codex`, `gemini` — each expose an SDK option for replacing the dispatched binary with a custom path:

| Runner | SDK option | Default |
|---|---|---|
| claude | `pathToClaudeCodeExecutable` (Anthropic SDK) | bundled CLI |
| codex  | `codexPath` (cyrus-codex-runner)             | `codex` on PATH |
| gemini | `geminiPath` (cyrus-gemini-runner)           | `gemini` on PATH |

(The `cursor` runner is in-process via the Cursor SDK — no spawned binary, so no analogous knob.)

Useful when operators wrap the runner binary for:

- Sandboxed / containerized dispatch (e.g. `docker run sandbox …`)
- Per-invocation credential brokering or mode switching
- Telemetry header injection or OTEL endpoint rewriting
- Any transform that needs to fire on every runner invocation

Today, none of these options can be set from `~/.cyrus/config.json`. `cyrus-claude-runner`, `cyrus-codex-runner`, and `cyrus-gemini-runner` each read their respective option from their own runner config, but nothing upstream of them in cyrus-edge-worker reads from cyrus config and forwards. So operators have to fork cyrus or replace the binary on PATH — neither great.

## Change

Adds three optional per-repository fields to `RepositoryConfigSchema`: `pathToClaudeCodeExecutable`, `codexPath`, `geminiPath`. Each is forwarded by `RunnerConfigBuilder.buildIssueConfig` to the returned runner config when the resolved runner type matches. Naming matches each SDK's existing option, so the cyrus docs entry maps 1:1 to the SDK docs.

Field placement: per-repository, matching the existing pattern for `model`, `fallbackModel`, `allowedTools`, `mcpConfigPath`. No top-level fallback (kept the surface minimal; can be added in a follow-up).

## Files

- `packages/core/src/config-schemas.ts` — three optional fields with JSDoc
- `packages/edge-worker/src/RunnerConfigBuilder.ts` — three runner-type-conditional forwards in `buildIssueConfig`'s claude/codex/gemini blocks
- `packages/core/schemas/*.json` — regenerated via `pnpm --filter cyrus-core generate:json-schema`
- `docs/CONFIG_FILE.md` — documents the three fields under a "Custom runner-binary paths" subsection
- `packages/edge-worker/test/RunnerConfigBuilder.runner-binary-paths.test.ts` — 9 tests: claude/codex/gemini × forwarded-when-set / omitted-when-unset / ignored-when-wrong-runner

## Verification

`pnpm build` and `pnpm test:packages:run` both clean on this branch. 632 edge-worker tests pass (was 626 on main, +6 for the new codex/gemini variants); 129 core tests pass; suite-wide green.

## Out of scope

- `executable` field (`"bun"` vs `"node"` for claude) — separate concern; wrapper scripts that shebang `bash` or `node` work fine via the default.
- Top-level config fallback — kept narrow for review.
- Plumbing in `buildChatConfig` — only added to `buildIssueConfig` since that's where the per-runner-type branches live. Small follow-up if you want the same knob for Slack chat sessions.
- Cursor runner — no spawned binary, no analogous SDK option.

Closes no issue — happy to file a separate one if you'd prefer.