### PR TITLE
fix(edge-worker): pin slack-mcp-server to v1.2.3 (CYPACK-1239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Pinned the Slack MCP server to v1.2.3.** v1.3.0 of `slack-mcp-server` requires additional Slack OAuth scopes; pinning avoids breaking existing Slack installations that haven't re-authorized. ([CYPACK-1239](https://linear.app/ceedar/issue/CYPACK-1239))
+- **Pinned the Slack MCP server to v1.2.3.** v1.3.0 of `slack-mcp-server` requires additional Slack OAuth scopes; pinning avoids breaking existing Slack installations that haven't re-authorized. ([CYPACK-1239](https://linear.app/ceedar/issue/CYPACK-1239), [#1247](https://github.com/cyrusagents/cyrus/pull/1247))
 
 ## [0.2.56] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Pinned the Slack MCP server to v1.2.3.** v1.3.0 of `slack-mcp-server` requires additional Slack OAuth scopes; pinning avoids breaking existing Slack installations that haven't re-authorized. ([CYPACK-1239](https://linear.app/ceedar/issue/CYPACK-1239))
+
 ## [0.2.56] - 2026-05-22
 
 ### Fixed

--- a/packages/edge-worker/src/McpConfigService.ts
+++ b/packages/edge-worker/src/McpConfigService.ts
@@ -137,7 +137,7 @@ export class McpConfigService {
 		if (slackBotToken) {
 			mcpConfig.slack = {
 				command: "npx",
-				args: ["-y", "slack-mcp-server@latest", "--transport", "stdio"],
+				args: ["-y", "slack-mcp-server@1.2.3", "--transport", "stdio"],
 				env: {
 					SLACK_MCP_XOXB_TOKEN: slackBotToken,
 				},


### PR DESCRIPTION
## Summary
- Pin `slack-mcp-server` from `@latest` to `@1.2.3` in `McpConfigService.ts`
- v1.3.0 requires additional Slack OAuth scopes that existing installations have not granted

Closes [CYPACK-1239](https://linear.app/ceedar/issue/CYPACK-1239/pin-slack-mcp-package-version)

## Test plan
- [ ] Verify Slack sessions still start and tools work with v1.2.3

<!-- generated-by-cyrus -->