### PR TITLE
fix(edge-worker): default CYRUS_APP_URL to DEFAULT_CYRUS_APP_URL (CYPACK-1232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **`log_failure_mode` MCP tool now registers when only `CYRUS_API_KEY` is set.** EdgeWorker previously required both `CYRUS_API_KEY` and `CYRUS_APP_URL` env vars to wire up the self-reported-failure-mode tool, so workspaces that hadn't overridden `CYRUS_APP_URL` silently shipped the failure-mode prompt addendum without a corresponding tool. The URL now falls back to the canonical default (`https://app.atcyrus.com`) via the shared `getCyrusAppUrl()` helper, matching the remote session store. ([CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232))
+- **`log_failure_mode` MCP tool now registers when only `CYRUS_API_KEY` is set.** EdgeWorker previously required both `CYRUS_API_KEY` and `CYRUS_APP_URL` env vars to wire up the self-reported-failure-mode tool, so workspaces that hadn't overridden `CYRUS_APP_URL` silently shipped the failure-mode prompt addendum without a corresponding tool. The URL now falls back to the canonical default (`https://app.atcyrus.com`) via the shared `getCyrusAppUrl()` helper, matching the remote session store. ([CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232), [#1240](https://github.com/cyrusagents/cyrus/pull/1240))
 
 ## [0.2.53] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`log_failure_mode` MCP tool now registers when only `CYRUS_API_KEY` is set.** EdgeWorker previously required both `CYRUS_API_KEY` and `CYRUS_APP_URL` env vars to wire up the self-reported-failure-mode tool, so workspaces that hadn't overridden `CYRUS_APP_URL` silently shipped the failure-mode prompt addendum without a corresponding tool. The URL now falls back to the canonical default (`https://app.atcyrus.com`) via the shared `getCyrusAppUrl()` helper, matching the remote session store. ([CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232))
+
 ## [0.2.53] - 2026-05-22
 
 ### Added

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -17,6 +17,7 @@ import {
 	HttpSessionStore,
 	normalizeMcpHttpTransport,
 } from "cyrus-claude-runner";
+import { getCyrusAppUrl } from "cyrus-cloudflare-tunnel-client";
 import { CodexRunner } from "cyrus-codex-runner";
 import { ConfigUpdater } from "cyrus-config-updater";
 import type {
@@ -302,22 +303,19 @@ export class EdgeWorker extends EventEmitter {
 		);
 
 		// Mirror Claude SDK session transcripts to the hosted control plane
-		// when CYRUS_APP_URL (destination), CYRUS_API_KEY (proof of team
-		// ownership), and CYRUS_TEAM_ID (which team the transcripts belong to)
-		// are all configured. If any is missing the store stays null and the
-		// SDK falls back to local JSONL only. Operators can also opt out
+		// when CYRUS_API_KEY (proof of team ownership) and CYRUS_TEAM_ID
+		// (which team the transcripts belong to) are configured. The
+		// destination URL defaults to DEFAULT_CYRUS_APP_URL but can be
+		// overridden via CYRUS_APP_URL for preview environments. If either
+		// of the required vars is missing the store stays null and the SDK
+		// falls back to local JSONL only. Operators can also opt out
 		// explicitly by setting CYRUS_DISABLE_REMOTE_SESSION_STORE=1, which
-		// keeps transcripts local even when the three vars above are present.
-		const sessionStoreBaseUrl = process.env.CYRUS_APP_URL;
+		// keeps transcripts local even when the vars above are present.
+		const sessionStoreBaseUrl = getCyrusAppUrl();
 		const sessionStoreApiKey = process.env.CYRUS_API_KEY;
 		const sessionStoreTeamId = process.env.CYRUS_TEAM_ID;
 		const sessionStoreDisabled = this.isRemoteSessionStoreDisabled();
-		if (
-			!sessionStoreDisabled &&
-			sessionStoreBaseUrl &&
-			sessionStoreApiKey &&
-			sessionStoreTeamId
-		) {
+		if (!sessionStoreDisabled && sessionStoreApiKey && sessionStoreTeamId) {
 			this.claudeSessionStore = new HttpSessionStore({
 				baseUrl: sessionStoreBaseUrl,
 				apiKey: sessionStoreApiKey,
@@ -329,7 +327,6 @@ export class EdgeWorker extends EventEmitter {
 			);
 		} else if (
 			sessionStoreDisabled &&
-			sessionStoreBaseUrl &&
 			sessionStoreApiKey &&
 			sessionStoreTeamId
 		) {
@@ -5575,8 +5572,8 @@ ${taskSection}`;
 	private getFailureModesClient(): FailureModesHttpClient | null {
 		if (this.failureModesClient) return this.failureModesClient;
 		const apiKey = process.env.CYRUS_API_KEY?.trim();
-		const baseUrl = process.env.CYRUS_APP_URL?.trim();
-		if (!apiKey || !baseUrl) return null;
+		if (!apiKey) return null;
+		const baseUrl = getCyrusAppUrl();
 		this.failureModesClient = createFetchFailureModesClient({
 			baseUrl,
 			apiKey,

--- a/packages/edge-worker/test/setup.ts
+++ b/packages/edge-worker/test/setup.ts
@@ -4,6 +4,14 @@ import { join } from "node:path";
 import type { SDKMessage } from "cyrus-claude-runner";
 import { vi } from "vitest";
 
+// Disable the remote session store in tests so EdgeWorker construction
+// doesn't try to instantiate HttpSessionStore. Tests using a partial
+// `cyrus-claude-runner` mock can omit the HttpSessionStore export, and
+// the CYRUS_APP_URL fallback (DEFAULT_CYRUS_APP_URL) means the store
+// would otherwise activate whenever CYRUS_API_KEY + CYRUS_TEAM_ID are
+// present in the developer's shell env.
+process.env.CYRUS_DISABLE_REMOTE_SESSION_STORE = "1";
+
 // Keep Claude SDK debug output inside the test workspace to avoid HOME write restrictions.
 const claudeConfigDir =
 	process.env.CLAUDE_CONFIG_DIR ??


### PR DESCRIPTION
## Summary

Fixes [CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232).

- `EdgeWorker` was reading `process.env.CYRUS_APP_URL` directly in two places. When unset, `getFailureModesClient()` returned `null`, so `createCyrusToolsOptions` omitted `options.failureModes` and the `log_failure_mode` MCP tool was never registered — even though the failure-mode prompt addendum was still injected into the agent's system prompt. The agent was being told to call a tool that didn't exist.
- Both call sites now use `getCyrusAppUrl()` from `cyrus-cloudflare-tunnel-client`, which falls back to `DEFAULT_CYRUS_APP_URL` (`https://app.atcyrus.com`) when the env var is unset.
- `getFailureModesClient()` now only gates on `CYRUS_API_KEY`.
- Tests: setup.ts sets `CYRUS_DISABLE_REMOTE_SESSION_STORE=1` so EdgeWorker construction doesn't try to instantiate `HttpSessionStore` (some test files partially mock `cyrus-claude-runner` without that export — previously masked because `CYRUS_APP_URL` was unset).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` in `packages/edge-worker` — 650/650 passing
- [ ] With only `CYRUS_API_KEY` set (no `CYRUS_APP_URL`), confirm `log_failure_mode` is registered and POSTs to `https://app.atcyrus.com`
- [ ] With `CYRUS_APP_URL` explicitly set to a preview URL, confirm no regression

<!-- generated-by-cyrus -->