### PR TITLE
Release v0.2.58

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.58] - 2026-05-26
+
 ### Added
 - **F1: `terminate-issue` command** — F1 can now drive a Linear issue to a terminal state (`completed` / `canceled` / `deleted`) via `apps/f1/f1 terminate-issue --issue-id <id> --action <completed|canceled|deleted>`. The new `CLIIssueTrackerService.terminateIssue` method updates the in-memory state (or removes the issue for `deleted`) and emits an `IssueStateChangeMessage` on the unified message bus via `CLIEventTransport.emitMessage`, so EdgeWorker's terminal-state cleanup path (stop sessions, run `cyrus-teardown.sh`, remove worktrees) is exercised end-to-end in CLI mode. EdgeWorker's CLI setup now subscribes to the transport's `"message"` event in addition to `"event"`. Unblocks F1 testing of the per-repo `cyrus-teardown.sh` feature shipped in [CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219), and any future terminal-state behavior. ([CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219), [#1233](https://github.com/cyrusagents/cyrus/pull/1233))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,57 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.58] - 2026-05-26
+
 ### Added
 - **Per-repo `cyrus-teardown.sh` auto-detection** — Place a `cyrus-teardown.sh` (or `.ps1` / `.cmd` / `.bat`) script in your repository root and Cyrus runs it inside the issue's worktree directory immediately before the worktree is removed when the Linear issue is **completed**, **canceled**, or **deleted**. Symmetric to the existing `cyrus-setup.sh` mechanism — no configuration needed, just commit the script. In multi-repo issues each repo's teardown runs independently with `cwd` set to that repo's worktree subdirectory; failures in one repo do not block other repos' teardowns or worktree removal. The script gets `LINEAR_ISSUE_IDENTIFIER` in env, a 2-minute timeout, and is non-blocking on failure. Closes upstream [cyrusagents/cyrus#1065](https://github.com/cyrusagents/cyrus/issues/1065); credit to @matthewbjones for the original direction in [#1111](https://github.com/cyrusagents/cyrus/pull/1111). ([CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219), [#1233](https://github.com/cyrusagents/cyrus/pull/1233))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.58
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.58
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.58
+
+#### cyrus-core
+- cyrus-core@0.2.58
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.58
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.58
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.58
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.58
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.58
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.58
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.58
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.58
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.58
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.58
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.58
 
 ## [0.2.57] - 2026-05-22
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.57",
+	"version": "0.2.58",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.58 to npm
- Add per-repo `cyrus-teardown.sh` auto-detection ([CYPACK-1219](https://linear.app/ceedar/issue/CYPACK-1219))

## Links
- [GitHub Release](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.58)
- [CHANGELOG.md](./CHANGELOG.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- generated-by-cyrus -->