### PR TITLE
Release v0.2.55

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.55] - 2026-05-22
+
 ### Changed
 - Documented the path-bearing `EdgeWorkerConfig` field gotcha in `CLAUDE.md`: top-level path fields like `slackMcpConfigs` / `linearMcpConfigs` / `githubMcpConfigs` are read directly off `this.config.<field>` and bypass the per-repo resolution loop, so they must be normalized in `EdgeWorker.normalizeConfigPaths()` (called from the constructor and on `configChanged`). ([#1242](https://github.com/cyrusagents/cyrus/pull/1242))
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Documented the path-bearing `EdgeWorkerConfig` field gotcha in `CLAUDE.md`: top-level path fields like `slackMcpConfigs` / `linearMcpConfigs` / `githubMcpConfigs` are read directly off `this.config.<field>` and bypass the per-repo resolution loop, so they must be normalized in `EdgeWorker.normalizeConfigPaths()` (called from the constructor and on `configChanged`). ([#1242](https://github.com/cyrusagents/cyrus/pull/1242))
+
 ## [0.2.54] - 2026-05-22
 
 _No internal-only changes._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,57 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.55] - 2026-05-22
+
 ### Fixed
 - **`~/`-prefixed paths in `slackMcpConfigs`, `linearMcpConfigs`, and `githubMcpConfigs` are now expanded.** When cyrus-hosted writes platform MCP config paths for a self-host runtime, it emits `~/.cyrus/mcp-configs/...` strings that were passed verbatim to `fs.readFileSync`, which does not expand tildes — Claude sessions would crash with `ENOENT: ~/.cyrus/mcp-configs/mcp-supabase.json`. EdgeWorker now runs the three platform MCP config arrays through `resolvePath` at construction and on config hot-reload, mirroring how repository-scoped paths have always been normalized. ([#1242](https://github.com/cyrusagents/cyrus/pull/1242))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.55
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.55
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.55
+
+#### cyrus-core
+- cyrus-core@0.2.55
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.55
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.55
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.55
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.55
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.55
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.55
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.55
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.55
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.55
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.55
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.55
 
 ## [0.2.54] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`~/`-prefixed paths in `slackMcpConfigs`, `linearMcpConfigs`, and `githubMcpConfigs` are now expanded.** When cyrus-hosted writes platform MCP config paths for a self-host runtime, it emits `~/.cyrus/mcp-configs/...` strings that were passed verbatim to `fs.readFileSync`, which does not expand tildes — Claude sessions would crash with `ENOENT: ~/.cyrus/mcp-configs/mcp-supabase.json`. EdgeWorker now runs the three platform MCP config arrays through `resolvePath` at construction and on config hot-reload, mirroring how repository-scoped paths have always been normalized. ([#1242](https://github.com/cyrusagents/cyrus/pull/1242))
+
 ## [0.2.54] - 2026-05-22
 
 ### Fixed
-- **`~/`-prefixed paths in `slackMcpConfigs`, `linearMcpConfigs`, and `githubMcpConfigs` are now expanded.** When cyrus-hosted writes platform MCP config paths for a self-host runtime, it emits `~/.cyrus/mcp-configs/...` strings that were passed verbatim to `fs.readFileSync`, which does not expand tildes — Claude sessions would crash with `ENOENT: ~/.cyrus/mcp-configs/mcp-supabase.json`. EdgeWorker now runs the three platform MCP config arrays through `resolvePath` at construction and on config hot-reload, mirroring how repository-scoped paths have always been normalized.
 - **`log_failure_mode` MCP tool now registers when only `CYRUS_API_KEY` is set.** EdgeWorker previously required both `CYRUS_API_KEY` and `CYRUS_APP_URL` env vars to wire up the self-reported-failure-mode tool, so workspaces that hadn't overridden `CYRUS_APP_URL` silently shipped the failure-mode prompt addendum without a corresponding tool. The URL now falls back to the canonical default (`https://app.atcyrus.com`) via the shared `getCyrusAppUrl()` helper, matching the remote session store. ([CYPACK-1232](https://linear.app/ceedar/issue/CYPACK-1232), [#1240](https://github.com/cyrusagents/cyrus/pull/1240))
 
 ### Packages

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.54",
+	"version": "0.2.55",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.55 to npm — ships the `~/` path expansion fix for platform MCP configs ([#1242](https://github.com/cyrusagents/cyrus/pull/1242)) that landed after v0.2.54 was tagged
- Bump all 15 packages and CLI to 0.2.55
- Update CHANGELOG.md and CHANGELOG.internal.md (move the #1242 entry to its correct version section)

## Links
- [GitHub Release](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.55)

<!-- generated-by-cyrus -->