### PR TITLE
fix(cli): thread allowed-tools and McpConfigs into cold-start EdgeWorkerConfig (CYPACK-1236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **`slackAllowedTools`, `githubAllowedTools`, `linearAllowedTools`, and the `*McpConfigs` arrays from `~/.cyrus/config.json` are now applied at cold start.** Previously these fields were only picked up after a post-start config-file change, so the very first session after restart silently fell back to the built-in defaults. ([CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236))
+- **`slackAllowedTools`, `githubAllowedTools`, `linearAllowedTools`, and the `*McpConfigs` arrays from `~/.cyrus/config.json` are now applied at cold start.** Previously these fields were only picked up after a post-start config-file change, so the very first session after restart silently fell back to the built-in defaults. ([CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236), [#1245](https://github.com/cyrusagents/cyrus/pull/1245))
 
 ### Removed
 - **Claude-in-Chrome browser integration is no longer enabled for agent sessions.** Cyrus previously passed `--chrome` to every Claude runner session, which registered the `mcp__claude-in-chrome__*` MCP tools. In cloud-runtime sessions there is no path from the worker to the user's local Chrome extension, so those tools always failed with "Browser extension is not connected" — leading agents to loop on a misdiagnosis instead of falling back. The flag and the associated screenshot/GIF upload-guidance hooks have been removed. ([PRO-9](https://linear.app/ceedar/issue/PRO-9/failed-chrome-extension-not-connecting-oswaldo-okeefe), [#1244](https://github.com/cyrusagents/cyrus/pull/1244))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - **`slackAllowedTools`, `githubAllowedTools`, `linearAllowedTools`, and the `*McpConfigs` arrays from `~/.cyrus/config.json` are now applied at cold start.** Previously these fields were only picked up after a post-start config-file change, so the very first session after restart silently fell back to the built-in defaults. ([CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236), [#1245](https://github.com/cyrusagents/cyrus/pull/1245))
 
+### Changed
+- **The `ALLOWED_TOOLS` environment variable has been renamed to `LINEAR_ALLOWED_TOOLS`** to match the per-channel naming used elsewhere (`slackAllowedTools`, `githubAllowedTools`). If you were setting `ALLOWED_TOOLS` to override Linear's tool allowlist, rename it to `LINEAR_ALLOWED_TOOLS`. ([CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236), [#1245](https://github.com/cyrusagents/cyrus/pull/1245))
+
 ### Removed
 - **Claude-in-Chrome browser integration is no longer enabled for agent sessions.** Cyrus previously passed `--chrome` to every Claude runner session, which registered the `mcp__claude-in-chrome__*` MCP tools. In cloud-runtime sessions there is no path from the worker to the user's local Chrome extension, so those tools always failed with "Browser extension is not connected" — leading agents to loop on a misdiagnosis instead of falling back. The flag and the associated screenshot/GIF upload-guidance hooks have been removed. ([PRO-9](https://linear.app/ceedar/issue/PRO-9/failed-chrome-extension-not-connecting-oswaldo-okeefe), [#1244](https://github.com/cyrusagents/cyrus/pull/1244))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`slackAllowedTools`, `githubAllowedTools`, `linearAllowedTools`, and the `*McpConfigs` arrays from `~/.cyrus/config.json` are now applied at cold start.** Previously these fields were only picked up after a post-start config-file change, so the very first session after restart silently fell back to the built-in defaults. ([CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236))
+
 ### Removed
 - **Claude-in-Chrome browser integration is no longer enabled for agent sessions.** Cyrus previously passed `--chrome` to every Claude runner session, which registered the `mcp__claude-in-chrome__*` MCP tools. In cloud-runtime sessions there is no path from the worker to the user's local Chrome extension, so those tools always failed with "Browser extension is not connected" — leading agents to loop on a misdiagnosis instead of falling back. The flag and the associated screenshot/GIF upload-guidance hooks have been removed. ([PRO-9](https://linear.app/ceedar/issue/PRO-9/failed-chrome-extension-not-connecting-oswaldo-okeefe), [#1244](https://github.com/cyrusagents/cyrus/pull/1244))
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -50,3 +50,5 @@ The interactive wizard will prompt you for:
   - Use this when running in Docker containers or when you need external access to the webhook server
   - When `true`: Server listens on `0.0.0.0` (all interfaces)
   - When `false` or unset: Server listens on `localhost` (local access only)
+- `LINEAR_ALLOWED_TOOLS` - Comma-separated list of tools allowed for Linear-triggered sessions. Overrides `linearAllowedTools` in `~/.cyrus/config.json` when set.
+- `DISALLOWED_TOOLS` - Comma-separated list of tools disallowed across all sessions. Overrides `defaultDisallowedTools` in `~/.cyrus/config.json` when set.

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -195,9 +195,17 @@ export class WorkerService {
 			repositories,
 			cyrusHome: this.cyrusHome,
 			linearAllowedTools:
-				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) || [],
+				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) ||
+				edgeConfig.linearAllowedTools ||
+				[],
+			slackAllowedTools: edgeConfig.slackAllowedTools,
+			githubAllowedTools: edgeConfig.githubAllowedTools,
+			slackMcpConfigs: edgeConfig.slackMcpConfigs,
+			linearMcpConfigs: edgeConfig.linearMcpConfigs,
+			githubMcpConfigs: edgeConfig.githubMcpConfigs,
 			defaultDisallowedTools:
 				process.env.DISALLOWED_TOOLS?.split(",").map((t) => t.trim()) ||
+				edgeConfig.defaultDisallowedTools ||
 				undefined,
 			// Model configuration: environment variables take precedence over config file.
 			// Legacy env vars/keys are still accepted for backwards compatibility.

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -195,7 +195,7 @@ export class WorkerService {
 			repositories,
 			cyrusHome: this.cyrusHome,
 			linearAllowedTools:
-				process.env.ALLOWED_TOOLS?.split(",").map((t) => t.trim()) ||
+				process.env.LINEAR_ALLOWED_TOOLS?.split(",").map((t) => t.trim()) ||
 				edgeConfig.linearAllowedTools ||
 				[],
 			slackAllowedTools: edgeConfig.slackAllowedTools,


### PR DESCRIPTION
## Summary

`WorkerService.startEdgeWorker` (`apps/cli/src/services/WorkerService.ts`) builds the initial `EdgeWorkerConfig` from `~/.cyrus/config.json` but was not threading through several per-channel fields. As a result, customizations in `config.json` were silently ignored at cold start, and the defaults from `ToolPermissionResolver` were used instead. The hot-reload path in `ConfigManager.loadConfigSafely` already merges these correctly, so values only took effect after a post-start config file change.

This is the exact failure mode the `CLAUDE.md` note around `EdgeWorkerConfig` warns about (CYHOST-967).

## Changes

- Add the following to the cold-start `EdgeWorkerConfig` in `WorkerService.ts`:
  - `slackAllowedTools`
  - `githubAllowedTools`
  - `slackMcpConfigs`
  - `linearMcpConfigs`
  - `githubMcpConfigs`
- Honor `edgeConfig.linearAllowedTools` from `config.json` as a fallback when `ALLOWED_TOOLS` env is not set.
- Honor `edgeConfig.defaultDisallowedTools` from `config.json` as a fallback when `DISALLOWED_TOOLS` env is not set.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — passes (warnings only, pre-existing)
- `pnpm --filter cyrus-ai test:run` — 94/94 passing

Linear: [CYPACK-1236](https://linear.app/ceedar/issue/CYPACK-1236/cold-start-path-in-workerservicestartedgeworker-drops)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->