### PR TITLE
fix(security): bump vitest to 4.1.0 to patch GHSA-5xrq-8626-4rwp (CYPACK-1278)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Security
+- Bumped `vitest` (and `@vitest/ui`, `@vitest/coverage-v8`) from `3.x` to `^4.1.0` across all packages to patch the critical advisory [GHSA-5xrq-8626-4rwp](https://github.com/advisories/GHSA-5xrq-8626-4rwp) (arbitrary file read/exec via the Vitest UI server; vulnerable `<4.1.0`). Migrated test mocks to satisfy Vitest 4's `new`-based mock construction (constructor mocks must use `function`/`class`, not arrows) and disabled biome's `useArrowFunction` rule for test files so the autofix can't revert them. Supersedes Dependabot PR #1279. ([CYPACK-1278](https://linear.app/ceedar/issue/CYPACK-1278), [#1285](https://github.com/cyrusagents/cyrus/pull/1285))
+
 ## [0.2.62] - 2026-06-02
 
 _No internal-only changes._

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -60,9 +60,9 @@
 	},
 	"devDependencies": {
 		"@types/node": "^20.0.0",
-		"@vitest/ui": "^3.1.4",
+		"@vitest/ui": "^4.1.0",
 		"nodemon": "^2.0.22",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	}
 }

--- a/apps/cli/src/commands/SelfAuthCommand.test.ts
+++ b/apps/cli/src/commands/SelfAuthCommand.test.ts
@@ -43,7 +43,10 @@ vi.mock("@linear/sdk", async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...(actual as object),
-		LinearClient: vi.fn(() => mockLinearClient),
+		// Regular function (not arrow) so vitest 4 can invoke the mock with `new`.
+		LinearClient: vi.fn(function () {
+			return mockLinearClient;
+		}),
 	};
 });
 
@@ -446,14 +449,16 @@ describe("SelfAuthCommand", () => {
 
 			// Update the LinearClient mock for this specific test
 			const { LinearClient } = await import("@linear/sdk");
-			(LinearClient as any).mockImplementation(() => ({
-				viewer: Promise.resolve({
-					organization: Promise.resolve({
-						id: "ws-123",
-						name: "Workspace",
+			(LinearClient as any).mockImplementation(function () {
+				return {
+					viewer: Promise.resolve({
+						organization: Promise.resolve({
+							id: "ws-123",
+							name: "Workspace",
+						}),
 					}),
-				}),
-			}));
+				};
+			});
 
 			await expect(command.execute([])).rejects.toThrow("process.exit called");
 			expect(mockExit).toHaveBeenCalledWith(0);
@@ -518,14 +523,16 @@ describe("SelfAuthCommand", () => {
 
 			// Update the LinearClient mock for this specific test
 			const { LinearClient } = await import("@linear/sdk");
-			(LinearClient as any).mockImplementation(() => ({
-				viewer: Promise.resolve({
-					organization: Promise.resolve({
-						id: "ws-new",
-						name: "New Workspace",
+			(LinearClient as any).mockImplementation(function () {
+				return {
+					viewer: Promise.resolve({
+						organization: Promise.resolve({
+							id: "ws-new",
+							name: "New Workspace",
+						}),
 					}),
-				}),
-			}));
+				};
+			});
 
 			await expect(command.execute([])).rejects.toThrow("process.exit called");
 			expect(mockExit).toHaveBeenCalledWith(0);

--- a/apps/f1/package.json
+++ b/apps/f1/package.json
@@ -40,7 +40,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"engines": {
 		"node": ">=18.0.0"

--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,18 @@
 			"test": "recommended"
 		}
 	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts", "**/test/**/*.ts"],
+			"linter": {
+				"rules": {
+					"complexity": {
+						"useArrowFunction": "off"
+					}
+				}
+			}
+		}
+	],
 	"formatter": {
 		"formatWithErrors": true
 	},

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -29,7 +29,7 @@
 		"@types/node": "^20.0.0",
 		"tsx": "^4.19.2",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"@types/node": "^20.12.7",
 		"typescript": "^5.4.5",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"keywords": [
 		"cloudflare",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -30,7 +30,7 @@
 	"devDependencies": {
 		"@types/node": "^20.12.7",
 		"typescript": "^5.4.5",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"keywords": [
 		"config",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
 		"fastify": "^5.8.5",
 		"tsx": "^4.20.6",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -50,10 +50,10 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"@types/node-forge": "^1.3.14",
-		"@vitest/coverage-v8": "^3.1.4",
+		"@vitest/coverage-v8": "^4.1.0",
 		"axios": "^1.16.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4",
+		"vitest": "^4.1.0",
 		"vitest-mock-extended": "^3.1.0"
 	},
 	"publishConfig": {

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -155,61 +155,55 @@ describe("EdgeWorker - Dynamic Tools Configuration", () => {
 		};
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					setWebhookHandler: vi.fn(),
-					setOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				setWebhookHandler: vi.fn(),
+				setOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock AgentSessionManager
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() =>
-				({
-					addSession: vi.fn(),
-					getSession: vi.fn(),
-					removeSession: vi.fn(),
-					getAllSessions: vi.fn().mockReturnValue([]),
-					clearAllSessions: vi.fn(),
-					on: vi.fn(), // EventEmitter method
-				}) as any,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return {
+				addSession: vi.fn(),
+				getSession: vi.fn(),
+				removeSession: vi.fn(),
+				getAllSessions: vi.fn().mockReturnValue([]),
+				clearAllSessions: vi.fn(),
+				on: vi.fn(), // EventEmitter method
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearClient
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					viewer: vi
-						.fn()
-						.mockResolvedValue({ id: "test-user", email: "test@example.com" }),
-					issue: vi.fn(),
-					comment: vi.fn(),
-					createComment: vi.fn(),
-					webhook: vi.fn(),
-					webhooks: vi.fn(),
-					createWebhook: vi.fn(),
-					updateWebhook: vi.fn(),
-					deleteWebhook: vi.fn(),
-					user: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				viewer: vi
+					.fn()
+					.mockResolvedValue({ id: "test-user", email: "test@example.com" }),
+				issue: vi.fn(),
+				comment: vi.fn(),
+				createComment: vi.fn(),
+				webhook: vi.fn(),
+				webhooks: vi.fn(),
+				createWebhook: vi.fn(),
+				updateWebhook: vi.fn(),
+				deleteWebhook: vi.fn(),
+				user: vi.fn(),
+			};
+		} as any);
 
 		edgeWorker = new EdgeWorker(mockConfig);
 	});

--- a/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-delivery.test.ts
@@ -22,10 +22,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 
@@ -85,7 +87,9 @@ describe("EdgeWorker - Feedback Delivery", () => {
 			stop: vi.fn(),
 			isStreaming: vi.fn().mockReturnValue(false),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation(() => mockClaudeRunner);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return mockClaudeRunner;
+		});
 
 		// Mock child session manager
 		mockChildAgentSessionManager = {
@@ -110,48 +114,44 @@ describe("EdgeWorker - Feedback Delivery", () => {
 		};
 
 		// Mock AgentSessionManager constructor
-		vi.mocked(AgentSessionManager).mockImplementation(
-			(_linearClient, ..._args) => {
-				// Return different managers based on some condition
-				// In real usage, these would be created per repository
-				return mockAgentSessionManager;
-			},
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function (
+			_linearClient,
+			..._args
+		) {
+			// Return different managers based on some condition
+			// In real usage, these would be created per repository
+			return mockAgentSessionManager;
+		});
 
 		// Mock other dependencies
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					users: {
-						me: vi.fn().mockResolvedValue({
-							id: "user-123",
-							name: "Test User",
-						}),
-					},
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({
+						id: "user-123",
+						name: "Test User",
+					}),
+				},
+			};
+		} as any);
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",

--- a/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.feedback-timeout.test.ts
@@ -22,10 +22,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 
@@ -87,7 +89,9 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 			stop: vi.fn(),
 			isStreaming: vi.fn().mockReturnValue(false),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation(() => mockClaudeRunner);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return mockClaudeRunner;
+		});
 
 		// Mock child session manager
 		mockChildAgentSessionManager = {
@@ -112,48 +116,44 @@ describe("EdgeWorker - Feedback Delivery Timeout Issue", () => {
 		};
 
 		// Mock AgentSessionManager constructor
-		vi.mocked(AgentSessionManager).mockImplementation(
-			(_linearClient, ..._args) => {
-				// Return different managers based on some condition
-				// In real usage, these would be created per repository
-				return mockAgentSessionManager;
-			},
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function (
+			_linearClient,
+			..._args
+		) {
+			// Return different managers based on some condition
+			// In real usage, these would be created per repository
+			return mockAgentSessionManager;
+		});
 
 		// Mock other dependencies
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					users: {
-						me: vi.fn().mockResolvedValue({
-							id: "user-123",
-							name: "Test User",
-						}),
-					},
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({
+						id: "user-123",
+						name: "Test User",
+					}),
+				},
+			};
+		} as any);
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",

--- a/packages/edge-worker/test/EdgeWorker.fetchPRBranchRef.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.fetchPRBranchRef.test.ts
@@ -20,10 +20,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -52,7 +54,9 @@ describe("EdgeWorker - fetchPRBranchRefs", () => {
 				description: "Test description",
 			}),
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner
 		mockClaudeRunner = {
@@ -63,7 +67,9 @@ describe("EdgeWorker - fetchPRBranchRefs", () => {
 			on: vi.fn(),
 			removeAllListeners: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation(() => mockClaudeRunner);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return mockClaudeRunner;
+		});
 
 		// Mock AgentSessionManager
 		mockAgentSessionManager = {
@@ -74,9 +80,9 @@ describe("EdgeWorker - fetchPRBranchRefs", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(),
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock LinearEventTransport
 		const mockLinearEventTransport = {
@@ -84,18 +90,18 @@ describe("EdgeWorker - fetchPRBranchRefs", () => {
 			start: vi.fn().mockResolvedValue(undefined),
 			stop: vi.fn().mockResolvedValue(undefined),
 		};
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() => mockLinearEventTransport,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return mockLinearEventTransport;
+		});
 
 		// Mock SharedApplicationServer
 		const mockSharedAppServer = {
 			start: vi.fn().mockResolvedValue(undefined),
 			stop: vi.fn().mockResolvedValue(undefined),
 		};
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() => mockSharedAppServer,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return mockSharedAppServer;
+		});
 
 		// Create EdgeWorker config
 		mockConfig = {

--- a/packages/edge-worker/test/EdgeWorker.issue-update-multiple-sessions.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.issue-update-multiple-sessions.test.ts
@@ -22,10 +22,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 
@@ -130,18 +132,17 @@ describe("EdgeWorker - Issue Update Session Delivery (CYPACK-954)", () => {
 			return { server: {} } as any;
 		});
 
-		vi.mocked(ClaudeRunner).mockImplementation(
-			() =>
-				({
-					supportsStreamingInput: true,
-					startStreaming: vi
-						.fn()
-						.mockResolvedValue({ sessionId: "claude-session-123" }),
-					stop: vi.fn(),
-					isStreaming: vi.fn().mockReturnValue(false),
-					isRunning: vi.fn().mockReturnValue(false),
-				}) as any,
-		);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return {
+				supportsStreamingInput: true,
+				startStreaming: vi
+					.fn()
+					.mockResolvedValue({ sessionId: "claude-session-123" }),
+				stop: vi.fn(),
+				isStreaming: vi.fn().mockReturnValue(false),
+				isRunning: vi.fn().mockReturnValue(false),
+			};
+		} as any);
 
 		mockAgentSessionManager = {
 			hasAgentRunner: vi.fn().mockReturnValue(false),
@@ -157,43 +158,38 @@ describe("EdgeWorker - Issue Update Session Delivery (CYPACK-954)", () => {
 			on: vi.fn(),
 		};
 
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					users: {
-						me: vi.fn().mockResolvedValue({
-							id: "user-123",
-							name: "Test User",
-						}),
-					},
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({
+						id: "user-123",
+						name: "Test User",
+					}),
+				},
+			};
+		} as any);
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",

--- a/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.label-based-prompt-command.test.ts
@@ -35,10 +35,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		...actual,
 		isAgentSessionCreatedWebhook: vi.fn(),
 		isAgentSessionPromptedWebhook: vi.fn(),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -104,7 +106,9 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			comments: vi.fn().mockResolvedValue({ nodes: [] }),
 			rawRequest: vi.fn(), // Add rawRequest to avoid validation warnings
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner to capture prompt
 		mockClaudeRunner = {
@@ -113,7 +117,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 				capturedPrompt = prompt;
 				return Promise.resolve({ sessionId: "claude-session-123" });
 			}),
-			startStreaming: vi.fn().mockImplementation((prompt: string) => {
+			startStreaming: vi.fn().mockImplementation(function (prompt: string) {
 				capturedPrompt = prompt;
 				return Promise.resolve({ sessionId: "claude-session-123" });
 			}),
@@ -122,7 +126,7 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation((config: any) => {
+		vi.mocked(ClaudeRunner).mockImplementation(function (config: any) {
 			capturedClaudeRunnerConfig = config;
 			return mockClaudeRunner;
 		});
@@ -144,33 +148,29 @@ describe("EdgeWorker - Label-Based Prompt Command", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock type guards for mention-triggered sessions
 		vi.mocked(isAgentSessionCreatedWebhook).mockReturnValue(true);

--- a/packages/edge-worker/test/EdgeWorker.linear-client-wrapper.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.linear-client-wrapper.test.ts
@@ -6,12 +6,14 @@ import { EdgeWorker } from "../src/EdgeWorker.js";
 // Mock modules
 vi.mock("@linear/sdk");
 vi.mock("../src/SharedApplicationServer.js", () => ({
-	SharedApplicationServer: vi.fn().mockImplementation(() => ({
-		start: vi.fn(),
-		registerLinearEventTransport: vi.fn(),
-		registerConfigUpdater: vi.fn(),
-		registerOAuthCallback: vi.fn(),
-	})),
+	SharedApplicationServer: vi.fn().mockImplementation(function () {
+		return {
+			start: vi.fn(),
+			registerLinearEventTransport: vi.fn(),
+			registerConfigUpdater: vi.fn(),
+			registerOAuthCallback: vi.fn(),
+		};
+	}),
 }));
 
 // Mock fs/promises for file operations
@@ -99,7 +101,9 @@ describe("EdgeWorker LinearClient Wrapper", () => {
 		};
 
 		// Mock LinearClient constructor
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 	});
 
 	describe("Auto-retry on 401 errors", () => {

--- a/packages/edge-worker/test/EdgeWorker.missing-session-recovery.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.missing-session-recovery.test.ts
@@ -23,10 +23,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 
@@ -71,18 +73,17 @@ describe("EdgeWorker - Missing Session/Repository Recovery (CYPACK-852)", () => 
 		});
 
 		// Mock ClaudeRunner
-		vi.mocked(ClaudeRunner).mockImplementation(
-			() =>
-				({
-					supportsStreamingInput: true,
-					startStreaming: vi
-						.fn()
-						.mockResolvedValue({ sessionId: "claude-session-123" }),
-					stop: vi.fn(),
-					isStreaming: vi.fn().mockReturnValue(false),
-					isRunning: vi.fn().mockReturnValue(false),
-				}) as any,
-		);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return {
+				supportsStreamingInput: true,
+				startStreaming: vi
+					.fn()
+					.mockResolvedValue({ sessionId: "claude-session-123" }),
+				stop: vi.fn(),
+				isStreaming: vi.fn().mockReturnValue(false),
+				isRunning: vi.fn().mockReturnValue(false),
+			};
+		} as any);
 
 		// Mock AgentSessionManager with methods for recovery testing
 		mockAgentSessionManager = {
@@ -107,44 +108,39 @@ describe("EdgeWorker - Missing Session/Repository Recovery (CYPACK-852)", () => 
 			on: vi.fn(),
 		};
 
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					users: {
-						me: vi.fn().mockResolvedValue({
-							id: "user-123",
-							name: "Test User",
-						}),
-					},
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({
+						id: "user-123",
+						name: "Test User",
+					}),
+				},
+			};
+		} as any);
 
 		mockConfig = {
 			proxyUrl: "http://localhost:3000",

--- a/packages/edge-worker/test/EdgeWorker.multi-repo-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.multi-repo-tools.test.ts
@@ -187,58 +187,52 @@ describe("EdgeWorker - Multi-Repo Tool Authorization", () => {
 			},
 		};
 
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					setWebhookHandler: vi.fn(),
-					setOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				setWebhookHandler: vi.fn(),
+				setOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() =>
-				({
-					addSession: vi.fn(),
-					getSession: vi.fn(),
-					removeSession: vi.fn(),
-					getAllSessions: vi.fn().mockReturnValue([]),
-					clearAllSessions: vi.fn(),
-					on: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return {
+				addSession: vi.fn(),
+				getSession: vi.fn(),
+				removeSession: vi.fn(),
+				getAllSessions: vi.fn().mockReturnValue([]),
+				clearAllSessions: vi.fn(),
+				on: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					viewer: vi
-						.fn()
-						.mockResolvedValue({ id: "test-user", email: "test@example.com" }),
-					issue: vi.fn(),
-					comment: vi.fn(),
-					createComment: vi.fn(),
-					webhook: vi.fn(),
-					webhooks: vi.fn(),
-					createWebhook: vi.fn(),
-					updateWebhook: vi.fn(),
-					deleteWebhook: vi.fn(),
-					user: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				viewer: vi
+					.fn()
+					.mockResolvedValue({ id: "test-user", email: "test@example.com" }),
+				issue: vi.fn(),
+				comment: vi.fn(),
+				createComment: vi.fn(),
+				webhook: vi.fn(),
+				webhooks: vi.fn(),
+				createWebhook: vi.fn(),
+				updateWebhook: vi.fn(),
+				deleteWebhook: vi.fn(),
+				user: vi.fn(),
+			};
+		} as any);
 
 		edgeWorker = new EdgeWorker(mockConfig);
 	});

--- a/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.parent-branch.test.ts
@@ -35,10 +35,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		...actual,
 		isAgentSessionCreatedWebhook: vi.fn(),
 		isAgentSessionPromptedWebhook: vi.fn(),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -102,7 +104,9 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			comments: vi.fn().mockResolvedValue({ nodes: [] }),
 			rawRequest: vi.fn(), // Add rawRequest to avoid validation warnings
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner to capture config
 		mockClaudeRunner = {
@@ -116,7 +120,7 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation((config: any) => {
+		vi.mocked(ClaudeRunner).mockImplementation(function (config: any) {
 			capturedClaudeRunnerConfig = config;
 			return mockClaudeRunner;
 		});
@@ -138,33 +142,29 @@ describe("EdgeWorker - Parent Branch Handling", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock type guards
 		vi.mocked(isAgentSessionCreatedWebhook).mockReturnValue(false);

--- a/packages/edge-worker/test/EdgeWorker.pr-review-trigger.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.pr-review-trigger.test.ts
@@ -22,10 +22,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 
@@ -136,15 +138,14 @@ describe("EdgeWorker - PR review trigger gate (CYPACK-1273)", () => {
 			return { server: {} } as any;
 		});
 
-		vi.mocked(ClaudeRunner).mockImplementation(
-			() =>
-				({
-					supportsStreamingInput: true,
-					stop: vi.fn(),
-					isStreaming: vi.fn().mockReturnValue(false),
-					isRunning: vi.fn().mockReturnValue(false),
-				}) as any,
-		);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return {
+				supportsStreamingInput: true,
+				stop: vi.fn(),
+				isStreaming: vi.fn().mockReturnValue(false),
+				isRunning: vi.fn().mockReturnValue(false),
+			};
+		} as any);
 
 		mockAgentSessionManager = {
 			getActiveMultiRepoSessionForRepository: vi.fn().mockReturnValue(null),
@@ -156,47 +157,40 @@ describe("EdgeWorker - PR review trigger gate (CYPACK-1273)", () => {
 			on: vi.fn(),
 		};
 
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		mockGitHubCommentService = {
 			postIssueComment: vi.fn().mockResolvedValue(undefined),
 			addReaction: vi.fn().mockResolvedValue(undefined),
 		};
 
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
-		vi.mocked(LinearClient).mockImplementation(
-			() =>
-				({
-					users: {
-						me: vi
-							.fn()
-							.mockResolvedValue({ id: "user-123", name: "Test User" }),
-					},
-				}) as any,
-		);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({ id: "user-123", name: "Test User" }),
+				},
+			};
+		} as any);
 	});
 
 	afterEach(() => {

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -40,10 +40,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		...actual,
 		isAgentSessionCreatedWebhook: vi.fn(),
 		isAgentSessionPromptedWebhook: vi.fn(),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -114,7 +116,9 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			comments: vi.fn().mockResolvedValue({ nodes: [] }),
 			rawRequest: vi.fn(),
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner
 		mockClaudeRunner = {
@@ -128,7 +132,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation((config: any) => {
+		vi.mocked(ClaudeRunner).mockImplementation(function (config: any) {
 			capturedRunnerType = "claude";
 			capturedRunnerConfig = config;
 			return mockClaudeRunner;
@@ -146,7 +150,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(GeminiRunner).mockImplementation((config: any) => {
+		vi.mocked(GeminiRunner).mockImplementation(function (config: any) {
 			capturedRunnerType = "gemini";
 			capturedRunnerConfig = config;
 			return mockGeminiRunner;
@@ -164,7 +168,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(CodexRunner).mockImplementation((config: any) => {
+		vi.mocked(CodexRunner).mockImplementation(function (config: any) {
 			capturedRunnerType = "codex";
 			capturedRunnerConfig = config;
 			return mockCodexRunner;
@@ -182,7 +186,7 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(CursorRunner).mockImplementation((config: any) => {
+		vi.mocked(CursorRunner).mockImplementation(function (config: any) {
 			capturedRunnerType = "cursor";
 			capturedRunnerConfig = config;
 			return mockCursorRunner;
@@ -204,33 +208,29 @@ describe("EdgeWorker - Runner Selection Based on Labels", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock type guards
 		vi.mocked(isAgentSessionCreatedWebhook).mockReturnValue(true);

--- a/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.screenshot-upload-hooks.test.ts
@@ -37,10 +37,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		...actual,
 		isAgentSessionCreatedWebhook: vi.fn(),
 		isAgentSessionPromptedWebhook: vi.fn(),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -115,7 +117,9 @@ describe("EdgeWorker - Screenshot Upload Guidance Hooks", () => {
 			comments: vi.fn().mockResolvedValue({ nodes: [] }),
 			rawRequest: vi.fn(),
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner - capture config for hook inspection
 		mockClaudeRunner = {
@@ -129,7 +133,7 @@ describe("EdgeWorker - Screenshot Upload Guidance Hooks", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation((config: any) => {
+		vi.mocked(ClaudeRunner).mockImplementation(function (config: any) {
 			capturedRunnerConfig = config;
 			return mockClaudeRunner;
 		});
@@ -146,7 +150,7 @@ describe("EdgeWorker - Screenshot Upload Guidance Hooks", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(GeminiRunner).mockImplementation((_config: any) => {
+		vi.mocked(GeminiRunner).mockImplementation(function (_config: any) {
 			return mockGeminiRunner;
 		});
 
@@ -166,33 +170,29 @@ describe("EdgeWorker - Screenshot Upload Guidance Hooks", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(),
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock type guards
 		vi.mocked(isAgentSessionCreatedWebhook).mockReturnValue(true);

--- a/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.status-endpoint.test.ts
@@ -18,28 +18,32 @@ vi.mock("cyrus-gemini-runner");
 vi.mock("cyrus-linear-event-transport");
 vi.mock("@linear/sdk");
 vi.mock("../src/SharedApplicationServer.js", () => ({
-	SharedApplicationServer: vi.fn().mockImplementation(() => ({
-		initializeFastify: vi.fn(),
-		getFastifyInstance: vi.fn().mockReturnValue({
-			get: vi.fn(),
-			post: vi.fn(),
-		}),
-		start: vi.fn().mockResolvedValue(undefined),
-		stop: vi.fn().mockResolvedValue(undefined),
-		getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
-	})),
+	SharedApplicationServer: vi.fn().mockImplementation(function () {
+		return {
+			initializeFastify: vi.fn(),
+			getFastifyInstance: vi.fn().mockReturnValue({
+				get: vi.fn(),
+				post: vi.fn(),
+			}),
+			start: vi.fn().mockResolvedValue(undefined),
+			stop: vi.fn().mockResolvedValue(undefined),
+			getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+		};
+	}),
 }));
 vi.mock("../src/AgentSessionManager.js", () => ({
-	AgentSessionManager: vi.fn().mockImplementation(() => ({
-		getAllAgentRunners: vi.fn().mockReturnValue([]),
-		getAllSessions: vi.fn().mockReturnValue([]),
-		createCyrusAgentSession: vi.fn(),
-		getSession: vi.fn(),
-		getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
-		setActivitySink: vi.fn(),
-		on: vi.fn(), // EventEmitter method
-		emit: vi.fn(), // EventEmitter method
-	})),
+	AgentSessionManager: vi.fn().mockImplementation(function () {
+		return {
+			getAllAgentRunners: vi.fn().mockReturnValue([]),
+			getAllSessions: vi.fn().mockReturnValue([]),
+			createCyrusAgentSession: vi.fn(),
+			getSession: vi.fn(),
+			getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
+			setActivitySink: vi.fn(),
+			on: vi.fn(), // EventEmitter method
+			emit: vi.fn(), // EventEmitter method
+		};
+	}),
 }));
 vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
@@ -51,10 +55,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		isIssueCommentMentionWebhook: vi.fn().mockReturnValue(false),
 		isIssueNewCommentWebhook: vi.fn().mockReturnValue(false),
 		isIssueUnassignedWebhook: vi.fn().mockReturnValue(false),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -273,18 +279,17 @@ describe("EdgeWorker - Status Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			edgeWorker = new EdgeWorker(mockConfig);
 
@@ -310,18 +315,17 @@ describe("EdgeWorker - Status Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			edgeWorker = new EdgeWorker(mockConfig);
 			(edgeWorker as any).registerStatusEndpoint();
@@ -355,18 +359,17 @@ describe("EdgeWorker - Status Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			edgeWorker = new EdgeWorker(mockConfig);
 			(edgeWorker as any).registerStatusEndpoint();

--- a/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.system-prompt-resume.test.ts
@@ -38,10 +38,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		...actual,
 		isAgentSessionCreatedWebhook: vi.fn(),
 		isAgentSessionPromptedWebhook: vi.fn(),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -104,7 +106,9 @@ describe("EdgeWorker - System Prompt Resume", () => {
 			comments: vi.fn().mockResolvedValue({ nodes: [] }),
 			rawRequest: vi.fn(), // Add rawRequest to avoid validation warnings
 		};
-		vi.mocked(LinearClient).mockImplementation(() => mockLinearClient);
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return mockLinearClient;
+		});
 
 		// Mock ClaudeRunner to capture config
 		mockClaudeRunner = {
@@ -118,7 +122,7 @@ describe("EdgeWorker - System Prompt Resume", () => {
 			addStreamMessage: vi.fn(),
 			updatePromptVersions: vi.fn(),
 		};
-		vi.mocked(ClaudeRunner).mockImplementation((config: any) => {
+		vi.mocked(ClaudeRunner).mockImplementation(function (config: any) {
 			capturedClaudeRunnerConfig = config;
 			return mockClaudeRunner;
 		});
@@ -154,33 +158,29 @@ describe("EdgeWorker - System Prompt Resume", () => {
 			setActivitySink: vi.fn(),
 			on: vi.fn(), // EventEmitter method
 		};
-		vi.mocked(AgentSessionManager).mockImplementation(
-			() => mockAgentSessionManager,
-		);
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		});
 
 		// Mock SharedApplicationServer
-		vi.mocked(SharedApplicationServer).mockImplementation(
-			() =>
-				({
-					start: vi.fn().mockResolvedValue(undefined),
-					stop: vi.fn().mockResolvedValue(undefined),
-					getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
-					getWebhookUrl: vi
-						.fn()
-						.mockReturnValue("http://localhost:3456/webhook"),
-					registerOAuthCallbackHandler: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
 
 		// Mock LinearEventTransport
-		vi.mocked(LinearEventTransport).mockImplementation(
-			() =>
-				({
-					register: vi.fn(),
-					on: vi.fn(),
-					removeAllListeners: vi.fn(),
-				}) as any,
-		);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
 
 		// Mock type guards
 		vi.mocked(isAgentSessionCreatedWebhook).mockReturnValue(false);

--- a/packages/edge-worker/test/EdgeWorker.version-endpoint.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.version-endpoint.test.ts
@@ -18,28 +18,32 @@ vi.mock("cyrus-gemini-runner");
 vi.mock("cyrus-linear-event-transport");
 vi.mock("@linear/sdk");
 vi.mock("../src/SharedApplicationServer.js", () => ({
-	SharedApplicationServer: vi.fn().mockImplementation(() => ({
-		initializeFastify: vi.fn(),
-		getFastifyInstance: vi.fn().mockReturnValue({
-			get: vi.fn(),
-			post: vi.fn(),
-		}),
-		start: vi.fn().mockResolvedValue(undefined),
-		stop: vi.fn().mockResolvedValue(undefined),
-		getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
-	})),
+	SharedApplicationServer: vi.fn().mockImplementation(function () {
+		return {
+			initializeFastify: vi.fn(),
+			getFastifyInstance: vi.fn().mockReturnValue({
+				get: vi.fn(),
+				post: vi.fn(),
+			}),
+			start: vi.fn().mockResolvedValue(undefined),
+			stop: vi.fn().mockResolvedValue(undefined),
+			getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+		};
+	}),
 }));
 vi.mock("../src/AgentSessionManager.js", () => ({
-	AgentSessionManager: vi.fn().mockImplementation(() => ({
-		getAllAgentRunners: vi.fn().mockReturnValue([]),
-		getAllSessions: vi.fn().mockReturnValue([]),
-		createCyrusAgentSession: vi.fn(),
-		getSession: vi.fn(),
-		getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
-		setActivitySink: vi.fn(),
-		on: vi.fn(), // EventEmitter method
-		emit: vi.fn(), // EventEmitter method
-	})),
+	AgentSessionManager: vi.fn().mockImplementation(function () {
+		return {
+			getAllAgentRunners: vi.fn().mockReturnValue([]),
+			getAllSessions: vi.fn().mockReturnValue([]),
+			createCyrusAgentSession: vi.fn(),
+			getSession: vi.fn(),
+			getActiveSessionsByIssueId: vi.fn().mockReturnValue([]),
+			setActivitySink: vi.fn(),
+			on: vi.fn(), // EventEmitter method
+			emit: vi.fn(), // EventEmitter method
+		};
+	}),
 }));
 vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = (await importOriginal()) as any;
@@ -51,10 +55,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 		isIssueCommentMentionWebhook: vi.fn().mockReturnValue(false),
 		isIssueNewCommentWebhook: vi.fn().mockReturnValue(false),
 		isIssueUnassignedWebhook: vi.fn().mockReturnValue(false),
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");
@@ -119,18 +125,17 @@ describe("EdgeWorker - Version Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			edgeWorker = new EdgeWorker(mockConfig);
 
@@ -156,18 +161,17 @@ describe("EdgeWorker - Version Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			// Config without version
 			edgeWorker = new EdgeWorker(mockConfig);
@@ -204,18 +208,17 @@ describe("EdgeWorker - Version Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			// Config with version
 			const configWithVersion: EdgeWorkerConfig = {
@@ -256,18 +259,17 @@ describe("EdgeWorker - Version Endpoint", () => {
 			const { SharedApplicationServer } = await import(
 				"../src/SharedApplicationServer.js"
 			);
-			vi.mocked(SharedApplicationServer).mockImplementation(
-				() =>
-					({
-						initializeFastify: vi.fn(),
-						getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
-						start: vi.fn().mockResolvedValue(undefined),
-						stop: vi.fn().mockResolvedValue(undefined),
-						getWebhookUrl: vi
-							.fn()
-							.mockReturnValue("http://localhost:3456/webhook"),
-					}) as any,
-			);
+			vi.mocked(SharedApplicationServer).mockImplementation(function () {
+				return {
+					initializeFastify: vi.fn(),
+					getFastifyInstance: vi.fn().mockReturnValue(mockFastify),
+					start: vi.fn().mockResolvedValue(undefined),
+					stop: vi.fn().mockResolvedValue(undefined),
+					getWebhookUrl: vi
+						.fn()
+						.mockReturnValue("http://localhost:3456/webhook"),
+				};
+			} as any);
 
 			// Config with empty string version - should still return empty string (not null)
 			// as the nullish coalescing operator only converts undefined/null to null

--- a/packages/edge-worker/test/EdgeWorker.versioning.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.versioning.test.ts
@@ -19,16 +19,18 @@ vi.mock("@linear/sdk", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@linear/sdk")>();
 	return {
 		...actual,
-		LinearClient: vi.fn().mockImplementation(() => ({
-			issue: vi.fn(),
-			viewer: Promise.resolve({
-				organization: Promise.resolve({ id: "ws-123", name: "Test" }),
-			}),
-			client: {
-				request: vi.fn(),
-				setHeader: vi.fn(),
-			},
-		})),
+		LinearClient: vi.fn().mockImplementation(function () {
+			return {
+				issue: vi.fn(),
+				viewer: Promise.resolve({
+					organization: Promise.resolve({ id: "ws-123", name: "Test" }),
+				}),
+				client: {
+					request: vi.fn(),
+					setHeader: vi.fn(),
+				},
+			};
+		}),
 	};
 });
 vi.mock("../src/SharedApplicationServer.js");
@@ -37,10 +39,12 @@ vi.mock("cyrus-core", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("cyrus-core")>();
 	return {
 		...actual,
-		PersistenceManager: vi.fn().mockImplementation(() => ({
-			loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
-			saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
-		})),
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
 	};
 });
 vi.mock("file-type");

--- a/packages/edge-worker/test/GitService.test.ts
+++ b/packages/edge-worker/test/GitService.test.ts
@@ -24,9 +24,11 @@ vi.mock("node:fs", () => ({
 }));
 
 vi.mock("../src/WorktreeIncludeService.js", () => ({
-	WorktreeIncludeService: vi.fn().mockImplementation(() => ({
-		copyIgnoredFiles: vi.fn().mockResolvedValue(undefined),
-	})),
+	WorktreeIncludeService: vi.fn().mockImplementation(function () {
+		return {
+			copyIgnoredFiles: vi.fn().mockResolvedValue(undefined),
+		};
+	}),
 }));
 
 const mockExecSync = vi.mocked(execSync);

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -29,7 +29,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/gemini-runner/test/SimpleGeminiRunner.test.ts
+++ b/packages/gemini-runner/test/SimpleGeminiRunner.test.ts
@@ -65,7 +65,11 @@ describe("SimpleGeminiRunner", () => {
 			_messages: [], // Internal state for test control
 		};
 
-		MockedGeminiRunner.mockImplementation(() => mockRunner);
+		// Regular function (not arrow) so vitest 4 can invoke the mock with `new`;
+		// returning an object from a constructor makes `new GeminiRunner()` yield it.
+		MockedGeminiRunner.mockImplementation(function () {
+			return mockRunner;
+		} as unknown as () => GeminiRunner);
 
 		runner = new SimpleGeminiRunner(defaultConfig);
 	});

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.2.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -26,7 +26,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",
-		"vitest": "^3.1.4"
+		"vitest": "^4.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^20.0.0
         version: 20.19.39
       '@vitest/ui':
-        specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: ^4.1.0
+        version: 4.1.8(vitest@4.1.8)
       nodemon:
         specifier: ^2.0.22
         version: 2.0.22
@@ -124,8 +124,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/f1:
     dependencies:
@@ -152,8 +152,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/claude-runner:
     dependencies:
@@ -192,8 +192,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cloudflare-tunnel-client:
     dependencies:
@@ -208,8 +208,8 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/codex-runner:
     dependencies:
@@ -230,8 +230,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/config-updater:
     dependencies:
@@ -255,8 +255,8 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -283,8 +283,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cursor-runner:
     dependencies:
@@ -305,8 +305,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/edge-worker:
     dependencies:
@@ -387,8 +387,8 @@ importers:
         specifier: ^1.3.14
         version: 1.3.14
       '@vitest/coverage-v8':
-        specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: ^4.1.0
+        version: 4.1.8(vitest@4.1.8)
       axios:
         specifier: ^1.16.0
         version: 1.16.0
@@ -396,11 +396,11 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.1(typescript@5.9.3)(vitest@3.2.4)
+        version: 3.1.1(typescript@5.9.3)(vitest@4.1.8)
 
   packages/gemini-runner:
     dependencies:
@@ -439,8 +439,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/github-event-transport:
     dependencies:
@@ -458,8 +458,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/gitlab-event-transport:
     dependencies:
@@ -477,8 +477,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/linear-event-transport:
     dependencies:
@@ -499,8 +499,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mcp-tools:
     dependencies:
@@ -530,8 +530,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/simple-agent-runner:
     dependencies:
@@ -552,8 +552,8 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/slack-event-transport:
     dependencies:
@@ -571,14 +571,10 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vitest:
-        specifier: ^3.1.4
-        version: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.159':
     resolution: {integrity: sha512-3nnH4yUNJVSyaU5DBlGw2yxc4zlnVvAnc9UOe+La47QVG7/dN+rWAgn4zCbqKk9bWFLDQ1Ek0r56EZE1Qo4UKQ==}
@@ -649,12 +645,20 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -664,6 +668,10 @@ packages:
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1050,10 +1058,6 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -1062,15 +1066,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@istanbuljs/schema@0.1.6':
-    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
-    engines: {node: '>=8'}
-
   '@joshua.litt/get-ripgrep@0.0.3':
     resolution: {integrity: sha512-rycdieAKKqXi2bsM7G2ayDiNk5CAX8ZOzsTQsirfOqUKPef04Xw40BWGGyimaOOuvPgLWYt3tPnLLG3TvPXi5Q==}
-
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1752,10 +1749,6 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -1915,6 +1908,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@statsig/client-core@3.31.0':
     resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
 
@@ -2004,20 +2000,20 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=7.1.11'
@@ -2027,25 +2023,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+  '@vitest/ui@4.1.8':
+    resolution: {integrity: sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==}
     peerDependencies:
-      vitest: 3.2.4
+      vitest: 4.1.8
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@xterm/headless@5.5.0':
     resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
@@ -2141,8 +2137,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2210,10 +2206,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
@@ -2234,16 +2226,12 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2323,6 +2311,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -2367,10 +2358,6 @@ packages:
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2447,9 +2434,6 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2461,9 +2445,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2498,8 +2479,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -2759,11 +2740,6 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@12.0.0:
     resolution: {integrity: sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==}
@@ -3040,16 +3016,9 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -3063,9 +3032,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
@@ -3194,9 +3160,6 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3215,8 +3178,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3438,6 +3401,9 @@ packages:
   obliterator@2.0.5:
     resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -3514,10 +3480,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -3527,10 +3489,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -3926,8 +3884,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
@@ -3942,10 +3900,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3973,9 +3927,6 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -4011,19 +3962,12 @@ packages:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
-
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
@@ -4033,16 +3977,8 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -4171,11 +4107,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4225,26 +4156,39 @@ packages:
       typescript: 3.x || 4.x || 5.x || 6.x
       vitest: '>=3.0.0'
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=7.1.11'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4283,10 +4227,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -4360,11 +4300,6 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.159':
     optional: true
 
@@ -4419,11 +4354,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.29.2':
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/runtime@7.29.2': {}
 
@@ -4431,6 +4370,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -4834,22 +4778,11 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
-
-  '@istanbuljs/schema@0.1.6': {}
 
   '@joshua.litt/get-ripgrep@0.0.3':
     dependencies:
@@ -4862,11 +4795,6 @@ snapshots:
       xdg-basedir: 5.1.0
     transitivePeerDependencies:
       - supports-color
-
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -5690,9 +5618,6 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
-
   '@polka/url@1.0.0-next.29': {}
 
   '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.1)':
@@ -5836,6 +5761,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@statsig/client-core@3.31.0': {}
 
   '@statsig/js-client@3.31.0':
@@ -5939,77 +5866,71 @@ snapshots:
       '@types/node': 20.19.39
     optional: true
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.8':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.8(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
+  '@vitest/ui@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.8
       fflate: 0.8.2
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.16
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xterm/headless@5.5.0': {}
 
@@ -6095,7 +6016,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.3:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -6175,8 +6096,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cac@6.7.14: {}
-
   cacache@15.3.0:
     dependencies:
       '@npmcli/fs': 1.1.1
@@ -6223,17 +6142,9 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chardet@2.1.1: {}
-
-  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -6306,6 +6217,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -6340,8 +6253,6 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-
-  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -6408,8 +6319,6 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6419,8 +6328,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -6447,7 +6354,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -6814,15 +6721,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@12.0.0:
     dependencies:
       foreground-child: 3.3.1
@@ -7140,24 +7038,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -7168,8 +7052,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -7296,8 +7178,6 @@ snapshots:
 
   long@5.3.2: {}
 
-  loupe@3.2.1: {}
-
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
@@ -7313,9 +7193,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -7539,6 +7419,8 @@ snapshots:
 
   obliterator@2.0.5: {}
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -7600,11 +7482,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.5
@@ -7613,8 +7490,6 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   peberminta@0.9.0: {}
 
@@ -8082,7 +7957,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -8097,12 +7972,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -8130,10 +7999,6 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   strtok3@10.3.5:
     dependencies:
@@ -8185,19 +8050,11 @@ snapshots:
       - encoding
       - supports-color
 
-  test-exclude@7.0.2:
-    dependencies:
-      '@istanbuljs/schema': 0.1.6
-      glob: 10.5.0
-      minimatch: 10.2.5
-
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
 
   tinybench@2.9.0: {}
-
-  tinyexec@0.3.2: {}
 
   tinyexec@1.1.2: {}
 
@@ -8206,11 +8063,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8308,28 +8161,6 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -8344,54 +8175,41 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest-mock-extended@3.1.1(typescript@5.9.3)(vitest@3.2.4):
+  vitest-mock-extended@3.1.1(typescript@5.9.3)(vitest@4.1.8):
     dependencies:
       ts-essentials: 10.2.0(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
-  vitest@3.2.4(@types/node@20.19.39)(@vitest/ui@3.2.4)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.39
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/ui': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   web-tree-sitter@0.25.10: {}
 
@@ -8421,12 +8239,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves the **critical** Vitest advisory [GHSA-5xrq-8626-4rwp](https://github.com/advisories/GHSA-5xrq-8626-4rwp) — *"When Vitest UI server is listening, arbitrary file can be read and executed"* (vulnerable `<4.1.0`, patched `>=4.1.0`).

Bumps `vitest` (plus `@vitest/ui` and `@vitest/coverage-v8`) from `3.x` → `^4.1.0` across every package/app that declares it, and fixes our tests to work with the major version bump.

This **supersedes Dependabot PR #1279**, which only bumped the dependency without the test migration the major version requires.

## Why the test changes were needed

Vitest 4 now constructs `vi.fn()` mocks with `new` (instead of `mock.apply`). Arrow functions can't be constructors, so any mock whose implementation was an arrow returning a class instance threw `"... is not a constructor"` ([migration notes](https://vitest.dev/guide/migration)). Converted those constructor-mock arrows to regular `function` expressions in:

- `packages/edge-worker/test/*` (64 mock conversions across 18 files)
- `packages/gemini-runner/test/SimpleGeminiRunner.test.ts`
- `apps/cli/src/commands/SelfAuthCommand.test.ts`

Also disabled biome's `useArrowFunction` rule for **test files only** (`biome.json` override) — otherwise biome's autofix reverts these constructor mocks back to arrows and re-breaks them.

**No production code changed** — this is a dev-dependency + test-only change.

## Verification

- `pnpm audit` → **0 advisories** (was 1 critical)
- `pnpm -r test:run` → all package + app suites green
- `pnpm typecheck`, `pnpm build`, `pnpm biome ci` → green

Closes CYPACK-1278.

<!-- generated-by-cyrus -->