### PR TITLE
Release v0.2.61

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.61] - 2026-06-01
+
+_No internal-only changes._
+
 ## [0.2.60] - 2026-05-28
 
 _No internal-only changes._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.61] - 2026-06-01
+
 ### Security
 - Bumped `qs` to >=6.15.2 to address a remotely triggerable DoS (`qs.stringify` crash on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set), pulled in transitively via `express`. ([CYPACK-1269](https://linear.app/ceedar/issue/CYPACK-1269), [#1274](https://github.com/ceedaragents/cyrus/pull/1274))
 
@@ -15,6 +17,53 @@ All notable changes to this project will be documented in this file.
 ### Added
 - New "PR review trigger" control: when disabled, a pull request review that requests changes on a Cyrus-opened PR no longer auto-starts a Cyrus session or posts an acknowledgement comment. Enabled by default, so existing behaviour is unchanged unless you turn it off. ([CYPACK-1273](https://linear.app/ceedar/issue/CYPACK-1273), [#1278](https://github.com/cyrusagents/cyrus/pull/1278))
 - A repository can now ship its own skills: any skill directories under `<repo>/.claude/skills/` are automatically discovered and made available to the agent whenever Cyrus works in that repo — for single-repo issues, multi-repo issues (skills from every participating repo are combined), and GitHub/GitLab mentions alike. ([CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261), [#1268](https://github.com/cyrusagents/cyrus/pull/1268))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.61
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.61
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.61
+
+#### cyrus-core
+- cyrus-core@0.2.61
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.61
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.61
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.61
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.61
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.61
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.61
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.61
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.61
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.61
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.61
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.61
 
 ## [0.2.60] - 2026-05-28
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.60",
+	"version": "0.2.61",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.61 to npm
- Update changelogs with v0.2.61 entries
- Bump package versions to 0.2.61
- Create git tag v0.2.61

## Changes
- CHANGELOG.md updated with v0.2.61 release notes
- CHANGELOG.internal.md updated
- All package versions bumped to 0.2.61

## Links
- [GitHub Release](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.61)

## Issues
- [CYPACK-1269](https://linear.app/ceedar/issue/CYPACK-1269) — qs DoS security fix
- [CYPACK-1271](https://linear.app/ceedar/issue/CYPACK-1271) — SDK 0.3.159 update
- [CYPACK-1268](https://linear.app/ceedar/issue/CYPACK-1268) — SDK 0.3.158 update
- [CYPACK-1265](https://linear.app/ceedar/issue/CYPACK-1265) — SDK 0.3.156 + anthropic-sdk 0.100.1 update
- [CYPACK-1273](https://linear.app/ceedar/issue/CYPACK-1273) — PR review trigger flag
- [CYPACK-1261](https://linear.app/ceedar/issue/CYPACK-1261) — Repo-level skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- generated-by-cyrus -->