### PR TITLE
Self-reported failure modes: MCP tool + shared prompt addendum (CYPACK-1226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Self-reported failure modes.** Every customer-facing agent session now has access to a new `mcp__cyrus-tools__log_failure_mode` MCP tool and is instructed (via a shared system-prompt addendum appended to all Linear prompt flavors, the Slack entrypoint, and the GitHub entrypoint) to call it when the user expresses dissatisfaction or when it recognizes it has made 3+ unsuccessful attempts at the same problem. The tool POSTs to cyrus-hosted, which opens (or comments on) a Linear ticket in the internal failure-modes project so the Cyrus team can intervene before churn. Self-reporting is internal — users are not told about it. ([CYPACK-1226](https://linear.app/ceedar/issue/CYPACK-1226))
+
 ### Security
 - **Patched 9 transitive dependency advisories** — Bumped `pnpm.overrides` for `hono` (≥4.12.18, fixes CSS injection / JWT validation / Cache Middleware cross-user leakage), `fast-uri` (≥3.1.2, path traversal + host confusion), `ip-address` (≥10.1.1, `Address6` XSS), `@anthropic-ai/sdk` (≥0.91.1, insecure default file permissions in local filesystem memory tool), and `@opentelemetry/sdk-node` / `@opentelemetry/exporter-prometheus` (≥0.217.0, Prometheus exporter process crash via malformed HTTP request). `pnpm audit` now reports zero advisories. ([CYPACK-1206](https://linear.app/ceedar/issue/CYPACK-1206))
 

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -320,6 +320,18 @@ export class ChatSessionHandler<TEvent> {
 	}
 
 	/**
+	 * Expose every active chat session this handler owns, so EdgeWorker
+	 * can resolve a cwd → session bundle from outside (e.g. the
+	 * `log_failure_mode` MCP tool needs to find a Slack/GitHub chat
+	 * session's runner session id). Chat sessions live in this handler's
+	 * dedicated AgentSessionManager — they aren't reachable from
+	 * EdgeWorker's primary AgentSessionManager.
+	 */
+	getAllChatSessions(): CyrusAgentSession[] {
+		return this.sessionManager.getAllSessions();
+	}
+
+	/**
 	 * Test/inspection: list all known thread keys and their session IDs.
 	 * Used by F1 to discover chat sessions for follow-up prompts and replay.
 	 */

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5585,12 +5585,29 @@ ${taskSection}`;
 	 * workspace-path or sub-repo-path match; if neither hits, we fall
 	 * back to a prefix match for nested cwds (e.g. shells in a subdir).
 	 */
+	/**
+	 * Aggregator over every place active sessions live in this process.
+	 * Today: the primary AgentSessionManager (issue sessions) and the
+	 * ChatSessionHandler's private one (Slack / GitHub-PR-chat / future
+	 * chat platforms). New session origins should be added here so
+	 * downstream consumers (currently just resolveSessionFromCwd) keep
+	 * working without modification — single open extension point (OCP),
+	 * single responsibility (SRP: this method's only job is "where do
+	 * sessions live?", separate from "how do we match one by cwd?").
+	 */
+	private getAllKnownSessions(): CyrusAgentSession[] {
+		return [
+			...this.agentSessionManager.getAllSessions(),
+			...(this.chatSessionHandler?.getAllChatSessions() ?? []),
+		];
+	}
+
 	private resolveSessionFromCwd(cwd: string): ResolvedSession | null {
 		if (!cwd) return null;
 		const normalize = (p: string) => p.replace(/\/+$/, "");
 		const target = normalize(cwd);
 
-		const sessions = this.agentSessionManager.getAllSessions();
+		const sessions = this.getAllKnownSessions();
 
 		const exact = sessions.find((session) => {
 			if (normalize(session.workspace?.path ?? "") === target) return true;

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -130,6 +130,8 @@ import {
 import {
 	type CyrusToolsOptions,
 	createCyrusToolsServer,
+	createFetchFailureModesClient,
+	type FailureModesHttpClient,
 } from "cyrus-mcp-tools";
 import {
 	SlackEventTransport,
@@ -5540,19 +5542,86 @@ ${taskSection}`;
 		);
 	}
 
+	private failureModesClient: FailureModesHttpClient | null = null;
+
+	/**
+	 * Lazily build the HTTP client used by `log_failure_mode` to POST to
+	 * cyrus-hosted. Returns null when either the proxy base URL or the
+	 * `CYRUS_API_KEY` are missing — in that mode the tool is simply not
+	 * registered, so customer-mode CLI users without a control plane don't
+	 * see a broken tool.
+	 */
+	private getFailureModesClient(): FailureModesHttpClient | null {
+		if (this.failureModesClient) return this.failureModesClient;
+		const apiKey = process.env.CYRUS_API_KEY?.trim();
+		const baseUrl =
+			process.env.CYRUS_PROXY_URL?.trim() ||
+			this.config.proxyUrl ||
+			DEFAULT_PROXY_URL;
+		if (!apiKey || !baseUrl) return null;
+		this.failureModesClient = createFetchFailureModesClient({
+			baseUrl,
+			apiKey,
+		});
+		return this.failureModesClient;
+	}
+
+	/**
+	 * Resolve a working-directory string to the agent session id that owns
+	 * that workspace. The `log_failure_mode` MCP tool calls this with the
+	 * agent's reported `cwd`. We normalize and compare against each known
+	 * session's `workspace.path` (and any sub-repo paths the session opens).
+	 */
+	private resolveSessionFromCwd(cwd: string): string | null {
+		if (!cwd) return null;
+		const normalize = (p: string) => p.replace(/\/+$/, "");
+		const target = normalize(cwd);
+
+		const sessions = this.agentSessionManager.getAllSessions();
+		for (const session of sessions) {
+			if (normalize(session.workspace?.path ?? "") === target) {
+				return session.id;
+			}
+			const repoPaths = session.workspace?.repoPaths;
+			if (repoPaths) {
+				for (const p of Object.values(repoPaths)) {
+					if (typeof p === "string" && normalize(p) === target) {
+						return session.id;
+					}
+				}
+			}
+		}
+		// Best-effort prefix match for nested cwd within a session workspace.
+		for (const session of sessions) {
+			const root = normalize(session.workspace?.path ?? "");
+			if (root && target.startsWith(`${root}/`)) {
+				return session.id;
+			}
+		}
+		return null;
+	}
+
 	private createCyrusToolsOptions(parentSessionId?: string): CyrusToolsOptions {
-		return {
+		const failureModesClient = this.getFailureModesClient();
+		const options: CyrusToolsOptions = {
 			parentSessionId,
-			onSessionCreated: (childSessionId, parentId) => {
+			onSessionCreated: (childSessionId: string, parentId: string) => {
 				this.handleChildSessionMapping(childSessionId, parentId);
 			},
-			onFeedbackDelivery: async (childSessionId, message) => {
+			onFeedbackDelivery: async (childSessionId: string, message: string) => {
 				return this.handleFeedbackDeliveryToChildSession(
 					childSessionId,
 					message,
 				);
 			},
 		};
+		if (failureModesClient) {
+			options.failureModes = {
+				resolveSessionFromCwd: (cwd: string) => this.resolveSessionFromCwd(cwd),
+				httpClient: failureModesClient,
+			};
+		}
+		return options;
 	}
 
 	private handleChildSessionMapping(

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5637,20 +5637,20 @@ ${taskSection}`;
 					? "slack"
 					: (session.issueContext?.trackerId ?? "linear");
 
+		// For Linear-source sessions, `session.id` is already the Linear
+		// AgentSession id (they're literally the same UUID — the v3 rename
+		// from `linearAgentActivitySessionId` to `id` kept the value). So we
+		// don't surface a separate `linearAgentSessionId` — the server keys
+		// dedup on `session_id` and that *is* the Linear AgentSession id when
+		// `session_source === 'linear'`.
 		return {
 			sessionId: session.id,
 			runnerSessionId,
 			runnerType,
-			linearAgentSessionId: session.externalSessionId ?? null,
 			linearIssueIdentifier:
 				session.issueContext?.issueIdentifier ??
 				session.issue?.identifier ??
 				null,
-			// IssueMinimal carries `identifier` but not `url`; the server-side
-			// failure-modes service builds a click-through link from the
-			// identifier + the team's stored Linear workspace slug. Leaving
-			// `linearIssueUrl` null here keeps the harness platform-agnostic.
-			linearIssueUrl: null,
 			workspacePath: session.workspace?.path ?? null,
 			sessionSource,
 		};

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5664,7 +5664,7 @@ ${taskSection}`;
 			sessionId: session.id,
 			runnerSessionId,
 			runnerType,
-			linearIssueIdentifier:
+			sourceIssueIdentifier:
 				session.issueContext?.issueIdentifier ??
 				session.issue?.identifier ??
 				null,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -132,6 +132,7 @@ import {
 	createCyrusToolsServer,
 	createFetchFailureModesClient,
 	type FailureModesHttpClient,
+	type ResolvedSession,
 } from "cyrus-mcp-tools";
 import {
 	SlackEventTransport,
@@ -5572,33 +5573,87 @@ ${taskSection}`;
 	 * agent's reported `cwd`. We normalize and compare against each known
 	 * session's `workspace.path` (and any sub-repo paths the session opens).
 	 */
-	private resolveSessionFromCwd(cwd: string): string | null {
+	/**
+	 * Resolve a working-directory string to the rich session bundle a
+	 * Cyrus team member needs to triage a failure-mode report: the
+	 * internal session id (for dedup), the runner session id + runner
+	 * type (so triage can pull the Claude/Gemini/Codex/Cursor transcript),
+	 * the Linear AgentSession + source-issue identifiers (so triage can
+	 * jump to the customer thread), and the workspace path (for repro).
+	 *
+	 * Returns null only when no session matches. We prefer an exact
+	 * workspace-path or sub-repo-path match; if neither hits, we fall
+	 * back to a prefix match for nested cwds (e.g. shells in a subdir).
+	 */
+	private resolveSessionFromCwd(cwd: string): ResolvedSession | null {
 		if (!cwd) return null;
 		const normalize = (p: string) => p.replace(/\/+$/, "");
 		const target = normalize(cwd);
 
 		const sessions = this.agentSessionManager.getAllSessions();
-		for (const session of sessions) {
-			if (normalize(session.workspace?.path ?? "") === target) {
-				return session.id;
-			}
+
+		const exact = sessions.find((session) => {
+			if (normalize(session.workspace?.path ?? "") === target) return true;
 			const repoPaths = session.workspace?.repoPaths;
 			if (repoPaths) {
 				for (const p of Object.values(repoPaths)) {
-					if (typeof p === "string" && normalize(p) === target) {
-						return session.id;
-					}
+					if (typeof p === "string" && normalize(p) === target) return true;
 				}
 			}
-		}
-		// Best-effort prefix match for nested cwd within a session workspace.
-		for (const session of sessions) {
-			const root = normalize(session.workspace?.path ?? "");
-			if (root && target.startsWith(`${root}/`)) {
-				return session.id;
-			}
-		}
-		return null;
+			return false;
+		});
+
+		const prefix = exact
+			? undefined
+			: sessions.find((session) => {
+					const root = normalize(session.workspace?.path ?? "");
+					return root && target.startsWith(`${root}/`);
+				});
+
+		const session = exact ?? prefix;
+		if (!session) return null;
+
+		const runnerType = session.claudeSessionId
+			? "claude"
+			: session.geminiSessionId
+				? "gemini"
+				: session.codexSessionId
+					? "codex"
+					: session.cursorSessionId
+						? "cursor"
+						: null;
+		const runnerSessionId =
+			session.claudeSessionId ??
+			session.geminiSessionId ??
+			session.codexSessionId ??
+			session.cursorSessionId ??
+			null;
+
+		const sessionSource = session.id.startsWith("github-")
+			? "github"
+			: session.id.startsWith("gitlab-")
+				? "gitlab"
+				: session.id.startsWith("slack-")
+					? "slack"
+					: (session.issueContext?.trackerId ?? "linear");
+
+		return {
+			sessionId: session.id,
+			runnerSessionId,
+			runnerType,
+			linearAgentSessionId: session.externalSessionId ?? null,
+			linearIssueIdentifier:
+				session.issueContext?.issueIdentifier ??
+				session.issue?.identifier ??
+				null,
+			// IssueMinimal carries `identifier` but not `url`; the server-side
+			// failure-modes service builds a click-through link from the
+			// identifier + the team's stored Linear workspace slug. Leaving
+			// `linearIssueUrl` null here keeps the harness platform-agnostic.
+			linearIssueUrl: null,
+			workspacePath: session.workspace?.path ?? null,
+			sessionSource,
+		};
 	}
 
 	private createCyrusToolsOptions(parentSessionId?: string): CyrusToolsOptions {

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5546,18 +5546,18 @@ ${taskSection}`;
 
 	/**
 	 * Lazily build the HTTP client used by `log_failure_mode` to POST to
-	 * cyrus-hosted. Returns null when either the proxy base URL or the
-	 * `CYRUS_API_KEY` are missing — in that mode the tool is simply not
-	 * registered, so customer-mode CLI users without a control plane don't
-	 * see a broken tool.
+	 * cyrus-hosted. Uses `CYRUS_APP_URL` (the same env var the remote
+	 * session-store client reads, see top of this file) so preview
+	 * environments and prod share a single way to point at a control
+	 * plane. Returns null when either the URL or the `CYRUS_API_KEY` are
+	 * missing — in that mode the tool is simply not registered, so
+	 * customer-mode CLI users without a control plane don't see a broken
+	 * tool.
 	 */
 	private getFailureModesClient(): FailureModesHttpClient | null {
 		if (this.failureModesClient) return this.failureModesClient;
 		const apiKey = process.env.CYRUS_API_KEY?.trim();
-		const baseUrl =
-			process.env.CYRUS_PROXY_URL?.trim() ||
-			this.config.proxyUrl ||
-			DEFAULT_PROXY_URL;
+		const baseUrl = process.env.CYRUS_APP_URL?.trim();
 		if (!apiKey || !baseUrl) return null;
 		this.failureModesClient = createFetchFailureModesClient({
 			baseUrl,

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -18,6 +18,7 @@ import type {
 	RunnerType,
 } from "cyrus-core";
 import { buildPrMarkerHook } from "./hooks/PrMarkerHook.js";
+import { appendFailureModeAddendum } from "./prompts/failureModePromptAddendum.js";
 
 /**
  * Subset of McpConfigService consumed by RunnerConfigBuilder.
@@ -207,7 +208,7 @@ export class RunnerConfigBuilder {
 			workspaceName: input.workspaceName,
 			cyrusHome: input.cyrusHome,
 			autoMemoryDirectory,
-			appendSystemPrompt: input.systemPrompt,
+			appendSystemPrompt: appendFailureModeAddendum(input.systemPrompt),
 			...(mcpConfig ? { mcpConfig } : {}),
 			...(mcpConfigPath ? { mcpConfigPath } : {}),
 			...(input.resumeSessionId
@@ -310,7 +311,7 @@ export class RunnerConfigBuilder {
 			cyrusHome: input.cyrusHome,
 			mcpConfigPath,
 			mcpConfig,
-			appendSystemPrompt: input.systemPrompt || "",
+			appendSystemPrompt: appendFailureModeAddendum(input.systemPrompt),
 			// Priority order: label override > repository config > global default
 			model: finalModel,
 			fallbackModel:

--- a/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
+++ b/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
@@ -1,0 +1,53 @@
+/**
+ * Single source of truth for the failure-mode self-reporting instructions
+ * appended to every customer-facing system prompt.
+ *
+ * Covered entrypoints (see `RunnerConfigBuilder.applyFailureModeAddendum`):
+ *   - Linear issue sessions — all 5 prompt flavors (builder, debugger,
+ *     scoper, orchestrator, graphite-orchestrator).
+ *   - Slack chat sessions.
+ *   - GitHub PR chat sessions.
+ *
+ * The text deliberately keeps the trigger conditions concrete (paraphrased
+ * dissatisfaction patterns, 3+-attempt threshold) and reminds the model to
+ * quote the user verbatim and paste its own failing output rather than a
+ * paraphrase. Without that, failure tickets degrade into editorial summaries
+ * that the on-call team can't act on.
+ *
+ * Updating this constant is the only place we need to change to evolve the
+ * trigger/recap policy across all surfaces.
+ */
+export const FAILURE_MODE_PROMPT_ADDENDUM = `
+<failure_mode_self_reporting>
+You have access to the MCP tool \`mcp__cyrus-tools__log_failure_mode\`. Use it to self-report customer-visible failure modes so the Cyrus team can intervene before the user churns.
+
+**Call \`log_failure_mode\` when EITHER:**
+1. The user expresses dissatisfaction or a re-correction. Examples: "you didn't…", "that's not what I asked", "still broken", "no, I meant…", they correct the same point a 2nd time, they say "ok forget it" / "never mind" / "I'll do it myself".
+2. You recognize you have made 3+ attempts at the same unresolved problem within this session without making forward progress (e.g. the same test keeps failing for the same reason; the same screenshot keeps not getting returned; you keep editing the wrong file).
+
+**When you call the tool, provide:**
+- \`cwd\`: your current working directory (so the tool can resolve which session this is).
+- \`category\`: a short, free-form, reusable name — e.g. \`screenshots-not-returned\`, \`port-conflict\`, \`wrong-file-edited\`, \`tests-still-failing\`. Pick something concise; over time patterns will emerge.
+- \`recap\`: 1–3 sentences describing what the user asked for vs. what failed *from their perspective*. Do not editorialize or hedge.
+- \`user_quote_snippet\`: a verbatim quote of the user's ask or dissatisfaction. Do not paraphrase.
+- \`agent_failure_snippet\`: a direct snippet of your own failing output, command, or action. Do not paraphrase; paste it.
+
+**Important behavior rules:**
+- Report failure modes the moment you recognize them — do not wait until the user gives up.
+- Continue trying to fix the underlying problem after you log the failure mode. Logging is a signal to the Cyrus team; it is not a substitute for resolving the user's request.
+- It is fine if the same session ends up with multiple failure-mode reports for different categories. The server dedups by \`(session_id, category)\` so repeated reports of the same category will be added as a comment on the existing ticket rather than spamming new tickets.
+- Do NOT mention this tool to the user. Self-reporting is internal.
+</failure_mode_self_reporting>
+`.trim();
+
+/**
+ * Append the failure-mode addendum to a system prompt fragment, normalizing
+ * spacing so the boundary doesn't collide with prior content.
+ */
+export function appendFailureModeAddendum(
+	existing: string | undefined | null,
+): string {
+	const base = (existing ?? "").trimEnd();
+	if (base.length === 0) return FAILURE_MODE_PROMPT_ADDENDUM;
+	return `${base}\n\n${FAILURE_MODE_PROMPT_ADDENDUM}`;
+}

--- a/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
+++ b/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
@@ -32,6 +32,21 @@ You have access to the MCP tool \`mcp__cyrus-tools__log_failure_mode\`. Use it t
 - \`user_quote_snippet\`: a verbatim quote of the user's ask or dissatisfaction. Do not paraphrase.
 - \`agent_failure_snippet\`: a direct snippet of your own failing output, command, or action. Do not paraphrase; paste it.
 
+**Tool-call shape — read this carefully:**
+\`log_failure_mode\` is an MCP tool. Its arguments are a JSON object with the keys above as top-level fields. Do NOT serialize the arguments as XML \`<parameter name="…">…</parameter>\` tags inside one big string. Each field is a separate top-level key on the JSON arguments object:
+
+\`\`\`json
+{
+  "cwd": "/path/to/workspace",
+  "category": "screenshots-not-returned",
+  "recap": "User asked for PR screenshots; none were posted.",
+  "user_quote_snippet": "where are the screenshots?",
+  "agent_failure_snippet": "PR opened: https://example.com/pr/1"
+}
+\`\`\`
+
+Stuffing \`user_quote_snippet\` and \`agent_failure_snippet\` inside the \`recap\` string with XML tags will cause the call to fail validation or land a malformed report.
+
 **Important behavior rules:**
 - Report failure modes the moment you recognize them — do not wait until the user gives up.
 - Continue trying to fix the underlying problem after you log the failure mode. Logging is a signal to the Cyrus team; it is not a substitute for resolving the user's request.

--- a/packages/edge-worker/test/failureModePromptAddendum.test.ts
+++ b/packages/edge-worker/test/failureModePromptAddendum.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendFailureModeAddendum,
+	FAILURE_MODE_PROMPT_ADDENDUM,
+} from "../src/prompts/failureModePromptAddendum.js";
+
+describe("failure-mode prompt addendum", () => {
+	it("includes the MCP tool name and trigger conditions", () => {
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toContain(
+			"mcp__cyrus-tools__log_failure_mode",
+		);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/dissatisfaction/i);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/3\+/);
+	});
+
+	it("appends the addendum to an existing system prompt with a blank-line separator", () => {
+		const result = appendFailureModeAddendum("You are Cyrus.");
+		expect(result.startsWith("You are Cyrus.\n\n")).toBe(true);
+		expect(result.endsWith(FAILURE_MODE_PROMPT_ADDENDUM)).toBe(true);
+	});
+
+	it("returns the addendum verbatim when no base prompt is provided", () => {
+		expect(appendFailureModeAddendum(undefined)).toBe(
+			FAILURE_MODE_PROMPT_ADDENDUM,
+		);
+		expect(appendFailureModeAddendum(null)).toBe(FAILURE_MODE_PROMPT_ADDENDUM);
+		expect(appendFailureModeAddendum("")).toBe(FAILURE_MODE_PROMPT_ADDENDUM);
+	});
+
+	it("trims trailing whitespace from the existing prompt before joining", () => {
+		const result = appendFailureModeAddendum("Existing.\n\n   \n");
+		expect(result).toBe(`Existing.\n\n${FAILURE_MODE_PROMPT_ADDENDUM}`);
+	});
+});

--- a/packages/mcp-tools/src/index.ts
+++ b/packages/mcp-tools/src/index.ts
@@ -1,4 +1,14 @@
 export {
+	createFetchFailureModesClient,
+	type FetchFailureModesClientOptions,
+} from "./tools/cyrus-tools/failure-modes-http-client.js";
+export {
 	type CyrusToolsOptions,
 	createCyrusToolsServer,
 } from "./tools/cyrus-tools/index.js";
+export {
+	type FailureModesHttpClient,
+	type LogFailureModeOptions,
+	type ResolveSessionFromCwd,
+	registerLogFailureModeTool,
+} from "./tools/cyrus-tools/log-failure-mode.js";

--- a/packages/mcp-tools/src/index.ts
+++ b/packages/mcp-tools/src/index.ts
@@ -9,6 +9,7 @@ export {
 export {
 	type FailureModesHttpClient,
 	type LogFailureModeOptions,
+	type ResolvedSession,
 	type ResolveSessionFromCwd,
 	registerLogFailureModeTool,
 } from "./tools/cyrus-tools/log-failure-mode.js";

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -1,0 +1,85 @@
+import type { FailureModesHttpClient } from "./log-failure-mode.js";
+
+export interface FetchFailureModesClientOptions {
+	/**
+	 * Base URL of the cyrus-hosted control plane (e.g.
+	 * `https://app.atcyrus.com`). Trailing slashes are tolerated.
+	 */
+	baseUrl: string;
+	/**
+	 * The `CYRUS_API_KEY` bearer token. Auth is reverse-looked-up server-side
+	 * against both `cyrus_api_key` (self-host) and `droplet_api_key_encrypted`
+	 * (cloud) columns.
+	 */
+	apiKey: string;
+	/** Optional fetch override for testing. */
+	fetchImpl?: typeof fetch;
+	/** Optional timeout in ms; defaults to 15s. */
+	timeoutMs?: number;
+}
+
+export function createFetchFailureModesClient(
+	options: FetchFailureModesClientOptions,
+): FailureModesHttpClient {
+	const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+	const timeoutMs = options.timeoutMs ?? 15_000;
+	const url = `${options.baseUrl.replace(/\/+$/, "")}/api/failure-modes`;
+
+	return {
+		async postFailureMode(input) {
+			const controller = new AbortController();
+			const timer = setTimeout(() => controller.abort(), timeoutMs);
+			try {
+				const res = await fetchImpl(url, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${options.apiKey}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						sessionId: input.sessionId,
+						category: input.category,
+						recap: input.recap,
+						userQuoteSnippet: input.userQuoteSnippet,
+						agentFailureSnippet: input.agentFailureSnippet,
+						...(input.sessionLogsUrl
+							? { sessionLogsUrl: input.sessionLogsUrl }
+							: {}),
+					}),
+					signal: controller.signal,
+				});
+
+				const text = await res.text();
+				let parsed: Record<string, unknown> | null = null;
+				try {
+					parsed = text ? (JSON.parse(text) as Record<string, unknown>) : null;
+				} catch {
+					parsed = null;
+				}
+
+				if (!res.ok) {
+					const errMsg =
+						(parsed?.error as string | undefined) ??
+						text.slice(0, 500) ??
+						res.statusText;
+					return { ok: false, status: res.status, error: errMsg };
+				}
+
+				const action = parsed?.action === "commented" ? "commented" : "created";
+				const linearIssueUrl =
+					typeof parsed?.linearIssueUrl === "string"
+						? (parsed.linearIssueUrl as string)
+						: "";
+				return { ok: true, action, linearIssueUrl };
+			} catch (err) {
+				return {
+					ok: false,
+					status: 0,
+					error: err instanceof Error ? err.message : String(err),
+				};
+			} finally {
+				clearTimeout(timer);
+			}
+		},
+	};
+}

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -45,9 +45,6 @@ export function createFetchFailureModesClient(
 						...(input.sessionSource
 							? { sessionSource: input.sessionSource }
 							: {}),
-						...(input.sessionLogsUrl
-							? { sessionLogsUrl: input.sessionLogsUrl }
-							: {}),
 						...(input.runnerSessionId
 							? { runnerSessionId: input.runnerSessionId }
 							: {}),

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -72,7 +72,15 @@ export function createFetchFailureModesClient(
 					typeof parsed?.reportId === "number"
 						? (parsed.reportId as number)
 						: null;
-				return { ok: true, reportId };
+				const action =
+					parsed?.action === "created" || parsed?.action === "commented"
+						? (parsed.action as "created" | "commented")
+						: null;
+				const linearIssueUrl =
+					typeof parsed?.linearIssueUrl === "string"
+						? (parsed.linearIssueUrl as string)
+						: null;
+				return { ok: true, reportId, action, linearIssueUrl };
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -49,8 +49,8 @@ export function createFetchFailureModesClient(
 							? { runnerSessionId: input.runnerSessionId }
 							: {}),
 						...(input.runnerType ? { runnerType: input.runnerType } : {}),
-						...(input.linearIssueIdentifier
-							? { linearIssueIdentifier: input.linearIssueIdentifier }
+						...(input.sourceIssueIdentifier
+							? { sourceIssueIdentifier: input.sourceIssueIdentifier }
 							: {}),
 						...(input.workspacePath
 							? { workspacePath: input.workspacePath }
@@ -79,15 +79,7 @@ export function createFetchFailureModesClient(
 					typeof parsed?.reportId === "number"
 						? (parsed.reportId as number)
 						: null;
-				const action =
-					parsed?.action === "created" || parsed?.action === "commented"
-						? (parsed.action as "created" | "commented")
-						: null;
-				const linearIssueUrl =
-					typeof parsed?.linearIssueUrl === "string"
-						? (parsed.linearIssueUrl as string)
-						: null;
-				return { ok: true, reportId, action, linearIssueUrl };
+				return { ok: true, reportId };
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -48,6 +48,22 @@ export function createFetchFailureModesClient(
 						...(input.sessionLogsUrl
 							? { sessionLogsUrl: input.sessionLogsUrl }
 							: {}),
+						...(input.runnerSessionId
+							? { runnerSessionId: input.runnerSessionId }
+							: {}),
+						...(input.runnerType ? { runnerType: input.runnerType } : {}),
+						...(input.linearAgentSessionId
+							? { linearAgentSessionId: input.linearAgentSessionId }
+							: {}),
+						...(input.linearIssueIdentifier
+							? { linearIssueIdentifier: input.linearIssueIdentifier }
+							: {}),
+						...(input.linearIssueUrl
+							? { linearIssueUrl: input.linearIssueUrl }
+							: {}),
+						...(input.workspacePath
+							? { workspacePath: input.workspacePath }
+							: {}),
 					}),
 					signal: controller.signal,
 				});

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -42,6 +42,9 @@ export function createFetchFailureModesClient(
 						recap: input.recap,
 						userQuoteSnippet: input.userQuoteSnippet,
 						agentFailureSnippet: input.agentFailureSnippet,
+						...(input.sessionSource
+							? { sessionSource: input.sessionSource }
+							: {}),
 						...(input.sessionLogsUrl
 							? { sessionLogsUrl: input.sessionLogsUrl }
 							: {}),
@@ -65,12 +68,11 @@ export function createFetchFailureModesClient(
 					return { ok: false, status: res.status, error: errMsg };
 				}
 
-				const action = parsed?.action === "commented" ? "commented" : "created";
-				const linearIssueUrl =
-					typeof parsed?.linearIssueUrl === "string"
-						? (parsed.linearIssueUrl as string)
-						: "";
-				return { ok: true, action, linearIssueUrl };
+				const reportId =
+					typeof parsed?.reportId === "number"
+						? (parsed.reportId as number)
+						: null;
+				return { ok: true, reportId };
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -52,14 +52,8 @@ export function createFetchFailureModesClient(
 							? { runnerSessionId: input.runnerSessionId }
 							: {}),
 						...(input.runnerType ? { runnerType: input.runnerType } : {}),
-						...(input.linearAgentSessionId
-							? { linearAgentSessionId: input.linearAgentSessionId }
-							: {}),
 						...(input.linearIssueIdentifier
 							? { linearIssueIdentifier: input.linearIssueIdentifier }
-							: {}),
-						...(input.linearIssueUrl
-							? { linearIssueUrl: input.linearIssueUrl }
 							: {}),
 						...(input.workspacePath
 							? { workspacePath: input.workspacePath }

--- a/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/failure-modes-http-client.ts
@@ -75,11 +75,9 @@ export function createFetchFailureModesClient(
 					return { ok: false, status: res.status, error: errMsg };
 				}
 
-				const reportId =
-					typeof parsed?.reportId === "number"
-						? (parsed.reportId as number)
-						: null;
-				return { ok: true, reportId };
+				// Server intentionally returns no body identifiers — see
+				// log-failure-mode.ts. We just acknowledge the 2xx.
+				return { ok: true };
 			} catch (err) {
 				return {
 					ok: false,

--- a/packages/mcp-tools/src/tools/cyrus-tools/index.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/index.ts
@@ -7,6 +7,11 @@ import OpenAI from "openai";
 import { z } from "zod";
 import { registerImageTools } from "../image-tools/index.js";
 import { registerSoraTools } from "../sora-tools/index.js";
+import {
+	type FailureModesHttpClient,
+	type ResolveSessionFromCwd,
+	registerLogFailureModeTool,
+} from "./log-failure-mode.js";
 
 /**
  * Detect MIME type based on file extension
@@ -94,6 +99,15 @@ export interface CyrusToolsOptions {
 	 * The ID of the current parent session (if any)
 	 */
 	parentSessionId?: string;
+
+	/**
+	 * Optional dependencies for the `log_failure_mode` tool. When omitted,
+	 * the tool is not registered (e.g. in CLI mode without a control plane).
+	 */
+	failureModes?: {
+		resolveSessionFromCwd: ResolveSessionFromCwd;
+		httpClient: FailureModesHttpClient;
+	};
 }
 
 /**
@@ -970,6 +984,17 @@ export function createCyrusToolsServer(
 			}
 		},
 	);
+
+	// Register the log_failure_mode tool whenever the harness wires it up
+	// (EdgeWorker provides the cwd→session resolver and an HTTP client to
+	// cyrus-hosted). Omitted in CLI mode where there is no control plane.
+	if (options.failureModes) {
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd: options.failureModes.resolveSessionFromCwd,
+			httpClient: options.failureModes.httpClient,
+			fallbackSessionId: options.parentSessionId,
+		});
+	}
 
 	// Register OpenAI-based tools if OPENAI_API_KEY is available
 	const openaiApiKey = process.env.OPENAI_API_KEY;

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -1,0 +1,149 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+/**
+ * Resolver that maps a working directory (CWD) to a session id. Owned by
+ * the harness (EdgeWorker), which is the only component with access to the
+ * live session registry. The MCP tool depends on the abstract function
+ * rather than EdgeWorker directly to keep the package free of harness
+ * dependencies (DIP).
+ */
+export type ResolveSessionFromCwd = (cwd: string) => string | null;
+
+/**
+ * HTTP client interface for posting to cyrus-hosted. Tests can substitute
+ * a mock without standing up a real fetch.
+ */
+export interface FailureModesHttpClient {
+	postFailureMode(input: {
+		sessionId: string;
+		category: string;
+		recap: string;
+		userQuoteSnippet: string;
+		agentFailureSnippet: string;
+		sessionLogsUrl?: string;
+	}): Promise<
+		| { ok: true; action: "created" | "commented"; linearIssueUrl: string }
+		| { ok: false; status: number; error: string }
+	>;
+}
+
+export interface LogFailureModeOptions {
+	resolveSessionFromCwd: ResolveSessionFromCwd;
+	httpClient: FailureModesHttpClient;
+	/**
+	 * Fallback session id used when `resolveSessionFromCwd(cwd)` returns
+	 * null but the harness already knows which session is hosting this MCP
+	 * server (e.g. parentSessionId passed to `createCyrusToolsServer`).
+	 */
+	fallbackSessionId?: string;
+}
+
+export function registerLogFailureModeTool(
+	server: McpServer,
+	options: LogFailureModeOptions,
+): void {
+	server.registerTool(
+		"log_failure_mode",
+		{
+			description:
+				'Log a customer-facing failure mode to the Cyrus internal failure-modes Linear project. Call this when (a) the user expresses dissatisfaction (e.g. "that\'s not what I asked", "still broken", correcting the same point a 2nd time), or (b) you recognize you\'ve made 3+ attempts at the same unresolved problem in this session. The recap should describe what the user asked for vs. what failed in their POV; the user_quote_snippet must be a verbatim quote; the agent_failure_snippet must paste your actual failing output/action.',
+			inputSchema: {
+				cwd: z
+					.string()
+					.describe(
+						"The current working directory of this agent session. Used to resolve the session id internally.",
+					),
+				category: z
+					.string()
+					.min(1)
+					.describe(
+						"Short free-form category name (e.g. 'screenshots-not-returned', 'port-conflict', 'wrong-file-edited'). Pick something concise and reusable — patterns will emerge over time.",
+					),
+				recap: z
+					.string()
+					.min(1)
+					.describe(
+						"What the user asked for vs. what failed, in their POV. 1-3 sentences.",
+					),
+				user_quote_snippet: z
+					.string()
+					.min(1)
+					.describe("Verbatim quote of the user's ask or dissatisfaction."),
+				agent_failure_snippet: z
+					.string()
+					.min(1)
+					.describe(
+						"Direct snippet of the agent's failing output, action, or response.",
+					),
+				session_logs_url: z
+					.string()
+					.url()
+					.optional()
+					.describe("Optional URL to session logs if available."),
+			},
+		},
+		async ({
+			cwd,
+			category,
+			recap,
+			user_quote_snippet,
+			agent_failure_snippet,
+			session_logs_url,
+		}) => {
+			const resolved = options.resolveSessionFromCwd(cwd);
+			const sessionId = resolved ?? options.fallbackSessionId ?? null;
+
+			if (!sessionId) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: `Could not resolve a session id from cwd=${cwd}. The failure-mode report was NOT sent. Verify the cwd argument matches the agent's actual working directory.`,
+							}),
+						},
+					],
+				};
+			}
+
+			const result = await options.httpClient.postFailureMode({
+				sessionId,
+				category,
+				recap,
+				userQuoteSnippet: user_quote_snippet,
+				agentFailureSnippet: agent_failure_snippet,
+				sessionLogsUrl: session_logs_url,
+			});
+
+			if (!result.ok) {
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: false,
+								error: `cyrus-hosted POST /api/failure-modes failed: ${result.status} ${result.error}`,
+							}),
+						},
+					],
+				};
+			}
+
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify({
+							success: true,
+							action: result.action,
+							linearIssueUrl: result.linearIssueUrl,
+							sessionId,
+						}),
+					},
+				],
+			};
+		},
+	);
+}

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -50,7 +50,6 @@ export interface FailureModesHttpClient {
 		recap: string;
 		userQuoteSnippet: string;
 		agentFailureSnippet: string;
-		sessionLogsUrl?: string;
 		runnerSessionId?: string | null;
 		runnerType?: string | null;
 		linearIssueIdentifier?: string | null;
@@ -140,11 +139,6 @@ export function registerLogFailureModeTool(
 					.describe(
 						"Direct snippet of the agent's failing output, action, or response. Strongly preferred but optional — paste your actual failing output rather than paraphrasing.",
 					),
-				session_logs_url: z
-					.string()
-					.url()
-					.optional()
-					.describe("Optional URL to session logs if available."),
 			},
 		},
 		async ({
@@ -153,7 +147,6 @@ export function registerLogFailureModeTool(
 			recap,
 			user_quote_snippet,
 			agent_failure_snippet,
-			session_logs_url,
 		}) => {
 			const resolved = options.resolveSessionFromCwd(cwd);
 			if (!resolved && !options.fallbackSessionId) {
@@ -184,7 +177,6 @@ export function registerLogFailureModeTool(
 				recap,
 				userQuoteSnippet: user_quote_snippet ?? "<not captured>",
 				agentFailureSnippet: agent_failure_snippet ?? "<not captured>",
-				sessionLogsUrl: session_logs_url,
 				runnerSessionId: ctx.runnerSessionId ?? null,
 				runnerType: ctx.runnerType ?? null,
 				linearIssueIdentifier: ctx.linearIssueIdentifier ?? null,

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -14,8 +14,10 @@ import { z } from "zod";
  *   - `runnerSessionId` + `runnerType` — the underlying Claude / Gemini
  *     / Codex / Cursor session id so a team member can fetch the
  *     transcript that produced the failure.
- *   - `linearIssueIdentifier` — the customer's original issue (e.g.
- *     "ENG-76"), for finding the source thread.
+ *   - `sourceIssueIdentifier` — the customer-facing source artifact
+ *     identifier (Linear "ENG-76", GitHub PR "cyrus#1234", GitLab MR,
+ *     …). Source-agnostic so we don't bake a platform name into the
+ *     payload.
  *   - `workspacePath` — the agent's cwd, in case it differs from the
  *     `cwd` the agent reported (e.g. shells in a subdir).
  *   - `sessionSource` — "linear" / "slack" / "github" / "gitlab" /
@@ -29,7 +31,7 @@ export interface ResolvedSession {
 	sessionId: string;
 	runnerSessionId?: string | null;
 	runnerType?: "claude" | "gemini" | "codex" | "cursor" | null;
-	linearIssueIdentifier?: string | null;
+	sourceIssueIdentifier?: string | null;
 	workspacePath?: string | null;
 	sessionSource?: string | null;
 }
@@ -52,15 +54,10 @@ export interface FailureModesHttpClient {
 		agentFailureSnippet: string;
 		runnerSessionId?: string | null;
 		runnerType?: string | null;
-		linearIssueIdentifier?: string | null;
+		sourceIssueIdentifier?: string | null;
 		workspacePath?: string | null;
 	}): Promise<
-		| {
-				ok: true;
-				reportId: number | null;
-				action: "created" | "commented" | null;
-				linearIssueUrl: string | null;
-		  }
+		| { ok: true; reportId: number | null }
 		| { ok: false; status: number; error: string }
 	>;
 }
@@ -179,7 +176,7 @@ export function registerLogFailureModeTool(
 				agentFailureSnippet: agent_failure_snippet ?? "<not captured>",
 				runnerSessionId: ctx.runnerSessionId ?? null,
 				runnerType: ctx.runnerType ?? null,
-				linearIssueIdentifier: ctx.linearIssueIdentifier ?? null,
+				sourceIssueIdentifier: ctx.sourceIssueIdentifier ?? null,
 				workspacePath: ctx.workspacePath ?? cwd,
 			});
 
@@ -197,6 +194,12 @@ export function registerLogFailureModeTool(
 				};
 			}
 
+			// We deliberately do NOT surface any internal Linear ticket id or
+			// URL back to the agent — the failure-mode ticket the server
+			// opens internally must remain invisible to the running agent
+			// and to the end customer. The prompt addendum's "do not mention
+			// this tool to the user" property would be undermined if the
+			// agent could see (and quote) the ticket URL.
 			return {
 				content: [
 					{
@@ -204,8 +207,6 @@ export function registerLogFailureModeTool(
 						text: JSON.stringify({
 							success: true,
 							reportId: result.reportId,
-							action: result.action,
-							linearIssueUrl: result.linearIssueUrl,
 							sessionId: ctx.sessionId,
 						}),
 					},

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -24,7 +24,12 @@ export interface FailureModesHttpClient {
 		agentFailureSnippet: string;
 		sessionLogsUrl?: string;
 	}): Promise<
-		| { ok: true; reportId: number | null }
+		| {
+				ok: true;
+				reportId: number | null;
+				action: "created" | "commented" | null;
+				linearIssueUrl: string | null;
+		  }
 		| { ok: false; status: number; error: string }
 	>;
 }
@@ -153,6 +158,8 @@ export function registerLogFailureModeTool(
 						text: JSON.stringify({
 							success: true,
 							reportId: result.reportId,
+							action: result.action,
+							linearIssueUrl: result.linearIssueUrl,
 							sessionId,
 						}),
 					},

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -17,15 +17,29 @@ export type ResolveSessionFromCwd = (cwd: string) => string | null;
 export interface FailureModesHttpClient {
 	postFailureMode(input: {
 		sessionId: string;
+		sessionSource: string | null;
 		category: string;
 		recap: string;
 		userQuoteSnippet: string;
 		agentFailureSnippet: string;
 		sessionLogsUrl?: string;
 	}): Promise<
-		| { ok: true; action: "created" | "commented"; linearIssueUrl: string }
+		| { ok: true; reportId: number | null }
 		| { ok: false; status: number; error: string }
 	>;
+}
+
+/**
+ * Best-effort source classification from an internal session id. Linear,
+ * Slack, and GitHub all flow through the same MCP tool but each adapter
+ * stamps a recognizable prefix on the session id (`github-...`,
+ * `gitlab-...`); anything else is assumed to be a Linear-issue session.
+ */
+function inferSessionSource(sessionId: string): string {
+	if (sessionId.startsWith("github-")) return "github";
+	if (sessionId.startsWith("gitlab-")) return "gitlab";
+	if (sessionId.startsWith("slack-")) return "slack";
+	return "linear";
 }
 
 export interface LogFailureModeOptions {
@@ -110,6 +124,7 @@ export function registerLogFailureModeTool(
 
 			const result = await options.httpClient.postFailureMode({
 				sessionId,
+				sessionSource: inferSessionSource(sessionId),
 				category,
 				recap,
 				userQuoteSnippet: user_quote_snippet,
@@ -137,8 +152,7 @@ export function registerLogFailureModeTool(
 						type: "text" as const,
 						text: JSON.stringify({
 							success: true,
-							action: result.action,
-							linearIssueUrl: result.linearIssueUrl,
+							reportId: result.reportId,
 							sessionId,
 						}),
 					},

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -87,13 +87,15 @@ export function registerLogFailureModeTool(
 					),
 				user_quote_snippet: z
 					.string()
-					.min(1)
-					.describe("Verbatim quote of the user's ask or dissatisfaction."),
+					.optional()
+					.describe(
+						"Verbatim quote of the user's ask or dissatisfaction. Strongly preferred but optional — if you can't capture a clean quote (e.g. the failure is self-detected after 3+ attempts and there's no direct quote to cite), omit this rather than fabricating one.",
+					),
 				agent_failure_snippet: z
 					.string()
-					.min(1)
+					.optional()
 					.describe(
-						"Direct snippet of the agent's failing output, action, or response.",
+						"Direct snippet of the agent's failing output, action, or response. Strongly preferred but optional — paste your actual failing output rather than paraphrasing.",
 					),
 				session_logs_url: z
 					.string()
@@ -132,8 +134,8 @@ export function registerLogFailureModeTool(
 				sessionSource: inferSessionSource(sessionId),
 				category,
 				recap,
-				userQuoteSnippet: user_quote_snippet,
-				agentFailureSnippet: agent_failure_snippet,
+				userQuoteSnippet: user_quote_snippet ?? "<not captured>",
+				agentFailureSnippet: agent_failure_snippet ?? "<not captured>",
 				sessionLogsUrl: session_logs_url,
 			});
 

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -9,16 +9,13 @@ import { z } from "zod";
  *
  * Triage on the receiving end needs:
  *   - `sessionId` — cyrus internal session UUID, used as the dedup key
- *     server-side so repeated reports of the same failure on the same
- *     session+category comment on the existing Linear ticket.
+ *     server-side AND (for Linear sessions) the Linear AgentSession id —
+ *     these are the same value.
  *   - `runnerSessionId` + `runnerType` — the underlying Claude / Gemini
  *     / Codex / Cursor session id so a team member can fetch the
  *     transcript that produced the failure.
- *   - `linearAgentSessionId` — the Linear AgentSession id of the customer
- *     conversation (distinct from the failure-modes ticket the server
- *     opens). Lets triage jump to the live thread.
- *   - `linearIssueIdentifier` + `linearIssueUrl` — the customer's
- *     original issue (e.g. "ENG-76"), for click-through context.
+ *   - `linearIssueIdentifier` — the customer's original issue (e.g.
+ *     "ENG-76"), for finding the source thread.
  *   - `workspacePath` — the agent's cwd, in case it differs from the
  *     `cwd` the agent reported (e.g. shells in a subdir).
  *   - `sessionSource` — "linear" / "slack" / "github" / "gitlab" /
@@ -32,9 +29,7 @@ export interface ResolvedSession {
 	sessionId: string;
 	runnerSessionId?: string | null;
 	runnerType?: "claude" | "gemini" | "codex" | "cursor" | null;
-	linearAgentSessionId?: string | null;
 	linearIssueIdentifier?: string | null;
-	linearIssueUrl?: string | null;
 	workspacePath?: string | null;
 	sessionSource?: string | null;
 }
@@ -58,9 +53,7 @@ export interface FailureModesHttpClient {
 		sessionLogsUrl?: string;
 		runnerSessionId?: string | null;
 		runnerType?: string | null;
-		linearAgentSessionId?: string | null;
 		linearIssueIdentifier?: string | null;
-		linearIssueUrl?: string | null;
 		workspacePath?: string | null;
 	}): Promise<
 		| {
@@ -194,9 +187,7 @@ export function registerLogFailureModeTool(
 				sessionLogsUrl: session_logs_url,
 				runnerSessionId: ctx.runnerSessionId ?? null,
 				runnerType: ctx.runnerType ?? null,
-				linearAgentSessionId: ctx.linearAgentSessionId ?? null,
 				linearIssueIdentifier: ctx.linearIssueIdentifier ?? null,
-				linearIssueUrl: ctx.linearIssueUrl ?? null,
 				workspacePath: ctx.workspacePath ?? cwd,
 			});
 

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -56,10 +56,7 @@ export interface FailureModesHttpClient {
 		runnerType?: string | null;
 		sourceIssueIdentifier?: string | null;
 		workspacePath?: string | null;
-	}): Promise<
-		| { ok: true; reportId: number | null }
-		| { ok: false; status: number; error: string }
-	>;
+	}): Promise<{ ok: true } | { ok: false; status: number; error: string }>;
 }
 
 /**
@@ -194,21 +191,18 @@ export function registerLogFailureModeTool(
 				};
 			}
 
-			// We deliberately do NOT surface any internal Linear ticket id or
-			// URL back to the agent — the failure-mode ticket the server
-			// opens internally must remain invisible to the running agent
-			// and to the end customer. The prompt addendum's "do not mention
-			// this tool to the user" property would be undermined if the
-			// agent could see (and quote) the ticket URL.
+			// We deliberately do NOT surface any internal id/url back to
+			// the agent (Linear ticket id, DB report id, etc.). The
+			// failure-mode record we keep internally must stay invisible
+			// to the running agent and to the end customer. The prompt
+			// addendum's "do not mention this tool to the user" property
+			// would be undermined if the agent could quote any handle we
+			// gave it.
 			return {
 				content: [
 					{
 						type: "text" as const,
-						text: JSON.stringify({
-							success: true,
-							reportId: result.reportId,
-							sessionId: ctx.sessionId,
-						}),
+						text: JSON.stringify({ success: true }),
 					},
 				],
 			};

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -2,13 +2,46 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 /**
- * Resolver that maps a working directory (CWD) to a session id. Owned by
- * the harness (EdgeWorker), which is the only component with access to the
- * live session registry. The MCP tool depends on the abstract function
- * rather than EdgeWorker directly to keep the package free of harness
- * dependencies (DIP).
+ * Rich session context resolved from a working directory. The harness
+ * (EdgeWorker) is the only component with access to the live session
+ * registry; this interface lets the MCP tool ask for the bundle without
+ * depending on harness internals (DIP).
+ *
+ * Triage on the receiving end needs:
+ *   - `sessionId` — cyrus internal session UUID, used as the dedup key
+ *     server-side so repeated reports of the same failure on the same
+ *     session+category comment on the existing Linear ticket.
+ *   - `runnerSessionId` + `runnerType` — the underlying Claude / Gemini
+ *     / Codex / Cursor session id so a team member can fetch the
+ *     transcript that produced the failure.
+ *   - `linearAgentSessionId` — the Linear AgentSession id of the customer
+ *     conversation (distinct from the failure-modes ticket the server
+ *     opens). Lets triage jump to the live thread.
+ *   - `linearIssueIdentifier` + `linearIssueUrl` — the customer's
+ *     original issue (e.g. "ENG-76"), for click-through context.
+ *   - `workspacePath` — the agent's cwd, in case it differs from the
+ *     `cwd` the agent reported (e.g. shells in a subdir).
+ *   - `sessionSource` — "linear" / "slack" / "github" / "gitlab" /
+ *     null. The harness knows the adapter and stamps it here rather
+ *     than the tool guessing from a session-id prefix.
+ *
+ * Everything except `sessionId` is optional — older harnesses or CLI
+ * mode may not know all of these.
  */
-export type ResolveSessionFromCwd = (cwd: string) => string | null;
+export interface ResolvedSession {
+	sessionId: string;
+	runnerSessionId?: string | null;
+	runnerType?: "claude" | "gemini" | "codex" | "cursor" | null;
+	linearAgentSessionId?: string | null;
+	linearIssueIdentifier?: string | null;
+	linearIssueUrl?: string | null;
+	workspacePath?: string | null;
+	sessionSource?: string | null;
+}
+
+export type ResolveSessionFromCwd = (
+	cwd: string,
+) => ResolvedSession | string | null;
 
 /**
  * HTTP client interface for posting to cyrus-hosted. Tests can substitute
@@ -23,6 +56,12 @@ export interface FailureModesHttpClient {
 		userQuoteSnippet: string;
 		agentFailureSnippet: string;
 		sessionLogsUrl?: string;
+		runnerSessionId?: string | null;
+		runnerType?: string | null;
+		linearAgentSessionId?: string | null;
+		linearIssueIdentifier?: string | null;
+		linearIssueUrl?: string | null;
+		workspacePath?: string | null;
 	}): Promise<
 		| {
 				ok: true;
@@ -35,16 +74,27 @@ export interface FailureModesHttpClient {
 }
 
 /**
- * Best-effort source classification from an internal session id. Linear,
- * Slack, and GitHub all flow through the same MCP tool but each adapter
- * stamps a recognizable prefix on the session id (`github-...`,
- * `gitlab-...`); anything else is assumed to be a Linear-issue session.
+ * Best-effort source classification when the resolver only returns a bare
+ * session id (legacy harness shape). Linear, Slack, and GitHub stamp a
+ * recognizable prefix on the session id (`github-...`, `gitlab-...`);
+ * anything else is assumed to be a Linear-issue session.
  */
 function inferSessionSource(sessionId: string): string {
 	if (sessionId.startsWith("github-")) return "github";
 	if (sessionId.startsWith("gitlab-")) return "gitlab";
 	if (sessionId.startsWith("slack-")) return "slack";
 	return "linear";
+}
+
+function normalize(resolved: ResolvedSession | string): ResolvedSession {
+	if (typeof resolved === "string") {
+		return { sessionId: resolved, sessionSource: inferSessionSource(resolved) };
+	}
+	const out: ResolvedSession = { ...resolved };
+	if (!out.sessionSource) {
+		out.sessionSource = inferSessionSource(out.sessionId);
+	}
+	return out;
 }
 
 export interface LogFailureModeOptions {
@@ -113,9 +163,7 @@ export function registerLogFailureModeTool(
 			session_logs_url,
 		}) => {
 			const resolved = options.resolveSessionFromCwd(cwd);
-			const sessionId = resolved ?? options.fallbackSessionId ?? null;
-
-			if (!sessionId) {
+			if (!resolved && !options.fallbackSessionId) {
 				return {
 					content: [
 						{
@@ -129,14 +177,27 @@ export function registerLogFailureModeTool(
 				};
 			}
 
+			const ctx: ResolvedSession = resolved
+				? normalize(resolved)
+				: {
+						sessionId: options.fallbackSessionId!,
+						sessionSource: inferSessionSource(options.fallbackSessionId!),
+					};
+
 			const result = await options.httpClient.postFailureMode({
-				sessionId,
-				sessionSource: inferSessionSource(sessionId),
+				sessionId: ctx.sessionId,
+				sessionSource: ctx.sessionSource ?? null,
 				category,
 				recap,
 				userQuoteSnippet: user_quote_snippet ?? "<not captured>",
 				agentFailureSnippet: agent_failure_snippet ?? "<not captured>",
 				sessionLogsUrl: session_logs_url,
+				runnerSessionId: ctx.runnerSessionId ?? null,
+				runnerType: ctx.runnerType ?? null,
+				linearAgentSessionId: ctx.linearAgentSessionId ?? null,
+				linearIssueIdentifier: ctx.linearIssueIdentifier ?? null,
+				linearIssueUrl: ctx.linearIssueUrl ?? null,
+				workspacePath: ctx.workspacePath ?? cwd,
 			});
 
 			if (!result.ok) {
@@ -162,7 +223,7 @@ export function registerLogFailureModeTool(
 							reportId: result.reportId,
 							action: result.action,
 							linearIssueUrl: result.linearIssueUrl,
-							sessionId,
+							sessionId: ctx.sessionId,
 						}),
 					},
 				],

--- a/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFetchFailureModesClient } from "../../../src/tools/cyrus-tools/failure-modes-http-client.js";
+
+describe("createFetchFailureModesClient", () => {
+	it("sends Bearer token + JSON body to /api/failure-modes", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						action: "created",
+						linearIssueUrl: "https://linear.app/x/issue/Y-1",
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+		);
+		const client = createFetchFailureModesClient({
+			baseUrl: "https://app.atcyrus.com/",
+			apiKey: "secret-key",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+		});
+
+		const result = await client.postFailureMode({
+			sessionId: "sess-1",
+			category: "x",
+			recap: "y",
+			userQuoteSnippet: "u",
+			agentFailureSnippet: "a",
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchImpl.mock.calls[0]!;
+		expect(url).toBe("https://app.atcyrus.com/api/failure-modes");
+		expect(init.method).toBe("POST");
+		expect(init.headers.Authorization).toBe("Bearer secret-key");
+		expect(init.headers["Content-Type"]).toBe("application/json");
+		const body = JSON.parse(init.body);
+		expect(body.sessionId).toBe("sess-1");
+		expect(result).toEqual({
+			ok: true,
+			action: "created",
+			linearIssueUrl: "https://linear.app/x/issue/Y-1",
+		});
+	});
+
+	it("maps non-2xx response to a structured error", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ error: "Invalid API key" }), {
+					status: 401,
+				}),
+		);
+		const client = createFetchFailureModesClient({
+			baseUrl: "https://example.com",
+			apiKey: "x",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+		});
+		const result = await client.postFailureMode({
+			sessionId: "s",
+			category: "c",
+			recap: "r",
+			userQuoteSnippet: "u",
+			agentFailureSnippet: "a",
+		});
+		expect(result).toEqual({
+			ok: false,
+			status: 401,
+			error: "Invalid API key",
+		});
+	});
+
+	it("returns a transport error when fetch throws", async () => {
+		const fetchImpl = vi.fn(async () => {
+			throw new Error("network down");
+		});
+		const client = createFetchFailureModesClient({
+			baseUrl: "https://example.com",
+			apiKey: "x",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+		});
+		const result = await client.postFailureMode({
+			sessionId: "s",
+			category: "c",
+			recap: "r",
+			userQuoteSnippet: "u",
+			agentFailureSnippet: "a",
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.status).toBe(0);
+			expect(result.error).toMatch(/network down/);
+		}
+	});
+});

--- a/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
@@ -5,13 +5,10 @@ describe("createFetchFailureModesClient", () => {
 	it("sends Bearer token + JSON body to /api/failure-modes", async () => {
 		const fetchImpl = vi.fn(
 			async () =>
-				new Response(
-					JSON.stringify({
-						success: true,
-						reportId: 42,
-					}),
-					{ status: 200, headers: { "content-type": "application/json" } },
-				),
+				new Response(JSON.stringify({ success: true }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
 		);
 		const client = createFetchFailureModesClient({
 			baseUrl: "https://app.atcyrus.com/",
@@ -37,10 +34,7 @@ describe("createFetchFailureModesClient", () => {
 		const body = JSON.parse(init.body);
 		expect(body.sessionId).toBe("sess-1");
 		expect(body.sessionSource).toBe("slack");
-		expect(result).toEqual({
-			ok: true,
-			reportId: 42,
-		});
+		expect(result).toEqual({ ok: true });
 	});
 
 	it("maps non-2xx response to a structured error", async () => {

--- a/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
@@ -9,6 +9,8 @@ describe("createFetchFailureModesClient", () => {
 					JSON.stringify({
 						success: true,
 						reportId: 42,
+						action: "created",
+						linearIssueUrl: "https://linear.app/x/issue/Y-1",
 					}),
 					{ status: 200, headers: { "content-type": "application/json" } },
 				),
@@ -37,7 +39,12 @@ describe("createFetchFailureModesClient", () => {
 		const body = JSON.parse(init.body);
 		expect(body.sessionId).toBe("sess-1");
 		expect(body.sessionSource).toBe("slack");
-		expect(result).toEqual({ ok: true, reportId: 42 });
+		expect(result).toEqual({
+			ok: true,
+			reportId: 42,
+			action: "created",
+			linearIssueUrl: "https://linear.app/x/issue/Y-1",
+		});
 	});
 
 	it("maps non-2xx response to a structured error", async () => {

--- a/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
@@ -8,8 +8,7 @@ describe("createFetchFailureModesClient", () => {
 				new Response(
 					JSON.stringify({
 						success: true,
-						action: "created",
-						linearIssueUrl: "https://linear.app/x/issue/Y-1",
+						reportId: 42,
 					}),
 					{ status: 200, headers: { "content-type": "application/json" } },
 				),
@@ -22,6 +21,7 @@ describe("createFetchFailureModesClient", () => {
 
 		const result = await client.postFailureMode({
 			sessionId: "sess-1",
+			sessionSource: "slack",
 			category: "x",
 			recap: "y",
 			userQuoteSnippet: "u",
@@ -36,11 +36,8 @@ describe("createFetchFailureModesClient", () => {
 		expect(init.headers["Content-Type"]).toBe("application/json");
 		const body = JSON.parse(init.body);
 		expect(body.sessionId).toBe("sess-1");
-		expect(result).toEqual({
-			ok: true,
-			action: "created",
-			linearIssueUrl: "https://linear.app/x/issue/Y-1",
-		});
+		expect(body.sessionSource).toBe("slack");
+		expect(result).toEqual({ ok: true, reportId: 42 });
 	});
 
 	it("maps non-2xx response to a structured error", async () => {
@@ -57,6 +54,7 @@ describe("createFetchFailureModesClient", () => {
 		});
 		const result = await client.postFailureMode({
 			sessionId: "s",
+			sessionSource: null,
 			category: "c",
 			recap: "r",
 			userQuoteSnippet: "u",
@@ -80,6 +78,7 @@ describe("createFetchFailureModesClient", () => {
 		});
 		const result = await client.postFailureMode({
 			sessionId: "s",
+			sessionSource: null,
 			category: "c",
 			recap: "r",
 			userQuoteSnippet: "u",

--- a/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/failure-modes-http-client.test.ts
@@ -9,8 +9,6 @@ describe("createFetchFailureModesClient", () => {
 					JSON.stringify({
 						success: true,
 						reportId: 42,
-						action: "created",
-						linearIssueUrl: "https://linear.app/x/issue/Y-1",
 					}),
 					{ status: 200, headers: { "content-type": "application/json" } },
 				),
@@ -42,8 +40,6 @@ describe("createFetchFailureModesClient", () => {
 		expect(result).toEqual({
 			ok: true,
 			reportId: 42,
-			action: "created",
-			linearIssueUrl: "https://linear.app/x/issue/Y-1",
 		});
 	});
 

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -58,7 +58,6 @@ describe("log_failure_mode tool", () => {
 			recap: "User asked for PR screenshots and none were posted.",
 			userQuoteSnippet: "where are the screenshots?",
 			agentFailureSnippet: "PR opened: https://github.com/x/y/pull/1",
-			sessionLogsUrl: undefined,
 			runnerSessionId: null,
 			runnerType: null,
 			linearIssueIdentifier: null,

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -1,0 +1,140 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FailureModesHttpClient } from "../../../src/tools/cyrus-tools/log-failure-mode.js";
+import { registerLogFailureModeTool } from "../../../src/tools/cyrus-tools/log-failure-mode.js";
+
+/**
+ * The MCP SDK doesn't expose a public "invoke tool by name" helper, but
+ * `server.registerTool` accepts a handler we can reach back to via the
+ * server's internal request handler. For unit testing the failure-mode
+ * tool's *logic* we just call the registered handler closure directly by
+ * inspecting `_registeredTools`. This is a private API and may change in a
+ * future MCP SDK release — the test is value-add over a pure type check
+ * because it exercises the cwd→sessionId resolution + HTTP client paths.
+ */
+function getHandler(server: McpServer, name: string) {
+	const tools = (
+		server as unknown as {
+			_registeredTools?: Record<
+				string,
+				{ handler: (args: any) => Promise<any> }
+			>;
+		}
+	)._registeredTools;
+	const t = tools?.[name];
+	if (!t) throw new Error(`tool ${name} not registered`);
+	return t.handler;
+}
+
+describe("log_failure_mode tool", () => {
+	let httpClient: FailureModesHttpClient;
+	let resolveSessionFromCwd: (cwd: string) => string | null;
+	let server: McpServer;
+
+	beforeEach(() => {
+		httpClient = {
+			postFailureMode: vi.fn(async () => ({
+				ok: true,
+				action: "created",
+				linearIssueUrl: "https://linear.app/ceedar/issue/CYPACK-9999",
+			})),
+		};
+		resolveSessionFromCwd = vi.fn((cwd: string) =>
+			cwd === "/work/CYPACK-1" ? "session-abc" : null,
+		);
+		server = new McpServer({ name: "test", version: "0.0.0" });
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd,
+			httpClient,
+		});
+	});
+
+	it("resolves cwd → sessionId and posts to the http client", async () => {
+		const handler = getHandler(server, "log_failure_mode");
+		const result = await handler({
+			cwd: "/work/CYPACK-1",
+			category: "screenshots-not-returned",
+			recap: "User asked for PR screenshots and none were posted.",
+			user_quote_snippet: "where are the screenshots?",
+			agent_failure_snippet: "PR opened: https://github.com/x/y/pull/1",
+		});
+
+		expect(httpClient.postFailureMode).toHaveBeenCalledWith({
+			sessionId: "session-abc",
+			category: "screenshots-not-returned",
+			recap: "User asked for PR screenshots and none were posted.",
+			userQuoteSnippet: "where are the screenshots?",
+			agentFailureSnippet: "PR opened: https://github.com/x/y/pull/1",
+			sessionLogsUrl: undefined,
+		});
+
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(true);
+		expect(payload.action).toBe("created");
+		expect(payload.sessionId).toBe("session-abc");
+		expect(payload.linearIssueUrl).toMatch(/CYPACK-9999/);
+	});
+
+	it("falls back to fallbackSessionId when cwd doesn't resolve", async () => {
+		server = new McpServer({ name: "test", version: "0.0.0" });
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd: () => null,
+			httpClient,
+			fallbackSessionId: "fallback-session",
+		});
+		const handler = getHandler(server, "log_failure_mode");
+		const result = await handler({
+			cwd: "/elsewhere",
+			category: "port-conflict",
+			recap: "Asked for port 3001 but agent stayed on 3000.",
+			user_quote_snippet: "please use port 3001",
+			agent_failure_snippet: "Starting dev server on :3000",
+		});
+
+		expect(httpClient.postFailureMode).toHaveBeenCalled();
+		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
+		expect(callArg.sessionId).toBe("fallback-session");
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(true);
+	});
+
+	it("returns an error result when sessionId cannot be resolved", async () => {
+		server = new McpServer({ name: "test", version: "0.0.0" });
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd: () => null,
+			httpClient,
+		});
+		const handler = getHandler(server, "log_failure_mode");
+		const result = await handler({
+			cwd: "/unknown",
+			category: "x",
+			recap: "y",
+			user_quote_snippet: "z",
+			agent_failure_snippet: "q",
+		});
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(false);
+		expect(payload.error).toMatch(/Could not resolve a session id/);
+		expect(httpClient.postFailureMode).not.toHaveBeenCalled();
+	});
+
+	it("surfaces HTTP failure as a tool error result", async () => {
+		(httpClient.postFailureMode as any).mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			error: "Invalid API key",
+		});
+		const handler = getHandler(server, "log_failure_mode");
+		const result = await handler({
+			cwd: "/work/CYPACK-1",
+			category: "x",
+			recap: "y",
+			user_quote_snippet: "z",
+			agent_failure_snippet: "q",
+		});
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(false);
+		expect(payload.error).toMatch(/401/);
+		expect(payload.error).toMatch(/Invalid API key/);
+	});
+});

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -27,8 +27,6 @@ describe("log_failure_mode tool", () => {
 			postFailureMode: vi.fn(async () => ({
 				ok: true,
 				reportId: 7,
-				action: "created" as const,
-				linearIssueUrl: "https://linear.app/ceedar/issue/CYPACK-9999",
 			})),
 		};
 		resolveSessionFromCwd = vi.fn((cwd: string) =>
@@ -60,16 +58,20 @@ describe("log_failure_mode tool", () => {
 			agentFailureSnippet: "PR opened: https://github.com/x/y/pull/1",
 			runnerSessionId: null,
 			runnerType: null,
-			linearIssueIdentifier: null,
+			sourceIssueIdentifier: null,
 			workspacePath: "/work/CYPACK-1",
 		});
 
 		const payload = JSON.parse(result.content[0].text);
 		expect(payload.success).toBe(true);
 		expect(payload.reportId).toBe(7);
-		expect(payload.action).toBe("created");
-		expect(payload.linearIssueUrl).toMatch(/CYPACK-9999/);
 		expect(payload.sessionId).toBe("session-abc");
+		// Linear issue id/url MUST NOT be surfaced back to the agent — the
+		// internal failure-mode ticket has to remain invisible to the
+		// running session and to the end customer.
+		expect(payload.linearIssueUrl).toBeUndefined();
+		expect(payload.linearIssueId).toBeUndefined();
+		expect(payload.action).toBeUndefined();
 	});
 
 	it("infers sessionSource from a `github-` prefix", async () => {
@@ -121,7 +123,7 @@ describe("log_failure_mode tool", () => {
 				sessionId: "cyrus-internal-abc",
 				runnerSessionId: "claude-9f87",
 				runnerType: "claude" as const,
-				linearIssueIdentifier: "ENG-76",
+				sourceIssueIdentifier: "ENG-76",
 				workspacePath: "/home/payton/.cyrus/worktrees/ENG-76",
 				sessionSource: "linear",
 			}),
@@ -139,7 +141,7 @@ describe("log_failure_mode tool", () => {
 		expect(callArg.sessionId).toBe("cyrus-internal-abc");
 		expect(callArg.runnerSessionId).toBe("claude-9f87");
 		expect(callArg.runnerType).toBe("claude");
-		expect(callArg.linearIssueIdentifier).toBe("ENG-76");
+		expect(callArg.sourceIssueIdentifier).toBe("ENG-76");
 		expect(callArg.workspacePath).toBe("/home/payton/.cyrus/worktrees/ENG-76");
 	});
 

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -59,6 +59,12 @@ describe("log_failure_mode tool", () => {
 			userQuoteSnippet: "where are the screenshots?",
 			agentFailureSnippet: "PR opened: https://github.com/x/y/pull/1",
 			sessionLogsUrl: undefined,
+			runnerSessionId: null,
+			runnerType: null,
+			linearAgentSessionId: null,
+			linearIssueIdentifier: null,
+			linearIssueUrl: null,
+			workspacePath: "/work/CYPACK-1",
 		});
 
 		const payload = JSON.parse(result.content[0].text);
@@ -109,6 +115,38 @@ describe("log_failure_mode tool", () => {
 		});
 		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
 		expect(callArg.sessionSource).toBe("slack");
+	});
+
+	it("forwards the rich resolved-session bundle to the HTTP client", async () => {
+		// Resolver returns the rich ResolvedSession shape (new contract).
+		(resolveSessionFromCwd as ReturnType<typeof vi.fn>).mockImplementation(
+			() => ({
+				sessionId: "cyrus-internal-abc",
+				runnerSessionId: "claude-9f87",
+				runnerType: "claude" as const,
+				linearAgentSessionId: "agent-sess-zzz",
+				linearIssueIdentifier: "ENG-76",
+				linearIssueUrl: null,
+				workspacePath: "/home/payton/.cyrus/worktrees/ENG-76",
+				sessionSource: "linear",
+			}),
+		);
+		const handler = getHandler(server, "log_failure_mode");
+		await handler({
+			cwd: "/home/payton/.cyrus/worktrees/ENG-76",
+			category: "nvidia-smi-not-available",
+			recap: "Asked for nvidia-smi; not installed.",
+			user_quote_snippet: "you should be able to run that",
+			agent_failure_snippet:
+				"$ nvidia-smi\nbash: nvidia-smi: command not found",
+		});
+		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
+		expect(callArg.sessionId).toBe("cyrus-internal-abc");
+		expect(callArg.runnerSessionId).toBe("claude-9f87");
+		expect(callArg.runnerType).toBe("claude");
+		expect(callArg.linearAgentSessionId).toBe("agent-sess-zzz");
+		expect(callArg.linearIssueIdentifier).toBe("ENG-76");
+		expect(callArg.workspacePath).toBe("/home/payton/.cyrus/worktrees/ENG-76");
 	});
 
 	it("substitutes '<not captured>' when the snippet fields are omitted", async () => {

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -111,6 +111,21 @@ describe("log_failure_mode tool", () => {
 		expect(callArg.sessionSource).toBe("slack");
 	});
 
+	it("substitutes '<not captured>' when the snippet fields are omitted", async () => {
+		const handler = getHandler(server, "log_failure_mode");
+		await handler({
+			cwd: "/work/CYPACK-1",
+			category: "x",
+			recap: "agent botched its own tool call; recap-only report",
+			// user_quote_snippet and agent_failure_snippet intentionally absent —
+			// reproduces the model-side XML-vs-JSON tool-format confusion seen
+			// in the field. The report should still land.
+		});
+		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
+		expect(callArg.userQuoteSnippet).toBe("<not captured>");
+		expect(callArg.agentFailureSnippet).toBe("<not captured>");
+	});
+
 	it("falls back to fallbackSessionId when cwd doesn't resolve", async () => {
 		server = new McpServer({ name: "test", version: "0.0.0" });
 		registerLogFailureModeTool(server, {

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -27,6 +27,8 @@ describe("log_failure_mode tool", () => {
 			postFailureMode: vi.fn(async () => ({
 				ok: true,
 				reportId: 7,
+				action: "created" as const,
+				linearIssueUrl: "https://linear.app/ceedar/issue/CYPACK-9999",
 			})),
 		};
 		resolveSessionFromCwd = vi.fn((cwd: string) =>
@@ -62,6 +64,8 @@ describe("log_failure_mode tool", () => {
 		const payload = JSON.parse(result.content[0].text);
 		expect(payload.success).toBe(true);
 		expect(payload.reportId).toBe(7);
+		expect(payload.action).toBe("created");
+		expect(payload.linearIssueUrl).toMatch(/CYPACK-9999/);
 		expect(payload.sessionId).toBe("session-abc");
 	});
 

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -61,9 +61,7 @@ describe("log_failure_mode tool", () => {
 			sessionLogsUrl: undefined,
 			runnerSessionId: null,
 			runnerType: null,
-			linearAgentSessionId: null,
 			linearIssueIdentifier: null,
-			linearIssueUrl: null,
 			workspacePath: "/work/CYPACK-1",
 		});
 
@@ -124,9 +122,7 @@ describe("log_failure_mode tool", () => {
 				sessionId: "cyrus-internal-abc",
 				runnerSessionId: "claude-9f87",
 				runnerType: "claude" as const,
-				linearAgentSessionId: "agent-sess-zzz",
 				linearIssueIdentifier: "ENG-76",
-				linearIssueUrl: null,
 				workspacePath: "/home/payton/.cyrus/worktrees/ENG-76",
 				sessionSource: "linear",
 			}),
@@ -144,7 +140,6 @@ describe("log_failure_mode tool", () => {
 		expect(callArg.sessionId).toBe("cyrus-internal-abc");
 		expect(callArg.runnerSessionId).toBe("claude-9f87");
 		expect(callArg.runnerType).toBe("claude");
-		expect(callArg.linearAgentSessionId).toBe("agent-sess-zzz");
 		expect(callArg.linearIssueIdentifier).toBe("ENG-76");
 		expect(callArg.workspacePath).toBe("/home/payton/.cyrus/worktrees/ENG-76");
 	});

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -24,10 +24,7 @@ describe("log_failure_mode tool", () => {
 
 	beforeEach(() => {
 		httpClient = {
-			postFailureMode: vi.fn(async () => ({
-				ok: true,
-				reportId: 7,
-			})),
+			postFailureMode: vi.fn(async () => ({ ok: true })),
 		};
 		resolveSessionFromCwd = vi.fn((cwd: string) =>
 			cwd === "/work/CYPACK-1" ? "session-abc" : null,
@@ -63,15 +60,11 @@ describe("log_failure_mode tool", () => {
 		});
 
 		const payload = JSON.parse(result.content[0].text);
-		expect(payload.success).toBe(true);
-		expect(payload.reportId).toBe(7);
-		expect(payload.sessionId).toBe("session-abc");
-		// Linear issue id/url MUST NOT be surfaced back to the agent — the
-		// internal failure-mode ticket has to remain invisible to the
-		// running session and to the end customer.
-		expect(payload.linearIssueUrl).toBeUndefined();
-		expect(payload.linearIssueId).toBeUndefined();
-		expect(payload.action).toBeUndefined();
+		// The tool returns ONLY {success: true}. No internal id (Linear
+		// ticket id/url, DB report id, or even the cyrus session id) is
+		// surfaced back to the agent — the failure-mode record has to
+		// remain invisible to the running session and to the end customer.
+		expect(payload).toEqual({ success: true });
 	});
 
 	it("infers sessionSource from a `github-` prefix", async () => {

--- a/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/log-failure-mode.test.ts
@@ -3,15 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FailureModesHttpClient } from "../../../src/tools/cyrus-tools/log-failure-mode.js";
 import { registerLogFailureModeTool } from "../../../src/tools/cyrus-tools/log-failure-mode.js";
 
-/**
- * The MCP SDK doesn't expose a public "invoke tool by name" helper, but
- * `server.registerTool` accepts a handler we can reach back to via the
- * server's internal request handler. For unit testing the failure-mode
- * tool's *logic* we just call the registered handler closure directly by
- * inspecting `_registeredTools`. This is a private API and may change in a
- * future MCP SDK release — the test is value-add over a pure type check
- * because it exercises the cwd→sessionId resolution + HTTP client paths.
- */
 function getHandler(server: McpServer, name: string) {
 	const tools = (
 		server as unknown as {
@@ -35,8 +26,7 @@ describe("log_failure_mode tool", () => {
 		httpClient = {
 			postFailureMode: vi.fn(async () => ({
 				ok: true,
-				action: "created",
-				linearIssueUrl: "https://linear.app/ceedar/issue/CYPACK-9999",
+				reportId: 7,
 			})),
 		};
 		resolveSessionFromCwd = vi.fn((cwd: string) =>
@@ -49,7 +39,7 @@ describe("log_failure_mode tool", () => {
 		});
 	});
 
-	it("resolves cwd → sessionId and posts to the http client", async () => {
+	it("resolves cwd → sessionId and POSTs the full payload", async () => {
 		const handler = getHandler(server, "log_failure_mode");
 		const result = await handler({
 			cwd: "/work/CYPACK-1",
@@ -61,6 +51,7 @@ describe("log_failure_mode tool", () => {
 
 		expect(httpClient.postFailureMode).toHaveBeenCalledWith({
 			sessionId: "session-abc",
+			sessionSource: "linear",
 			category: "screenshots-not-returned",
 			recap: "User asked for PR screenshots and none were posted.",
 			userQuoteSnippet: "where are the screenshots?",
@@ -70,9 +61,50 @@ describe("log_failure_mode tool", () => {
 
 		const payload = JSON.parse(result.content[0].text);
 		expect(payload.success).toBe(true);
-		expect(payload.action).toBe("created");
+		expect(payload.reportId).toBe(7);
 		expect(payload.sessionId).toBe("session-abc");
-		expect(payload.linearIssueUrl).toMatch(/CYPACK-9999/);
+	});
+
+	it("infers sessionSource from a `github-` prefix", async () => {
+		(resolveSessionFromCwd as ReturnType<typeof vi.fn>).mockImplementation(
+			() => "github-abc-123",
+		);
+		server = new McpServer({ name: "test", version: "0.0.0" });
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd,
+			httpClient,
+		});
+		const handler = getHandler(server, "log_failure_mode");
+		await handler({
+			cwd: "/work/anywhere",
+			category: "x",
+			recap: "y",
+			user_quote_snippet: "z",
+			agent_failure_snippet: "q",
+		});
+		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
+		expect(callArg.sessionSource).toBe("github");
+	});
+
+	it("infers sessionSource from a `slack-` prefix", async () => {
+		(resolveSessionFromCwd as ReturnType<typeof vi.fn>).mockImplementation(
+			() => "slack-T123-C456",
+		);
+		server = new McpServer({ name: "test", version: "0.0.0" });
+		registerLogFailureModeTool(server, {
+			resolveSessionFromCwd,
+			httpClient,
+		});
+		const handler = getHandler(server, "log_failure_mode");
+		await handler({
+			cwd: "/x",
+			category: "x",
+			recap: "y",
+			user_quote_snippet: "z",
+			agent_failure_snippet: "q",
+		});
+		const callArg = (httpClient.postFailureMode as any).mock.calls[0][0];
+		expect(callArg.sessionSource).toBe("slack");
 	});
 
 	it("falls back to fallbackSessionId when cwd doesn't resolve", async () => {


### PR DESCRIPTION
## Summary
- New `mcp__cyrus-tools__log_failure_mode` MCP tool that POSTs to cyrus-hosted `/api/failure-modes` with the `CYRUS_API_KEY`. Resolves `cwd → sessionId` against the live `AgentSessionManager` so the tool stays stateless and the agent just passes its cwd.
- Shared system-prompt addendum (`failureModePromptAddendum.ts`) instructing every session when to call the tool. Injected once in `RunnerConfigBuilder` so it covers all 5 Linear prompt flavors (builder/debugger/scoper/orchestrator/graphite-orchestrator), the Slack entrypoint, and the GitHub entrypoint — single source of truth.
- DIP throughout: `FailureModesHttpClient` interface + `ResolveSessionFromCwd` resolver are both injectable, so tests don't touch fetch and don't need a live EdgeWorker.
- Self-reporting is internal — the addendum explicitly tells the model not to mention the tool to the user.

This is the cyrus side of [CYPACK-1226](https://linear.app/ceedar/issue/CYPACK-1226). The control plane side (endpoint, dedup, silence cron) ships in `cyrus-hosted` as a paired PR.

## Test plan
- [x] `pnpm typecheck` clean across all packages
- [x] `pnpm test:packages:run` — 1,395 tests pass (mcp-tools, edge-worker addendum, fetch client all covered)
- [x] `pnpm lint` clean (no new violations)
- [ ] Manual: assign a Linear issue to Cyrus on a self-host team, simulate dissatisfaction, verify the agent calls the tool and a ticket appears in the failure-modes project with `runtime: self-host`
- [ ] Manual: same for a cloud team — ticket appears with `runtime: cloud`