### PR TITLE
feat(edge-worker): add global_teardown_script hook (CYPACK-1219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **New `global_teardown_script` config option** — Cyrus can now run a teardown script from inside an issue's worktree immediately before the worktree is deleted when the issue reaches a terminal state (`completed`, `canceled`, or `deleted`). Useful for tearing down per-issue resources (local databases, containers, cloud sandboxes) set up by `global_setup_script`. Teardown does **not** fire on unassignment — the worktree is preserved for re-assignment. Scripts must be idempotent, run with a 2-minute timeout, are non-blocking on failure, and receive only `LINEAR_ISSUE_IDENTIFIER` in the environment. ([CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219), original PR by @matthewbjones at [#1066](https://github.com/cyrusagents/cyrus/pull/1066))
+
 ### Security
 - **Patched 9 transitive dependency advisories** — Bumped `pnpm.overrides` for `hono` (≥4.12.18, fixes CSS injection / JWT validation / Cache Middleware cross-user leakage), `fast-uri` (≥3.1.2, path traversal + host confusion), `ip-address` (≥10.1.1, `Address6` XSS), `@anthropic-ai/sdk` (≥0.91.1, insecure default file permissions in local filesystem memory tool), and `@opentelemetry/sdk-node` / `@opentelemetry/exporter-prometheus` (≥0.217.0, Prometheus exporter process crash via malformed HTTP request). `pnpm audit` now reports zero advisories. ([CYPACK-1206](https://linear.app/ceedar/issue/CYPACK-1206))
 

--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -382,6 +382,20 @@ Sets default allowed tools for each prompt type across all repositories. Reposit
 
 Path to a script that runs for all repositories when creating new worktrees. See the main README for details on setup scripts.
 
+### `global_teardown_script` (string)
+
+Path to a script that runs from inside the issue's worktree directory immediately before the worktree is deleted, when an issue reaches a terminal state (`completed`, `canceled`, or `deleted`). Useful for tearing down per-issue resources (local databases, containers, cloud sandboxes) created by the setup script.
+
+Important behaviors:
+
+- Runs only on terminal-state transitions — **unassigning an issue does not trigger teardown** (the worktree is preserved for re-assignment).
+- Failures are logged but do not block worktree deletion.
+- The script has a **2-minute timeout**.
+- Receives only `LINEAR_ISSUE_IDENTIFIER` in the environment (no `LINEAR_ISSUE_ID` or `LINEAR_ISSUE_TITLE`, which are not available on the terminal-state path).
+- Must be **idempotent** — cleanup may be retried.
+
+See [SETUP_SCRIPTS.md](./SETUP_SCRIPTS.md) for full details.
+
 ---
 
 ## Tool Configuration Priority

--- a/docs/SETUP_SCRIPTS.md
+++ b/docs/SETUP_SCRIPTS.md
@@ -74,3 +74,68 @@ Make sure the script is executable: `chmod +x /opt/cyrus/bin/global-setup.sh`
 - If the global script fails, Cyrus logs the error but continues with repository script execution
 - Both scripts have a 5-minute timeout to prevent hanging
 - Script failures don't prevent worktree creation
+
+---
+
+## Global Teardown Script
+
+You can also configure a teardown script that runs from inside the issue's worktree directory **immediately before the worktree is deleted**, when the issue reaches a terminal state.
+
+### Configuration
+
+Add `global_teardown_script` to your `~/.cyrus/config.json`:
+
+```json
+{
+  "repositories": [...],
+  "global_teardown_script": "/opt/cyrus/bin/global-teardown.sh"
+}
+```
+
+### When it runs
+
+The teardown script fires only when an issue reaches a terminal state:
+
+- Linear issue moved to **completed**
+- Linear issue moved to **canceled**
+- Linear issue **deleted**
+
+It does **not** fire on issue unassignment — re-assignment is a normal flow and Cyrus preserves the worktree (and any setup-script artifacts) so a re-assigned issue can resume work immediately.
+
+### Environment
+
+The teardown script receives **only**:
+
+- `LINEAR_ISSUE_IDENTIFIER` — the issue identifier (e.g., `CEA-123`)
+
+`LINEAR_ISSUE_ID` and `LINEAR_ISSUE_TITLE` are **not** available on the terminal-state cleanup path. Setup scripts receive all three; teardown scripts receive only the identifier. Do not reference fields that aren't set.
+
+### Working directory
+
+The script runs with the issue's worktree directory as its working directory, so it can read `.env.local`, local databases, or any other artifacts written by the setup script.
+
+### Important behaviors
+
+- **Idempotent.** Cleanup may be retried, so the script may run more than once for the same issue. Write your teardown so re-running it is safe.
+- **Non-blocking on failure.** If the teardown script fails (non-zero exit, error, timeout, etc.), Cyrus logs the failure and proceeds with worktree deletion.
+- **2-minute timeout.** Teardown is intended for lightweight cleanup; longer-running teardown will be killed.
+- **`stdio: "inherit"`.** Anything the script echoes — including secrets — lands in the edge-worker logs.
+
+### Example Usage
+
+```bash
+#!/bin/bash
+# global-teardown.sh - Tear down per-issue resources
+set -euo pipefail
+
+# Identifier is the only env var available
+echo "Tearing down resources for $LINEAR_ISSUE_IDENTIFIER"
+
+# Idempotent cleanup — guard against re-runs
+if [ -f .env.local ]; then
+  # e.g., stop a per-issue Docker compose stack
+  docker compose -f docker-compose.cyrus.yml down --volumes || true
+fi
+```
+
+Make sure the script is executable: `chmod +x /opt/cyrus/bin/global-teardown.sh`

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -552,6 +552,9 @@
 		"global_setup_script": {
 			"type": "string"
 		},
+		"global_teardown_script": {
+			"type": "string"
+		},
 		"defaultAllowedTools": {
 			"type": "array",
 			"items": {

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -546,6 +546,9 @@
 		"global_setup_script": {
 			"type": "string"
 		},
+		"global_teardown_script": {
+			"type": "string"
+		},
 		"defaultAllowedTools": {
 			"type": "array",
 			"items": {

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -381,6 +381,14 @@ export const EdgeConfigSchema = z.object({
 	/** Optional path to global setup script that runs for all repositories */
 	global_setup_script: z.string().optional(),
 
+	/**
+	 * Optional path to a global teardown script that runs inside the issue's
+	 * worktree directory immediately before worktree deletion when an issue
+	 * reaches a terminal state (completed, canceled, or deleted). The script
+	 * must be idempotent — cleanup may be retried.
+	 */
+	global_teardown_script: z.string().optional(),
+
 	/** Default tools to allow across all repositories */
 	defaultAllowedTools: z.array(z.string()).optional(),
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -3256,7 +3256,11 @@ ${taskSection}`;
 		}
 
 		// Delete worktrees for this issue, keyed by the Linear issue identifier.
-		this.gitService.deleteWorktree(message.workItemIdentifier);
+		// Pass the global teardown script (if configured) so it runs in the
+		// worktree before any filesystem removal.
+		this.gitService.deleteWorktree(message.workItemIdentifier, {
+			globalTeardownScript: this.config.global_teardown_script,
+		});
 
 		this.logger.info(
 			`Completed cleanup for ${message.workItemIdentifier}: stopped ${sessions.length} session(s)`,

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -38,6 +38,30 @@ export interface GitServiceOptions {
 }
 
 /**
+ * Per-call options for {@link GitService.deleteWorktree}.
+ */
+export interface DeleteWorktreeOptions {
+	/**
+	 * Optional path to a global teardown script. When provided, the script is
+	 * executed inside the issue's worktree directory before any filesystem
+	 * removal. Failures are logged but do not block deletion.
+	 */
+	globalTeardownScript?: string;
+}
+
+/**
+ * Hook script timeout for the setup phase (5 minutes). Setup may need to
+ * install dependencies, so it gets a longer budget than teardown.
+ */
+const SETUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Hook script timeout for the teardown phase (2 minutes). Teardown is intended
+ * for lightweight cleanup; if it cannot finish in 2 minutes it is killed.
+ */
+const TEARDOWN_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
  * Service responsible for Git worktree operations
  */
 export class GitService {
@@ -134,22 +158,59 @@ export class GitService {
 	}
 
 	/**
-	 * Run a setup script with proper error handling and logging
+	 * Run a setup script with proper error handling and logging.
+	 * Thin wrapper that delegates to {@link runHookScript} for shared behavior
+	 * across setup and teardown hooks.
 	 */
-	private async runSetupScript(
+	private runSetupScript(
 		scriptPath: string,
 		scriptType: "global" | "repository",
 		workspacePath: string,
 		issue: Issue,
-	): Promise<void> {
+	): void {
+		const label = scriptType === "global" ? "global setup" : "repository setup";
+		this.runHookScript({
+			scriptPath,
+			label,
+			workspacePath,
+			env: {
+				LINEAR_ISSUE_ID: issue.id,
+				LINEAR_ISSUE_IDENTIFIER: issue.identifier,
+				LINEAR_ISSUE_TITLE: issue.title || "",
+			},
+			timeoutMs: SETUP_TIMEOUT_MS,
+			postFailureMessage: "   Continuing with worktree creation...",
+		});
+	}
+
+	/**
+	 * Shared hook script runner used by both setup and teardown paths.
+	 *
+	 * Behavior:
+	 * - Expands a leading `~` in `scriptPath` to the user's home directory.
+	 * - Skips with a warning if the script does not exist or (on Unix) lacks
+	 *   the owner-execute bit.
+	 * - Runs the script with `cwd=workspacePath`, `stdio="inherit"`, and the
+	 *   provided env merged onto `process.env`.
+	 * - On failure logs the error (including SIGTERM-as-timeout) and returns
+	 *   normally — failures are non-blocking by design.
+	 */
+	private runHookScript(opts: {
+		scriptPath: string;
+		label: string;
+		workspacePath: string;
+		env: Record<string, string>;
+		timeoutMs: number;
+		postFailureMessage?: string;
+	}): void {
+		const { scriptPath, label, workspacePath, env, timeoutMs } = opts;
+
 		// Expand ~ to home directory
 		const expandedPath = scriptPath.replace(/^~/, homedir());
 
 		// Check if script exists
 		if (!existsSync(expandedPath)) {
-			this.logger.warn(
-				`⚠️  ${scriptType === "global" ? "Global" : "Repository"} setup script not found: ${scriptPath}`,
-			);
+			this.logger.warn(`⚠️  ${label} script not found: ${scriptPath}`);
 			return;
 		}
 
@@ -160,21 +221,22 @@ export class GitService {
 				// Check if file has execute permission for the owner
 				if (!(stats.mode & 0o100)) {
 					this.logger.warn(
-						`⚠️  ${scriptType === "global" ? "Global" : "Repository"} setup script is not executable: ${scriptPath}`,
+						`⚠️  ${label} script is not executable: ${scriptPath}`,
 					);
 					this.logger.warn(`   Run: chmod +x "${expandedPath}"`);
 					return;
 				}
 			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
 				this.logger.warn(
-					`⚠️  Cannot check permissions for ${scriptType} setup script: ${(error as Error).message}`,
+					`⚠️  Cannot check permissions for ${label} script: ${message}`,
 				);
 				return;
 			}
 		}
 
 		const scriptName = basename(expandedPath);
-		this.logger.info(`ℹ️  Running ${scriptType} setup script: ${scriptName}`);
+		this.logger.info(`ℹ️  Running ${label} script: ${scriptName}`);
 
 		try {
 			// Determine the command based on the script extension and platform
@@ -198,33 +260,30 @@ export class GitService {
 				stdio: "inherit",
 				env: {
 					...process.env,
-					LINEAR_ISSUE_ID: issue.id,
-					LINEAR_ISSUE_IDENTIFIER: issue.identifier,
-					LINEAR_ISSUE_TITLE: issue.title || "",
+					...env,
 				},
-				timeout: 5 * 60 * 1000, // 5 minute timeout
+				timeout: timeoutMs,
 			});
 
-			this.logger.info(
-				`✅ ${scriptType === "global" ? "Global" : "Repository"} setup script completed successfully`,
-			);
+			this.logger.info(`✅ ${label} script completed successfully`);
 		} catch (error) {
+			const timeoutMinutes = Math.round(timeoutMs / 60000);
+			const signal =
+				error && typeof error === "object" && "signal" in error
+					? (error as { signal?: NodeJS.Signals | null }).signal
+					: undefined;
 			const errorMessage =
-				(error as any).signal === "SIGTERM"
-					? "Script execution timed out (exceeded 5 minutes)"
-					: (error as Error).message;
+				signal === "SIGTERM"
+					? `Script execution timed out (exceeded ${timeoutMinutes} minute${timeoutMinutes === 1 ? "" : "s"})`
+					: error instanceof Error
+						? error.message
+						: String(error);
 
-			this.logger.error(
-				`❌ ${scriptType === "global" ? "Global" : "Repository"} setup script failed: ${errorMessage}`,
-			);
+			this.logger.error(`❌ ${label} script failed: ${errorMessage}`);
 
-			// Log stderr if available
-			if ((error as any).stderr) {
-				this.logger.error("   stderr:", (error as any).stderr.toString());
+			if (opts.postFailureMessage) {
+				this.logger.info(opts.postFailureMessage);
 			}
-
-			// Continue execution despite setup script failure
-			this.logger.info(`   Continuing with worktree creation...`);
 		}
 	}
 
@@ -489,12 +548,7 @@ export class GitService {
 
 			// Run global setup script if configured
 			if (globalSetupScript) {
-				await this.runSetupScript(
-					globalSetupScript,
-					"global",
-					workspacePath,
-					issue,
-				);
+				this.runSetupScript(globalSetupScript, "global", workspacePath, issue);
 			}
 
 			return {
@@ -529,7 +583,7 @@ export class GitService {
 
 		// Run global setup script once in the parent directory
 		if (globalSetupScript) {
-			await this.runSetupScript(globalSetupScript, "global", parentPath, issue);
+			this.runSetupScript(globalSetupScript, "global", parentPath, issue);
 		}
 
 		const repoPaths: Record<string, string> = {};
@@ -819,20 +873,11 @@ export class GitService {
 
 			// First, run the global setup script if configured
 			if (globalSetupScript) {
-				await this.runSetupScript(
-					globalSetupScript,
-					"global",
-					workspacePath,
-					issue,
-				);
+				this.runSetupScript(globalSetupScript, "global", workspacePath, issue);
 			}
 
 			// Then, check for repository setup scripts (cross-platform)
-			await this.runRepoSetupScript(
-				repository.repositoryPath,
-				workspacePath,
-				issue,
-			);
+			this.runRepoSetupScript(repository.repositoryPath, workspacePath, issue);
 
 			return {
 				path: workspacePath,
@@ -880,8 +925,12 @@ export class GitService {
 	 * directory is the root in both cases.
 	 *
 	 * @param issueIdentifier - The issue identifier (e.g., "DEF-123")
+	 * @param options - Optional per-call options (e.g., global teardown script)
 	 */
-	deleteWorktree(issueIdentifier: string): void {
+	deleteWorktree(
+		issueIdentifier: string,
+		options?: DeleteWorktreeOptions,
+	): void {
 		const workspacePath = join(
 			getDefaultWorktreesDir(this.cyrusHome),
 			issueIdentifier,
@@ -897,6 +946,21 @@ export class GitService {
 		this.logger.info(
 			`Deleting worktree directory for ${issueIdentifier} at ${workspacePath}`,
 		);
+
+		// Run global teardown script before any filesystem removal so it can
+		// still read .env.local / local DBs / setup-script artifacts. Failures
+		// are logged but do not block deletion (handled inside runHookScript).
+		if (options?.globalTeardownScript) {
+			this.runHookScript({
+				scriptPath: options.globalTeardownScript,
+				label: "global teardown",
+				workspacePath,
+				env: {
+					LINEAR_ISSUE_IDENTIFIER: issueIdentifier,
+				},
+				timeoutMs: TEARDOWN_TIMEOUT_MS,
+			});
+		}
 
 		// Find all git worktrees that are within this workspace path.
 		// In multi-repo layouts, there may be subdirectories that are each worktrees.
@@ -1032,11 +1096,11 @@ export class GitService {
 	/**
 	 * Find and run a repository-specific setup script (cyrus-setup.sh/.ps1/.cmd/.bat)
 	 */
-	private async runRepoSetupScript(
+	private runRepoSetupScript(
 		repositoryPath: string,
 		workspacePath: string,
 		issue: Issue,
-	): Promise<void> {
+	): void {
 		const isWindows = process.platform === "win32";
 		const setupScripts = [
 			{
@@ -1079,7 +1143,7 @@ export class GitService {
 
 		if (scriptToRun) {
 			const scriptPath = join(repositoryPath, scriptToRun.file);
-			await this.runSetupScript(scriptPath, "repository", workspacePath, issue);
+			this.runSetupScript(scriptPath, "repository", workspacePath, issue);
 		}
 	}
 }

--- a/packages/edge-worker/test/EdgeWorker.teardown-wiring.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.teardown-wiring.test.ts
@@ -1,0 +1,146 @@
+import {
+	EdgeConfigSchema,
+	type EdgeWorkerConfig,
+	type RepositoryConfig,
+} from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+
+vi.mock("fs/promises", () => ({
+	readFile: vi.fn(),
+	writeFile: vi.fn(),
+	mkdir: vi.fn(),
+	rename: vi.fn(),
+	readdir: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("cyrus-claude-runner");
+vi.mock("cyrus-codex-runner");
+vi.mock("cyrus-gemini-runner");
+vi.mock("cyrus-linear-event-transport");
+vi.mock("@linear/sdk");
+vi.mock("../src/SharedApplicationServer.js", () => ({
+	SharedApplicationServer: vi.fn().mockImplementation(() => ({
+		initializeFastify: vi.fn(),
+		getFastifyInstance: vi
+			.fn()
+			.mockReturnValue({ get: vi.fn(), post: vi.fn() }),
+		start: vi.fn().mockResolvedValue(undefined),
+		stop: vi.fn().mockResolvedValue(undefined),
+		getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+	})),
+}));
+vi.mock("../src/AgentSessionManager.js", () => ({
+	AgentSessionManager: vi.fn().mockImplementation(() => ({
+		getSessionsByIssueId: vi.fn().mockReturnValue([]),
+		getAllAgentRunners: vi.fn().mockReturnValue([]),
+		getAllSessions: vi.fn().mockReturnValue([]),
+		createResponseActivity: vi.fn().mockResolvedValue(undefined),
+		requestSessionStop: vi.fn(),
+		removeSession: vi.fn(),
+		setActivitySink: vi.fn(),
+		on: vi.fn(),
+		emit: vi.fn(),
+	})),
+}));
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(() => ({
+			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+		})),
+	};
+});
+vi.mock("file-type");
+vi.mock("chokidar", () => ({
+	watch: vi.fn().mockReturnValue({
+		on: vi.fn().mockReturnThis(),
+		close: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
+
+describe("EdgeWorker — global_teardown_script wiring", () => {
+	const mockRepository: RepositoryConfig = {
+		id: "test-repo",
+		name: "Test Repo",
+		repositoryPath: "/test/repo",
+		workspaceBaseDir: "/test/workspaces",
+		baseBranch: "main",
+		linearWorkspaceId: "test-workspace",
+		isActive: true,
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	it("passes global_teardown_script through to gitService.deleteWorktree on terminal-state message", async () => {
+		const config: EdgeWorkerConfig = {
+			platform: "linear",
+			cyrusHome: "/test/.cyrus",
+			repositories: [mockRepository],
+			linearWorkspaces: {
+				"test-workspace": { linearToken: "test-token" },
+			},
+			global_teardown_script: "/path/to/teardown.sh",
+		} as any;
+
+		const edgeWorker = new EdgeWorker(config);
+		const deleteWorktreeSpy = vi
+			.spyOn((edgeWorker as any).gitService, "deleteWorktree")
+			.mockImplementation(() => undefined);
+
+		await (edgeWorker as any).handleIssueStateChangeMessage({
+			workItemId: "issue-123",
+			workItemIdentifier: "DEF-123",
+		});
+
+		expect(deleteWorktreeSpy).toHaveBeenCalledWith("DEF-123", {
+			globalTeardownScript: "/path/to/teardown.sh",
+		});
+	});
+
+	it("passes undefined when global_teardown_script is not configured", async () => {
+		const config: EdgeWorkerConfig = {
+			platform: "linear",
+			cyrusHome: "/test/.cyrus",
+			repositories: [mockRepository],
+			linearWorkspaces: {
+				"test-workspace": { linearToken: "test-token" },
+			},
+		} as any;
+
+		const edgeWorker = new EdgeWorker(config);
+		const deleteWorktreeSpy = vi
+			.spyOn((edgeWorker as any).gitService, "deleteWorktree")
+			.mockImplementation(() => undefined);
+
+		await (edgeWorker as any).handleIssueStateChangeMessage({
+			workItemId: "issue-456",
+			workItemIdentifier: "DEF-456",
+		});
+
+		expect(deleteWorktreeSpy).toHaveBeenCalledWith("DEF-456", {
+			globalTeardownScript: undefined,
+		});
+	});
+});
+
+describe("EdgeConfigSchema — global_teardown_script", () => {
+	it("accepts global_teardown_script as an optional string", () => {
+		const result = EdgeConfigSchema.safeParse({
+			repositories: [],
+			global_teardown_script: "/path/to/teardown.sh",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("treats global_teardown_script as optional", () => {
+		const result = EdgeConfigSchema.safeParse({ repositories: [] });
+		expect(result.success).toBe(true);
+	});
+});

--- a/packages/edge-worker/test/GitService.test.ts
+++ b/packages/edge-worker/test/GitService.test.ts
@@ -683,6 +683,181 @@ describe("GitService", () => {
 				{ recursive: true, force: true },
 			);
 		});
+
+		describe("global teardown script", () => {
+			const WORKSPACE = "/home/user/.cyrus/worktrees/DEF-123";
+			const SCRIPT = "/home/user/scripts/teardown.sh";
+
+			const setupExecutableTeardownScript = () => {
+				mockExistsSync.mockImplementation((path: any) => {
+					const p = String(path);
+					if (p === WORKSPACE) return true;
+					if (p === SCRIPT) return true;
+					return false;
+				});
+				mockStatSync.mockImplementation((path: any) => {
+					const p = String(path);
+					if (p === SCRIPT) {
+						return { mode: 0o755, isFile: () => false } as any;
+					}
+					return { isFile: () => false } as any;
+				});
+				mockReaddirSync.mockReturnValue([] as any);
+			};
+
+			it("runs the teardown script before rmSync with LINEAR_ISSUE_IDENTIFIER in env", () => {
+				setupExecutableTeardownScript();
+
+				const callOrder: string[] = [];
+				mockExecSync.mockImplementation((cmd: any, opts: any) => {
+					if (String(cmd).includes("teardown.sh")) {
+						callOrder.push("teardown");
+						expect(opts.cwd).toBe(WORKSPACE);
+						expect(opts.env.LINEAR_ISSUE_IDENTIFIER).toBe("DEF-123");
+						expect(opts.env.LINEAR_ISSUE_ID).toBeUndefined();
+						expect(opts.env.LINEAR_ISSUE_TITLE).toBeUndefined();
+						expect(opts.timeout).toBe(2 * 60 * 1000);
+					}
+					return Buffer.from("");
+				});
+				mockRmSync.mockImplementation(() => {
+					callOrder.push("rm");
+				});
+
+				gitService.deleteWorktree("DEF-123", {
+					globalTeardownScript: SCRIPT,
+				});
+
+				expect(callOrder).toEqual(["teardown", "rm"]);
+			});
+
+			it("does not block deletion when teardown script fails", () => {
+				setupExecutableTeardownScript();
+
+				mockExecSync.mockImplementation((cmd: any) => {
+					if (String(cmd).includes("teardown.sh")) {
+						throw new Error("script failed");
+					}
+					return Buffer.from("");
+				});
+
+				gitService.deleteWorktree("DEF-123", {
+					globalTeardownScript: SCRIPT,
+				});
+
+				expect(mockRmSync).toHaveBeenCalledWith(WORKSPACE, {
+					recursive: true,
+					force: true,
+				});
+				expect(mockLogger.error).toHaveBeenCalledWith(
+					expect.stringContaining("global teardown script failed"),
+				);
+			});
+
+			it("does not invoke execSync when no teardown script is configured", () => {
+				mockExistsSync.mockImplementation(
+					(path: any) => String(path) === WORKSPACE,
+				);
+				mockReaddirSync.mockReturnValue([] as any);
+
+				gitService.deleteWorktree("DEF-123");
+
+				expect(mockExecSync).not.toHaveBeenCalled();
+				expect(mockRmSync).toHaveBeenCalledWith(WORKSPACE, {
+					recursive: true,
+					force: true,
+				});
+			});
+
+			it("warns and skips when teardown script does not exist", () => {
+				mockExistsSync.mockImplementation((path: any) => {
+					const p = String(path);
+					if (p === WORKSPACE) return true;
+					// Script path does NOT exist
+					return false;
+				});
+				mockReaddirSync.mockReturnValue([] as any);
+
+				gitService.deleteWorktree("DEF-123", {
+					globalTeardownScript: SCRIPT,
+				});
+
+				expect(mockExecSync).not.toHaveBeenCalled();
+				expect(mockLogger.warn).toHaveBeenCalledWith(
+					expect.stringContaining("global teardown script not found"),
+				);
+				expect(mockRmSync).toHaveBeenCalled();
+			});
+
+			it("warns and skips when teardown script is not executable", () => {
+				const originalPlatform = process.platform;
+				Object.defineProperty(process, "platform", { value: "linux" });
+				try {
+					mockExistsSync.mockImplementation((path: any) => {
+						const p = String(path);
+						if (p === WORKSPACE) return true;
+						if (p === SCRIPT) return true;
+						return false;
+					});
+					mockStatSync.mockImplementation((path: any) => {
+						const p = String(path);
+						if (p === SCRIPT) {
+							// Mode 0o644 — no owner-execute bit
+							return { mode: 0o644, isFile: () => false } as any;
+						}
+						return { isFile: () => false } as any;
+					});
+					mockReaddirSync.mockReturnValue([] as any);
+
+					gitService.deleteWorktree("DEF-123", {
+						globalTeardownScript: SCRIPT,
+					});
+
+					expect(mockExecSync).not.toHaveBeenCalled();
+					expect(mockLogger.warn).toHaveBeenCalledWith(
+						expect.stringContaining("global teardown script is not executable"),
+					);
+					expect(mockRmSync).toHaveBeenCalled();
+				} finally {
+					Object.defineProperty(process, "platform", {
+						value: originalPlatform,
+					});
+				}
+			});
+
+			it("logs '(exceeded 2 minutes)' when teardown script times out (SIGTERM)", () => {
+				setupExecutableTeardownScript();
+
+				mockExecSync.mockImplementation((cmd: any) => {
+					if (String(cmd).includes("teardown.sh")) {
+						const err: any = new Error("timeout");
+						err.signal = "SIGTERM";
+						throw err;
+					}
+					return Buffer.from("");
+				});
+
+				gitService.deleteWorktree("DEF-123", {
+					globalTeardownScript: SCRIPT,
+				});
+
+				expect(mockLogger.error).toHaveBeenCalledWith(
+					expect.stringContaining("timed out (exceeded 2 minutes)"),
+				);
+				expect(mockRmSync).toHaveBeenCalled();
+			});
+
+			it("does not attempt teardown when the workspace directory is missing", () => {
+				mockExistsSync.mockReturnValue(false);
+
+				gitService.deleteWorktree("DEF-123", {
+					globalTeardownScript: SCRIPT,
+				});
+
+				expect(mockExecSync).not.toHaveBeenCalled();
+				expect(mockRmSync).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe("createGitWorktree - 0 repos", () => {


### PR DESCRIPTION
## Summary

Re-implements the `global_teardown_script` feature originally proposed by @matthewbjones in [#1066](https://github.com/cyrusagents/cyrus/pull/1066) (rebased as [#1111](https://github.com/cyrusagents/cyrus/pull/1111)), addressing the [CYHOST-960](https://linear.app/ceedar/issue/CYHOST-960) critique up front.

Adds a `global_teardown_script` config field that runs inside the issue's worktree directory immediately **before** worktree deletion when an issue reaches a terminal state (`completed`, `canceled`, or `deleted`). Unassignment is intentionally **not** a trigger — re-assignment is a normal flow and the worktree must survive it.

Closes upstream [cyrusagents/cyrus#1065](https://github.com/cyrusagents/cyrus/issues/1065).
Linear: [CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219).

## What changed

- **Shared `runHookScript` helper in `GitService`** — Both `runSetupScript` and the new teardown path delegate to a single private helper. The original PR duplicated ~80 lines verbatim; this version respects DRY/OCP and makes adding a third hook later cheap.
- **No `"repository"` branch** in teardown (YAGNI — per-repo teardown would require new per-repo iteration machinery in `deleteWorktree` and has no current use case).
- **Named timeout constants** — `SETUP_TIMEOUT_MS` (5 min) and `TEARDOWN_TIMEOUT_MS` (2 min) at module top; no inline magic numbers.
- **Proper error narrowing** — `error instanceof Error` and a typed shape for `signal`; no `(error as any)` casts.
- **Dead `stderr` branch removed** — Under `stdio: "inherit"`, `execSync` doesn't capture stderr, so the catch-and-read pattern was unreachable. Applied to both setup and teardown via the shared helper.
- **`deleteWorktree(issueIdentifier, options?)`** — Optional `DeleteWorktreeOptions.globalTeardownScript` keeps the API surface small while leaving room for future per-call options.
- **`EdgeWorker.handleIssueStateChangeMessage`** wires `this.config.global_teardown_script` through to `gitService.deleteWorktree`.
- **JSON schema snapshots regenerated** via `pnpm --filter cyrus-core generate:json-schema`.
- **Docs**: new section in [`docs/SETUP_SCRIPTS.md`](./docs/SETUP_SCRIPTS.md) covering idempotency, env-var contract (only `LINEAR_ISSUE_IDENTIFIER`), terminal-state scope, 2-minute timeout, and non-blocking failure semantics. New entry in [`docs/CONFIG_FILE.md`](./docs/CONFIG_FILE.md).
- **Changelog**: entry under `[Unreleased]` crediting @matthewbjones.

## Test plan

- [x] Happy path — teardown runs **before** `rmSync`, with `LINEAR_ISSUE_IDENTIFIER` set and `LINEAR_ISSUE_ID` / `LINEAR_ISSUE_TITLE` not set
- [x] Failure non-blocking — script throws → deletion still happens
- [x] Unconfigured → no `execSync`, deletion still happens
- [x] Missing script path → warn + skip, no `execSync`
- [x] Not executable (mode without `0o100`) → warn + skip, no `execSync`
- [x] Timeout (SIGTERM) → log includes `"timed out (exceeded 2 minutes)"`
- [x] Workspace dir missing → teardown NOT attempted
- [x] EdgeWorker wiring — `handleIssueStateChangeMessage` forwards `config.global_teardown_script` to `gitService.deleteWorktree`
- [x] Zod schema accepts and treats `global_teardown_script` as optional
- [x] `pnpm typecheck` clean; biome lint clean on touched files
- [x] All existing `GitService` and `edge-worker` package tests still pass (634 in edge-worker, 129 in core)

## Credit

Original feature design and PR by @matthewbjones at [#1066](https://github.com/cyrusagents/cyrus/pull/1066). This is a from-scratch re-implementation (no cherry-pick), so it doesn't carry the author's commits — but the behavioral surface is intentionally aligned with the original proposal.

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->