### PR TITLE
feat(edge-worker): honor prReviewTrigger flag to gate pull_request_review (CYPACK-1273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Updated `@anthropic-ai/claude-agent-sdk` from 0.3.154 to 0.3.156 and `@anthropic-ai/sdk` from 0.100.0 to 0.100.1. See the [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1265](https://linear.app/ceedar/issue/CYPACK-1265), [#1270](https://github.com/cyrusagents/cyrus/pull/1270))
 
 ### Added
+- New "PR review trigger" control: when disabled, a pull request review that requests changes on a Cyrus-opened PR no longer auto-starts a Cyrus session or posts an acknowledgement comment. Enabled by default, so existing behaviour is unchanged unless you turn it off. ([CYPACK-1273](https://linear.app/ceedar/issue/CYPACK-1273))
 - A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically discovered and made available to the agent whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
 
 ## [0.2.60] - 2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Updated `@anthropic-ai/claude-agent-sdk` from 0.3.154 to 0.3.156 and `@anthropic-ai/sdk` from 0.100.0 to 0.100.1. See the [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for details. ([CYPACK-1265](https://linear.app/ceedar/issue/CYPACK-1265), [#1270](https://github.com/cyrusagents/cyrus/pull/1270))
 
 ### Added
-- New "PR review trigger" control: when disabled, a pull request review that requests changes on a Cyrus-opened PR no longer auto-starts a Cyrus session or posts an acknowledgement comment. Enabled by default, so existing behaviour is unchanged unless you turn it off. ([CYPACK-1273](https://linear.app/ceedar/issue/CYPACK-1273))
+- New "PR review trigger" control: when disabled, a pull request review that requests changes on a Cyrus-opened PR no longer auto-starts a Cyrus session or posts an acknowledgement comment. Enabled by default, so existing behaviour is unchanged unless you turn it off. ([CYPACK-1273](https://linear.app/ceedar/issue/CYPACK-1273), [#1278](https://github.com/cyrusagents/cyrus/pull/1278))
 - A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically discovered and made available to the agent whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
 
 ## [0.2.60] - 2026-05-28

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -231,6 +231,7 @@ export class WorkerService {
 					| "cursor"
 					| undefined) || edgeConfig.defaultRunner,
 			issueUpdateTrigger: edgeConfig.issueUpdateTrigger,
+			prReviewTrigger: edgeConfig.prReviewTrigger,
 			promptDefaults: edgeConfig.promptDefaults,
 			linearWorkspaces: edgeConfig.linearWorkspaces,
 			webhookBaseUrl: process.env.CYRUS_BASE_URL,

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -603,6 +603,9 @@
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},
+		"prReviewTrigger": {
+			"type": "boolean"
+		},
 		"userAccessControl": {
 			"type": "object",
 			"properties": {

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -597,6 +597,9 @@
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},
+		"prReviewTrigger": {
+			"type": "boolean"
+		},
 		"userAccessControl": {
 			"type": "object",
 			"properties": {

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -459,6 +459,13 @@ export const EdgeConfigSchema = z.object({
 	issueUpdateTrigger: z.boolean().optional(),
 
 	/**
+	 * Whether to trigger agent sessions when a pull request review requests changes.
+	 * When disabled, a `pull_request_review` event produces no acknowledgement comment
+	 * and no agent session. Defaults to true if not specified.
+	 */
+	prReviewTrigger: z.boolean().optional(),
+
+	/**
 	 * Global user access control settings.
 	 * Applied to all repositories unless overridden.
 	 */

--- a/packages/core/test/json-schema-export.test.ts
+++ b/packages/core/test/json-schema-export.test.ts
@@ -56,6 +56,7 @@ describe("JSON Schema export", () => {
 				"linearMcpConfigs",
 				"githubMcpConfigs",
 				"issueUpdateTrigger",
+				"prReviewTrigger",
 				"userAccessControl",
 				"promptDefaults",
 				"sandbox",

--- a/packages/edge-worker/src/ConfigManager.ts
+++ b/packages/edge-worker/src/ConfigManager.ts
@@ -250,6 +250,10 @@ export class ConfigManager extends EventEmitter {
 				// otherwise keep current or default to true
 				issueUpdateTrigger:
 					parsedConfig.issueUpdateTrigger ?? this.config.issueUpdateTrigger,
+				// PR review trigger: use parsed value if explicitly set,
+				// otherwise keep current or default to true
+				prReviewTrigger:
+					parsedConfig.prReviewTrigger ?? this.config.prReviewTrigger,
 				// Sandbox / egress proxy config
 				sandbox: parsedConfig.sandbox ?? this.config.sandbox,
 			};
@@ -347,6 +351,7 @@ export class ConfigManager extends EventEmitter {
 			"defaultDisallowedTools",
 			"promptDefaults",
 			"issueUpdateTrigger",
+			"prReviewTrigger",
 			"linearWorkspaces",
 			"userAccessControl",
 			"sandbox",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1202,6 +1202,16 @@ export class EdgeWorker extends EventEmitter {
 				}
 			}
 
+			// Honor the PR-review trigger toggle: when disabled, ignore
+			// pull_request_review events entirely — no acknowledgement comment and
+			// no agent session. Defaults to enabled when the flag is unset.
+			if (isPullRequestReview && this.config.prReviewTrigger === false) {
+				this.logger.debug(
+					`PR review trigger is disabled, ignoring pull_request_review on ${repoFullName}#${prNumber}`,
+				);
+				return;
+			}
+
 			// Only trigger on comments that mention the bot (when configured)
 			// Skip this check for pull_request_review events — reviews don't @mention the bot
 			if (

--- a/packages/edge-worker/test/ConfigManager.pr-review-trigger.test.ts
+++ b/packages/edge-worker/test/ConfigManager.pr-review-trigger.test.ts
@@ -1,0 +1,87 @@
+import { readFile } from "node:fs/promises";
+import type { EdgeWorkerConfig, ILogger } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigManager } from "../src/ConfigManager.js";
+
+vi.mock("node:fs/promises");
+
+/**
+ * Tests for CYPACK-1273: ensure the `prReviewTrigger` flag participates in
+ * the config hot-reload pipeline — both the merge in `loadConfigSafely()` and
+ * the global-change detection in `detectGlobalConfigChanges()`. Without these,
+ * a `prReviewTrigger` change written to config.json while Cyrus is running
+ * would be silently dropped (see CLAUDE.md note #9).
+ */
+describe("ConfigManager - prReviewTrigger hot-reload (CYPACK-1273)", () => {
+	let logger: ILogger;
+
+	const baseConfig: EdgeWorkerConfig = {
+		proxyUrl: "http://localhost:3000",
+		cyrusHome: "/tmp/cyrus-home",
+		repositories: [
+			{
+				id: "repo-1",
+				name: "Repo 1",
+				repositoryPath: "/test/repo",
+				baseBranch: "main",
+				workspaceBaseDir: "/test/workspaces",
+			},
+		],
+	} as unknown as EdgeWorkerConfig;
+
+	function makeManager(config: EdgeWorkerConfig): ConfigManager {
+		return new ConfigManager(
+			config,
+			logger,
+			"/tmp/cyrus-home/config.json",
+			new Map(config.repositories.map((r) => [r.id, r])),
+		);
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as ILogger;
+	});
+
+	it("merges prReviewTrigger:false from the reloaded config file", async () => {
+		const manager = makeManager(baseConfig);
+		vi.mocked(readFile).mockResolvedValue(
+			JSON.stringify({
+				repositories: baseConfig.repositories,
+				prReviewTrigger: false,
+			}) as any,
+		);
+
+		const newConfig = await (manager as any).loadConfigSafely();
+
+		expect(newConfig).not.toBeNull();
+		expect(newConfig.prReviewTrigger).toBe(false);
+	});
+
+	it("detects a prReviewTrigger change as a global config change", () => {
+		const manager = makeManager(baseConfig);
+
+		const changed = (manager as any).detectGlobalConfigChanges({
+			...baseConfig,
+			prReviewTrigger: false,
+		});
+
+		expect(changed).toBe(true);
+	});
+
+	it("preserves an existing prReviewTrigger value when the file omits it", async () => {
+		const manager = makeManager({ ...baseConfig, prReviewTrigger: false });
+		vi.mocked(readFile).mockResolvedValue(
+			JSON.stringify({ repositories: baseConfig.repositories }) as any,
+		);
+
+		const newConfig = await (manager as any).loadConfigSafely();
+
+		expect(newConfig.prReviewTrigger).toBe(false);
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.pr-review-trigger.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.pr-review-trigger.test.ts
@@ -1,0 +1,246 @@
+import { LinearClient } from "@linear/sdk";
+import { ClaudeRunner } from "cyrus-claude-runner";
+import type { EdgeWorkerConfig, RepositoryConfig } from "cyrus-core";
+import { LinearEventTransport } from "cyrus-linear-event-transport";
+import { createCyrusToolsServer } from "cyrus-mcp-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+import { TEST_CYRUS_HOME } from "./test-dirs.js";
+
+// Mock all dependencies (mirrors EdgeWorker.issue-update-multiple-sessions.test.ts)
+vi.mock("fs/promises");
+vi.mock("cyrus-claude-runner");
+vi.mock("cyrus-mcp-tools");
+vi.mock("cyrus-codex-runner");
+vi.mock("cyrus-linear-event-transport");
+vi.mock("@linear/sdk");
+vi.mock("../src/SharedApplicationServer.js");
+vi.mock("../src/AgentSessionManager.js");
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(() => ({
+			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+		})),
+	};
+});
+
+/**
+ * Tests for CYPACK-1273: honor the `prReviewTrigger` config flag in the
+ * edge-worker GitHub webhook handler.
+ *
+ * When `prReviewTrigger === false`, a `pull_request_review` event that requests
+ * changes must be ignored entirely — no acknowledgement comment and no agent
+ * session. When the flag is `true` or unset (default), behaviour is unchanged.
+ */
+describe("EdgeWorker - PR review trigger gate (CYPACK-1273)", () => {
+	let edgeWorker: EdgeWorker;
+	let mockAgentSessionManager: any;
+	let mockGitHubCommentService: any;
+
+	const mockRepository: RepositoryConfig = {
+		id: "test-repo",
+		name: "Test Repo",
+		repositoryPath: "/test/repo",
+		workspaceBaseDir: "/test/workspaces",
+		baseBranch: "main",
+		linearWorkspaceId: "test-workspace",
+		isActive: true,
+		allowedTools: ["Read", "Edit"],
+		labelPrompts: {},
+		teamKeys: ["TEST"],
+	};
+
+	// A `pull_request_review` event requesting changes (mirrors fixtures from
+	// packages/github-event-transport/test/fixtures.ts).
+	function createPrReviewEvent(): any {
+		const repository = {
+			full_name: "testorg/my-repo",
+			name: "my-repo",
+			owner: { login: "testorg" },
+		};
+		return {
+			eventType: "pull_request_review",
+			deliveryId: "delivery-pr-review-001",
+			payload: {
+				action: "submitted",
+				review: {
+					id: 777,
+					body: "Please fix the error handling in the main function",
+					state: "changes_requested",
+					html_url:
+						"https://github.com/testorg/my-repo/pull/42#pullrequestreview-777",
+					user: { login: "reviewer" },
+					submitted_at: "2025-01-15T10:30:00Z",
+					commit_id: "abc123",
+				},
+				pull_request: {
+					number: 42,
+					title: "Fix failing tests",
+					head: { ref: "fix-tests" },
+					base: { ref: "main" },
+				},
+				repository,
+				sender: { login: "reviewer" },
+				installation: { id: 55555, node_id: "MDIzOk" },
+			},
+		};
+	}
+
+	function buildConfig(prReviewTrigger: boolean | undefined): EdgeWorkerConfig {
+		return {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: TEST_CYRUS_HOME,
+			repositories: [mockRepository],
+			linearWorkspaces: {
+				"test-workspace": { linearToken: "test-token" },
+			},
+			...(prReviewTrigger === undefined ? {} : { prReviewTrigger }),
+			handlers: {
+				createWorkspace: vi.fn().mockResolvedValue({
+					path: "/test/workspaces/PR-42",
+					isGitWorktree: false,
+				}),
+			},
+		} as EdgeWorkerConfig;
+	}
+
+	function createWorker(prReviewTrigger: boolean | undefined): EdgeWorker {
+		const worker = new EdgeWorker(buildConfig(prReviewTrigger));
+		(worker as any).agentSessionManager = mockAgentSessionManager;
+		(worker as any).gitHubCommentService = mockGitHubCommentService;
+		// Token resolution succeeds so the (enabled) ack path can post.
+		(worker as any).resolveGitHubToken = vi
+			.fn()
+			.mockResolvedValue("ghs_test_token");
+		// Match the repo so the enabled path reaches the ack comment.
+		(worker as any).findRepositoryByGitHubUrl = vi
+			.fn()
+			.mockReturnValue(mockRepository);
+		// Stop the enabled path right after the ack comment (return early).
+		(worker as any).createGitHubWorkspace = vi.fn().mockResolvedValue(null);
+		return worker;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		delete process.env.GITHUB_BOT_USERNAME;
+
+		vi.mocked(createCyrusToolsServer).mockImplementation(() => {
+			return { server: {} } as any;
+		});
+
+		vi.mocked(ClaudeRunner).mockImplementation(
+			() =>
+				({
+					supportsStreamingInput: true,
+					stop: vi.fn(),
+					isStreaming: vi.fn().mockReturnValue(false),
+					isRunning: vi.fn().mockReturnValue(false),
+				}) as any,
+		);
+
+		mockAgentSessionManager = {
+			getActiveMultiRepoSessionForRepository: vi.fn().mockReturnValue(null),
+			getActiveSessionsByBranchName: vi.fn().mockReturnValue([]),
+			createCyrusAgentSession: vi.fn(),
+			getSession: vi.fn().mockReturnValue(null),
+			setActivitySink: vi.fn(),
+			addAgentRunner: vi.fn(),
+			on: vi.fn(),
+		};
+
+		vi.mocked(AgentSessionManager).mockImplementation(
+			() => mockAgentSessionManager,
+		);
+
+		mockGitHubCommentService = {
+			postIssueComment: vi.fn().mockResolvedValue(undefined),
+			addReaction: vi.fn().mockResolvedValue(undefined),
+		};
+
+		vi.mocked(SharedApplicationServer).mockImplementation(
+			() =>
+				({
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+					registerOAuthCallbackHandler: vi.fn(),
+				}) as any,
+		);
+
+		vi.mocked(LinearEventTransport).mockImplementation(
+			() =>
+				({
+					register: vi.fn(),
+					on: vi.fn(),
+					removeAllListeners: vi.fn(),
+				}) as any,
+		);
+
+		vi.mocked(LinearClient).mockImplementation(
+			() =>
+				({
+					users: {
+						me: vi
+							.fn()
+							.mockResolvedValue({ id: "user-123", name: "Test User" }),
+					},
+				}) as any,
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("ignores a changes_requested review when prReviewTrigger is false", async () => {
+		edgeWorker = createWorker(false);
+
+		await (edgeWorker as any).handleGitHubWebhook(createPrReviewEvent());
+
+		// No token resolution, no acknowledgement comment, no session.
+		expect((edgeWorker as any).resolveGitHubToken).not.toHaveBeenCalled();
+		expect(mockGitHubCommentService.postIssueComment).not.toHaveBeenCalled();
+		expect(
+			mockAgentSessionManager.createCyrusAgentSession,
+		).not.toHaveBeenCalled();
+	});
+
+	it("posts an acknowledgement comment when prReviewTrigger is true", async () => {
+		edgeWorker = createWorker(true);
+
+		await (edgeWorker as any).handleGitHubWebhook(createPrReviewEvent());
+
+		expect((edgeWorker as any).resolveGitHubToken).toHaveBeenCalled();
+		expect(mockGitHubCommentService.postIssueComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				issueNumber: 42,
+				body: "Received your change request. Getting started on those changes now.",
+			}),
+		);
+	});
+
+	it("posts an acknowledgement comment when prReviewTrigger is unset (default enabled)", async () => {
+		edgeWorker = createWorker(undefined);
+
+		await (edgeWorker as any).handleGitHubWebhook(createPrReviewEvent());
+
+		expect((edgeWorker as any).resolveGitHubToken).toHaveBeenCalled();
+		expect(mockGitHubCommentService.postIssueComment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				issueNumber: 42,
+				body: "Received your change request. Getting started on those changes now.",
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Enforcement half of CYHOST-1021's "PR review trigger" toggle. The edge-worker now honors a `prReviewTrigger` config flag so that, when the toggle is **OFF**, a `pull_request_review` event requesting changes produces **no Cyrus session and no acknowledgement comment**.

Without this change the CYHOST-1021 toggle has no effect — a reviewer requesting changes on a Cyrus-opened PR always auto-triggers Cyrus to start working.

## Changes

- **`packages/core/src/config-schemas.ts`** — add `prReviewTrigger?: boolean` to `EdgeConfigSchema`, mirroring `issueUpdateTrigger`. JSON schemas regenerated.
- **`packages/edge-worker/src/ConfigManager.ts`** — merge the field in `loadConfigSafely()` and add it to the `globalKeys` change-detection list (per the CLAUDE.md whitelist rule).
- **`apps/cli/src/services/WorkerService.ts`** — pass `prReviewTrigger` from `edgeConfig` into the runtime config.
- **`packages/edge-worker/src/EdgeWorker.ts`** — early return in `handleGitHubWebhook`: when `isPullRequestReview && this.config.prReviewTrigger === false`, log at debug and return **before** token resolution, the acknowledgement comment, and any session creation.
- **Tests** — `EdgeWorker.pr-review-trigger.test.ts` covers disabled, enabled, and unset (default) paths.
- **CHANGELOG** updated.

## Field naming

Matches the agreed CYHOST-1021 contract: `pr_review_trigger_enabled` → `prReviewTrigger`. Defaults to enabled when unset (backwards compatible).

## Acceptance criteria

- [x] `prReviewTrigger === false`: `changes_requested` review ignored — no eyes/ack comment, no session.
- [x] `prReviewTrigger` true or unset: behaviour unchanged.
- [x] Unit tests cover disabled and enabled paths.
- [x] CHANGELOG updated.

## Testing

- `pnpm typecheck` ✅
- `pnpm --filter cyrus-edge-worker test:run` ✅ (673 tests)
- `pnpm --filter cyrus-core test:run` ✅ (137 tests)

Closes CYPACK-1273.

<!-- generated-by-cyrus -->