### PR TITLE
fix(edge-worker): grant write access to all sub-worktree git metadata dirs in multi-repo sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
+
 
 ## [0.2.62] - 2026-06-02
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4128,7 +4128,7 @@ ${taskSection}`;
 			...new Set([
 				attachmentsDir,
 				...allRepoPaths,
-				...this.gitService.getGitMetadataDirectories(workspace.path),
+				...this.gitService.getGitMetadataDirectoriesForWorkspace(workspace),
 			]),
 		];
 
@@ -7148,7 +7148,9 @@ ${input.userComment}
 				attachmentsDir,
 				repository.repositoryPath,
 				...additionalAllowedDirectories,
-				...this.gitService.getGitMetadataDirectories(session.workspace.path),
+				...this.gitService.getGitMetadataDirectoriesForWorkspace(
+					session.workspace,
+				),
 			]),
 		];
 

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -176,6 +176,35 @@ export class GitService {
 	}
 
 	/**
+	 * Resolve mutable Git metadata directories for an entire workspace,
+	 * including every repository in a multi-repo session.
+	 *
+	 * For single-repo workspaces `workspace.path` is itself the worktree, so
+	 * resolving from it is sufficient. For multi-repo workspaces, however,
+	 * `workspace.path` is a plain parent container (not a git repo) and each
+	 * repository lives in a sub-worktree under `workspace.repoPaths`. Each of
+	 * those sub-worktrees has its own linked git metadata (for example
+	 * `<mainRepo>/.git/worktrees/<name>/`) that must be writable by sandboxes —
+	 * resolving only from the container would miss them entirely, breaking
+	 * `git add`/`git merge`/etc. with "Operation not permitted".
+	 */
+	public getGitMetadataDirectoriesForWorkspace(workspace: Workspace): string[] {
+		const candidateWorkingDirs = new Set<string>([
+			workspace.path,
+			...Object.values(workspace.repoPaths ?? {}),
+		]);
+
+		const resolvedDirectories = new Set<string>();
+		for (const workingDir of candidateWorkingDirs) {
+			for (const metadataDir of this.getGitMetadataDirectories(workingDir)) {
+				resolvedDirectories.add(metadataDir);
+			}
+		}
+
+		return [...resolvedDirectories];
+	}
+
+	/**
 	 * Find an existing worktree by its checked-out branch name.
 	 * Parses `git worktree list --porcelain` output and returns the worktree path
 	 * if a worktree is found with the given branch checked out, or null otherwise.

--- a/packages/edge-worker/test/GitService.test.ts
+++ b/packages/edge-worker/test/GitService.test.ts
@@ -226,6 +226,81 @@ describe("GitService", () => {
 		});
 	});
 
+	describe("getGitMetadataDirectoriesForWorkspace", () => {
+		// Map each worktree cwd to the metadata dirs `git rev-parse` reports for it.
+		const metadataByCwd: Record<string, { gitDir: string; commonDir: string }> =
+			{
+				"/ws/ENG-1/repo-a": {
+					gitDir: "/repos/repo-a/.git/worktrees/ENG-1",
+					commonDir: "/repos/repo-a/.git",
+				},
+				"/ws/ENG-1/repo-b": {
+					gitDir: "/repos/repo-b/.git/worktrees/ENG-1",
+					commonDir: "/repos/repo-b/.git",
+				},
+			};
+
+		const installRevParseMock = () => {
+			mockExecSync.mockImplementation((cmd: any, opts: any) => {
+				const cmdStr = String(cmd);
+				const cwd = String(opts?.cwd ?? "");
+				const entry = metadataByCwd[cwd];
+				if (!entry) {
+					// Container dir / non-repo path: git rev-parse fails.
+					throw new Error("not a git repository");
+				}
+				if (cmdStr.includes("--git-dir")) return `${entry.gitDir}\n`;
+				if (cmdStr.includes("--git-common-dir")) return `${entry.commonDir}\n`;
+				return "";
+			});
+		};
+
+		it("collects metadata dirs from every sub-worktree in a multi-repo workspace", () => {
+			installRevParseMock();
+
+			const result = gitService.getGitMetadataDirectoriesForWorkspace({
+				// Parent container is NOT a git repo (mkdirSync'd directory).
+				path: "/ws/ENG-1",
+				isGitWorktree: true,
+				repoPaths: {
+					"repo-a": "/ws/ENG-1/repo-a",
+					"repo-b": "/ws/ENG-1/repo-b",
+				},
+			});
+
+			expect(new Set(result)).toEqual(
+				new Set([
+					"/repos/repo-a/.git/worktrees/ENG-1",
+					"/repos/repo-a/.git",
+					"/repos/repo-b/.git/worktrees/ENG-1",
+					"/repos/repo-b/.git",
+				]),
+			);
+		});
+
+		it("resolves from workspace.path for single-repo workspaces", () => {
+			mockExecSync.mockImplementation((cmd: any, opts: any) => {
+				const cmdStr = String(cmd);
+				if (String(opts?.cwd) !== "/ws/ENG-2") {
+					throw new Error("not a git repository");
+				}
+				if (cmdStr.includes("--git-dir"))
+					return "/repos/repo-a/.git/worktrees/ENG-2\n";
+				if (cmdStr.includes("--git-common-dir")) return "/repos/repo-a/.git\n";
+				return "";
+			});
+
+			const result = gitService.getGitMetadataDirectoriesForWorkspace({
+				path: "/ws/ENG-2",
+				isGitWorktree: true,
+			});
+
+			expect(new Set(result)).toEqual(
+				new Set(["/repos/repo-a/.git/worktrees/ENG-2", "/repos/repo-a/.git"]),
+			);
+		});
+	});
+
 	// Shared helpers for test data
 	const makeIssue = (overrides: Partial<any> = {}): any => ({
 		id: "issue-1",


### PR DESCRIPTION
## Problem

When the agent ran under a sandbox (notably the **Codex runner**) in a **multi-repo workspace**, git commands (`git add`, `git commit`, `git merge`, …) failed with **"Operation not permitted"** while creating lock files such as `index.lock` and `ORIG_HEAD.lock`. Read-only git commands still worked because they don't write metadata.

## Root cause

In a multi-repo session (`GitService.createGitWorktree`, the "N repos" branch), `workspace.path` is a plain parent container created with `mkdirSync` — it is **not** a git repo. Each repository lives in a sub-worktree at `workspace.repoPaths[repo.id]` (`<container>/<repo.name>`), and each sub-worktree has its own linked git metadata under `<mainRepo>/.git/worktrees/<name>/`.

Both sandbox-allowlist call sites in `EdgeWorker.ts` computed the writable git-metadata directories with `getGitMetadataDirectories(workspace.path)` — running `git rev-parse` from the **container**, which isn't a git repo. So the per-sub-worktree metadata dirs were never added to the sandbox's writable roots (Codex `--add-dir`), and git's lock-file writes were denied at the OS level.

Single-repo sessions were unaffected because there `workspace.path` *is* the worktree.

## Fix

- Add `GitService.getGitMetadataDirectoriesForWorkspace(workspace)` which resolves git-metadata dirs from `workspace.path` **and every entry in `workspace.repoPaths`**, deduped.
- Point both `allowedDirectories` builders in `EdgeWorker.ts` (issue setup + resume path) at the new method. Those dirs flow into the Codex runner's `additionalDirectories` → codex `--add-dir`, making them writable under `workspace-write`.

## Tests

- Added two `GitService.test.ts` cases: multi-repo collects metadata dirs from every sub-worktree; single-repo still resolves from `workspace.path`.
- Full `GitService.test.ts` suite passes; `pnpm build` + `pnpm typecheck` pass across the monorepo (run by the pre-commit hook).

## Note / follow-up (out of scope)

The Claude-runner sandbox in `RunnerConfigBuilder.buildSandboxConfig()` lists only `workspace.path` in `allowWrite` (git-metadata dirs are in `allowRead` only). That's a separate sandbox mechanism and wasn't the reported failure, so it's left untouched here — but enabling the Claude sandbox for git-writing sessions would hit the same wall and would need the metadata dirs added to `allowWrite`.