### PR TITLE
Release v0.2.53

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.53] - 2026-05-22
+
+_No internal-only changes._
+
 ## [0.2.52] - 2026-05-13
 
 _No internal-only changes._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.53] - 2026-05-22
+
 ### Added
 - **Per-platform allowed tools — explicit defaults exported from `cyrus-core`** — `cyrus-core` now exports three canonical lists (`LINEAR_DEFAULT_ALLOWED_TOOLS`, `SLACK_DEFAULT_ALLOWED_TOOLS`, `GITHUB_DEFAULT_ALLOWED_TOOLS`) plus a `getDefaultAllowedTools(platform)` resolver. Each list is **completely explicit** — workspace MCP prefixes (`mcp__linear`, `mcp__cyrus-tools`, `mcp__cyrus-docs`, and for Slack `mcp__slack`) are members of the list, not implicitly appended at runtime. cyrus-hosted imports the same constants so the source of truth lives in one place. ([CYHOST-967](https://linear.app/ceedar/issue/CYHOST-967))
 - **`EdgeConfig` accepts `slackAllowedTools` and `githubAllowedTools`** — two optional top-level keys for team-level platform overrides. When unset, the resolver falls back to the matching cyrus-core default. ([CYHOST-967](https://linear.app/ceedar/issue/CYHOST-967))
@@ -25,6 +27,53 @@ All notable changes to this project will be documented in this file.
 ### Security
 - **Patched 4 transitive dependency advisories** — Bumped `pnpm.overrides` for `brace-expansion` (≥5.0.6, DoS via large numeric ranges defeating `max` protection), `ws` (≥8.20.1, uninitialized memory disclosure on `close()` with `TypedArray` reason), `protobufjs` (≥7.5.8, DoS via unbounded recursive JSON descriptor expansion), and `uuid` (≥11.1.1, missing buffer bounds check in `v3`/`v5`/`v6`). `pnpm audit` now reports zero advisories. ([CYPACK-1230](https://linear.app/ceedar/issue/CYPACK-1230), [#1238](https://github.com/cyrusagents/cyrus/pull/1238))
 - **Patched 9 transitive dependency advisories** — Bumped `pnpm.overrides` for `hono` (≥4.12.18, fixes CSS injection / JWT validation / Cache Middleware cross-user leakage), `fast-uri` (≥3.1.2, path traversal + host confusion), `ip-address` (≥10.1.1, `Address6` XSS), `@anthropic-ai/sdk` (≥0.91.1, insecure default file permissions in local filesystem memory tool), and `@opentelemetry/sdk-node` / `@opentelemetry/exporter-prometheus` (≥0.217.0, Prometheus exporter process crash via malformed HTTP request). `pnpm audit` now reports zero advisories. ([CYPACK-1206](https://linear.app/ceedar/issue/CYPACK-1206))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.53
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.53
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.53
+
+#### cyrus-core
+- cyrus-core@0.2.53
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.53
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.53
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.53
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.53
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.53
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.53
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.53
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.53
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.53
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.53
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.53
 
 ## [0.2.52] - 2026-05-13
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.52",
+	"version": "0.2.53",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.53 to npm
- Update changelogs (CHANGELOG.md + CHANGELOG.internal.md)
- Create git tag v0.2.53

## Links
- [GitHub Release](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.53)
- Linear: CYPACK-1231

## Test plan
- [x] All packages published to npm
- [x] Git tag v0.2.53 created and pushed
- [x] GitHub Release published

<!-- generated-by-cyrus -->