### PR TITLE
fix(edge-worker): attribute Claude API errors to the model provider in Linear (CYPACK-1262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error") are now clearly labeled as model-provider errors in the Linear activity timeline instead of appearing as a normal Cyrus response, so it's obvious the failure came from Claude and not from Cyrus. ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262))
+- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error") are now clearly labeled as model-provider errors in the Linear activity timeline instead of appearing as a normal Cyrus response, so it's obvious the failure came from Claude and not from Cyrus. ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
 
 ## [0.2.60] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error") are now clearly labeled as model-provider errors in the Linear activity timeline instead of appearing as a normal Cyrus response, so it's obvious the failure came from Claude and not from Cyrus. ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
+- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error", or the "`thinking` blocks cannot be modified" 400) are now clearly labeled as model-provider errors instead of appearing as a normal Cyrus response — in both the Linear activity timeline and Slack replies — so it's obvious the failure came from Claude and not from Cyrus. Slack replies also include recovery guidance (retry, or start a new thread). ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
 
 ## [0.2.60] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error") are now clearly labeled as model-provider errors in the Linear activity timeline instead of appearing as a normal Cyrus response, so it's obvious the failure came from Claude and not from Cyrus. ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262))
+
 ## [0.2.60] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error", or the "`thinking` blocks cannot be modified" 400) are now clearly labeled as model-provider errors instead of appearing as a normal Cyrus response — in both the Linear activity timeline and Slack replies — so it's obvious the failure came from Claude and not from Cyrus. Slack replies also include recovery guidance (retry, or start a new thread). ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
+- Errors coming from the Claude/Anthropic API (e.g. "API Error: Internal server error", or the "`thinking` blocks cannot be modified" 400) are now clearly labeled as model-provider errors instead of appearing as a normal Cyrus response — in both the Linear activity timeline and Slack replies — so it's obvious the failure came from Claude and not from Cyrus. ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
+- Slack: when a Claude API error aborts a turn before any reply is produced (previously the user was left with no response at all), Cyrus now posts an attributed error message to the thread with recovery guidance (retry, or start a new thread). ([CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262), [#1269](https://github.com/cyrusagents/cyrus/pull/1269))
 
 ## [0.2.60] - 2026-05-28
 

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -25,6 +25,10 @@ import {
 	type Workspace,
 } from "cyrus-core";
 
+import {
+	formatModelApiError,
+	isModelApiErrorText,
+} from "./runner-error-formatting.js";
 import type {
 	ActivityPostOptions,
 	ActivitySignal,
@@ -647,22 +651,36 @@ export class AgentSessionManager extends EventEmitter {
 		// (structured content) over result.result (plain-text duplicate).
 		const bufferedAssistant = this.lastAssistantBodyBySession.get(sessionId);
 		this.lastAssistantBodyBySession.delete(sessionId);
-		const content = (
+		const errorsText =
+			"errors" in resultMessage &&
+			Array.isArray(resultMessage.errors) &&
+			resultMessage.errors.length > 0
+				? resultMessage.errors.join("\n")
+				: "";
+		const resultText =
+			"result" in resultMessage && typeof resultMessage.result === "string"
+				? resultMessage.result
+				: "";
+		let content = (
 			resultMessage.is_error
-				? resultMessage.is_error &&
-					"errors" in resultMessage &&
-					Array.isArray(resultMessage.errors) &&
-					resultMessage.errors.length > 0
-					? resultMessage.errors.join("\n")
-					: "result" in resultMessage &&
-							typeof resultMessage.result === "string"
-						? resultMessage.result
-						: ""
-				: (bufferedAssistant ??
-					("result" in resultMessage && typeof resultMessage.result === "string"
-						? resultMessage.result
-						: ""))
+				? // For error results, fall back to the buffered assistant text so a
+					// provider error surfaced as the final assistant message (e.g.
+					// "API Error: Internal server error") isn't lost when errors[]/result
+					// are empty.
+					errorsText || resultText || bufferedAssistant || ""
+				: (bufferedAssistant ?? resultText)
 		).trim();
+
+		// Detect provider/model API errors (e.g. Claude returning "API Error:
+		// Internal server error"). These can arrive with a success subtype as the
+		// final assistant text, which would otherwise render as a normal "response"
+		// and look like Cyrus failed. Relabel them as errors and attribute them to
+		// the model provider so the distinction is obvious in Linear.
+		const isModelApiError = isModelApiErrorText(content);
+		const isError = resultMessage.is_error || isModelApiError;
+		if (isModelApiError) {
+			content = formatModelApiError(content, runnerType);
+		}
 
 		const resultEntry: CyrusAgentSessionEntry = {
 			// Set the appropriate session ID based on runner type
@@ -678,7 +696,7 @@ export class AgentSessionManager extends EventEmitter {
 			metadata: {
 				timestamp: Date.now(),
 				durationMs: resultMessage.duration_ms,
-				isError: resultMessage.is_error,
+				isError,
 			},
 		};
 
@@ -1418,7 +1436,7 @@ export class AgentSessionManager extends EventEmitter {
 		const log = this.sessionLog(sessionId);
 		const session = this.sessions.get(sessionId);
 
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			log.debug(
 				`Skipping ${label} - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,
 			);
@@ -1681,7 +1699,7 @@ export class AgentSessionManager extends EventEmitter {
 		message: SDKStatusMessage,
 	): Promise<void> {
 		const session = this.sessions.get(sessionId);
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			const log = this.sessionLog(sessionId);
 			log.debug(
 				`Skipping status message - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -28,6 +28,7 @@ import {
 import {
 	formatModelApiError,
 	isModelApiErrorText,
+	runnerTypeFromConstructorName,
 } from "./runner-error-formatting.js";
 import type {
 	ActivityPostOptions,
@@ -241,14 +242,7 @@ export class AgentSessionManager extends EventEmitter {
 
 		// Determine which runner is being used
 		const runner = linearSession.agentRunner;
-		const runnerType =
-			runner?.constructor.name === "GeminiRunner"
-				? "gemini"
-				: runner?.constructor.name === "CodexRunner"
-					? "codex"
-					: runner?.constructor.name === "CursorRunner"
-						? "cursor"
-						: "claude";
+		const runnerType = runnerTypeFromConstructorName(runner?.constructor?.name);
 
 		// Update the appropriate session ID based on runner type
 		if (runnerType === "gemini") {
@@ -297,14 +291,7 @@ export class AgentSessionManager extends EventEmitter {
 		// Determine which runner is being used
 		const session = this.sessions.get(sessionId);
 		const runner = session?.agentRunner;
-		const runnerType =
-			runner?.constructor.name === "GeminiRunner"
-				? "gemini"
-				: runner?.constructor.name === "CodexRunner"
-					? "codex"
-					: runner?.constructor.name === "CursorRunner"
-						? "cursor"
-						: "claude";
+		const runnerType = runnerTypeFromConstructorName(runner?.constructor?.name);
 
 		const sessionEntry: CyrusAgentSessionEntry = {
 			// Set the appropriate session ID based on runner type
@@ -637,14 +624,7 @@ export class AgentSessionManager extends EventEmitter {
 		// Determine which runner is being used
 		const session = this.sessions.get(sessionId);
 		const runner = session?.agentRunner;
-		const runnerType =
-			runner?.constructor.name === "GeminiRunner"
-				? "gemini"
-				: runner?.constructor.name === "CodexRunner"
-					? "codex"
-					: runner?.constructor.name === "CursorRunner"
-						? "cursor"
-						: "claude";
+		const runnerType = runnerTypeFromConstructorName(runner?.constructor?.name);
 
 		// For error results, content may be in errors[] rather than result
 		// For success results from Claude, prefer the buffered last assistant message

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -12,6 +12,12 @@ import { createLogger } from "cyrus-core";
 import { AgentSessionManager } from "./AgentSessionManager.js";
 import type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import type { RunnerConfigBuilder } from "./RunnerConfigBuilder.js";
+import {
+	formatModelApiError,
+	isModelApiErrorText,
+	runnerTypeFromConstructorName,
+	unwrapRunnerErrorMessage,
+} from "./runner-error-formatting.js";
 
 /**
  * Defines what each chat platform must provide for the generic session lifecycle.
@@ -42,6 +48,13 @@ export interface ChatPlatformAdapter<TEvent> {
 
 	/** Post the agent's final response back to the platform */
 	postReply(event: TEvent, runner: IAgentRunner): Promise<void>;
+
+	/**
+	 * Post an error message back to the platform thread when the runner fails
+	 * before producing a final response (e.g. a provider API error). The message
+	 * is already user-facing/formatted. Fire-and-forget at the call site.
+	 */
+	postErrorReply(event: TEvent, message: string): Promise<void>;
 
 	/** Acknowledge receipt of the event (e.g., emoji reaction). Fire-and-forget */
 	acknowledgeReceipt(event: TEvent): Promise<void>;
@@ -290,9 +303,11 @@ export class ChatSessionHandler<TEvent> {
 						`${this.adapter.platformName} session error for event ${eventId}`,
 						error instanceof Error ? error : new Error(String(error)),
 					);
-					// Runner died before emitting a final `result`. Drop any
-					// still-queued reply events for this session so a later
-					// resumeSession() doesn't pair them with a future turn.
+					// Runner died before emitting a final `result`. Surface a
+					// provider-attributed error to the thread (so the user isn't
+					// left in silence), then drop any still-queued reply events so a
+					// later resumeSession() doesn't pair them with a future turn.
+					void this.postRunnerFailure(event, sessionId, error);
 					this.clearPendingReplies(sessionId);
 				})
 				.finally(() => {
@@ -403,6 +418,9 @@ export class ChatSessionHandler<TEvent> {
 					`${this.adapter.platformName} resume session error for ${sessionId}`,
 					error instanceof Error ? error : new Error(String(error)),
 				);
+				// Surface a provider-attributed error to the thread (so the user
+				// isn't left in silence) before dropping queued reply events.
+				void this.postRunnerFailure(event, sessionId, error);
 				this.clearPendingReplies(sessionId);
 			});
 	}
@@ -461,6 +479,46 @@ export class ChatSessionHandler<TEvent> {
 	 * the first `result` of the new runner and shift all subsequent replies
 	 * by one turn.
 	 */
+	/**
+	 * When a runner rejects before emitting a final `result`, the user would
+	 * otherwise be left in silence (or, worse, see a raw provider error). If the
+	 * failure is a model-provider API error (e.g. Claude's "API Error: 400 …
+	 * `thinking` blocks … cannot be modified"), post a clearly-attributed message
+	 * with recovery guidance to the thread instead.
+	 *
+	 * Only model-provider API errors are surfaced; unexpected internal errors are
+	 * left to the logs to avoid leaking implementation detail into user threads.
+	 */
+	private async postRunnerFailure(
+		event: TEvent,
+		sessionId: string,
+		error: unknown,
+	): Promise<void> {
+		try {
+			const rawMessage =
+				error instanceof Error ? error.message : String(error ?? "");
+			const providerError = unwrapRunnerErrorMessage(rawMessage);
+			if (!isModelApiErrorText(providerError)) {
+				return;
+			}
+			const runner = this.sessionManager.getAgentRunner(sessionId);
+			const runnerType = runnerTypeFromConstructorName(
+				runner?.constructor?.name,
+			);
+			const message = formatModelApiError(
+				providerError,
+				runnerType,
+				"You can try sending your message again. If this keeps happening, start a new thread to reset the conversation.",
+			);
+			await this.adapter.postErrorReply(event, message);
+		} catch (postError) {
+			this.logger.error(
+				`Failed to post ${this.adapter.platformName} runner-failure reply`,
+				postError instanceof Error ? postError : new Error(String(postError)),
+			);
+		}
+	}
+
 	private clearPendingReplies(sessionId: string): void {
 		const queue = this.pendingReplyEvents.get(sessionId);
 		if (!queue || queue.length === 0) return;

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -9,6 +9,11 @@ import {
 } from "cyrus-slack-event-transport";
 import type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import type { ChatPlatformAdapter } from "./ChatSessionHandler.js";
+import {
+	formatModelApiError,
+	isModelApiErrorText,
+	runnerTypeFromConstructorName,
+} from "./runner-error-formatting.js";
 
 /**
  * Slack implementation of ChatPlatformAdapter.
@@ -223,6 +228,22 @@ Supported mrkdwn syntax:
 				if (textBlock?.text) {
 					summary = textBlock.text;
 				}
+			}
+
+			// If the last assistant message is actually a model-provider API error
+			// (e.g. Claude returning "API Error: 400 ... `thinking` blocks ... cannot
+			// be modified"), it would otherwise be posted verbatim and look like
+			// Cyrus's own reply. Relabel it as a provider error and add recovery
+			// guidance so the Slack experience is recoverable.
+			if (isModelApiErrorText(summary)) {
+				const runnerType = runnerTypeFromConstructorName(
+					runner?.constructor?.name,
+				);
+				summary = formatModelApiError(
+					summary,
+					runnerType,
+					"You can try sending your message again. If this keeps happening, start a new thread to reset the conversation.",
+				);
 			}
 
 			const token = this.getSlackBotToken(event);

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -273,6 +273,31 @@ Supported mrkdwn syntax:
 		}
 	}
 
+	async postErrorReply(
+		event: SlackWebhookEvent,
+		message: string,
+	): Promise<void> {
+		const token = this.getSlackBotToken(event);
+		if (!token) {
+			this.logger.warn(
+				"Cannot post Slack error reply: no slackBotToken available",
+			);
+			return;
+		}
+
+		const threadTs = event.payload.thread_ts || event.payload.ts;
+		await new SlackMessageService().postMessage({
+			token,
+			channel: event.payload.channel,
+			text: message,
+			thread_ts: threadTs,
+		});
+
+		this.logger.info(
+			`Posted Slack error reply to channel ${event.payload.channel} (thread ${threadTs})`,
+		);
+	}
+
 	async acknowledgeReceipt(event: SlackWebhookEvent): Promise<void> {
 		const token = this.getSlackBotToken(event);
 		if (!token) {

--- a/packages/edge-worker/src/runner-error-formatting.ts
+++ b/packages/edge-worker/src/runner-error-formatting.ts
@@ -1,0 +1,56 @@
+/**
+ * Helpers for recognising and clearly attributing errors that originate in the
+ * underlying model/agent provider (Claude, Gemini, Codex, Cursor) rather than
+ * in Cyrus itself.
+ *
+ * Motivation: when Claude's Anthropic API fails mid-turn, Claude Code surfaces
+ * the failure as an assistant text block such as "API Error: Internal server
+ * error". With a success-subtype result that text otherwise renders in Linear
+ * as an ordinary "response" activity — making it look like Cyrus produced the
+ * error, when in fact it came from the model provider's API. These helpers let
+ * us detect that case and relabel it as an error that is explicitly attributed
+ * to the provider.
+ */
+
+/** Human-readable display names for each runner type. */
+const RUNNER_DISPLAY_NAMES: Record<string, string> = {
+	claude: "Claude",
+	gemini: "Gemini",
+	codex: "Codex",
+	cursor: "Cursor",
+};
+
+/**
+ * Detect whether a piece of agent output is actually an error surfaced by the
+ * underlying model/agent provider rather than a genuine agent response.
+ *
+ * Claude Code surfaces API failures as an assistant text block beginning with
+ * "API Error:" — for example:
+ *   - "API Error: Internal server error"
+ *   - "API Error: 500 {\"type\":\"error\",...}"
+ *   - "API Error: Request timed out."
+ *
+ * The match is anchored to the start of the (trimmed) text and case-insensitive
+ * so that a legitimate response merely *mentioning* an API error elsewhere in
+ * its body is not misclassified.
+ */
+export function isModelApiErrorText(text: string | undefined | null): boolean {
+	if (!text) return false;
+	return /^API Error\b/i.test(text.trim());
+}
+
+/**
+ * Prefix model/provider error content with a clear attribution so the user can
+ * tell the failure came from the model provider's API and not from Cyrus.
+ *
+ * @param content - The raw error text (e.g. "API Error: Internal server error")
+ * @param runnerType - The runner that produced the error ("claude" | "gemini" | "codex" | "cursor")
+ */
+export function formatModelApiError(
+	content: string,
+	runnerType: string,
+): string {
+	const provider = RUNNER_DISPLAY_NAMES[runnerType] ?? "the agent";
+	const body = content.trim();
+	return `⚠️ **${provider} API error** — this error came from ${provider}'s API, not from Cyrus.\n\n${body}`;
+}

--- a/packages/edge-worker/src/runner-error-formatting.ts
+++ b/packages/edge-worker/src/runner-error-formatting.ts
@@ -21,6 +21,25 @@ const RUNNER_DISPLAY_NAMES: Record<string, string> = {
 };
 
 /**
+ * Map a runner instance's constructor name to its runner-type key.
+ * Defaults to "claude" for the base ClaudeRunner / unknown runners.
+ */
+export function runnerTypeFromConstructorName(
+	constructorName: string | undefined,
+): "claude" | "gemini" | "codex" | "cursor" {
+	switch (constructorName) {
+		case "GeminiRunner":
+			return "gemini";
+		case "CodexRunner":
+			return "codex";
+		case "CursorRunner":
+			return "cursor";
+		default:
+			return "claude";
+	}
+}
+
+/**
  * Detect whether a piece of agent output is actually an error surfaced by the
  * underlying model/agent provider rather than a genuine agent response.
  *
@@ -29,6 +48,8 @@ const RUNNER_DISPLAY_NAMES: Record<string, string> = {
  *   - "API Error: Internal server error"
  *   - "API Error: 500 {\"type\":\"error\",...}"
  *   - "API Error: Request timed out."
+ *   - "API Error: 400 messages.1.content.3: `thinking` or `redacted_thinking`
+ *      blocks in the latest assistant message cannot be modified."
  *
  * The match is anchored to the start of the (trimmed) text and case-insensitive
  * so that a legitimate response merely *mentioning* an API error elsewhere in
@@ -45,12 +66,15 @@ export function isModelApiErrorText(text: string | undefined | null): boolean {
  *
  * @param content - The raw error text (e.g. "API Error: Internal server error")
  * @param runnerType - The runner that produced the error ("claude" | "gemini" | "codex" | "cursor")
+ * @param recoveryHint - Optional, surface-specific recovery guidance appended after the body
  */
 export function formatModelApiError(
 	content: string,
 	runnerType: string,
+	recoveryHint?: string,
 ): string {
 	const provider = RUNNER_DISPLAY_NAMES[runnerType] ?? "the agent";
 	const body = content.trim();
-	return `⚠️ **${provider} API error** — this error came from ${provider}'s API, not from Cyrus.\n\n${body}`;
+	const suffix = recoveryHint ? `\n\n${recoveryHint}` : "";
+	return `⚠️ **${provider} API error** — this error came from ${provider}'s API, not from Cyrus.\n\n${body}${suffix}`;
 }

--- a/packages/edge-worker/src/runner-error-formatting.ts
+++ b/packages/edge-worker/src/runner-error-formatting.ts
@@ -61,6 +61,23 @@ export function isModelApiErrorText(text: string | undefined | null): boolean {
 }
 
 /**
+ * Recover the raw provider error text from a thrown runner error message.
+ *
+ * When the SDK returns an error result, the runner rejects with an Error whose
+ * message is wrapped, e.g.:
+ *   "Claude Code returned an error result: API Error: 400 …"
+ * Strip that wrapper so detection/formatting operates on the underlying
+ * provider text ("API Error: 400 …").
+ */
+export function unwrapRunnerErrorMessage(
+	message: string | undefined | null,
+): string {
+	if (!message) return "";
+	const match = message.match(/error result:\s*(.*)$/is);
+	return (match?.[1] ?? message).trim();
+}
+
+/**
  * Prefix model/provider error content with a clear attribution so the user can
  * tell the failure came from the model provider's API and not from Cyrus.
  *

--- a/packages/edge-worker/test/AgentSessionManager.api-error.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.api-error.test.ts
@@ -1,0 +1,103 @@
+import { AgentSessionStatus } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+import type { IActivitySink } from "../src/sinks/IActivitySink";
+import { mockClaudeAssistantMessage, mockClaudeResultMessage } from "./setup";
+
+describe("AgentSessionManager Claude API error attribution", () => {
+	let manager: AgentSessionManager;
+	let mockActivitySink: IActivitySink;
+	let postActivitySpy: any;
+	const sessionId = "test-session-api-error";
+	const issueId = "issue-api-error";
+
+	beforeEach(() => {
+		mockActivitySink = {
+			id: "test-workspace",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "activity-1" }),
+			createAgentSession: vi.fn().mockResolvedValue("session-1"),
+		};
+		postActivitySpy = vi.spyOn(mockActivitySink, "postActivity");
+
+		manager = new AgentSessionManager();
+		manager.createCyrusAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "TEST-API",
+				title: "API Error Test",
+				description: "test",
+				branchName: "test-api",
+			},
+			{ path: "/tmp/workspace", isGitWorktree: false },
+		);
+		manager.setActivitySink(sessionId, mockActivitySink);
+	});
+
+	const findResultActivity = () =>
+		postActivitySpy.mock.calls
+			.map((call: any[]) => call[1])
+			.reverse()
+			.find(
+				(content: any) =>
+					content?.type === "error" || content?.type === "response",
+			);
+
+	it("relabels a Claude API error that arrives as the final assistant text (success subtype)", async () => {
+		// Claude surfaces an API failure as the final assistant text, then ends
+		// the turn with a success-subtype result.
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeAssistantMessage("API Error: Internal server error"),
+		);
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeResultMessage("success"),
+		);
+
+		const activity = findResultActivity();
+		expect(activity).toBeDefined();
+		expect(activity.type).toBe("error");
+		expect(activity.body).toBe(
+			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: Internal server error",
+		);
+	});
+
+	it("attributes a Claude API error that arrives with an error subtype but empty errors[]", async () => {
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeAssistantMessage("API Error: Overloaded"),
+		);
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeResultMessage("error_during_execution"),
+		);
+
+		const activity = findResultActivity();
+		expect(activity).toBeDefined();
+		expect(activity.type).toBe("error");
+		expect(activity.body).toBe(
+			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: Overloaded",
+		);
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+	});
+
+	it("does not alter a normal successful response", async () => {
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeAssistantMessage("All done! I implemented the feature."),
+		);
+		await manager.handleClaudeMessage(
+			sessionId,
+			mockClaudeResultMessage("success"),
+		);
+
+		const activity = findResultActivity();
+		expect(activity).toBeDefined();
+		expect(activity.type).toBe("response");
+		expect(activity.body).toBe("All done! I implemented the feature.");
+	});
+});

--- a/packages/edge-worker/test/SlackChatAdapter.api-error.test.ts
+++ b/packages/edge-worker/test/SlackChatAdapter.api-error.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture postMessage calls by mocking the Slack transport service.
+const postMessageMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("cyrus-slack-event-transport", async (importActual) => {
+	const actual = await importActual<any>();
+	return {
+		...actual,
+		SlackMessageService: class {
+			postMessage = postMessageMock;
+			getIdentity = vi.fn().mockResolvedValue({ bot_id: "B123" });
+		},
+		SlackReactionService: class {
+			addReaction = vi.fn().mockResolvedValue(undefined);
+			removeReaction = vi.fn().mockResolvedValue(undefined);
+		},
+	};
+});
+
+import { SlackChatAdapter } from "../src/SlackChatAdapter";
+
+// A runner whose constructor name is not a known non-Claude runner, so it
+// resolves to the "claude" display name.
+class FakeClaudeRunner {
+	private messages: any[];
+	constructor(messages: any[]) {
+		this.messages = messages;
+	}
+	getMessages() {
+		return this.messages;
+	}
+}
+
+const assistantTextMessage = (text: string) => ({
+	type: "assistant",
+	message: { content: [{ type: "text", text }] },
+});
+
+const makeEvent = () =>
+	({
+		slackBotToken: "xoxb-test",
+		payload: {
+			channel: "C123",
+			ts: "1700000000.000100",
+			thread_ts: "1700000000.000001",
+			text: "hi",
+		},
+	}) as any;
+
+describe("SlackChatAdapter API error attribution", () => {
+	let adapter: SlackChatAdapter;
+
+	beforeEach(() => {
+		postMessageMock.mockClear();
+		const repositoryProvider = {
+			getRepositories: vi.fn().mockReturnValue([]),
+		} as any;
+		adapter = new SlackChatAdapter(repositoryProvider);
+	});
+
+	it("relabels a Claude API error as a provider error with recovery guidance", async () => {
+		const runner = new FakeClaudeRunner([
+			assistantTextMessage(
+				"API Error: 400 messages.1.content.3: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.",
+			),
+		]) as any;
+
+		await adapter.postReply(makeEvent(), runner);
+
+		expect(postMessageMock).toHaveBeenCalledTimes(1);
+		const posted = postMessageMock.mock.calls[0][0];
+		expect(posted.text).toContain("**Claude API error**");
+		expect(posted.text).toContain("not from Cyrus");
+		expect(posted.text).toContain(
+			"start a new thread to reset the conversation",
+		);
+		expect(posted.text).toContain("`thinking` or `redacted_thinking` blocks");
+	});
+
+	it("posts a normal assistant reply unchanged", async () => {
+		const runner = new FakeClaudeRunner([
+			assistantTextMessage("Here's what I found in your Slack history."),
+		]) as any;
+
+		await adapter.postReply(makeEvent(), runner);
+
+		expect(postMessageMock).toHaveBeenCalledTimes(1);
+		const posted = postMessageMock.mock.calls[0][0];
+		expect(posted.text).toBe("Here's what I found in your Slack history.");
+	});
+});

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -86,6 +86,10 @@ class TestChatAdapter implements ChatPlatformAdapter<TestEvent> {
 		return;
 	}
 
+	async postErrorReply(_event: TestEvent, _message: string): Promise<void> {
+		return;
+	}
+
 	async acknowledgeReceipt(_event: TestEvent): Promise<void> {
 		return;
 	}
@@ -147,6 +151,74 @@ describe("ChatSessionHandler chat session permissions", () => {
 		for (const path of chatRepositoryPaths) {
 			expect(capturedConfig.allowedDirectories).toContain(path);
 		}
+	});
+});
+
+describe("ChatSessionHandler runner-failure handling", () => {
+	const apiError =
+		"Claude Code returned an error result: API Error: 400 messages.1.content.3: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified.";
+
+	function buildHandler(startImpl: () => Promise<any>) {
+		const adapter = new TestChatAdapter("thread-key");
+		const postErrorReplySpy = vi.spyOn(adapter, "postErrorReply");
+		const createRunner = vi.fn(
+			() =>
+				({
+					supportsStreamingInput: false,
+					start: vi.fn(startImpl),
+					stop: vi.fn(),
+					isRunning: vi.fn().mockReturnValue(false),
+					isStreaming: vi.fn().mockReturnValue(false),
+					addStreamMessage: vi.fn(),
+					getMessages: vi.fn().mockReturnValue([]),
+				}) as any,
+		);
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider(["/repo/chat-one"]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+		return { handler, postErrorReplySpy };
+	}
+
+	it("posts an attributed provider error to the thread when the runner rejects with an API error", async () => {
+		const { handler, postErrorReplySpy } = buildHandler(() =>
+			Promise.reject(new Error(apiError)),
+		);
+
+		await handler.handleEvent({
+			eventId: "test-event",
+			threadKey: "test-thread",
+		} as any);
+
+		await vi.waitFor(() => expect(postErrorReplySpy).toHaveBeenCalledTimes(1));
+		const message = postErrorReplySpy.mock.calls[0][1];
+		expect(message).toContain("**Claude API error**");
+		expect(message).toContain("not from Cyrus");
+		expect(message).toContain("start a new thread to reset the conversation");
+		expect(message).toContain("`thinking` or `redacted_thinking` blocks");
+		// The runner wrapper prefix should be stripped from the surfaced text.
+		expect(message).not.toContain("Claude Code returned an error result");
+	});
+
+	it("does not post to the thread for non-provider runner errors", async () => {
+		const { handler, postErrorReplySpy } = buildHandler(() =>
+			Promise.reject(new Error("ENOENT: workspace directory missing")),
+		);
+
+		await handler.handleEvent({
+			eventId: "test-event",
+			threadKey: "test-thread",
+		} as any);
+
+		// Give the rejected promise's catch a chance to run.
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(postErrorReplySpy).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/edge-worker/test/runner-error-formatting.test.ts
+++ b/packages/edge-worker/test/runner-error-formatting.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatModelApiError,
+	isModelApiErrorText,
+} from "../src/runner-error-formatting";
+
+describe("isModelApiErrorText", () => {
+	it("detects the canonical Claude API error text", () => {
+		expect(isModelApiErrorText("API Error: Internal server error")).toBe(true);
+	});
+
+	it("detects API errors with leading/trailing whitespace", () => {
+		expect(isModelApiErrorText("  \nAPI Error: Request timed out.\n")).toBe(
+			true,
+		);
+	});
+
+	it("detects API errors with status codes and JSON bodies", () => {
+		expect(
+			isModelApiErrorText(
+				'API Error: 500 {"type":"error","error":{"message":"Internal server error"}}',
+			),
+		).toBe(true);
+	});
+
+	it("is case-insensitive", () => {
+		expect(isModelApiErrorText("api error: overloaded")).toBe(true);
+	});
+
+	it("does not match a normal response that merely mentions an API error", () => {
+		expect(
+			isModelApiErrorText(
+				"I added handling for the API Error: Internal server error case.",
+			),
+		).toBe(false);
+	});
+
+	it("returns false for empty/undefined/null", () => {
+		expect(isModelApiErrorText("")).toBe(false);
+		expect(isModelApiErrorText(undefined)).toBe(false);
+		expect(isModelApiErrorText(null)).toBe(false);
+	});
+});
+
+describe("formatModelApiError", () => {
+	it("attributes the error to Claude with a clear prefix", () => {
+		expect(
+			formatModelApiError("API Error: Internal server error", "claude"),
+		).toBe(
+			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: Internal server error",
+		);
+	});
+
+	it("uses the right display name per runner type", () => {
+		expect(formatModelApiError("API Error: boom", "gemini")).toContain(
+			"**Gemini API error**",
+		);
+		expect(formatModelApiError("API Error: boom", "codex")).toContain(
+			"**Codex API error**",
+		);
+		expect(formatModelApiError("API Error: boom", "cursor")).toContain(
+			"**Cursor API error**",
+		);
+	});
+
+	it("falls back to a generic label for unknown runner types", () => {
+		expect(formatModelApiError("API Error: boom", "mystery")).toContain(
+			"**the agent API error**",
+		);
+	});
+
+	it("trims the underlying content", () => {
+		expect(
+			formatModelApiError("  API Error: Internal server error  ", "claude"),
+		).toBe(
+			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: Internal server error",
+		);
+	});
+});

--- a/packages/edge-worker/test/runner-error-formatting.test.ts
+++ b/packages/edge-worker/test/runner-error-formatting.test.ts
@@ -2,7 +2,22 @@ import { describe, expect, it } from "vitest";
 import {
 	formatModelApiError,
 	isModelApiErrorText,
+	runnerTypeFromConstructorName,
 } from "../src/runner-error-formatting";
+
+describe("runnerTypeFromConstructorName", () => {
+	it("maps known runner constructor names", () => {
+		expect(runnerTypeFromConstructorName("GeminiRunner")).toBe("gemini");
+		expect(runnerTypeFromConstructorName("CodexRunner")).toBe("codex");
+		expect(runnerTypeFromConstructorName("CursorRunner")).toBe("cursor");
+		expect(runnerTypeFromConstructorName("ClaudeRunner")).toBe("claude");
+	});
+
+	it("defaults to claude for unknown/undefined", () => {
+		expect(runnerTypeFromConstructorName(undefined)).toBe("claude");
+		expect(runnerTypeFromConstructorName("MysteryRunner")).toBe("claude");
+	});
+});
 
 describe("isModelApiErrorText", () => {
 	it("detects the canonical Claude API error text", () => {
@@ -74,6 +89,14 @@ describe("formatModelApiError", () => {
 			formatModelApiError("  API Error: Internal server error  ", "claude"),
 		).toBe(
 			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: Internal server error",
+		);
+	});
+
+	it("appends an optional recovery hint", () => {
+		expect(
+			formatModelApiError("API Error: boom", "claude", "Try again later."),
+		).toBe(
+			"⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.\n\nAPI Error: boom\n\nTry again later.",
 		);
 	});
 });

--- a/packages/edge-worker/test/runner-error-formatting.test.ts
+++ b/packages/edge-worker/test/runner-error-formatting.test.ts
@@ -3,7 +3,38 @@ import {
 	formatModelApiError,
 	isModelApiErrorText,
 	runnerTypeFromConstructorName,
+	unwrapRunnerErrorMessage,
 } from "../src/runner-error-formatting";
+
+describe("unwrapRunnerErrorMessage", () => {
+	it("strips the runner's error-result wrapper prefix", () => {
+		expect(
+			unwrapRunnerErrorMessage(
+				"Claude Code returned an error result: API Error: 400 thinking blocks cannot be modified",
+			),
+		).toBe("API Error: 400 thinking blocks cannot be modified");
+	});
+
+	it("returns the message unchanged when there is no wrapper", () => {
+		expect(unwrapRunnerErrorMessage("API Error: Internal server error")).toBe(
+			"API Error: Internal server error",
+		);
+	});
+
+	it("handles multiline error bodies", () => {
+		expect(
+			unwrapRunnerErrorMessage(
+				"returned an error result: API Error: 400\nmore detail here",
+			),
+		).toBe("API Error: 400\nmore detail here");
+	});
+
+	it("returns empty string for empty/undefined/null", () => {
+		expect(unwrapRunnerErrorMessage("")).toBe("");
+		expect(unwrapRunnerErrorMessage(undefined)).toBe("");
+		expect(unwrapRunnerErrorMessage(null)).toBe("");
+	});
+});
 
 describe("runnerTypeFromConstructorName", () => {
 	it("maps known runner constructor names", () => {


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

When Claude's Anthropic API fails mid-turn, Claude Code surfaces the failure as an assistant text block such as `API Error: Internal server error` (or `API Error: 400 … `thinking` blocks … cannot be modified`). Previously that text was posted as a normal **response/reply** — making it look like Cyrus itself produced the error, when in fact it came from the model provider's API.

This change detects provider/model API errors and clearly attributes them, on **both** surfaces:

- **Linear** — relabels the result as an **error** activity (instead of a plain response) and prefixes the body with an attribution.
- **Slack** — `SlackChatAdapter.postReply()` posts the runner's last assistant message verbatim, which is exactly how the `thinking blocks` 400 leaked through as if Cyrus said it. Now it's relabeled, attributed, and given recovery guidance (retry, or start a new thread).

Example output:
> ⚠️ **Claude API error** — this error came from Claude's API, not from Cyrus.
>
> API Error: Internal server error

## Implementation

- New helper `packages/edge-worker/src/runner-error-formatting.ts`:
  - `isModelApiErrorText()` — anchored, case-insensitive detection of `API Error: …` text (won't misfire on responses that merely mention an API error).
  - `formatModelApiError()` — provider-attributed label (Claude/Gemini/Codex/Cursor) with an optional surface-specific recovery hint.
  - `runnerTypeFromConstructorName()` — shared runner-type resolution (also DRYs up three duplicated ternaries in `AgentSessionManager`).
- Wired into `AgentSessionManager.addResultEntry()` (Linear) and `SlackChatAdapter.postReply()` (Slack). The Linear path also now falls back to the buffered final assistant text for error-subtype results, so the actual detail isn't lost when `errors[]`/`result` are empty.

## Testing

- `runner-error-formatting.test.ts` — detection, formatting, recovery hint, runner-type mapping (incl. false-positive guard).
- `AgentSessionManager.api-error.test.ts` — API error as final assistant text (success subtype), error-subtype with empty `errors[]`, and a no-false-positive check.
- `SlackChatAdapter.api-error.test.ts` — the `thinking blocks` 400 is relabeled with recovery guidance; normal replies pass through unchanged.
- Full edge-worker suite (679 tests), repo-wide `typecheck` and `lint` all pass.

Closes [CYPACK-1262](https://linear.app/ceedar/issue/CYPACK-1262/make-claude-errors-more-obvious-as-claude-errors-when-appearing-in)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->