### PR TITLE
feat(edge-worker): inject per-repo .claude/skills into skills whitelist (CYPACK-1261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically added to the agent's available skills whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
+- A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically discovered and made available to the agent whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
 
 ## [0.2.60] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically added to the agent's available skills whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261))
+
 ## [0.2.60] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically added to the agent's available skills whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261))
+- A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically added to the agent's available skills whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
 
 ## [0.2.60] - 2026-05-28
 

--- a/apps/f1/test-drives/2026-05-28-cypack-1261-repo-local-skills.md
+++ b/apps/f1/test-drives/2026-05-28-cypack-1261-repo-local-skills.md
@@ -1,0 +1,55 @@
+# Test Drive: CYPACK-1261 — Per-repo `.claude/skills/` discovery
+
+**Date**: 2026-05-28
+**Goal**: Verify repo-local skills (`<repo>/.claude/skills/*`) are both *whitelisted* and *discovered* by Claude Code — for single-repo (cwd-based) and multi-repo (`--add-dir`-based) sessions.
+**Test Repos**: `/tmp/f1-mr-primary-*` (ships `primary-canary-skill`), `/tmp/f1-mr-secondary-*` (ships `secondary-canary-skill`)
+
+## Why this drive
+
+The SDK `skills` flag is a **context filter over *discovered* skills**, not a discovery mechanism (SDK docs: *"a context filter, not a sandbox: unlisted skills are hidden… but their files remain on disk"*). So the open risk was: for multi-repo sessions the cwd is the workspace *container* and each repo lives in a sibling sub-worktree — would whitelisting the names actually surface skills the CLI never scanned? Connor pointed to the Claude Code skills doc: `--add-dir` is the documented exception that auto-loads `.claude/skills/` from each added directory.
+
+## Part A — SDK mechanism probe (deterministic)
+
+Drove the bundled `@anthropic-ai/claude-agent-sdk` `query()` directly and read the `system/init` message's `skills[]` (the CLI's discovered+enabled list, emitted at init before any API turn). Layout: `cwd/` has no skills; `cwd/sub_added/.claude/skills/canary-added-skill`; `cwd/sub_notadded/.claude/skills/canary-notadded-skill`.
+
+| Scenario | `canary-added` (subdir via `--add-dir`) | `canary-notadded` (subdir, not added) |
+|---|---|---|
+| No `additionalDirectories` | **false** — cwd scan does not recurse | false |
+| `additionalDirectories:[sub_added]`, `skills:'all'` | **true** — discovered | false |
+| `additionalDirectories:[sub_added]`, `skills:['canary-added-skill']` (Cyrus's shape) | **true** — discovered + enabled | false |
+
+**Conclusion**: `--add-dir <dir>` auto-loads `<dir>/.claude/skills`, *even when `<dir>` is a subdirectory of cwd and cwd has no skills*, and it is *necessary* (no add-dir → not discovered). The subdir nuance I flagged is confirmed safe.
+
+## Part B — Live single-repo F1 session
+
+`CYRUS_REPO_PATH=<primary>` (ships `primary-canary-skill`), issue created, session started, repo selection resolved.
+
+Captured the `claude_query_options` the EdgeWorker passed to the runner:
+
+```
+"skills": [ "verify-and-ship", "investigate", "summarize", "implementation", "debug", "primary-canary-skill" ]
+cqo.cwd = .../worktrees/DEF-1            # single-repo cwd == the worktree
+(cqo.additionalDirectoryCount absent)     # correct — no extra dirs needed for single-repo
+```
+
+The repo-shipped `primary-canary-skill` flows through `discoverSkillNames` into the runner's whitelist **and** the skills-guidance system prompt. Because cwd is the worktree, the CLI discovers `<cwd>/.claude/skills/primary-canary-skill` directly — no `--add-dir` required (and none emitted).
+
+> Note: the subsequent *model turn* errored with `Not logged in` — full API turns need credentials not present in this F1 environment. Skill **discovery** happens at CLI init (what Part A measures) and the **whitelist** is captured pre-turn, so neither validation depends on a completed turn.
+
+## Part C — Multi-repo wiring
+
+F1's CLI router did not honor the `[repos=a,b]` description tag (it fell through to repository *selection*) — an F1 harness limitation, not a product issue — so a fully-live multi-repo agent turn wasn't reachable here. Multi-repo correctness is instead covered by:
+- **Part A** — proves the CLI `--add-dir` discovery mechanism for sub-worktrees.
+- **Unit test** `RunnerConfigBuilder.additional-directories.test.ts` — proves the EdgeWorker emits `additionalDirectories = session.workspace.repoPaths` values (excluding cwd) for multi-repo, and omits it for single-repo.
+
+## Verification Results
+
+- [x] Single-repo: repo-local skill name in runner whitelist + guidance (live)
+- [x] Single-repo: cwd == worktree, so CLI discovers repo skills directly (live telemetry)
+- [x] `--add-dir` sub-worktree → `.claude/skills` discovered (SDK probe)
+- [x] No `--add-dir` → sub-worktree skills NOT discovered (negative control)
+- [x] Multi-repo `additionalDirectories` wiring (unit test)
+
+## Retrospective
+
+The mechanism is sound end-to-end. Follow-up cleanup from this drive: removed a dead `allowedDirectories` SDK query-option spread in `ClaudeRunner` (the SDK never read it; `config.allowedDirectories` is still used for `Read(<dir>/**)` grants + home-dir deny exclusions). Possible future F1 improvement: make the CLI router honor `[repos=...]` description tags so live multi-repo drives are reachable.

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -113,6 +113,11 @@ function buildSanitizedQueryOptions(
 	if (Array.isArray(o.allowedDirectories)) {
 		out.allowedDirectoryCount = (o.allowedDirectories as unknown[]).length;
 	}
+	if (Array.isArray(o.additionalDirectories)) {
+		out.additionalDirectoryCount = (
+			o.additionalDirectories as unknown[]
+		).length;
+	}
 	if (Array.isArray(o.settingSources)) {
 		out.settingSources = o.settingSources;
 	}
@@ -669,6 +674,13 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					}),
 					...(this.config.allowedDirectories && {
 						allowedDirectories: this.config.allowedDirectories,
+					}),
+					// `--add-dir` for each extra working-tree root. Beyond the
+					// permission grant, `--add-dir` auto-loads each directory's
+					// `.claude/skills/` — the documented exception that makes
+					// repo-local skills in multi-repo sub-worktrees discoverable.
+					...(this.config.additionalDirectories?.length && {
+						additionalDirectories: this.config.additionalDirectories,
 					}),
 					...(processedAllowedTools && { allowedTools: processedAllowedTools }),
 					...(processedDisallowedTools.length > 0 && {

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -89,7 +89,7 @@ function serializeQueryOptionsReplacer(_key: string, value: unknown): unknown {
  *   - model / fallbackModel / maxTurns / outputFormat
  *   - system prompt SHAPE (type/preset/has-append) — not the text
  *   - tool allowlist/denylist (counts + first 50 entries)
- *   - resumeSessionId, workingDirectory, allowedDirectories
+ *   - resumeSessionId, workingDirectory, additionalDirectories
  *   - mcpServer NAMES only
  *   - presence flags for hooks/plugins/canUseTool/sandbox
  *   - env KEY NAMES only (no values)
@@ -110,9 +110,9 @@ function buildSanitizedQueryOptions(
 	if (typeof o.maxTurns === "number") out.maxTurns = o.maxTurns;
 	if (typeof o.outputFormat === "string") out.outputFormat = o.outputFormat;
 	if (typeof o.cwd === "string") out.cwd = o.cwd;
-	if (Array.isArray(o.allowedDirectories)) {
-		out.allowedDirectoryCount = (o.allowedDirectories as unknown[]).length;
-	}
+	// Per-directory Read grants are surfaced via the `Read(<dir>/**)` entries in
+	// allowedToolsPreview below; `additionalDirectories` is the only directory
+	// list actually passed to the SDK, so it's the one worth counting here.
 	if (Array.isArray(o.additionalDirectories)) {
 		out.additionalDirectoryCount = (
 			o.additionalDirectories as unknown[]
@@ -672,13 +672,13 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					...(this.config.workingDirectory && {
 						cwd: this.config.workingDirectory,
 					}),
-					...(this.config.allowedDirectories && {
-						allowedDirectories: this.config.allowedDirectories,
-					}),
-					// `--add-dir` for each extra working-tree root. Beyond the
-					// permission grant, `--add-dir` auto-loads each directory's
-					// `.claude/skills/` — the documented exception that makes
-					// repo-local skills in multi-repo sub-worktrees discoverable.
+					// NOTE: there is no SDK `allowedDirectories` query option — the
+					// SDK only honors `additionalDirectories` (the `--add-dir`
+					// flag). `config.allowedDirectories` is consumed earlier to
+					// build `Read(<dir>/**)` tool grants + home-dir deny
+					// exclusions; it must NOT be forwarded here (the SDK would drop
+					// it). Use `additionalDirectories` for `--add-dir`, which also
+					// auto-loads each added dir's `.claude/skills/`.
 					...(this.config.additionalDirectories?.length && {
 						additionalDirectories: this.config.additionalDirectories,
 					}),

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -29,6 +29,13 @@ export interface ClaudeRunnerConfig {
 	allowedTools?: string[];
 	disallowedTools?: string[];
 	allowedDirectories?: string[];
+	/**
+	 * Extra working-tree roots passed to the SDK `additionalDirectories` option
+	 * (the `--add-dir` flag). Beyond widening the permission scope, `--add-dir`
+	 * auto-loads each directory's `.claude/skills/` — the documented exception
+	 * that makes repo-local skills in multi-repo sub-worktrees discoverable.
+	 */
+	additionalDirectories?: string[];
 	resumeSessionId?: string; // Session ID to resume from previous Claude session
 	workspaceName?: string;
 	systemPrompt?: string;

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -414,6 +414,15 @@ export interface AgentRunnerConfig {
 	disallowedTools?: string[];
 	/** Directories the agent can read from */
 	allowedDirectories?: string[];
+	/**
+	 * Extra working-tree roots to register with the agent beyond the cwd.
+	 * For Claude this maps to the SDK `additionalDirectories` option (the
+	 * `--add-dir` flag), which — unlike a plain permission grant — also
+	 * auto-loads each directory's `.claude/skills/`. Used for multi-repo
+	 * sessions where the participating repos live in sibling sub-worktrees of
+	 * the cwd, so their repo-local skills get discovered.
+	 */
+	additionalDirectories?: string[];
 	/** Session ID to resume from a previous session */
 	resumeSessionId?: string;
 	/** Workspace name for logging and organization */

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1473,7 +1473,7 @@ export class EdgeWorker extends EventEmitter {
 					undefined, // issueDescription
 					200, // maxTurns
 					undefined, // linearWorkspaceId
-					undefined, // skillContext
+					this.buildSkillSessionContext(repository, undefined, session),
 					"github", // sessionPlatform → uses githubMcpConfigs override
 				);
 
@@ -2141,7 +2141,7 @@ ${taskSection}`;
 					undefined, // issueDescription
 					200, // maxTurns
 					undefined, // linearWorkspaceId
-					undefined, // skillContext
+					this.buildSkillSessionContext(repository, undefined, session),
 					"gitlab", // sessionPlatform → uses githubMcpConfigs override
 				);
 
@@ -4479,7 +4479,7 @@ ${taskSection}`;
 					fullIssue.description || undefined, // Description tags can override label selectors
 					undefined, // maxTurns
 					linearWorkspaceId,
-					this.buildSkillSessionContext(primaryRepo, fullIssue),
+					this.buildSkillSessionContext(primaryRepo, fullIssue, session),
 				);
 
 			log.debug(
@@ -5179,13 +5179,21 @@ ${taskSection}`;
 	 * - the active repository's Cyrus config ID,
 	 * - the Linear team that owns the issue, and
 	 * - the Linear label IDs attached to the issue.
+	 *
+	 * The session's repo working-tree path(s) are also captured so that
+	 * repo-local skills (`<repoPath>/.claude/skills/*`) get unioned into the
+	 * resolved whitelist. When a `session` is provided its workspace is used to
+	 * resolve those paths (covering multi-repo sessions); otherwise the active
+	 * repository's path is used.
 	 */
 	private buildSkillSessionContext(
 		repository: RepositoryConfig,
 		fullIssue?: Issue,
+		session?: CyrusAgentSession,
 	): SkillSessionContext {
 		const context: SkillSessionContext = {
 			repositoryId: repository.id,
+			repoPaths: this.resolveSkillRepoPaths(repository, session),
 		};
 		if (fullIssue?.teamId) {
 			context.linearTeamId = fullIssue.teamId;
@@ -5197,6 +5205,29 @@ ${taskSection}`;
 			context.linearLabelIds = [...(fullIssue?.labelIds ?? [])];
 		}
 		return context;
+	}
+
+	/**
+	 * Resolve the repo working-tree path(s) whose `.claude/skills/` directories
+	 * should contribute to the skill whitelist for a session.
+	 *
+	 * - Multi-repo sessions: every sub-worktree in `workspace.repoPaths`.
+	 * - Single-repo / GitHub-mention sessions: the active repository's path.
+	 */
+	private resolveSkillRepoPaths(
+		repository: RepositoryConfig,
+		session?: CyrusAgentSession,
+	): string[] {
+		const repoPaths = session?.workspace?.repoPaths;
+		if (repoPaths) {
+			const paths = Object.values(repoPaths).filter(
+				(p): p is string => typeof p === "string" && p.length > 0,
+			);
+			if (paths.length > 0) {
+				return [...new Set(paths)];
+			}
+		}
+		return [repository.repositoryPath];
 	}
 
 	/**
@@ -6083,6 +6114,7 @@ ${taskSection}`;
 		const skillsContext = this.buildSkillSessionContext(
 			repositories[0]!,
 			input.fullIssue,
+			input.session,
 		);
 		systemPrompt += await this.skillsPluginResolver.buildSkillsGuidance(
 			undefined,
@@ -6341,6 +6373,7 @@ ${input.userComment}
 		const plugins = await this.skillsPluginResolver.resolve();
 		const resolvedSkillContext: SkillSessionContext = skillContext ?? {
 			repositoryId: repository.id,
+			repoPaths: this.resolveSkillRepoPaths(repository, session),
 		};
 		const allowedSkillNames =
 			await this.skillsPluginResolver.discoverSkillNames(
@@ -7140,7 +7173,7 @@ ${input.userComment}
 				fullIssue.description || undefined, // Description tags can override label selectors
 				maxTurns, // Pass maxTurns if specified
 				resolvedWorkspaceId,
-				this.buildSkillSessionContext(repository, fullIssue),
+				this.buildSkillSessionContext(repository, fullIssue, session),
 			);
 
 		// Create the appropriate runner based on session state

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -357,11 +357,22 @@ export class RunnerConfigBuilder {
 					: [...input.platformMcpConfigOverrides]
 				: undefined;
 
+		// Multi-repo sessions place each repo in a sibling sub-worktree of the
+		// cwd (the workspace container). Register those sub-worktrees as
+		// `--add-dir` roots so the runner auto-loads each one's `.claude/skills/`
+		// — the cwd-rooted project-skill scan alone would miss them. Single-repo
+		// sessions have cwd === the worktree, so there is nothing extra to add.
+		const cwd = input.session.workspace.path;
+		const additionalDirectories = Object.values(
+			input.session.workspace.repoPaths ?? {},
+		).filter((p): p is string => typeof p === "string" && p !== cwd);
+
 		const config: AgentRunnerConfig & Record<string, unknown> = {
-			workingDirectory: input.session.workspace.path,
+			workingDirectory: cwd,
 			allowedTools: input.allowedTools,
 			disallowedTools: input.disallowedTools,
 			allowedDirectories: input.allowedDirectories,
+			...(additionalDirectories.length > 0 && { additionalDirectories }),
 			workspaceName: input.session.issue?.identifier || input.session.issueId,
 			cyrusHome: input.cyrusHome,
 			mcpConfigPath,

--- a/packages/edge-worker/src/SkillsPluginResolver.ts
+++ b/packages/edge-worker/src/SkillsPluginResolver.ts
@@ -12,6 +12,14 @@ export interface SkillSessionContext {
 	repositoryId?: string;
 	linearTeamId?: string;
 	linearLabelIds?: string[];
+	/**
+	 * Working-tree paths of the repositories participating in this session.
+	 * Each repo's `<repoPath>/.claude/skills/*` directory names are unioned into
+	 * the resolved skill whitelist so a repo can ship its own skills. Carries one
+	 * path for single-repo / GitHub-mention sessions and every participating
+	 * worktree for multi-repo sessions.
+	 */
+	repoPaths?: string[];
 }
 
 /**
@@ -142,6 +150,13 @@ export class SkillsPluginResolver {
 	 *   dimension matches the session context (AND across dimensions, OR
 	 *   within each list).
 	 * - When `context` is omitted, no filtering is applied (all skills returned).
+	 *
+	 * Repo-local skills: when `context.repoPaths` is provided, each
+	 * `<repoPath>/.claude/skills/*` directory name is also unioned in. These are
+	 * implicitly scoped to the repository by virtue of living in it, so the
+	 * `scope.json` filter is NOT applied to them. They are appended after the
+	 * plugin skills, so a plugin skill of the same name takes precedence in the
+	 * (display-order-sensitive) dedup.
 	 */
 	async discoverSkillNames(
 		plugins: SdkPluginConfig[],
@@ -151,38 +166,51 @@ export class SkillsPluginResolver {
 
 		for (const plugin of plugins) {
 			const skillsDir = join(plugin.path, "skills");
-			let entries: {
-				isDirectory(): boolean;
-				isSymbolicLink(): boolean;
-				name: string;
-			}[];
-			try {
-				entries = await readdir(skillsDir, { withFileTypes: true });
-			} catch {
-				// Plugin directory doesn't exist or isn't readable — skip
-				continue;
-			}
+			const entries = await this.readSkillDirEntries(skillsDir);
 
 			for (const entry of entries) {
-				if (!(entry.isDirectory() || entry.isSymbolicLink())) {
-					continue;
-				}
-
 				if (context) {
-					const scope = await this.loadSkillScope(skillsDir, entry.name);
+					const scope = await this.loadSkillScope(skillsDir, entry);
 					if (!this.scopeMatches(scope, context)) {
 						this.logger.debug(
-							`Skill "${entry.name}" excluded by scope filter for current session`,
+							`Skill "${entry}" excluded by scope filter for current session`,
 						);
 						continue;
 					}
 				}
 
-				skillNames.push(entry.name);
+				skillNames.push(entry);
+			}
+		}
+
+		// Union repo-local skills shipped in each participating repo's working
+		// tree. No scope.json filtering — presence in the repo is the scope.
+		for (const repoPath of context?.repoPaths ?? []) {
+			const skillsDir = join(repoPath, ".claude", "skills");
+			const entries = await this.readSkillDirEntries(skillsDir);
+			for (const entry of entries) {
+				skillNames.push(entry);
 			}
 		}
 
 		return [...new Set(skillNames)];
+	}
+
+	/**
+	 * Read the immediate subdirectory (and symlink) names of a `skills/`
+	 * directory. Returns an empty array when the directory is missing or
+	 * unreadable, so callers can treat "no skills dir" as a no-op.
+	 */
+	private async readSkillDirEntries(skillsDir: string): Promise<string[]> {
+		try {
+			const entries = await readdir(skillsDir, { withFileTypes: true });
+			return entries
+				.filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+				.map((entry) => entry.name);
+		} catch {
+			// Directory doesn't exist or isn't readable — skip
+			return [];
+		}
 	}
 
 	/**

--- a/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
@@ -1,0 +1,122 @@
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
+		getDefaultModelForRunner: () => "opus",
+		getDefaultFallbackModelForRunner: () => "sonnet",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(): RepositoryConfig {
+	return {
+		id: "repo-a",
+		name: "Repo A",
+		repositoryPath: "/repos/repo-a",
+		allowedTools: [],
+	} as unknown as RepositoryConfig;
+}
+
+function makeSession(
+	workspace: CyrusAgentSession["workspace"],
+): CyrusAgentSession {
+	return {
+		issueId: "issue-1",
+		issue: { identifier: "ABC-1" },
+		workspace,
+	} as unknown as CyrusAgentSession;
+}
+
+function buildIssueConfig(session: CyrusAgentSession) {
+	return makeBuilder().buildIssueConfig({
+		session,
+		repository: makeRepository(),
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	});
+}
+
+describe("RunnerConfigBuilder additionalDirectories (multi-repo skill discovery)", () => {
+	it("registers each multi-repo sub-worktree as an additional directory", () => {
+		const session = makeSession({
+			path: "/ws/root",
+			isGitWorktree: true,
+			repoPaths: {
+				"repo-a": "/ws/root/repo-a",
+				"repo-b": "/ws/root/repo-b",
+			},
+		} as unknown as CyrusAgentSession["workspace"]);
+
+		const { config } = buildIssueConfig(session);
+
+		expect(config.workingDirectory).toBe("/ws/root");
+		expect(config.additionalDirectories).toEqual([
+			"/ws/root/repo-a",
+			"/ws/root/repo-b",
+		]);
+	});
+
+	it("omits additionalDirectories for single-repo sessions (cwd is the worktree)", () => {
+		const session = makeSession({
+			path: "/ws/repo-a-worktree",
+			isGitWorktree: true,
+		} as unknown as CyrusAgentSession["workspace"]);
+
+		const { config } = buildIssueConfig(session);
+
+		expect(config.workingDirectory).toBe("/ws/repo-a-worktree");
+		expect(config.additionalDirectories).toBeUndefined();
+	});
+
+	it("excludes the cwd itself from additionalDirectories", () => {
+		// A repoPaths entry equal to the workspace root must not be re-added as
+		// an --add-dir (it is already the cwd).
+		const session = makeSession({
+			path: "/ws/root",
+			isGitWorktree: true,
+			repoPaths: {
+				"repo-a": "/ws/root",
+				"repo-b": "/ws/root/repo-b",
+			},
+		} as unknown as CyrusAgentSession["workspace"]);
+
+		const { config } = buildIssueConfig(session);
+
+		expect(config.additionalDirectories).toEqual(["/ws/root/repo-b"]);
+	});
+});

--- a/packages/edge-worker/test/SkillsPluginResolver.repoLocal.test.ts
+++ b/packages/edge-worker/test/SkillsPluginResolver.repoLocal.test.ts
@@ -1,0 +1,183 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ILogger } from "cyrus-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SkillsPluginResolver } from "../src/SkillsPluginResolver.js";
+
+function createTestLogger(): ILogger {
+	return {
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		debug: () => {},
+		withContext: () => createTestLogger(),
+	} as unknown as ILogger;
+}
+
+async function writeManifest(cyrusHome: string): Promise<void> {
+	const manifestDir = join(cyrusHome, "user-skills-plugin", ".claude-plugin");
+	await mkdir(manifestDir, { recursive: true });
+	await writeFile(
+		join(manifestDir, "plugin.json"),
+		JSON.stringify({ name: "user-skills", description: "" }),
+		"utf-8",
+	);
+}
+
+async function writeUserSkill(
+	cyrusHome: string,
+	name: string,
+	scope?: Record<string, string[]>,
+): Promise<void> {
+	const skillDir = join(cyrusHome, "user-skills-plugin", "skills", name);
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: test ${name}\n---\n\nbody\n`,
+		"utf-8",
+	);
+	if (scope) {
+		await writeFile(
+			join(skillDir, "scope.json"),
+			JSON.stringify(scope),
+			"utf-8",
+		);
+	}
+}
+
+/**
+ * Create a repo-local skill at `<repoPath>/.claude/skills/<name>`. Optionally
+ * also write a `scope.json` to prove it is ignored for repo-local skills.
+ */
+async function writeRepoSkill(
+	repoPath: string,
+	name: string,
+	scope?: Record<string, string[]>,
+): Promise<void> {
+	const skillDir = join(repoPath, ".claude", "skills", name);
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: repo skill ${name}\n---\n\nbody\n`,
+		"utf-8",
+	);
+	if (scope) {
+		await writeFile(
+			join(skillDir, "scope.json"),
+			JSON.stringify(scope),
+			"utf-8",
+		);
+	}
+}
+
+describe("SkillsPluginResolver repo-local skill discovery", () => {
+	let home: string;
+	let repoA: string;
+	let repoB: string;
+	let resolver: SkillsPluginResolver;
+
+	beforeEach(async () => {
+		const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		home = join(tmpdir(), `cyrus-repolocal-home-${stamp}`);
+		repoA = join(tmpdir(), `cyrus-repolocal-repoA-${stamp}`);
+		repoB = join(tmpdir(), `cyrus-repolocal-repoB-${stamp}`);
+		await mkdir(home, { recursive: true });
+		await mkdir(repoA, { recursive: true });
+		await mkdir(repoB, { recursive: true });
+		await writeManifest(home);
+		resolver = new SkillsPluginResolver(home, createTestLogger());
+	});
+
+	afterEach(async () => {
+		for (const dir of [home, repoA, repoB]) {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("unions repo-local skill directory names into the whitelist", async () => {
+		await writeUserSkill(home, "plugin-skill");
+		await writeRepoSkill(repoA, "repo-skill");
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA],
+		});
+
+		expect(names).toContain("plugin-skill");
+		expect(names).toContain("repo-skill");
+	});
+
+	it("unions skills from every repo in a multi-repo session", async () => {
+		await writeRepoSkill(repoA, "skill-a");
+		await writeRepoSkill(repoB, "skill-b");
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA, repoB],
+		});
+
+		expect(names).toContain("skill-a");
+		expect(names).toContain("skill-b");
+	});
+
+	it("is a no-op when a repo has no .claude/skills directory", async () => {
+		await writeUserSkill(home, "plugin-skill");
+		// repoA has no .claude/skills directory at all
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA],
+		});
+
+		expect(names).toEqual(["plugin-skill"]);
+	});
+
+	it("does not apply scope.json filtering to repo-local skills", async () => {
+		// A scope that would NOT match the session context — must be ignored
+		// for repo-local skills (presence in the repo is the scope).
+		await writeRepoSkill(repoA, "repo-skill", {
+			repositoryIds: ["some-other-repo"],
+		});
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA],
+		});
+
+		expect(names).toContain("repo-skill");
+	});
+
+	it("deduplicates names when a repo-local skill collides with a plugin skill", async () => {
+		await writeUserSkill(home, "shared");
+		await writeRepoSkill(repoA, "shared");
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA],
+		});
+
+		expect(names.filter((n) => n === "shared")).toHaveLength(1);
+	});
+
+	it("ignores files (only directories/symlinks count as skills)", async () => {
+		const skillsDir = join(repoA, ".claude", "skills");
+		await mkdir(skillsDir, { recursive: true });
+		await writeFile(join(skillsDir, "README.md"), "not a skill", "utf-8");
+		await writeRepoSkill(repoA, "real-skill");
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+			repoPaths: [repoA],
+		});
+
+		expect(names).toContain("real-skill");
+		expect(names).not.toContain("README.md");
+	});
+});


### PR DESCRIPTION
## Summary

Repositories can now ship their own Claude skills. When Cyrus runs an agent session for a repo, the skill directories under that repo's working tree (`<repoPath>/.claude/skills/*`) are discovered and made available to the agent — alongside Cyrus's own plugin-dir skills. Works for single-repo Linear issues, multi-repo Linear issues, and GitHub/GitLab mentions.

## Two parts (both required)

The SDK `skills` flag is **a context filter over *discovered* skills, not a discovery mechanism** (per SDK docs: *"This is a context filter, not a sandbox: unlisted skills are hidden… but their files remain on disk"*). So making repo-local skills work needs both **discovery** and **enablement**:

### 1. Enablement — whitelist the names
- `SkillSessionContext` gains `repoPaths?: string[]`. `discoverSkillNames` reads each `<repoPath>/.claude/skills/*` and unions those names into the `skills` whitelist. Repo-local skills are implicitly scoped by living in the repo, so the `scope.json` filter is **not** applied to them.
- `buildSkillSessionContext` populates `repoPaths` from the session: multi-repo → every sub-worktree in `workspace.repoPaths`; single-repo / mention → the active repo path. All call sites (Linear new + continuation, prompt-assembly guidance, GitHub + GitLab mentions) thread the session through.

### 2. Discovery — make Claude Code actually find them
Claude Code discovers project skills from `<cwd>/.claude/skills`. For **single-repo / mention** sessions the cwd *is* the repo worktree, so discovery already works. For **multi-repo** sessions the cwd is the workspace *container* and each repo lives in a sibling sub-worktree — so the cwd-rooted scan misses them and the whitelist names would be inert.

Fix: register each multi-repo sub-worktree via the SDK's `additionalDirectories` option (`--add-dir`). Per [Claude Code skills docs](https://code.claude.com/docs/en/skills), `--add-dir` is the documented exception that *auto-loads `.claude/skills/` from each added directory*.
- `RunnerConfigBuilder.buildIssueConfig` now derives `additionalDirectories` from `session.workspace.repoPaths` (excluding the cwd); `ClaudeRunner` forwards it to the SDK query. `additionalDirectories` was added to `AgentRunnerConfig` / `ClaudeRunnerConfig`.

## Why `additionalDirectories` and not the existing `allowedDirectories`?

Reasonable question, since `ClaudeRunner` already passed an `allowedDirectories` key into the SDK `query()` options. Two different things share that name, and only one was dead:

- **`config.allowedDirectories` is *not* dead** — it does real work inside `ClaudeRunner`, just never as an SDK option: `ClaudeRunner.ts:519-532` turns each entry into a `Read(<dir>/**)` tool grant; `ClaudeRunner.ts:539-543` excludes those dirs from the home-directory deny rules (`buildHomeDirectoryDisallowedTools`); `RunnerConfigBuilder.ts:471-473` feeds them to the sandbox `allowRead`.
- **What *was* dead** is the single line that *forwarded* `allowedDirectories` into the SDK `query()` options. The SDK has zero references to `allowedDirectories` (it destructures `additionalDirectories` → `--add-dir`), so that spread was silently dropped. This PR removes it (and its orphaned `allowedDirectoryCount` telemetry).

I did **not** repurpose `allowedDirectories` into the SDK's add-dir slot, for two substantive reasons:

1. **Wrong directories.** `allowedDirectories` holds `attachmentsDir + main-clone repo paths (repo.repositoryPath) + git-metadata dirs`. Skills need the *per-issue sub-worktrees* (`session.workspace.repoPaths`) — where the agent actually works. For multi-repo, the main clone may be on a different branch than the issue worktree, so its `.claude/skills` could differ; add-dir must point at the worktrees.
2. **Scope side effects.** Reanimating that dead key as a live `--add-dir` would silently widen the session's file/permission scope to the attachments dir, git internals, and main clones. Cyrus deliberately gates file access via tool allowlists + sandbox, *not* via SDK add-dir — so that would be an unrelated behavioral regression.

A purpose-built `additionalDirectories` carrying exactly the sub-worktrees (minus cwd) is correct for discovery and free of those side effects. Net result: exactly one directory list now reaches the SDK (`additionalDirectories`), and the misleading dead line is gone.

> Aside: `permissions.additionalDirectories` (a *settings.json* key) grants file access only and does **not** load skills — only the top-level SDK `additionalDirectories` / `--add-dir` does.

## Testing

- `SkillsPluginResolver.repoLocal.test.ts` — repo-local union, multi-repo union, missing-dir no-op, `scope.json` ignored for repo-local, collision dedup, files-vs-dirs.
- `RunnerConfigBuilder.additional-directories.test.ts` — multi-repo sets `additionalDirectories` to the sub-worktrees, single-repo omits it, cwd is excluded.
- Full edge-worker suite green (670 tests); claude-runner green (114 tests). `pnpm build` / `typecheck` / `lint` pass.
- **Empirical validation** (see `apps/f1/test-drives/2026-05-28-cypack-1261-repo-local-skills.md`): an SDK probe against the bundled `@anthropic-ai/claude-agent-sdk` confirms `--add-dir <subdir>` auto-loads that dir's `.claude/skills` even when it's a subdirectory of cwd and cwd has no skills — and that it's *necessary* (no add-dir → not discovered). A live single-repo F1 session shows the repo-shipped `primary-canary-skill` flowing into the runner's `skills` whitelist with cwd = the worktree.

## Acceptance criteria

- [x] Single-repo Linear issue: repo-local skill names appear in the whitelist (discovered via cwd)
- [x] Multi-repo Linear issue: skills from every participating repo unioned **and** discovered via `--add-dir`
- [x] GitHub mention: resolved repo's `.claude/skills/` included
- [x] Existing plugin-dir skills and `scope.json` filtering unchanged
- [x] Unit coverage for repo-local discovery incl. multi-repo union and missing-dir no-op

Linear: [CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261/inject-per-repo-claudeskills-into-the-claude-skills-whitelist)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
