### PR TITLE
fix(edge-worker): expand ~ in platform MCP config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **`~/`-prefixed paths in `slackMcpConfigs`, `linearMcpConfigs`, and `githubMcpConfigs` are now expanded.** When cyrus-hosted writes platform MCP config paths for a self-host runtime, it emits `~/.cyrus/mcp-configs/...` strings that were passed verbatim to `fs.readFileSync`, which does not expand tildes — Claude sessions would crash with `ENOENT: ~/.cyrus/mcp-configs/mcp-supabase.json`. EdgeWorker now runs the three platform MCP config arrays through `resolvePath` at construction and on config hot-reload, mirroring how repository-scoped paths have always been normalized.
 - **`log_failure_mode` MCP tool now registers when only `CYRUS_API_KEY` is set.** EdgeWorker previously required both `CYRUS_API_KEY` and `CYRUS_APP_URL` env vars to wire up the self-reported-failure-mode tool, so workspaces that hadn't overridden `CYRUS_APP_URL` silently shipped the failure-mode prompt addendum without a corresponding tool. The URL now falls back to the canonical default (`https://app.atcyrus.com`) via the shared `getCyrusAppUrl()` helper, matching the remote session store. ([CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232), [#1240](https://github.com/cyrusagents/cyrus/pull/1240))
 
 ## [0.2.53] - 2026-05-22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,14 @@ The agent automatically moves issues to the "started" state when assigned. Linea
 
    Symptom of forgetting this: the new tool is callable at runtime (the runtime knows about it via the live MCP server) but it never appears in the `/settings/tools` MCP Servers section — so operators can't see it, can't toggle it on/off per platform, and per-repo overrides treat it as unknown.
 
+11. **Adding a new path-bearing field to `EdgeWorkerConfig`**: cyrus-hosted emits self-host paths with literal `~/` prefixes (e.g. `~/.cyrus/mcp-configs/mcp-supabase.json`) because the user's home directory is not known server-side. Node's `fs.readFileSync` does **not** expand `~`, so any path string that flows from `config.json` to `readFileSync` (or to a child SDK that does the same) must be run through `resolvePath` from `cyrus-core` first.
+
+   Per-repository paths (`repositoryPath`, `workspaceBaseDir`, `mcpConfigPath`, `promptTemplatePath`) are already normalized at three sites in `EdgeWorker.ts`: the constructor, `addNewRepositories`, and `updateModifiedRepositories`. Each builds a `resolvedRepo` via `resolvePath(...)` before inserting into `this.repositories`, so downstream consumers (e.g. `RunnerConfigBuilder`, `McpConfigService.buildMergedMcpConfigPath`) get already-absolute paths.
+
+   **Top-level (non-repo-scoped) path fields are a separate, easy-to-miss codepath.** They live directly on `EdgeWorkerConfig` and are read straight off `this.config.<field>` — they do not go through the repo-resolution loop. When you add one, you must also normalize it. The canonical site for this is `EdgeWorker.normalizeConfigPaths()` (called once in the constructor and once on `configChanged`); add your field there alongside `slackMcpConfigs` / `linearMcpConfigs` / `githubMcpConfigs`.
+
+   Symptom of forgetting this: self-host sessions crash with `ENOENT: no such file or directory, open '~/.cyrus/...'` while cloud sessions (which get absolute paths from cyrus-hosted) work fine. This bit us with the three platform MCP config arrays added in CYHOST-967 / v0.2.53 — they were the only path-bearing fields on `EdgeWorkerConfig` that bypassed normalization, and crashed every self-host session that had a connected platform MCP integration.
+
 ## Dependency Security Policy (MANDATE)
 
 Our team's mandated approach for addressing Dependabot advisories and other

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -293,9 +293,30 @@ export class EdgeWorker extends EventEmitter {
 		}
 	>();
 
+	/**
+	 * Resolve `~/` prefixes in path-bearing config fields that are otherwise
+	 * passed verbatim to `fs.readFileSync` (which does not expand tildes).
+	 * Repository-scoped paths are normalized separately in addNew /
+	 * updateModified; this covers the platform-level MCP config lists that
+	 * cyrus-hosted writes with literal `~/.cyrus/...` prefixes when
+	 * generating self-host config.
+	 */
+	private static normalizeConfigPaths(
+		config: EdgeWorkerConfig,
+	): EdgeWorkerConfig {
+		const resolveList = (paths: string[] | undefined): string[] | undefined =>
+			paths ? paths.map(resolvePath) : undefined;
+		return {
+			...config,
+			slackMcpConfigs: resolveList(config.slackMcpConfigs),
+			linearMcpConfigs: resolveList(config.linearMcpConfigs),
+			githubMcpConfigs: resolveList(config.githubMcpConfigs),
+		};
+	}
+
 	constructor(config: EdgeWorkerConfig) {
 		super();
-		this.config = config;
+		this.config = EdgeWorker.normalizeConfigPaths(config);
 		this.cyrusHome = config.cyrusHome;
 		this.logger = createLogger({ component: "EdgeWorker" });
 		this.persistenceManager = new PersistenceManager(
@@ -622,7 +643,7 @@ export class EdgeWorker extends EventEmitter {
 				await this.addNewRepositories(changes.added);
 				// Live-update sandbox / egress proxy settings
 				await this.applySandboxConfigChanges(changes.newConfig);
-				this.config = changes.newConfig;
+				this.config = EdgeWorker.normalizeConfigPaths(changes.newConfig);
 				this.configManager.setConfig(changes.newConfig);
 				this.runnerSelectionService.setConfig(changes.newConfig);
 				this.toolPermissionResolver.setConfig(changes.newConfig);


### PR DESCRIPTION
## Summary

`cyrus-hosted` writes `~/.cyrus/mcp-configs/mcp-<slug>.json` into `slackMcpConfigs` / `linearMcpConfigs` / `githubMcpConfigs` for self-host runtimes. Those strings flow through EdgeWorker / RunnerConfigBuilder unchanged and end up at `fs.readFileSync(path)`, which **does not expand `~`** — sessions crashed with:

\`\`\`
ENOENT: no such file or directory, open '~/.cyrus/mcp-configs/mcp-supabase.json'
    at ClaudeRunner.startWithPrompt (...ClaudeRunner.ts:592)
\`\`\`

Repository-scoped path fields (`repositoryPath`, `workspaceBaseDir`, `mcpConfigPath`, `promptTemplatePath`) were already normalized via `resolvePath` at construction / add / update. The three platform-level MCP config arrays were not. This PR normalizes them at the same boundary — once at construction and once on config hot-reload — so the rest of the code stays oblivious to whether the original config used `~`.

## Test plan
- [x] `pnpm build` — all packages green
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` in `packages/edge-worker` — 650/650 passing
- [ ] Restart the local cyrus process pointing at a self-host config with `linearMcpConfigs: ["~/.cyrus/mcp-configs/mcp-supabase.json"]` and confirm the session no longer crashes