### PR TITLE
feat(edge-worker): reply on PR when no repo is configured for incoming GitHub webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- When a GitHub webhook arrives from a repo Cyrus has no configuration for, and the event is an @-mention or a `pull_request_review` requesting changes, Cyrus now posts a one-time reply on the pull request explaining the failure and citing likely causes (org rename/transfer, typo in the configured GitHub URL, or App installed on an unconfigured repo). Previously the webhook was silently dropped with only a server-side warning log.
+- GitHub App manifest in the `cyrus-setup-github` skill now subscribes to `repository` and `organization` webhook events so future renames, transfers, and org renames can be reconciled automatically.
+
 ### Changed
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.2.123` to `0.3.154` and `@anthropic-ai/sdk` from `^0.91.x` to `^0.100.0`. See [claude-agent-sdk CHANGELOG](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1257](https://linear.app/ceedar/issue/CYPACK-1257), [#1264](https://github.com/cyrusagents/cyrus/pull/1264))
 - Refreshed mandatory tool allowance list per SDK v0.3.154: removed deprecated `RemoteTrigger` tool, added new `Workflow` tool to `availableTools` in `config.ts` and all platform default lists in `allowed-tools-defaults.ts`. ([CYPACK-1257](https://linear.app/ceedar/issue/CYPACK-1257), [#1264](https://github.com/cyrusagents/cyrus/pull/1264))

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -207,6 +207,7 @@ export class EdgeWorker extends EventEmitter {
 	private sessionRepositories: Map<string, string> = new Map(); // Maps session ID to repository ID
 	private lastStopTimeBySession: Map<string, number> = new Map(); // Maps session ID to timestamp of last stop signal (for double-stop detection)
 	private warmInstances: Map<string, WarmQuery> = new Map(); // Pre-warmed Claude sessions keyed by agentSessionId
+	private notifiedUnconfiguredRepos: Set<string> = new Set(); // GitHub repo full names we've already replied to about missing config (dedup per process)
 	private issueTrackers: Map<string, IIssueTrackerService> = new Map(); // one issue tracker per Linear workspace (keyed by linearWorkspaceId)
 	private linearEventTransport: LinearEventTransport | null = null; // Single event transport for webhook delivery
 	private gitHubEventTransport: GitHubEventTransport | null = null; // GitHub event transport for forwarded GitHub webhooks
@@ -1249,6 +1250,45 @@ export class EdgeWorker extends EventEmitter {
 				this.logger.warn(
 					`No repository configured for GitHub repo: ${repoFullName}`,
 				);
+
+				// Only reply on signals where the user clearly directed something at us:
+				// an explicit @-mention, or a pull_request_review requesting changes.
+				const wasMentioned =
+					!!botUsername && commentBody.includes(`@${botUsername}`);
+				const shouldReply = wasMentioned || isPullRequestReview;
+
+				if (
+					shouldReply &&
+					reactionToken &&
+					prNumber &&
+					!this.notifiedUnconfiguredRepos.has(repoFullName)
+				) {
+					this.notifiedUnconfiguredRepos.add(repoFullName);
+					this.gitHubCommentService
+						.postIssueComment({
+							token: reactionToken,
+							owner: extractRepoOwner(event),
+							repo: extractRepoName(event),
+							issueNumber: prNumber,
+							body: [
+								`Cyrus received this webhook but has no repository configured for \`${repoFullName}\`, so no agent session was started.`,
+								``,
+								`**Likely causes:**`,
+								`- The owner/org was **renamed or transferred** on GitHub. Webhooks are delivered under the current owner name, but Cyrus's stored \`githubUrl\` still points at the old one. GitHub's web redirects don't apply to webhook payloads — the config has to be updated explicitly.`,
+								`- The configured \`githubUrl\` has a typo (e.g. wrong org/owner) and doesn't match the repo this event came from.`,
+								`- The GitHub App / webhook is installed on a repo Cyrus isn't configured for at all.`,
+								``,
+								`**Fix (cyrus-hosted users):** open the repository in your Cyrus dashboard and update its GitHub URL to \`https://github.com/${repoFullName}\` — that will push a corrected \`config.json\` down to the worker. Editing the worker's \`~/.cyrus/config.json\` directly won't stick, because cyrus-hosted overwrites it on the next sync.`,
+								``,
+								`**Fix (self-hosted users):** open \`~/.cyrus/config.json\` on the worker and update the \`githubUrl\` of the relevant repository to \`https://github.com/${repoFullName}\`, or remove the GitHub App from this repo if it shouldn't be sending events to Cyrus.`,
+							].join("\n"),
+						})
+						.catch((err: unknown) => {
+							this.logger.warn(
+								`Failed to post unconfigured-repo notice: ${err instanceof Error ? err.message : err}`,
+							);
+						});
+				}
 				return;
 			}
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1274,7 +1274,7 @@ export class EdgeWorker extends EventEmitter {
 
 					const fix = isManagedCustomer
 						? `**What to do:** there's currently no self-serve way to update the stored repository URL on your plan — please reach out to Cyrus support and reference \`${repoFullName}\` and we'll reconcile it on the backend.`
-						: `**What to do:** open \`~/.cyrus/config.json\` on the worker and update the \`githubUrl\` of the relevant repository to \`https://github.com/${repoFullName}\`, then restart the worker. If this repo shouldn't be sending events to Cyrus at all, remove the GitHub App from it instead.`;
+						: `**What to do:** open \`~/.cyrus/config.json\` on the worker and update the \`githubUrl\` of the relevant repository to \`https://github.com/${repoFullName}\`. The worker watches the config file and will pick up the change automatically. If this repo shouldn't be sending events to Cyrus at all, remove the GitHub App from it instead.`;
 
 					this.gitHubCommentService
 						.postIssueComment({

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -207,7 +207,6 @@ export class EdgeWorker extends EventEmitter {
 	private sessionRepositories: Map<string, string> = new Map(); // Maps session ID to repository ID
 	private lastStopTimeBySession: Map<string, number> = new Map(); // Maps session ID to timestamp of last stop signal (for double-stop detection)
 	private warmInstances: Map<string, WarmQuery> = new Map(); // Pre-warmed Claude sessions keyed by agentSessionId
-	private notifiedUnconfiguredRepos: Set<string> = new Set(); // GitHub repo full names we've already replied to about missing config (dedup per process)
 	private issueTrackers: Map<string, IIssueTrackerService> = new Map(); // one issue tracker per Linear workspace (keyed by linearWorkspaceId)
 	private linearEventTransport: LinearEventTransport | null = null; // Single event transport for webhook delivery
 	private gitHubEventTransport: GitHubEventTransport | null = null; // GitHub event transport for forwarded GitHub webhooks
@@ -1257,13 +1256,7 @@ export class EdgeWorker extends EventEmitter {
 					!!botUsername && commentBody.includes(`@${botUsername}`);
 				const shouldReply = wasMentioned || isPullRequestReview;
 
-				if (
-					shouldReply &&
-					reactionToken &&
-					prNumber &&
-					!this.notifiedUnconfiguredRepos.has(repoFullName)
-				) {
-					this.notifiedUnconfiguredRepos.add(repoFullName);
+				if (shouldReply && reactionToken && prNumber) {
 					this.gitHubCommentService
 						.postIssueComment({
 							token: reactionToken,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1257,24 +1257,32 @@ export class EdgeWorker extends EventEmitter {
 				const shouldReply = wasMentioned || isPullRequestReview;
 
 				if (shouldReply && reactionToken && prNumber) {
+					// Presence of CYRUS_API_KEY indicates this worker is paired with the
+					// managed control plane (paid customer). Absence means the worker is
+					// running on the Community plan (self-managed config.json).
+					const isManagedCustomer = !!process.env.CYRUS_API_KEY;
+
+					const commonPreamble = [
+						`Cyrus received this webhook but has no repository configured for \`${repoFullName}\`, so no agent session was started.`,
+						``,
+						`**Likely causes:**`,
+						`- The owner/org was **renamed or transferred** on GitHub. Webhooks are delivered under the current owner name, but Cyrus's stored repository URL still points at the old one. GitHub's web redirects don't apply to webhook payloads — the stored URL has to be updated explicitly.`,
+						`- The stored repository URL has a typo (e.g. wrong org/owner) and doesn't match the repo this event came from.`,
+						`- The GitHub App / webhook is installed on a repo Cyrus isn't configured for at all.`,
+						``,
+					];
+
+					const fix = isManagedCustomer
+						? `**What to do:** there's currently no self-serve way to update the stored repository URL on your plan — please reach out to Cyrus support and reference \`${repoFullName}\` and we'll reconcile it on the backend.`
+						: `**What to do:** open \`~/.cyrus/config.json\` on the worker and update the \`githubUrl\` of the relevant repository to \`https://github.com/${repoFullName}\`, then restart the worker. If this repo shouldn't be sending events to Cyrus at all, remove the GitHub App from it instead.`;
+
 					this.gitHubCommentService
 						.postIssueComment({
 							token: reactionToken,
 							owner: extractRepoOwner(event),
 							repo: extractRepoName(event),
 							issueNumber: prNumber,
-							body: [
-								`Cyrus received this webhook but has no repository configured for \`${repoFullName}\`, so no agent session was started.`,
-								``,
-								`**Likely causes:**`,
-								`- The owner/org was **renamed or transferred** on GitHub. Webhooks are delivered under the current owner name, but Cyrus's stored \`githubUrl\` still points at the old one. GitHub's web redirects don't apply to webhook payloads — the config has to be updated explicitly.`,
-								`- The configured \`githubUrl\` has a typo (e.g. wrong org/owner) and doesn't match the repo this event came from.`,
-								`- The GitHub App / webhook is installed on a repo Cyrus isn't configured for at all.`,
-								``,
-								`**Fix (cyrus-hosted users):** open the repository in your Cyrus dashboard and update its GitHub URL to \`https://github.com/${repoFullName}\` — that will push a corrected \`config.json\` down to the worker. Editing the worker's \`~/.cyrus/config.json\` directly won't stick, because cyrus-hosted overwrites it on the next sync.`,
-								``,
-								`**Fix (self-hosted users):** open \`~/.cyrus/config.json\` on the worker and update the \`githubUrl\` of the relevant repository to \`https://github.com/${repoFullName}\`, or remove the GitHub App from this repo if it shouldn't be sending events to Cyrus.`,
-							].join("\n"),
+							body: [...commonPreamble, fix].join("\n"),
 						})
 						.catch((err: unknown) => {
 							this.logger.warn(

--- a/skills/cyrus-setup-github/SKILL.md
+++ b/skills/cyrus-setup-github/SKILL.md
@@ -161,8 +161,10 @@ Construct the manifest, substituting `AGENT_NAME`, `HOMEPAGE_URL`, and `CYRUS_BA
   },
   "default_events": [
     "issue_comment",
+    "organization",
     "pull_request_review",
-    "pull_request_review_comment"
+    "pull_request_review_comment",
+    "repository"
   ]
 }
 ```


### PR DESCRIPTION
## Summary

- When a GitHub webhook arrives from a repo not configured in this worker, and the event is an @-mention or a `pull_request_review` requesting changes, Cyrus now posts a reply on the PR explaining the failure and the likely causes (org rename/transfer, typo in the stored repository URL, or App installed on an unconfigured repo). Previously the webhook was dropped silently with only a server-side `WARN` log.
- The reply's "what to do" line branches on the presence of `CYRUS_API_KEY` so the message matches the user's plan:
  - **`CYRUS_API_KEY` set** (managed plan customer) — no self-serve way to update the stored repository URL on this plan; the reply asks them to contact support and references the repo full name.
  - **`CYRUS_API_KEY` unset** (Community / self-managed) — the reply tells them to edit `~/.cyrus/config.json` and restart the worker.
- Adds `repository` and `organization` to the GitHub App manifest `default_events` in the `cyrus-setup-github` skill so newly-created self-hosted Apps subscribe to rename/transfer events. Companion cyrus-hosted PR cyrusagents/cyrus-hosted#876 consumes those events to keep the stored URL in sync automatically.

## Motivation

Customer hit this after renaming their GitHub org: every `issue_comment` and `pull_request_review` webhook silently dropped because `findRepositoryByGitHubUrl` was matching against the stale URL. The only failure signal was a `WARN` in worker logs. The graceful reply gives users immediate visibility on the PR thread itself.

The reply is gated on @-mention or `pull_request_review` (user-initiated signals) so unrelated PR chatter doesn't trigger comments. No dedup — if a user @-mentions Cyrus three times on a broken PR, three replies is clearer than silence after the first.

## Test plan

- [ ] Unit: webhook with unmatched repo + @-mention, `CYRUS_API_KEY` unset → reply with self-host fix copy
- [ ] Unit: webhook with unmatched repo + @-mention, `CYRUS_API_KEY` set → reply with "contact support" copy
- [ ] Unit: `pull_request_review` with `changes_requested` on unmatched repo → posts reply
- [ ] Unit: random PR comment without @-mention on unmatched repo → no reply
- [ ] Manual: rename a test repo on GitHub, @-mention Cyrus on a PR, verify reply appears with correct plan-specific copy for the worker's env
- [ ] Manual: confirm new GitHub App created via `cyrus-setup-github` skill subscribes to `repository` and `organization` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)