### PR TITLE
feat(edge-worker): resume prior runner session on issue re-delegation (opt-in)

### DIFF
--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -444,6 +444,28 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	/**
 	 * Internal method to start a Claude session with either string or streaming prompt
 	 */
+	/**
+	 * Heuristic: did this error come from the SDK being unable to resume the
+	 * requested session — e.g. the prior transcript no longer exists on disk?
+	 * Used to fall back to a cold start exactly once instead of hard-failing.
+	 * If the real message doesn't match, the fallback simply doesn't trigger
+	 * and the error propagates as before (no behavior change).
+	 */
+	private isResumeFailure(error: unknown): boolean {
+		const msg = (
+			error instanceof Error ? error.message : String(error)
+		).toLowerCase();
+		return (
+			msg.includes("no conversation found") ||
+			msg.includes("session not found") ||
+			msg.includes("no such session") ||
+			msg.includes("could not resume") ||
+			msg.includes("could not find session") ||
+			(msg.includes("resume") && msg.includes("not found")) ||
+			(msg.includes("session") && msg.includes("does not exist"))
+		);
+	}
+
 	private async startWithPrompt(
 		stringPrompt?: string | null,
 		streamingInitialPrompt?: string,
@@ -755,68 +777,100 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 			// Use pre-warmed session if available (eliminates cold-start subprocess spawn cost).
 			// warmSession.query() accepts both string and AsyncIterable<SDKUserMessage>,
 			// so promptForQuery works correctly for both start() and startStreaming().
-			if (this.config.warmSession) {
-				this.logger.debug("Using pre-warmed session for first turn");
-				this.activeQuery = this.config.warmSession.query(promptForQuery);
-			} else {
-				this.activeQuery = query(queryOptions);
-			}
-			for await (const message of this.activeQuery) {
-				if (!this.sessionInfo?.isRunning) {
-					this.logger.info("Session was stopped, breaking from query loop");
-					break;
-				}
-
-				// Extract session ID from first message if we don't have one yet
-				if (!this.sessionInfo.sessionId && message.session_id) {
-					this.sessionInfo.sessionId = message.session_id;
-					this.logger.event("claude_session_id_assigned", {
-						claudeSessionId: message.session_id,
-					});
-
-					// Update streaming prompt with session ID if it exists
-					if (this.streamingPrompt) {
-						this.streamingPrompt.updateSessionId(message.session_id);
+			// Cross-session/transcript resume can fail when the SDK cannot locate
+			// the prior transcript (e.g. it was cleaned up). If that happens
+			// before any message is produced, fall back once to a cold start so
+			// the run still proceeds instead of hard-failing.
+			let resumeFallbackUsed = false;
+			for (;;) {
+				try {
+					if (this.config.warmSession) {
+						this.logger.debug("Using pre-warmed session for first turn");
+						this.activeQuery = this.config.warmSession.query(promptForQuery);
+					} else {
+						this.activeQuery = query(queryOptions);
 					}
+					for await (const message of this.activeQuery) {
+						if (!this.sessionInfo?.isRunning) {
+							this.logger.info("Session was stopped, breaking from query loop");
+							break;
+						}
 
-					// Re-setup logging now that we have the session ID
-					this.setupLogging();
-				}
+						// Extract session ID from first message if we don't have one yet
+						if (!this.sessionInfo.sessionId && message.session_id) {
+							this.sessionInfo.sessionId = message.session_id;
+							this.logger.event("claude_session_id_assigned", {
+								claudeSessionId: message.session_id,
+							});
 
-				this.messages.push(message);
+							// Update streaming prompt with session ID if it exists
+							if (this.streamingPrompt) {
+								this.streamingPrompt.updateSessionId(message.session_id);
+							}
 
-				// Log to detailed JSON log
-				if (this.logStream) {
-					const logEntry = {
-						type: "sdk-message",
-						message,
-						timestamp: new Date().toISOString(),
-					};
-					this.logStream.write(`${JSON.stringify(logEntry)}\n`);
-				}
+							// Re-setup logging now that we have the session ID
+							this.setupLogging();
+						}
 
-				// Log to human-readable log
-				if (this.readableLogStream) {
-					this.writeReadableLogEntry(message);
-				}
+						this.messages.push(message);
 
-				// Emit all messages (including result) immediately in-loop.
-				// When keepSessionWarm is true, the streamingPrompt stays open for
-				// follow-up messages so the SDK session can be reused. Otherwise we
-				// complete the streaming prompt on result so the for-await loop exits
-				// and the subprocess can shut down (pre-warm-sessions behavior).
-				this.logger.event("message_emitted", {
-					messageType: message.type,
-					claudeSessionId: this.sessionInfo?.sessionId,
-				});
-				this.emit("message", message);
-				this.processMessage(message);
-				if (
-					message.type === "result" &&
-					!this.keepSessionWarm &&
-					this.streamingPrompt
-				) {
-					this.streamingPrompt.complete();
+						// Log to detailed JSON log
+						if (this.logStream) {
+							const logEntry = {
+								type: "sdk-message",
+								message,
+								timestamp: new Date().toISOString(),
+							};
+							this.logStream.write(`${JSON.stringify(logEntry)}\n`);
+						}
+
+						// Log to human-readable log
+						if (this.readableLogStream) {
+							this.writeReadableLogEntry(message);
+						}
+
+						// Emit all messages (including result) immediately in-loop.
+						// When keepSessionWarm is true, the streamingPrompt stays open for
+						// follow-up messages so the SDK session can be reused. Otherwise we
+						// complete the streaming prompt on result so the for-await loop exits
+						// and the subprocess can shut down (pre-warm-sessions behavior).
+						this.logger.event("message_emitted", {
+							messageType: message.type,
+							claudeSessionId: this.sessionInfo?.sessionId,
+						});
+						this.emit("message", message);
+						this.processMessage(message);
+						if (
+							message.type === "result" &&
+							!this.keepSessionWarm &&
+							this.streamingPrompt
+						) {
+							this.streamingPrompt.complete();
+						}
+					}
+					break;
+				} catch (queryError) {
+					const opts = queryOptions.options as { resume?: string } | undefined;
+					if (
+						!resumeFallbackUsed &&
+						!this.config.warmSession &&
+						opts?.resume &&
+						this.sessionInfo?.sessionId == null &&
+						this.messages.length === 0 &&
+						this.isResumeFailure(queryError)
+					) {
+						resumeFallbackUsed = true;
+						this.logger.event("session_resume_failed_fallback", {
+							resumeSessionId: opts.resume,
+							error:
+								queryError instanceof Error
+									? queryError.message
+									: String(queryError),
+						});
+						opts.resume = undefined;
+						continue;
+					}
+					throw queryError;
 				}
 			}
 

--- a/packages/claude-runner/test/ClaudeRunner.resume-fallback.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.resume-fallback.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: vi.fn(),
+}));
+
+// Mock file system operations (mirrors ClaudeRunner.test.ts)
+vi.mock("fs", () => ({
+	mkdirSync: vi.fn(),
+	existsSync: vi.fn(() => false),
+	readFileSync: vi.fn(() => ""),
+	createWriteStream: vi.fn(() => ({
+		write: vi.fn(),
+		end: vi.fn(),
+		on: vi.fn(),
+	})),
+}));
+
+vi.mock("os", () => ({
+	homedir: vi.fn(() => "/mock/home"),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeRunner } from "../src/ClaudeRunner";
+import type { ClaudeRunnerConfig } from "../src/types";
+
+describe("ClaudeRunner - cross-session resume fallback", () => {
+	let mockQuery: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockQuery = vi.mocked(query);
+	});
+
+	it("isResumeFailure() recognizes transcript-not-found errors", () => {
+		const runner = new ClaudeRunner({
+			workingDirectory: "/tmp/test",
+			cyrusHome: "/tmp/test-cyrus-home",
+		} as ClaudeRunnerConfig) as any;
+
+		expect(
+			runner.isResumeFailure(
+				new Error("No conversation found with session ID"),
+			),
+		).toBe(true);
+		expect(runner.isResumeFailure(new Error("could not resume session"))).toBe(
+			true,
+		);
+		expect(runner.isResumeFailure(new Error("rate limit exceeded"))).toBe(
+			false,
+		);
+	});
+
+	it("retries once without resume when resume fails before any message", async () => {
+		const runner = new ClaudeRunner({
+			workingDirectory: "/tmp/test",
+			cyrusHome: "/tmp/test-cyrus-home",
+			resumeSessionId: "stale-session-id",
+		} as ClaudeRunnerConfig);
+
+		// queryOptions is mutated in place across retries, so capture the resume
+		// value at the moment of each call rather than reading mock.calls later.
+		const seenResume: Array<string | undefined> = [];
+
+		// First attempt (with resume) throws a transcript-not-found error before
+		// yielding anything; second attempt (cold) succeeds.
+		mockQuery
+			.mockImplementationOnce((qo: any) => {
+				// An async-iterable whose first next() rejects — models the SDK
+				// failing to locate the prior transcript when resuming.
+				seenResume.push(qo.options.resume);
+				return {
+					[Symbol.asyncIterator]() {
+						return {
+							next: () =>
+								Promise.reject(
+									new Error(
+										"No conversation found with session ID stale-session-id",
+									),
+								),
+						};
+					},
+				};
+			})
+			.mockImplementationOnce(async function* (qo: any) {
+				seenResume.push(qo.options.resume);
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "Hi" }] },
+					parent_tool_use_id: null,
+					session_id: "fresh-session-id",
+				} as any;
+			});
+
+		const info = await runner.start("hello");
+
+		expect(mockQuery).toHaveBeenCalledTimes(2);
+		// First call carried the resume id; the retry dropped it (cold start).
+		expect(seenResume).toEqual(["stale-session-id", undefined]);
+		// The cold run produced the live session.
+		expect(info.sessionId).toBe("fresh-session-id");
+	});
+
+	it("does not retry when resume is not set", async () => {
+		const runner = new ClaudeRunner({
+			workingDirectory: "/tmp/test",
+			cyrusHome: "/tmp/test-cyrus-home",
+		} as ClaudeRunnerConfig);
+
+		const errorEvents: Error[] = [];
+		runner.on("error", (e) => errorEvents.push(e));
+
+		mockQuery.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]() {
+				return {
+					next: () =>
+						Promise.reject(new Error("No conversation found with session ID")),
+				};
+			},
+		}));
+
+		await runner.start("hello");
+
+		expect(mockQuery).toHaveBeenCalledTimes(1);
+		expect(errorEvents).toHaveLength(1);
+	});
+});

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -504,6 +504,9 @@
 					"linearRefreshToken": {
 						"type": "string"
 					},
+					"linearTokenExpiresAt": {
+						"type": "number"
+					},
 					"linearWorkspaceSlug": {
 						"type": "string"
 					},

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -475,6 +475,9 @@
 							}
 						},
 						"additionalProperties": false
+					},
+					"resumeAcrossSessions": {
+						"type": "boolean"
 					}
 				},
 				"required": [

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -498,6 +498,9 @@
 					"linearRefreshToken": {
 						"type": "string"
 					},
+					"linearTokenExpiresAt": {
+						"type": "number"
+					},
 					"linearWorkspaceSlug": {
 						"type": "string"
 					},

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -475,6 +475,9 @@
 							}
 						},
 						"additionalProperties": false
+					},
+					"resumeAcrossSessions": {
+						"type": "boolean"
 					}
 				},
 				"required": ["id", "name", "repositoryPath", "baseBranch"],

--- a/packages/core/schemas/RepositoryConfig.json
+++ b/packages/core/schemas/RepositoryConfig.json
@@ -470,6 +470,9 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"resumeAcrossSessions": {
+			"type": "boolean"
 		}
 	},
 	"required": [

--- a/packages/core/schemas/RepositoryConfigPayload.json
+++ b/packages/core/schemas/RepositoryConfigPayload.json
@@ -470,6 +470,9 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"resumeAcrossSessions": {
+			"type": "boolean"
 		}
 	},
 	"required": ["id", "name", "repositoryPath", "baseBranch"],

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -64,6 +64,27 @@ export interface SerializableEdgeWorkerState {
 	// Issue to repository mapping (for caching user repository selections)
 	// v4.1: string[] (multi-repo). Migration: old Record<string, string> auto-converts.
 	issueRepositoryCache?: Record<string, string[]>;
+	// Last runner session id captured per issue. Survives session pruning
+	// (sessions are removed when an issue goes terminal/unassigned) so a later
+	// re-delegation on the same issue can resume the prior runner conversation
+	// instead of cold-starting. Additive/optional — no version bump required.
+	issueLastSession?: Record<string, IssueLastSession>;
+}
+
+/**
+ * Durable record of the most recent runner session for an issue, kept
+ * independently of the (prunable) live session map. Only one of the runner id
+ * fields is set, matching the runner that produced it.
+ */
+export interface IssueLastSession {
+	claudeSessionId?: string;
+	geminiSessionId?: string;
+	codexSessionId?: string;
+	cursorSessionId?: string;
+	/** Worktree path the runner used, for diagnostics / transcript locating. */
+	workspacePath?: string;
+	/** Epoch ms of the last capture. */
+	updatedAt: number;
 }
 
 /**

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -260,6 +260,8 @@ const PromptDefaultsSchema = z.object({
 export const LinearWorkspaceConfigSchema = z.object({
 	linearToken: z.string(),
 	linearRefreshToken: z.string().optional(),
+	/** Epoch ms when linearToken expires (~24h after issue). Written on every refresh; drives proactive renewal (CRATE-153). */
+	linearTokenExpiresAt: z.number().optional(),
 	/** Linear workspace URL slug (e.g., "ceedar" from "https://linear.app/ceedar/...") */
 	linearWorkspaceSlug: z.string().optional(),
 	/** Human-readable workspace name (e.g., "Ceedar") */

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -311,6 +311,14 @@ export const RepositoryConfigSchema = z.object({
 
 	// Repository-specific user access control
 	userAccessControl: UserAccessControlConfigSchema.optional(),
+
+	/**
+	 * When true, a newly-created agent session on an issue this repo has worked
+	 * before resumes the most recent prior runner conversation instead of
+	 * cold-starting (re-reading all issue context). Also enableable globally via
+	 * the CYRUS_RESUME_ACROSS_SESSIONS env var. Default false.
+	 */
+	resumeAcrossSessions: z.boolean().optional(),
 });
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -238,6 +238,7 @@ export {
 // Linear adapters have been moved to cyrus-linear-event-transport package
 // Import them directly from that package instead of from cyrus-core
 export type {
+	IssueLastSession,
 	SerializableEdgeWorkerState,
 	SerializedCyrusAgentSession,
 	SerializedCyrusAgentSessionEntry,

--- a/packages/core/test/linear-workspace-config.test.ts
+++ b/packages/core/test/linear-workspace-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { LinearWorkspaceConfigSchema } from "../src/config-schemas.js";
+
+describe("LinearWorkspaceConfigSchema", () => {
+	it("preserves linearTokenExpiresAt so proactive refresh can persist expiry (CRATE-153)", () => {
+		const parsed = LinearWorkspaceConfigSchema.parse({
+			linearToken: "lin_oauth_abc",
+			linearRefreshToken: "lin_refresh_def",
+			linearWorkspaceName: "AGC-prod",
+			linearTokenExpiresAt: 1780000000000,
+		});
+		expect(parsed.linearTokenExpiresAt).toBe(1780000000000);
+	});
+
+	it("keeps linearTokenExpiresAt optional for configs written before the field existed", () => {
+		const parsed = LinearWorkspaceConfigSchema.parse({
+			linearToken: "lin_oauth_abc",
+		});
+		expect(parsed.linearTokenExpiresAt).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -18,6 +18,7 @@ import {
 	createLogger,
 	type IAgentRunner,
 	type ILogger,
+	type IssueLastSession,
 	type IssueMinimal,
 	type RepositoryContext,
 	type SerializedCyrusAgentSession,
@@ -74,6 +75,11 @@ export class AgentSessionManager extends EventEmitter {
 	private taskSubjectsById: Map<string, string> = new Map(); // Cache task subjects by task ID (e.g., "1" → "Fix login bug")
 	private activeStatusActivitiesBySession: Map<string, string> = new Map(); // Maps session ID to active compacting status activity ID
 	private stopRequestedSessions: Set<string> = new Set(); // Sessions explicitly stopped by user signal
+	// Durable per-issue record of the most recent runner session id. Unlike
+	// `sessions`, this is NOT cleared by removeSession()/cleanup(), so a later
+	// re-delegation on the same issue (a fresh agent session) can resume the
+	// prior runner conversation instead of cold-starting. Keyed by issue ID.
+	private issueLastSession: Map<string, IssueLastSession> = new Map();
 	// Per-session serialization queue for handleClaudeMessage. The EdgeWorker's
 	// onMessage callback is fire-and-forget, so without serialization the async
 	// handlers can interleave — causing tool_result to be processed before its
@@ -265,6 +271,46 @@ export class AgentSessionManager extends EventEmitter {
 			permissionMode: claudeSystemMessage.permissionMode,
 			apiKeySource: claudeSystemMessage.apiKeySource,
 		};
+
+		// Record this as the issue's most recent runner session so a future
+		// re-delegation can resume it even after this session is pruned.
+		this.recordLastSessionForIssue(linearSession, runnerType);
+	}
+
+	/**
+	 * Update the durable per-issue last-session record from a live session.
+	 * Only the field matching `runnerType` is set, mirroring how a session
+	 * carries exactly one runner id.
+	 */
+	private recordLastSessionForIssue(
+		session: CyrusAgentSession,
+		runnerType: "claude" | "gemini" | "codex" | "cursor",
+	): void {
+		const issueId = this.getSessionIssueId(session);
+		if (!issueId) return;
+		const sessionId =
+			runnerType === "gemini"
+				? session.geminiSessionId
+				: runnerType === "codex"
+					? session.codexSessionId
+					: runnerType === "cursor"
+						? session.cursorSessionId
+						: session.claudeSessionId;
+		if (!sessionId) return;
+		this.issueLastSession.set(issueId, {
+			[`${runnerType}SessionId`]: sessionId,
+			workspacePath: session.workspace?.path,
+			updatedAt: Date.now(),
+		});
+	}
+
+	/**
+	 * Durable record of the most recent runner session for an issue, kept even
+	 * after the live session has been pruned. Used to resume a prior
+	 * conversation when a new agent session is created on the same issue.
+	 */
+	getLastSessionForIssue(issueId: string): IssueLastSession | undefined {
+		return this.issueLastSession.get(issueId);
 	}
 
 	/**
@@ -1418,7 +1464,7 @@ export class AgentSessionManager extends EventEmitter {
 		const log = this.sessionLog(sessionId);
 		const session = this.sessions.get(sessionId);
 
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			log.debug(
 				`Skipping ${label} - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,
 			);
@@ -1589,6 +1635,7 @@ export class AgentSessionManager extends EventEmitter {
 	serializeState(): {
 		sessions: Record<string, SerializedCyrusAgentSession>;
 		entries: Record<string, SerializedCyrusAgentSessionEntry[]>;
+		issueLastSession: Record<string, IssueLastSession>;
 	} {
 		const sessions: Record<string, SerializedCyrusAgentSession> = {};
 		const entries: Record<string, SerializedCyrusAgentSessionEntry[]> = {};
@@ -1607,7 +1654,11 @@ export class AgentSessionManager extends EventEmitter {
 			}));
 		}
 
-		return { sessions, entries };
+		const issueLastSession = Object.fromEntries(
+			this.issueLastSession.entries(),
+		);
+
+		return { sessions, entries, issueLastSession };
 	}
 
 	/**
@@ -1616,10 +1667,21 @@ export class AgentSessionManager extends EventEmitter {
 	restoreState(
 		serializedSessions: Record<string, SerializedCyrusAgentSession>,
 		serializedEntries: Record<string, SerializedCyrusAgentSessionEntry[]>,
+		serializedIssueLastSession?: Record<string, IssueLastSession>,
 	): void {
 		// Clear existing state
 		this.sessions.clear();
 		this.entries.clear();
+		this.issueLastSession.clear();
+
+		// Restore durable per-issue last-session records (survives pruning)
+		if (serializedIssueLastSession) {
+			for (const [issueId, record] of Object.entries(
+				serializedIssueLastSession,
+			)) {
+				this.issueLastSession.set(issueId, record);
+			}
+		}
 
 		// Restore sessions (migrate old sessions without repositories field)
 		for (const [sessionId, sessionData] of Object.entries(serializedSessions)) {
@@ -1681,7 +1743,7 @@ export class AgentSessionManager extends EventEmitter {
 		message: SDKStatusMessage,
 	): Promise<void> {
 		const session = this.sessions.get(sessionId);
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			const log = this.sessionLog(sessionId);
 			log.debug(
 				`Skipping status message - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -151,6 +151,13 @@ import { DefaultSkillsDeployer } from "./DefaultSkillsDeployer.js";
 import { EgressProxy } from "./EgressProxy.js";
 import { GitService } from "./GitService.js";
 import { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
+import {
+	containsLinearReauthorizationError,
+	LINEAR_TOKEN_REFRESH_CHECK_INTERVAL_MS,
+	LINEAR_TOKEN_SOFT_REFRESH_TTL_MS,
+	LINEAR_TOKEN_TURN_START_MIN_TTL_MS,
+	shouldRefreshLinearToken,
+} from "./linearTokenRefreshPolicy.js";
 import { McpConfigService } from "./McpConfigService.js";
 import { PromptBuilder } from "./PromptBuilder.js";
 import type {
@@ -208,6 +215,7 @@ export class EdgeWorker extends EventEmitter {
 	private lastStopTimeBySession: Map<string, number> = new Map(); // Maps session ID to timestamp of last stop signal (for double-stop detection)
 	private warmInstances: Map<string, WarmQuery> = new Map(); // Pre-warmed Claude sessions keyed by agentSessionId
 	private issueTrackers: Map<string, IIssueTrackerService> = new Map(); // one issue tracker per Linear workspace (keyed by linearWorkspaceId)
+	private linearTokenRefreshTimer: NodeJS.Timeout | null = null; // Proactive OAuth token renewal (CRATE-153)
 	private linearEventTransport: LinearEventTransport | null = null; // Single event transport for webhook delivery
 	private gitHubEventTransport: GitHubEventTransport | null = null; // GitHub event transport for forwarded GitHub webhooks
 	private gitHubAppTokenProvider: GitHubAppTokenProvider | null = null; // Self-hosted GitHub App token minting
@@ -701,6 +709,12 @@ export class EdgeWorker extends EventEmitter {
 				);
 			});
 		}
+
+		// Proactively renew Linear OAuth tokens before they expire (CRATE-153).
+		// Without this, the token only refreshes when a daemon-side call hits a
+		// 401 — leaving long dead-token windows during which agent sessions
+		// snapshot an expired token into their MCP config and status writes fail.
+		this.startLinearTokenRefreshScheduler();
 
 		// Start shared application server (this also starts Cloudflare tunnel if CLOUDFLARE_TOKEN is set)
 		await this.sharedApplicationServer.start();
@@ -2534,6 +2548,12 @@ ${taskSection}`;
 	 * Stop the edge worker
 	 */
 	async stop(): Promise<void> {
+		// Stop proactive Linear token refresh scheduler
+		if (this.linearTokenRefreshTimer) {
+			clearInterval(this.linearTokenRefreshTimer);
+			this.linearTokenRefreshTimer = null;
+		}
+
 		// Stop config file watcher
 		await this.configManager.stop();
 
@@ -2864,7 +2884,10 @@ ${taskSection}`;
 			// Update existing issue tracker in-place
 			const issueTracker = this.issueTrackers.get(workspaceId);
 			if (issueTracker) {
-				(issueTracker as LinearIssueTrackerService).setAccessToken(newToken);
+				(issueTracker as LinearIssueTrackerService).setAccessToken(
+					newToken,
+					newWsConfig.linearTokenExpiresAt,
+				);
 				this.logger.info(
 					`🔑 Updated Linear token for workspace ${workspaceId}`,
 				);
@@ -2888,6 +2911,24 @@ ${taskSection}`;
 		if (anyTokenChanged) {
 			// Push refreshed workspace configs to AttachmentService
 			this.attachmentService.setLinearWorkspaces(newWorkspaces);
+
+			// Pre-warmed sessions snapshotted the OLD token into their MCP
+			// Authorization headers at warmup time — and Linear revokes the old
+			// token on refresh, so those snapshots are now dead. Discard them;
+			// the next message cold-starts with a fresh config (CRATE-153).
+			if (this.warmInstances.size > 0) {
+				this.logger.info(
+					`🔑 Discarding ${this.warmInstances.size} pre-warmed session(s) holding a rotated Linear token`,
+				);
+				for (const warm of this.warmInstances.values()) {
+					try {
+						warm.close();
+					} catch {
+						// Best-effort: the subprocess may already be gone
+					}
+				}
+				this.warmInstances.clear();
+			}
 		}
 	}
 
@@ -5182,8 +5223,40 @@ ${taskSection}`;
 	private async handleClaudeMessage(
 		sessionId: string,
 		message: SDKMessage,
-		_repositoryId: string,
+		repositoryId: string,
 	): Promise<void> {
+		// CRATE-153: an agent hitting `MCP server "linear" requires
+		// re-authorization` means its turn snapshotted a token that has since
+		// expired/rotated. The snapshot is unfixable for this turn — but log it
+		// LOUDLY and refresh the token now so the next turn starts healthy.
+		if (containsLinearReauthorizationError(message)) {
+			this.logger.error(
+				`🔑 Session ${sessionId} hit a stale Linear token (MCP "linear" requires re-authorization). ` +
+					"Status writes through the hosted Linear MCP will fail for the rest of this turn — " +
+					"the agent should fall back to mcp__cyrus-tools__linear_update_issue_status. " +
+					"Forcing a token refresh so subsequent turns get a fresh snapshot.",
+			);
+			const wsId = this.repositories.get(repositoryId)?.linearWorkspaceId;
+			const tracker = wsId
+				? (this.issueTrackers.get(wsId) as
+						| Partial<LinearIssueTrackerService>
+						| undefined)
+				: undefined;
+			if (typeof tracker?.ensureFreshToken === "function") {
+				// "Ensure fresh", not "force rotate": if the daemon already
+				// holds a fresh token (only the session's snapshot is stale),
+				// this no-ops instead of needlessly revoking it.
+				tracker
+					.ensureFreshToken(LINEAR_TOKEN_SOFT_REFRESH_TTL_MS)
+					.catch((error: unknown) => {
+						this.logger.error(
+							"Post-reauthorization-error token refresh failed:",
+							error,
+						);
+					});
+			}
+		}
+
 		await this.agentSessionManager.handleClaudeMessage(sessionId, message);
 	}
 
@@ -6412,6 +6485,36 @@ ${input.userComment}
 			issueIdentifier: session.issueContext?.issueIdentifier,
 		});
 
+		// CRATE-153: the runner config below snapshots the Linear token into a
+		// static MCP Authorization header for the whole turn. Make sure that
+		// snapshot has enough runway — if the token is near death (or of
+		// unknown age), refresh it BEFORE building the config. Failure is
+		// non-fatal: the turn proceeds with the existing token, same as before.
+		try {
+			const wsIdForToken =
+				linearWorkspaceId ?? repository.linearWorkspaceId ?? null;
+			const trackerForToken = wsIdForToken
+				? (this.issueTrackers.get(wsIdForToken) as
+						| Partial<LinearIssueTrackerService>
+						| undefined)
+				: undefined;
+			if (typeof trackerForToken?.ensureFreshToken === "function") {
+				const { refreshed } = await trackerForToken.ensureFreshToken(
+					LINEAR_TOKEN_TURN_START_MIN_TTL_MS,
+				);
+				if (refreshed) {
+					log.info(
+						"🔑 Refreshed near-expiry Linear token before building runner config",
+					);
+				}
+			}
+		} catch (error) {
+			log.error(
+				"Turn-start Linear token refresh failed (continuing with current token):",
+				error,
+			);
+		}
+
 		// Resolve plugins once so we can also derive the per-session scoped
 		// skill allow-list from the same filesystem snapshot.
 		const plugins = await this.skillsPluginResolver.resolve();
@@ -7403,6 +7506,71 @@ ${input.userComment}
 	// ========================================================================
 
 	/**
+	 * Start the proactive Linear token refresh scheduler (CRATE-153).
+	 *
+	 * Linear access tokens live ~24h and the OLD token is revoked the moment a
+	 * refresh succeeds, so timing matters: the policy refreshes early while the
+	 * worker is idle, and only forces a refresh under active turns when the
+	 * token is about to die anyway. See linearTokenRefreshPolicy.ts.
+	 */
+	private startLinearTokenRefreshScheduler(): void {
+		if (this.linearTokenRefreshTimer) return;
+
+		const check = () => {
+			this.checkLinearTokenFreshness().catch((error) => {
+				this.logger.error("Linear token freshness check failed:", error);
+			});
+		};
+
+		this.linearTokenRefreshTimer = setInterval(
+			check,
+			LINEAR_TOKEN_REFRESH_CHECK_INTERVAL_MS,
+		);
+		this.linearTokenRefreshTimer.unref?.();
+
+		// Also check immediately: after a restart the persisted expiry may be
+		// unknown (pre-CRATE-153 configs) or already in the past.
+		check();
+	}
+
+	/**
+	 * Refresh any workspace token that the policy considers stale.
+	 */
+	private async checkLinearTokenFreshness(): Promise<void> {
+		const busy = this.computeStatus() === "busy";
+
+		for (const [workspaceId, tracker] of this.issueTrackers) {
+			const service = tracker as Partial<LinearIssueTrackerService>;
+			// CLI-platform trackers don't do OAuth
+			if (
+				typeof service.ensureFreshToken !== "function" ||
+				typeof service.getTokenExpiresAt !== "function"
+			) {
+				continue;
+			}
+
+			const expiresAt = service.getTokenExpiresAt();
+			if (!shouldRefreshLinearToken({ expiresAt, now: Date.now(), busy })) {
+				continue;
+			}
+
+			this.logger.info(
+				`🔑 Proactively refreshing Linear token for workspace ${workspaceId} (expiry: ${
+					expiresAt ? new Date(expiresAt).toISOString() : "unknown"
+				}, busy: ${busy})`,
+			);
+			try {
+				await service.ensureFreshToken(LINEAR_TOKEN_SOFT_REFRESH_TTL_MS);
+			} catch (error) {
+				this.logger.error(
+					`Proactive Linear token refresh failed for workspace ${workspaceId}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	/**
 	 * Build OAuth config for LinearIssueTrackerService.
 	 * Uses workspace-level token storage.
 	 * Returns undefined if OAuth credentials are not available.
@@ -7438,6 +7606,7 @@ ${input.userComment}
 			clientSecret,
 			refreshToken: workspaceConfig.linearRefreshToken,
 			workspaceId: linearWorkspaceId,
+			expiresAt: workspaceConfig.linearTokenExpiresAt,
 			onTokenRefresh: async (tokens) => {
 				// Update workspace config in memory
 				if (this.config.linearWorkspaces?.[linearWorkspaceId]) {
@@ -7445,12 +7614,15 @@ ${input.userComment}
 						tokens.accessToken;
 					this.config.linearWorkspaces[linearWorkspaceId].linearRefreshToken =
 						tokens.refreshToken;
+					this.config.linearWorkspaces[linearWorkspaceId].linearTokenExpiresAt =
+						tokens.expiresAt;
 				}
 
 				// Persist tokens to config.json
 				await this.saveOAuthTokens({
 					linearToken: tokens.accessToken,
 					linearRefreshToken: tokens.refreshToken,
+					linearTokenExpiresAt: tokens.expiresAt,
 					linearWorkspaceId: linearWorkspaceId,
 					linearWorkspaceName: workspaceName,
 				});
@@ -7464,6 +7636,8 @@ ${input.userComment}
 	private async saveOAuthTokens(tokens: {
 		linearToken: string;
 		linearRefreshToken?: string;
+		/** Epoch ms when linearToken expires — drives proactive renewal (CRATE-153) */
+		linearTokenExpiresAt?: number;
 		linearWorkspaceId: string;
 		linearWorkspaceName?: string;
 	}): Promise<void> {
@@ -7492,6 +7666,16 @@ ${input.userComment}
 								linearRefreshToken:
 									config.linearWorkspaces[tokens.linearWorkspaceId]
 										.linearRefreshToken,
+							}
+						: {}),
+				...(tokens.linearTokenExpiresAt
+					? { linearTokenExpiresAt: tokens.linearTokenExpiresAt }
+					: config.linearWorkspaces[tokens.linearWorkspaceId]
+								?.linearTokenExpiresAt
+						? {
+								linearTokenExpiresAt:
+									config.linearWorkspaces[tokens.linearWorkspaceId]
+										.linearTokenExpiresAt,
 							}
 						: {}),
 				...(tokens.linearWorkspaceName

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4473,6 +4473,40 @@ ${taskSection}`;
 				);
 			}
 
+			// Cross-session resume: when enabled, a brand-new agent session on an
+			// issue with prior Cyrus work resumes the most recent prior runner
+			// conversation instead of cold-starting and re-reading everything.
+			// Seeding the matching runner id onto the session also makes
+			// buildIssueConfig() force the runner type to match the resumed
+			// transcript (see RunnerConfigBuilder.buildIssueConfig).
+			let resumeSessionId: string | undefined;
+			const crossResume = this.resolveCrossSessionResume(
+				fullIssue.id,
+				sessionId,
+				primaryRepo,
+			);
+			if (crossResume) {
+				resumeSessionId = crossResume.resumeSessionId;
+				if (crossResume.runner === "claude")
+					session.claudeSessionId = resumeSessionId;
+				else if (crossResume.runner === "gemini")
+					session.geminiSessionId = resumeSessionId;
+				else if (crossResume.runner === "codex")
+					session.codexSessionId = resumeSessionId;
+				else if (crossResume.runner === "cursor")
+					session.cursorSessionId = resumeSessionId;
+				log.info(
+					`Resuming prior ${crossResume.runner} session ${resumeSessionId} for issue ${fullIssue.identifier} (cross-session resume)`,
+				);
+				await this.activityPoster
+					.postThoughtActivity(
+						sessionId,
+						linearWorkspaceId,
+						"Resuming from a previous session on this issue.",
+					)
+					.catch(() => {});
+			}
+
 			// Create agent runner with system prompt from assembly
 			// buildAgentRunnerConfig now determines runner type from labels internally
 			const { config: runnerConfig, runnerType } =
@@ -4484,7 +4518,7 @@ ${taskSection}`;
 					allowedTools,
 					allowedDirectories,
 					disallowedTools,
-					undefined, // resumeSessionId
+					resumeSessionId,
 					labels, // Pass labels for runner selection and model override
 					fullIssue.description || undefined, // Description tags can override label selectors
 					undefined, // maxTurns
@@ -6631,6 +6665,83 @@ ${input.userComment}
 	}
 
 	/**
+	 * Whether cross-session resume is enabled.
+	 *
+	 * When on, a newly-created agent session for an issue that Cyrus has worked
+	 * before resumes the most recent prior runner conversation instead of
+	 * cold-starting and re-reading all the issue context. Opt-in (it changes
+	 * behavior — the agent picks up potentially stale context) via
+	 * `CYRUS_RESUME_ACROSS_SESSIONS=1` (or `=true`), or per-repository config
+	 * `resumeAcrossSessions: true`.
+	 */
+	private isCrossSessionResumeEnabled(repository?: RepositoryConfig): boolean {
+		if (repository?.resumeAcrossSessions === true) return true;
+		const raw = process.env.CYRUS_RESUME_ACROSS_SESSIONS;
+		if (!raw) return false;
+		const v = raw.toLowerCase().trim();
+		return v === "1" || v === "true";
+	}
+
+	/**
+	 * Resolve a runner session id to resume when creating a NEW agent session
+	 * on an issue with prior Cyrus work. Returns undefined (→ cold start) when
+	 * the feature is off or no prior session is known.
+	 *
+	 * Resolution order:
+	 *  (a) a still-tracked prior session for the same issue (covers
+	 *      re-delegation while the issue is open and not yet pruned), then
+	 *  (b) the durable per-issue record (covers reopen-after-terminal, where
+	 *      the live session was pruned but the SDK transcript survives on disk).
+	 *
+	 * The worktree path is deterministic per issue identifier, so the recreated
+	 * worktree shares the cwd the prior transcript is keyed by — no workspace
+	 * juggling is needed here.
+	 */
+	private resolveCrossSessionResume(
+		issueId: string,
+		currentSessionId: string,
+		repository?: RepositoryConfig,
+	): { resumeSessionId: string; runner: RunnerType } | undefined {
+		if (!this.isCrossSessionResumeEnabled(repository)) return undefined;
+
+		const prior = this.agentSessionManager
+			.getSessionsByIssueId(issueId)
+			.filter((s) => s.id !== currentSessionId)
+			.filter(
+				(s) =>
+					s.claudeSessionId ||
+					s.geminiSessionId ||
+					s.codexSessionId ||
+					s.cursorSessionId,
+			)
+			.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))[0];
+
+		const record: {
+			claudeSessionId?: string;
+			geminiSessionId?: string;
+			codexSessionId?: string;
+			cursorSessionId?: string;
+		} = prior
+			? {
+					claudeSessionId: prior.claudeSessionId,
+					geminiSessionId: prior.geminiSessionId,
+					codexSessionId: prior.codexSessionId,
+					cursorSessionId: prior.cursorSessionId,
+				}
+			: (this.agentSessionManager.getLastSessionForIssue(issueId) ?? {});
+
+		if (record.claudeSessionId)
+			return { resumeSessionId: record.claudeSessionId, runner: "claude" };
+		if (record.geminiSessionId)
+			return { resumeSessionId: record.geminiSessionId, runner: "gemini" };
+		if (record.codexSessionId)
+			return { resumeSessionId: record.codexSessionId, runner: "codex" };
+		if (record.cursorSessionId)
+			return { resumeSessionId: record.cursorSessionId, runner: "cursor" };
+		return undefined;
+	}
+
+	/**
 	 * Whether the remote Claude session store is explicitly disabled.
 	 *
 	 * The remote store mirrors SDK transcripts to the Cyrus hosted control
@@ -6813,6 +6924,7 @@ ${input.userComment}
 			agentSessionEntries: serializedState.entries,
 			childToParentAgentSession,
 			issueRepositoryCache,
+			issueLastSession: serializedState.issueLastSession,
 		};
 	}
 
@@ -6825,6 +6937,7 @@ ${input.userComment}
 			this.agentSessionManager.restoreState(
 				state.agentSessions,
 				state.agentSessionEntries,
+				state.issueLastSession,
 			);
 
 			// Rebuild session-to-repo mapping from issueRepositoryCache

--- a/packages/edge-worker/src/linearTokenRefreshPolicy.ts
+++ b/packages/edge-worker/src/linearTokenRefreshPolicy.ts
@@ -1,0 +1,89 @@
+/**
+ * Policy for proactive Linear OAuth token refresh (CRATE-153).
+ *
+ * Linear access tokens live ~24h, and Linear REVOKES the previous access
+ * token the moment a refresh succeeds. Agent sessions snapshot the token
+ * into a static MCP Authorization header at turn start, so a refresh kills
+ * the hosted Linear MCP server for every in-flight turn.
+ *
+ * The policy balances those forces:
+ *  - unknown expiry        → refresh (token of unknown age; assume stale)
+ *  - < forced TTL left     → refresh even while busy (in-flight snapshots
+ *                            are about to die naturally anyway)
+ *  - < soft TTL left, idle → refresh while nobody is running, so new turns
+ *                            always snapshot a token with hours of runway
+ *  - otherwise             → leave the token alone
+ */
+
+/** Refresh regardless of running turns when this little validity remains. */
+export const LINEAR_TOKEN_FORCED_REFRESH_TTL_MS = 30 * 60 * 1000;
+
+/** Refresh while the worker is idle when this little validity remains. */
+export const LINEAR_TOKEN_SOFT_REFRESH_TTL_MS = 4 * 60 * 60 * 1000;
+
+/** Turn-start guard: ensure at least this much runway before snapshotting. */
+export const LINEAR_TOKEN_TURN_START_MIN_TTL_MS = 30 * 60 * 1000;
+
+/** How often the proactive refresh scheduler checks token freshness. */
+export const LINEAR_TOKEN_REFRESH_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+/**
+ * Detect the stale-token failure an agent session hits when its snapshotted
+ * MCP Authorization header outlives the Linear token: the SDK surfaces it as
+ * an error tool_result reading `MCP server "linear" requires re-authorization`.
+ *
+ * Used to (a) log the failure loudly instead of letting it pass as a quiet
+ * tool error, and (b) trigger an immediate token refresh so the NEXT turn
+ * starts with a working token (this turn's header is already unfixable).
+ */
+export function containsLinearReauthorizationError(message: unknown): boolean {
+	const msg = message as {
+		type?: string;
+		message?: { content?: unknown };
+	};
+	if (!msg || msg.type !== "user") return false;
+
+	const content = msg.message?.content;
+	if (!Array.isArray(content)) return false;
+
+	for (const block of content) {
+		const b = block as {
+			type?: string;
+			is_error?: boolean;
+			content?: unknown;
+		};
+		if (b?.type !== "tool_result" || b.is_error !== true) continue;
+
+		let text = "";
+		if (typeof b.content === "string") {
+			text = b.content;
+		} else if (Array.isArray(b.content)) {
+			text = b.content
+				.map((c) => (c as { text?: string })?.text ?? "")
+				.join("\n");
+		}
+
+		if (text.includes("requires re-authorization")) return true;
+	}
+
+	return false;
+}
+
+export function shouldRefreshLinearToken(args: {
+	/** Epoch ms when the current access token expires, or null if unknown */
+	expiresAt: number | null;
+	/** Current time, epoch ms */
+	now: number;
+	/** Whether any agent turns are currently running */
+	busy: boolean;
+}): boolean {
+	const { expiresAt, now, busy } = args;
+
+	if (expiresAt === null) return true;
+
+	const remaining = expiresAt - now;
+	if (remaining < LINEAR_TOKEN_FORCED_REFRESH_TTL_MS) return true;
+	if (remaining < LINEAR_TOKEN_SOFT_REFRESH_TTL_MS && !busy) return true;
+
+	return false;
+}

--- a/packages/edge-worker/test/AgentSessionManager.issue-last-session.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.issue-last-session.test.ts
@@ -1,0 +1,86 @@
+import type { SDKSystemMessage } from "cyrus-claude-runner";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+
+/**
+ * The durable per-issue "last session" record lets a newly-created agent
+ * session on an issue resume the prior runner conversation even after the live
+ * session has been pruned (e.g. when the issue went terminal/unassigned).
+ */
+describe("AgentSessionManager - issueLastSession durable record", () => {
+	let manager: AgentSessionManager;
+	const sessionId = "session-1";
+	const issueId = "issue-1";
+
+	const systemInit: SDKSystemMessage = {
+		type: "system",
+		subtype: "init",
+		session_id: "claude-abc",
+		model: "opus",
+		tools: [],
+		permissionMode: "allowed_tools",
+		apiKeySource: "claude_desktop",
+	};
+
+	beforeEach(() => {
+		manager = new AgentSessionManager();
+		manager.createCyrusAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "TEST-1",
+				title: "Test",
+				description: "",
+				branchName: "test-branch",
+			},
+			{ path: "/worktrees/TEST-1", isGitWorktree: true },
+		);
+	});
+
+	it("records the claude session id (and workspace) for the issue on init", async () => {
+		await manager.handleClaudeMessage(sessionId, systemInit);
+
+		const record = manager.getLastSessionForIssue(issueId);
+		expect(record?.claudeSessionId).toBe("claude-abc");
+		expect(record?.workspacePath).toBe("/worktrees/TEST-1");
+		expect(record?.updatedAt).toBeGreaterThan(0);
+	});
+
+	it("survives removeSession() so a re-delegation can still resume", async () => {
+		await manager.handleClaudeMessage(sessionId, systemInit);
+
+		manager.removeSession(sessionId);
+
+		// Live session is gone...
+		expect(manager.getSession(sessionId)).toBeUndefined();
+		expect(manager.getSessionsByIssueId(issueId)).toHaveLength(0);
+		// ...but the durable record remains.
+		expect(manager.getLastSessionForIssue(issueId)?.claudeSessionId).toBe(
+			"claude-abc",
+		);
+	});
+
+	it("round-trips through serializeState()/restoreState()", async () => {
+		await manager.handleClaudeMessage(sessionId, systemInit);
+
+		const serialized = manager.serializeState();
+		expect(serialized.issueLastSession[issueId]?.claudeSessionId).toBe(
+			"claude-abc",
+		);
+
+		const restored = new AgentSessionManager();
+		restored.restoreState(
+			serialized.sessions,
+			serialized.entries,
+			serialized.issueLastSession,
+		);
+		expect(restored.getLastSessionForIssue(issueId)?.claudeSessionId).toBe(
+			"claude-abc",
+		);
+	});
+
+	it("returns undefined for an issue with no prior session", () => {
+		expect(manager.getLastSessionForIssue("unknown-issue")).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.cross-session-resume.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.cross-session-resume.test.ts
@@ -1,0 +1,168 @@
+import { ClaudeRunner } from "cyrus-claude-runner";
+import { LinearEventTransport } from "cyrus-linear-event-transport";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+import type { EdgeWorkerConfig, RepositoryConfig } from "../src/types.js";
+import { TEST_CYRUS_HOME } from "./test-dirs.js";
+
+vi.mock("fs/promises", () => ({
+	readFile: vi.fn(),
+	writeFile: vi.fn(),
+	mkdir: vi.fn(),
+	rename: vi.fn(),
+}));
+vi.mock("cyrus-claude-runner");
+vi.mock("cyrus-linear-event-transport");
+vi.mock("@linear/sdk");
+vi.mock("../src/SharedApplicationServer.js");
+vi.mock("../src/AgentSessionManager.js");
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
+	};
+});
+vi.mock("file-type");
+
+/**
+ * Unit tests for EdgeWorker.resolveCrossSessionResume — the glue that lets a
+ * newly-created agent session resume a prior runner conversation on the same
+ * issue. The durable-record persistence and the runner fallback are covered in
+ * their own suites; here we exercise the resolution + opt-in gating.
+ */
+describe("EdgeWorker - cross-session resume resolution", () => {
+	let edgeWorker: EdgeWorker;
+	let mockASM: any;
+
+	const ISSUE = "issue-1";
+	const CURRENT = "new-session";
+
+	const repository: RepositoryConfig = {
+		id: "repo-1",
+		name: "Repo",
+		repositoryPath: "/repo",
+		workspaceBaseDir: "/workspaces",
+		baseBranch: "main",
+		linearWorkspaceId: "ws-1",
+		isActive: true,
+	};
+
+	beforeEach(() => {
+		delete process.env.CYRUS_RESUME_ACROSS_SESSIONS;
+
+		mockASM = {
+			getSessionsByIssueId: vi.fn().mockReturnValue([]),
+			getLastSessionForIssue: vi.fn().mockReturnValue(undefined),
+			on: vi.fn(),
+		};
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockASM;
+		});
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
+		vi.mocked(ClaudeRunner).mockImplementation(function () {
+			return {};
+		} as any);
+
+		const config: EdgeWorkerConfig = {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: TEST_CYRUS_HOME,
+			repositories: [repository],
+			linearWorkspaces: { "ws-1": { linearToken: "t" } },
+			handlers: {
+				createWorkspace: vi.fn().mockResolvedValue({
+					path: "/workspaces/issue-1",
+					isGitWorktree: false,
+				}),
+			},
+		} as any;
+
+		edgeWorker = new EdgeWorker(config);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.CYRUS_RESUME_ACROSS_SESSIONS;
+	});
+
+	const resolve = () =>
+		(edgeWorker as any).resolveCrossSessionResume(ISSUE, CURRENT, repository);
+
+	it("returns undefined when the feature is disabled (default)", () => {
+		mockASM.getSessionsByIssueId.mockReturnValue([
+			{ id: "old", claudeSessionId: "claude-old", updatedAt: 1 },
+		]);
+		expect(resolve()).toBeUndefined();
+	});
+
+	it("resumes the most recent live prior session when enabled via env", () => {
+		process.env.CYRUS_RESUME_ACROSS_SESSIONS = "1";
+		mockASM.getSessionsByIssueId.mockReturnValue([
+			{ id: "old-a", claudeSessionId: "claude-a", updatedAt: 10 },
+			{ id: "old-b", claudeSessionId: "claude-b", updatedAt: 99 },
+			{ id: CURRENT, updatedAt: 100 }, // current session excluded
+		]);
+		expect(resolve()).toEqual({
+			resumeSessionId: "claude-b",
+			runner: "claude",
+		});
+	});
+
+	it("falls back to the durable record when no live session remains", () => {
+		process.env.CYRUS_RESUME_ACROSS_SESSIONS = "true";
+		mockASM.getSessionsByIssueId.mockReturnValue([]);
+		mockASM.getLastSessionForIssue.mockReturnValue({
+			claudeSessionId: "claude-durable",
+			updatedAt: 5,
+		});
+		expect(resolve()).toEqual({
+			resumeSessionId: "claude-durable",
+			runner: "claude",
+		});
+	});
+
+	it("maps non-claude runner ids to the right runner", () => {
+		process.env.CYRUS_RESUME_ACROSS_SESSIONS = "1";
+		mockASM.getSessionsByIssueId.mockReturnValue([
+			{ id: "old", geminiSessionId: "gem-1", updatedAt: 1 },
+		]);
+		expect(resolve()).toEqual({ resumeSessionId: "gem-1", runner: "gemini" });
+	});
+
+	it("can be enabled per-repository without the env var", () => {
+		const r = { ...repository, resumeAcrossSessions: true };
+		mockASM.getSessionsByIssueId.mockReturnValue([
+			{ id: "old", claudeSessionId: "claude-x", updatedAt: 1 },
+		]);
+		expect(
+			(edgeWorker as any).resolveCrossSessionResume(ISSUE, CURRENT, r),
+		).toEqual({ resumeSessionId: "claude-x", runner: "claude" });
+	});
+
+	it("returns undefined when enabled but no prior session exists", () => {
+		process.env.CYRUS_RESUME_ACROSS_SESSIONS = "1";
+		expect(resolve()).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.linear-client-wrapper.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.linear-client-wrapper.test.ts
@@ -201,6 +201,7 @@ describe("EdgeWorker LinearClient Wrapper", () => {
 					"workspace-123": {
 						linearToken: "refreshed_token",
 						linearRefreshToken: "new_refresh_token",
+						linearTokenExpiresAt: 1780086399000,
 						linearWorkspaceName: "Test Workspace",
 					},
 				},
@@ -208,7 +209,12 @@ describe("EdgeWorker LinearClient Wrapper", () => {
 
 			(edgeWorker as any).updateLinearWorkspaceTokens(newConfig);
 
-			expect(setAccessTokenSpy).toHaveBeenCalledWith("refreshed_token");
+			// CRATE-153: the persisted expiry travels with the token so the
+			// proactive refresh scheduler knows the new token's lifetime.
+			expect(setAccessTokenSpy).toHaveBeenCalledWith(
+				"refreshed_token",
+				1780086399000,
+			);
 		});
 
 		it("should not call setAccessToken when token has not changed", () => {

--- a/packages/edge-worker/test/linearTokenRefreshPolicy.test.ts
+++ b/packages/edge-worker/test/linearTokenRefreshPolicy.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+	LINEAR_TOKEN_FORCED_REFRESH_TTL_MS,
+	LINEAR_TOKEN_SOFT_REFRESH_TTL_MS,
+	shouldRefreshLinearToken,
+} from "../src/linearTokenRefreshPolicy.js";
+
+/**
+ * Policy for proactive Linear OAuth token refresh (CRATE-153).
+ *
+ * Constraint discovered during investigation: Linear REVOKES the previous
+ * access token the moment a refresh succeeds. In-flight agent sessions hold
+ * static Authorization-header snapshots, so refreshing while turns are
+ * running kills their hosted Linear MCP access. The policy therefore:
+ *   - refreshes early (hours before expiry) while the worker is idle
+ *   - only forces a refresh under active turns when the token is about to
+ *     die anyway (the snapshots are about to die naturally regardless)
+ */
+
+import { containsLinearReauthorizationError } from "../src/linearTokenRefreshPolicy.js";
+
+const NOW = 1_780_000_000_000;
+const hours = (n: number) => n * 60 * 60 * 1000;
+
+describe("containsLinearReauthorizationError", () => {
+	it("detects the real-world stale-token tool_result from the CRATE-80 session", () => {
+		// Verbatim shape from logs/CRATE-80/session-cfc5acfe...jsonl
+		const message = {
+			type: "user",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						content:
+							'MCP server "linear" requires re-authorization (token expired)',
+						is_error: true,
+						tool_use_id: "toolu_01DQUg1poCadpYMmmCHyveqk",
+					},
+				],
+			},
+		};
+		expect(containsLinearReauthorizationError(message)).toBe(true);
+	});
+
+	it("detects the error when tool_result content is a block array", () => {
+		const message = {
+			type: "user",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						content: [
+							{
+								type: "text",
+								text: 'Error: MCP server "linear" requires re-authorization',
+							},
+						],
+						is_error: true,
+					},
+				],
+			},
+		};
+		expect(containsLinearReauthorizationError(message)).toBe(true);
+	});
+
+	it("ignores successful tool results and unrelated errors", () => {
+		expect(
+			containsLinearReauthorizationError({
+				type: "user",
+				message: {
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							content: "ok",
+							is_error: false,
+						},
+						{
+							type: "tool_result",
+							content: "Error: file not found",
+							is_error: true,
+						},
+					],
+				},
+			}),
+		).toBe(false);
+	});
+
+	it("ignores assistant and malformed messages", () => {
+		expect(
+			containsLinearReauthorizationError({ type: "assistant", message: {} }),
+		).toBe(false);
+		expect(containsLinearReauthorizationError(null)).toBe(false);
+		expect(containsLinearReauthorizationError("nope")).toBe(false);
+	});
+});
+
+describe("shouldRefreshLinearToken", () => {
+	it("refreshes when expiry is unknown (token of unknown age)", () => {
+		expect(
+			shouldRefreshLinearToken({ expiresAt: null, now: NOW, busy: false }),
+		).toBe(true);
+		expect(
+			shouldRefreshLinearToken({ expiresAt: null, now: NOW, busy: true }),
+		).toBe(true);
+	});
+
+	it("does not refresh a token with plenty of runway", () => {
+		expect(
+			shouldRefreshLinearToken({
+				expiresAt: NOW + hours(20),
+				now: NOW,
+				busy: false,
+			}),
+		).toBe(false);
+	});
+
+	it("refreshes an aging token while idle (soft threshold)", () => {
+		expect(
+			shouldRefreshLinearToken({
+				expiresAt: NOW + LINEAR_TOKEN_SOFT_REFRESH_TTL_MS - 1,
+				now: NOW,
+				busy: false,
+			}),
+		).toBe(true);
+	});
+
+	it("does NOT refresh an aging token while busy — refresh would revoke snapshots held by running turns", () => {
+		expect(
+			shouldRefreshLinearToken({
+				expiresAt: NOW + LINEAR_TOKEN_SOFT_REFRESH_TTL_MS - 1,
+				now: NOW,
+				busy: true,
+			}),
+		).toBe(false);
+	});
+
+	it("refreshes a nearly-dead token even while busy — the snapshots die naturally in moments anyway", () => {
+		expect(
+			shouldRefreshLinearToken({
+				expiresAt: NOW + LINEAR_TOKEN_FORCED_REFRESH_TTL_MS - 1,
+				now: NOW,
+				busy: true,
+			}),
+		).toBe(true);
+	});
+
+	it("refreshes an already-expired token regardless of activity", () => {
+		expect(
+			shouldRefreshLinearToken({
+				expiresAt: NOW - 1000,
+				now: NOW,
+				busy: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/packages/linear-event-transport/src/LinearIssueTrackerService.ts
+++ b/packages/linear-event-transport/src/LinearIssueTrackerService.ts
@@ -19,10 +19,14 @@ export interface LinearOAuthConfig {
 	refreshToken: string;
 	/** Workspace ID for coalescing concurrent refreshes across instances */
 	workspaceId: string;
+	/** Epoch ms when the current access token expires, if known (persisted from a prior refresh) */
+	expiresAt?: number;
 	/** Called when tokens are refreshed - use to persist new tokens */
 	onTokenRefresh?: (tokens: {
 		accessToken: string;
 		refreshToken: string;
+		/** Epoch ms when the new access token expires (now + expires_in) */
+		expiresAt: number;
 	}) => void | Promise<void>;
 }
 
@@ -93,6 +97,13 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 	private static workspaceRefreshTokens: Map<string, string> = new Map();
 
 	/**
+	 * Static map storing the current access-token expiry (epoch ms) per workspace.
+	 * Linear access tokens live ~24h and the OLD token is revoked the moment a
+	 * refresh happens, so all instances sharing a workspace must agree on expiry.
+	 */
+	private static workspaceTokenExpiresAt: Map<string, number> = new Map();
+
+	/**
 	 * Create a new LinearIssueTrackerService.
 	 *
 	 * @param linearClient - Configured LinearClient instance
@@ -114,6 +125,14 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 			LinearIssueTrackerService.workspaceRefreshTokens.set(
 				oauthConfig.workspaceId,
 				oauthConfig.refreshToken,
+			);
+		}
+
+		// Register known token expiry (persisted from a prior refresh)
+		if (oauthConfig?.expiresAt) {
+			LinearIssueTrackerService.workspaceTokenExpiresAt.set(
+				oauthConfig.workspaceId,
+				oauthConfig.expiresAt,
 			);
 		}
 
@@ -253,10 +272,15 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 			expires_in: number;
 		};
 
-		// Update shared static map for all instances sharing this workspace
+		// Update shared static maps for all instances sharing this workspace
 		LinearIssueTrackerService.workspaceRefreshTokens.set(
 			workspaceId,
 			data.refresh_token,
+		);
+		const expiresAt = Date.now() + data.expires_in * 1000;
+		LinearIssueTrackerService.workspaceTokenExpiresAt.set(
+			workspaceId,
+			expiresAt,
 		);
 
 		// Notify caller so they can persist tokens to disk
@@ -265,6 +289,7 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 				await onTokenRefresh({
 					accessToken: data.access_token,
 					refreshToken: data.refresh_token,
+					expiresAt,
 				});
 			} catch (err) {
 				this.logger.error("onTokenRefresh callback failed:", err);
@@ -286,17 +311,78 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 	}
 
 	/**
+	 * Get the epoch-ms expiry of the current access token, if known.
+	 * Returns null when no refresh has happened yet and no expiry was persisted.
+	 */
+	getTokenExpiresAt(): number | null {
+		if (!this.oauthConfig) return null;
+		return (
+			LinearIssueTrackerService.workspaceTokenExpiresAt.get(
+				this.oauthConfig.workspaceId,
+			) ?? null
+		);
+	}
+
+	/**
+	 * Proactively refresh the access token when it is expired, close to expiry,
+	 * or of unknown age (CRATE-153).
+	 *
+	 * IMPORTANT: Linear revokes the previous access token the moment a refresh
+	 * succeeds, so callers must time invocations to avoid killing tokens that
+	 * in-flight sessions have snapshotted (e.g. static MCP Authorization headers).
+	 *
+	 * Coalesced: concurrent calls (including 401-triggered refreshes) share one
+	 * HTTP refresh via the existing refreshPromise / pendingRefreshes machinery.
+	 *
+	 * @param minTtlMs - Refresh unless the token is known to be valid for at
+	 *                   least this many more milliseconds.
+	 * @returns whether a refresh was performed
+	 */
+	async ensureFreshToken(minTtlMs: number): Promise<{ refreshed: boolean }> {
+		if (!this.oauthConfig) return { refreshed: false };
+
+		const expiresAt = this.getTokenExpiresAt();
+		if (expiresAt !== null && expiresAt - Date.now() > minTtlMs) {
+			return { refreshed: false };
+		}
+
+		if (!this.refreshPromise) {
+			this.refreshPromise = this.doTokenRefresh().catch((refreshError) => {
+				this.refreshPromise = null;
+				this.logger.error("Proactive token refresh failed:", refreshError);
+				throw refreshError;
+			});
+		}
+
+		const newToken = await this.refreshPromise;
+		this.refreshPromise = null;
+		// This instance's client must start using the new token immediately —
+		// the old one is already revoked.
+		if (this.linearClient.client) {
+			this.linearClient.client.setHeader("Authorization", `Bearer ${newToken}`);
+		}
+		return { refreshed: true };
+	}
+
+	/**
 	 * Update the access token using setHeader on the underlying GraphQL client.
 	 * This is more efficient than recreating the entire LinearClient.
 	 * @param token - New access token
+	 * @param expiresAt - Epoch ms when this token expires, when known
 	 */
-	setAccessToken(token: string): void {
+	setAccessToken(token: string, expiresAt?: number): void {
 		// Clear any cached refresh promise so subsequent 401s trigger a fresh refresh
 		// rather than reusing a stale resolved promise with an old token.
 		this.refreshPromise = null;
 		// Guard for test mocks that may not have the .client property
 		if (this.linearClient.client) {
 			this.linearClient.client.setHeader("Authorization", `Bearer ${token}`);
+		}
+		if (expiresAt && this.oauthConfig) {
+			LinearIssueTrackerService.workspaceTokenExpiresAt.set(
+				this.oauthConfig.workspaceId,
+				expiresAt,
+			);
 		}
 	}
 

--- a/packages/linear-event-transport/test/LinearIssueTrackerService.tokenRefresh.test.ts
+++ b/packages/linear-event-transport/test/LinearIssueTrackerService.tokenRefresh.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LinearIssueTrackerService } from "../src/LinearIssueTrackerService.js";
+
+/**
+ * Tests for proactive OAuth token refresh (CRATE-153).
+ *
+ * Linear access tokens live ~24h and Linear REVOKES the old access token the
+ * moment a refresh is performed. These tests cover:
+ *  - expiry tracking from the refresh response (expires_in -> expiresAt)
+ *  - ensureFreshToken(): refreshes when expiry is unknown or within the
+ *    threshold, no-ops when the token has plenty of runway
+ *  - coalescing: concurrent ensureFreshToken calls share one HTTP refresh
+ */
+
+function makeMockLinearClient() {
+	return {
+		client: {
+			request: vi.fn().mockResolvedValue({}),
+			setHeader: vi.fn(),
+		},
+	} as any;
+}
+
+function makeOAuthConfig(overrides: Record<string, unknown> = {}) {
+	return {
+		clientId: "client-id",
+		clientSecret: "client-secret",
+		refreshToken: "refresh-token-1",
+		workspaceId: `ws-${Math.random().toString(36).slice(2)}`,
+		...overrides,
+	} as any;
+}
+
+function mockRefreshResponse(accessToken = "new-access", expiresIn = 86399) {
+	return {
+		ok: true,
+		json: async () => ({
+			access_token: accessToken,
+			refresh_token: "new-refresh",
+			expires_in: expiresIn,
+		}),
+	} as Response;
+}
+
+describe("LinearIssueTrackerService proactive token refresh", () => {
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(mockRefreshResponse());
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it("reports token expiry from oauth config", () => {
+		const expiresAt = Date.now() + 10_000_000;
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt }),
+		);
+		expect(service.getTokenExpiresAt()).toBe(expiresAt);
+	});
+
+	it("ensureFreshToken refreshes when expiry is unknown", async () => {
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig(),
+		);
+		const result = await service.ensureFreshToken(60 * 60 * 1000);
+		expect(result.refreshed).toBe(true);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("ensureFreshToken no-ops when the token has runway beyond the threshold", async () => {
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt: Date.now() + 20 * 60 * 60 * 1000 }),
+		);
+		const result = await service.ensureFreshToken(60 * 60 * 1000);
+		expect(result.refreshed).toBe(false);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("ensureFreshToken refreshes when remaining ttl is below the threshold", async () => {
+		const client = makeMockLinearClient();
+		const service = new LinearIssueTrackerService(
+			client,
+			makeOAuthConfig({ expiresAt: Date.now() + 10 * 60 * 1000 }),
+		);
+		const result = await service.ensureFreshToken(60 * 60 * 1000);
+		expect(result.refreshed).toBe(true);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		// the instance's client must start using the new token immediately
+		expect(client.client.setHeader).toHaveBeenCalledWith(
+			"Authorization",
+			"Bearer new-access",
+		);
+	});
+
+	it("updates tracked expiry after a refresh", async () => {
+		const before = Date.now();
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt: Date.now() + 1000 }),
+		);
+		await service.ensureFreshToken(60 * 60 * 1000);
+		const expiresAt = service.getTokenExpiresAt();
+		expect(expiresAt).not.toBeNull();
+		// ~24h from now (expires_in 86399s)
+		expect(expiresAt!).toBeGreaterThan(before + 86_000_000);
+	});
+
+	it("passes expiresAt to onTokenRefresh so callers can persist it", async () => {
+		const onTokenRefresh = vi.fn();
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt: Date.now() + 1000, onTokenRefresh }),
+		);
+		await service.ensureFreshToken(60 * 60 * 1000);
+		expect(onTokenRefresh).toHaveBeenCalledTimes(1);
+		const arg = onTokenRefresh.mock.calls[0][0];
+		expect(arg.accessToken).toBe("new-access");
+		expect(arg.refreshToken).toBe("new-refresh");
+		expect(typeof arg.expiresAt).toBe("number");
+		expect(arg.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("coalesces concurrent ensureFreshToken calls into one HTTP refresh", async () => {
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt: Date.now() + 1000 }),
+		);
+		const [a, b] = await Promise.all([
+			service.ensureFreshToken(60 * 60 * 1000),
+			service.ensureFreshToken(60 * 60 * 1000),
+		]);
+		expect(a.refreshed).toBe(true);
+		expect(b.refreshed).toBe(true);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("ensureFreshToken no-ops without oauth config", async () => {
+		const service = new LinearIssueTrackerService(makeMockLinearClient());
+		const result = await service.ensureFreshToken(60 * 60 * 1000);
+		expect(result.refreshed).toBe(false);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("setAccessToken records the new expiry when provided", () => {
+		const service = new LinearIssueTrackerService(
+			makeMockLinearClient(),
+			makeOAuthConfig({ expiresAt: Date.now() + 1000 }),
+		);
+		const newExpiry = Date.now() + 86_399_000;
+		service.setAccessToken("rotated-token", newExpiry);
+		expect(service.getTokenExpiresAt()).toBe(newExpiry);
+	});
+});

--- a/packages/mcp-tools/src/tools/cyrus-tools/index.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/index.ts
@@ -606,6 +606,78 @@ export function createCyrusToolsServer(
 	);
 
 	server.registerTool(
+		"linear_update_issue_status",
+		{
+			description:
+				"Update a Linear issue's workflow status (e.g. move to 'In Review' after opening a PR). Goes through Cyrus's own Linear client, which auto-refreshes expired OAuth tokens — prefer this over the hosted Linear MCP server's save_issue for status changes, which can fail with 'requires re-authorization' when the token rotates mid-session.",
+			inputSchema: {
+				issueId: z
+					.string()
+					.describe("Issue identifier (e.g. 'PROJ-123') or UUID"),
+				status: z
+					.string()
+					.describe(
+						"Target workflow state, by name (case-insensitive, e.g. 'In Review', 'Done') or state UUID",
+					),
+			},
+		},
+		async ({ issueId, status }) => {
+			const fail = (payload: Record<string, unknown>) => ({
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify({ success: false, ...payload }),
+					},
+				],
+			});
+			try {
+				const issue = await linearClient.issue(issueId);
+				if (!issue) {
+					return fail({ error: `Issue ${issueId} not found` });
+				}
+
+				const team = await issue.team;
+				if (!team) {
+					return fail({ error: `Could not resolve team for issue ${issueId}` });
+				}
+
+				const states = await team.states();
+				const wanted = status.trim().toLowerCase();
+				const match = states.nodes.find(
+					(s: { id: string; name: string }) =>
+						s.id === status || s.name.toLowerCase() === wanted,
+				);
+				if (!match) {
+					return fail({
+						error: `No workflow state matching '${status}' for issue ${issueId}`,
+						availableStatuses: states.nodes.map(
+							(s: { name: string }) => s.name,
+						),
+					});
+				}
+
+				await linearClient.updateIssue(issue.id, { stateId: match.id });
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								message: `Updated ${issue.identifier} status to '${match.name}'`,
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				return fail({
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		},
+	);
+
+	server.registerTool(
 		"linear_get_child_issues",
 		{
 			description:

--- a/packages/mcp-tools/test/tools/cyrus-tools/update-issue-status.test.ts
+++ b/packages/mcp-tools/test/tools/cyrus-tools/update-issue-status.test.ts
@@ -1,0 +1,112 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it, vi } from "vitest";
+import { createCyrusToolsServer } from "../../../src/tools/cyrus-tools/index.js";
+
+/**
+ * Tests for linear_update_issue_status (CRATE-153).
+ *
+ * Status writes previously had to go through the hosted Linear MCP server,
+ * whose Authorization header is a static token snapshot that dies when the
+ * OAuth token rotates. This tool goes through the daemon's LinearClient,
+ * which auto-refreshes on 401 — so the critical "move to In Review" write
+ * keeps working even mid-rotation.
+ */
+
+function makeMockLinearClient(overrides: Record<string, unknown> = {}) {
+	const states = {
+		nodes: [
+			{ id: "state-backlog", name: "Backlog", type: "backlog" },
+			{ id: "state-in-review", name: "In Review", type: "started" },
+			{ id: "state-done", name: "Done", type: "completed" },
+		],
+	};
+	return {
+		issue: vi.fn().mockResolvedValue({
+			id: "issue-uuid-1",
+			identifier: "CRATE-80",
+			team: Promise.resolve({
+				id: "team-1",
+				states: vi.fn().mockResolvedValue(states),
+			}),
+		}),
+		updateIssue: vi.fn().mockResolvedValue({ success: true }),
+		...overrides,
+	} as any;
+}
+
+async function callTool(linearClient: any, args: Record<string, unknown>) {
+	const server = createCyrusToolsServer(linearClient);
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: "test-client", version: "1.0.0" });
+	await Promise.all([
+		server.connect(serverTransport),
+		client.connect(clientTransport),
+	]);
+	const result = await client.callTool({
+		name: "linear_update_issue_status",
+		arguments: args,
+	});
+	await client.close();
+	await server.close();
+	const text = (result.content as Array<{ type: string; text: string }>)[0]
+		?.text;
+	return JSON.parse(text ?? "{}");
+}
+
+describe("linear_update_issue_status tool", () => {
+	it("updates the issue state by case-insensitive status name", async () => {
+		const linearClient = makeMockLinearClient();
+		const result = await callTool(linearClient, {
+			issueId: "CRATE-80",
+			status: "in review",
+		});
+		expect(result.success).toBe(true);
+		expect(linearClient.updateIssue).toHaveBeenCalledWith("issue-uuid-1", {
+			stateId: "state-in-review",
+		});
+		expect(result.message).toContain("CRATE-80");
+		expect(result.message).toContain("In Review");
+	});
+
+	it("returns the available states when the requested status does not exist", async () => {
+		const linearClient = makeMockLinearClient();
+		const result = await callTool(linearClient, {
+			issueId: "CRATE-80",
+			status: "Shipped",
+		});
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("Shipped");
+		expect(result.availableStatuses).toEqual(["Backlog", "In Review", "Done"]);
+		expect(linearClient.updateIssue).not.toHaveBeenCalled();
+	});
+
+	it("surfaces underlying API failures loudly instead of silently no-oping", async () => {
+		const linearClient = makeMockLinearClient({
+			updateIssue: vi
+				.fn()
+				.mockRejectedValue(
+					new Error("Authentication required, not authenticated"),
+				),
+		});
+		const result = await callTool(linearClient, {
+			issueId: "CRATE-80",
+			status: "Done",
+		});
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("Authentication required");
+	});
+
+	it("fails loudly when the issue cannot be found", async () => {
+		const linearClient = makeMockLinearClient({
+			issue: vi.fn().mockResolvedValue(null),
+		});
+		const result = await callTool(linearClient, {
+			issueId: "CRATE-999",
+			status: "Done",
+		});
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("CRATE-999");
+	});
+});


### PR DESCRIPTION
## Problem

When the agent is **re-delegated / re-mentioned** on a Linear issue it has already worked on, Linear fires a fresh `agentSessionCreated` webhook with a brand-new `agentSession.id`. `EdgeWorker.initializeAgentRunner` passes `resumeSessionId = undefined` unconditionally, so every re-delegation **cold-starts a new runner session and re-reads the entire issue context** — burning tokens and latency, and losing the prior conversation.

(Follow-up comments within the *same* agent session already resume via `claudeSessionId`; only the new-agent-session path cold-starts.)

Observed in practice: a single issue accumulating many independent runner transcripts in its worktree, one per delegation, none resuming the others.

## Change

Opt-in **cross-session resume**: when a new agent session is created on an issue with prior work, resume the most recent prior runner conversation instead of cold-starting.

- **Durable per-issue record** (`issueLastSession`) in `cyrus-core` state + `AgentSessionManager`. Captured wherever a runner session id is captured; **not** cleared by `removeSession()`, so it survives the session pruning that happens when an issue goes terminal/unassigned. Additive optional state field — no persistence version bump, old state loads unchanged.
- **`initializeAgentRunner`** resolves a `resumeSessionId`: (a) the most-recent still-live session for the issue, else (b) the durable record. It seeds the matching runner-id field on the new session so `RunnerConfigBuilder.buildIssueConfig` keeps the runner type consistent with the resumed transcript, and posts a short "Resuming from a previous session" note to the thread. The issue's worktree path is deterministic per identifier, so the runner cwd already matches the transcript — no workspace juggling needed.
- **`ClaudeRunner`** falls back to a cold start exactly once if the SDK can't locate the prior transcript (e.g. it was cleaned up), so re-delegation never hard-fails.
- **Opt-in**, default off: env `CYRUS_RESUME_ACROSS_SESSIONS=1` or per-repository `resumeAcrossSessions: true`.

## Why it's safe

Off by default. When on, the only new behavior is passing a resume id on session creation; if resume isn't possible the runner degrades to today's cold-start path.

## Tests

- `AgentSessionManager.issue-last-session` — record captured on init, **survives `removeSession()`**, round-trips through serialize/restore.
- `EdgeWorker.cross-session-resume` — resolution + opt-in gating (env and per-repo), most-recent-wins, current-session excluded, durable-record fallback, runner-type mapping, disabled-by-default.
- `ClaudeRunner.resume-fallback` — `isResumeFailure` heuristic; retries once cold on resume failure; no retry when resume isn't set.

Full suites pass (core 137, claude-runner 117, edge-worker 692); build, typecheck, biome, and committed JSON schemas all green.

## Manual verification

With `CYRUS_RESUME_ACROSS_SESSIONS=1`, re-delegating on an issue with a prior completed session logs `Resuming prior claude session <id> … (cross-session resume)` and `[event:session_resumed]`, and the new session's messages carry the prior `claudeSessionId` — confirming it continued the previous conversation rather than cold-starting.
