### PR TITLE
Make hosted MCP configs available to Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
+- Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
-- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters and approvals, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools without requiring interactive approval. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
-- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288))
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/apps/f1/test-drives/2026-06-04-cypack-1286-codex-mcp-config.md
+++ b/apps/f1/test-drives/2026-06-04-cypack-1286-codex-mcp-config.md
@@ -1,0 +1,59 @@
+# Test Drive: CYPACK-1286 — Codex MCP Config Wiring
+
+**Date**: 2026-06-04
+**Goal**: Validate the F1 issue/session path for a Codex-selected session and confirm MCP config reaches the Codex runner.
+**Test Repo**: `/tmp/f1-test-drive-cypack-1286-codex-mcp`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible
+
+### EdgeWorker
+- [x] Session started
+- [x] Worktree created
+- [x] Description-tag routing selected the F1 test repository
+- [x] Codex runner selected via `[agent=codex]`
+- [x] Codex runner logged MCP config handoff
+- [ ] Agent completed prompt processing
+
+### Renderer
+- [x] Activities were created
+- [x] Activity payloads were readable
+- [x] Error activity captured the local Codex runtime failure
+
+## Session Log
+
+```bash
+pnpm --filter cyrus-f1 build
+apps/f1/f1 init-test-repo --path /tmp/f1-test-drive-cypack-1286-codex-mcp
+CYRUS_PORT=3600 CYRUS_REPO_PATH=/tmp/f1-test-drive-cypack-1286-codex-mcp node apps/f1/dist/server.js
+CYRUS_PORT=3600 apps/f1/f1 ping
+CYRUS_PORT=3600 apps/f1/f1 status
+CYRUS_PORT=3600 apps/f1/f1 create-issue \
+  --title "CYPACK-1286 Codex MCP smoke" \
+  --description "[agent=codex] [repo=f1-test/primary-repo]\n\nReply with exactly: codex f1 smoke ok"
+CYRUS_PORT=3600 apps/f1/f1 start-session --issue-id issue-1
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 20
+CYRUS_PORT=3600 apps/f1/f1 stop-session --session-id session-1
+```
+
+Key server log evidence:
+
+```text
+Repositories selected: [F1 Test Repository] (description-tag routing)
+Label-based runner selection for new session: codex (session session-1)
+[CodexRunner] Configured 1 MCP server(s) for codex config (docs: https://platform.openai.com/docs/docs-mcp)
+```
+
+The runner failed after startup because local Codex could not access its session directory:
+
+```text
+Fatal error: Codex cannot access session files at /Users/agentops/.codex/sessions (permission denied).
+```
+
+## Final Retrospective
+
+The F1 drive validates the Cyrus side of the Codex path: issue creation, repository routing, worktree creation, Codex runner selection, activity rendering, and Codex MCP config handoff. Full prompt processing was blocked by local filesystem permissions on the host Codex session store, not by Cyrus runner config assembly.

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -489,11 +489,13 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
-function isConfigObject(value: unknown): value is CodexConfigOverrides {
-	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+function isConfigObject(
+	value: unknown,
+): value is Record<string, CodexConfigValue> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function ensureCodexMcpToolApproval(
+function setMissingCodexMcpToolApproval(
 	mapped: CodexConfigOverrides,
 	toolName: string,
 ): void {
@@ -511,21 +513,30 @@ function ensureCodexMcpToolApproval(
 	mapped.tools = tools;
 }
 
-function applyCyrusMcpApprovalSemantics(
+function applyCyrusMcpAllowedToolsSemantics(
 	mapped: CodexConfigOverrides,
 	allowedToolsFilter: McpAllowedToolsFilter,
-	options: { approveListedTools: boolean },
+	options: { hasNativeToolFilter: boolean },
 ): void {
+	const shouldGenerateToolFilter =
+		!allowedToolsFilter.allowAll &&
+		allowedToolsFilter.tools.length > 0 &&
+		!options.hasNativeToolFilter;
+
+	if (shouldGenerateToolFilter) {
+		mapped.enabled_tools = allowedToolsFilter.tools;
+	}
+
+	// Codex separates tool visibility (`enabled_tools`) from MCP approval. Cyrus
+	// allowedTools are already the operator's allow-list, so generated allowances
+	// must also be approved for non-interactive Codex exec runs.
 	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
 		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
 	}
 
-	// Codex separates tool visibility (`enabled_tools`) from approval. Cyrus
-	// allowedTools are already the operator's allow-list, so generated MCP
-	// allowances must also be pre-approved for non-interactive Codex exec runs.
-	if (options.approveListedTools && !allowedToolsFilter.allowAll) {
+	if (shouldGenerateToolFilter) {
 		for (const tool of allowedToolsFilter.tools) {
-			ensureCodexMcpToolApproval(mapped, tool);
+			setMissingCodexMcpToolApproval(mapped, tool);
 		}
 	}
 }
@@ -928,17 +939,9 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			const hasNativeToolFilter =
 				Object.hasOwn(mapped, "enabled_tools") ||
 				Object.hasOwn(mapped, "disabled_tools");
-			if (
-				allowedToolsFilter &&
-				!allowedToolsFilter.allowAll &&
-				allowedToolsFilter.tools.length > 0 &&
-				!hasNativeToolFilter
-			) {
-				mapped.enabled_tools = allowedToolsFilter.tools;
-			}
 			if (allowedToolsFilter) {
-				applyCyrusMcpApprovalSemantics(mapped, allowedToolsFilter, {
-					approveListedTools: !hasNativeToolFilter,
+				applyCyrusMcpAllowedToolsSemantics(mapped, allowedToolsFilter, {
+					hasNativeToolFilter,
 				});
 			}
 			// If the MCP config already contains Codex-native enabled_tools or

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -63,6 +63,7 @@ interface McpAllowedToolsFilter {
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
+const CODEX_MCP_APPROVE_MODE = "approve";
 
 function toFiniteNumber(value: number | undefined): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -488,6 +489,47 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
+function isConfigObject(value: unknown): value is CodexConfigOverrides {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function ensureCodexMcpToolApproval(
+	mapped: CodexConfigOverrides,
+	toolName: string,
+): void {
+	const tools = isConfigObject(mapped.tools) ? { ...mapped.tools } : {};
+	const existingToolConfig = tools[toolName];
+	const toolConfig = isConfigObject(existingToolConfig)
+		? { ...existingToolConfig }
+		: {};
+
+	if (!Object.hasOwn(toolConfig, "approval_mode")) {
+		toolConfig.approval_mode = CODEX_MCP_APPROVE_MODE;
+	}
+
+	tools[toolName] = toolConfig;
+	mapped.tools = tools;
+}
+
+function applyCyrusMcpApprovalSemantics(
+	mapped: CodexConfigOverrides,
+	allowedToolsFilter: McpAllowedToolsFilter,
+	options: { approveListedTools: boolean },
+): void {
+	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
+		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
+	}
+
+	// Codex separates tool visibility (`enabled_tools`) from approval. Cyrus
+	// allowedTools are already the operator's allow-list, so generated MCP
+	// allowances must also be pre-approved for non-interactive Codex exec runs.
+	if (options.approveListedTools && !allowedToolsFilter.allowAll) {
+		for (const tool of allowedToolsFilter.tools) {
+			ensureCodexMcpToolApproval(mapped, tool);
+		}
+	}
+}
+
 function copyConfigString(
 	target: CodexConfigOverrides,
 	source: Record<string, unknown>,
@@ -893,6 +935,11 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				!hasNativeToolFilter
 			) {
 				mapped.enabled_tools = allowedToolsFilter.tools;
+			}
+			if (allowedToolsFilter) {
+				applyCyrusMcpApprovalSemantics(mapped, allowedToolsFilter, {
+					approveListedTools: !hasNativeToolFilter,
+				});
 			}
 			// If the MCP config already contains Codex-native enabled_tools or
 			// disabled_tools, keep those exact filters. They are more specific to

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -432,6 +432,62 @@ function buildMcpAllowedToolsFilters(
 	return filters;
 }
 
+function normalizeMcpServerFilterName(serverName: string): string {
+	return serverName.replace(/[-_]+/g, "").toLowerCase();
+}
+
+function mergeMcpAllowedToolsFilters(
+	filters: McpAllowedToolsFilter[],
+): McpAllowedToolsFilter | undefined {
+	if (filters.length === 0) {
+		return undefined;
+	}
+
+	const merged: McpAllowedToolsFilter = {
+		allowAll: false,
+		tools: [],
+	};
+
+	for (const filter of filters) {
+		if (filter.allowAll) {
+			return { allowAll: true, tools: [] };
+		}
+
+		for (const tool of filter.tools) {
+			if (!merged.tools.includes(tool)) {
+				merged.tools.push(tool);
+			}
+		}
+	}
+
+	return merged;
+}
+
+function getMcpAllowedToolsFilter(
+	filters: Map<string, McpAllowedToolsFilter>,
+	serverName: string,
+): McpAllowedToolsFilter | undefined {
+	const matchingFilters: McpAllowedToolsFilter[] = [];
+	const exact = filters.get(serverName);
+	if (exact) {
+		matchingFilters.push(exact);
+	}
+
+	const normalizedServerName = normalizeMcpServerFilterName(serverName);
+	for (const [allowedServerName, filter] of filters.entries()) {
+		if (allowedServerName === serverName) {
+			continue;
+		}
+		if (
+			normalizeMcpServerFilterName(allowedServerName) === normalizedServerName
+		) {
+			matchingFilters.push(filter);
+		}
+	}
+
+	return mergeMcpAllowedToolsFilters(matchingFilters);
+}
+
 function copyConfigString(
 	target: CodexConfigOverrides,
 	source: Record<string, unknown>,
@@ -823,7 +879,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				continue;
 			}
 
-			const allowedToolsFilter = allowedToolsFilters.get(serverName);
+			const allowedToolsFilter = getMcpAllowedToolsFilter(
+				allowedToolsFilters,
+				serverName,
+			);
 			const hasNativeToolFilter =
 				Object.hasOwn(mapped, "enabled_tools") ||
 				Object.hasOwn(mapped, "disabled_tools");

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -377,6 +377,61 @@ function loadMcpConfigFromPaths(
 	return mcpServers;
 }
 
+function copyConfigString(
+	target: CodexConfigOverrides,
+	source: Record<string, unknown>,
+	key: string,
+): void {
+	if (typeof source[key] === "string") {
+		target[key] = source[key] as string;
+	}
+}
+
+function copyConfigNumber(
+	target: CodexConfigOverrides,
+	source: Record<string, unknown>,
+	key: string,
+): void {
+	if (typeof source[key] === "number") {
+		target[key] = source[key] as number;
+	}
+}
+
+function copyConfigBoolean(
+	target: CodexConfigOverrides,
+	source: Record<string, unknown>,
+	key: string,
+): void {
+	if (typeof source[key] === "boolean") {
+		target[key] = source[key] as boolean;
+	}
+}
+
+function copyConfigArray(
+	target: CodexConfigOverrides,
+	source: Record<string, unknown>,
+	key: string,
+): void {
+	if (Array.isArray(source[key])) {
+		target[key] = source[
+			key
+		] as CodexConfigOverrides[keyof CodexConfigOverrides];
+	}
+}
+
+function copyConfigObject(
+	target: CodexConfigOverrides,
+	source: Record<string, unknown>,
+	sourceKey: string,
+	targetKey: string = sourceKey,
+): void {
+	const value = source[sourceKey];
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		target[targetKey] =
+			value as CodexConfigOverrides[keyof CodexConfigOverrides];
+	}
+}
+
 export declare interface CodexRunner {
 	on<K extends keyof CodexRunnerEvents>(
 		event: K,
@@ -681,57 +736,26 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			}
 
 			const mapped: CodexConfigOverrides = {};
-			if (typeof configAny.command === "string") {
-				mapped.command = configAny.command;
-			}
-			if (Array.isArray(configAny.args)) {
-				mapped.args =
-					configAny.args as unknown as CodexConfigOverrides[keyof CodexConfigOverrides];
-			}
-			if (
-				configAny.env &&
-				typeof configAny.env === "object" &&
-				!Array.isArray(configAny.env)
-			) {
-				mapped.env =
-					configAny.env as unknown as CodexConfigOverrides[keyof CodexConfigOverrides];
-			}
-			if (typeof configAny.cwd === "string") {
-				mapped.cwd = configAny.cwd;
-			}
-			if (typeof configAny.url === "string") {
-				mapped.url = configAny.url;
-			}
-			if (
-				configAny.http_headers &&
-				typeof configAny.http_headers === "object" &&
-				!Array.isArray(configAny.http_headers)
-			) {
-				mapped.http_headers =
-					configAny.http_headers as unknown as CodexConfigOverrides[keyof CodexConfigOverrides];
-			}
-			if (
-				configAny.headers &&
-				typeof configAny.headers === "object" &&
-				!Array.isArray(configAny.headers)
-			) {
-				mapped.http_headers =
-					configAny.headers as unknown as CodexConfigOverrides[keyof CodexConfigOverrides];
-			}
-			if (
-				configAny.env_http_headers &&
-				typeof configAny.env_http_headers === "object" &&
-				!Array.isArray(configAny.env_http_headers)
-			) {
-				mapped.env_http_headers =
-					configAny.env_http_headers as unknown as CodexConfigOverrides[keyof CodexConfigOverrides];
-			}
-			if (typeof configAny.bearer_token_env_var === "string") {
-				mapped.bearer_token_env_var = configAny.bearer_token_env_var;
-			}
-			if (typeof configAny.timeout === "number") {
-				mapped.timeout = configAny.timeout;
-			}
+			copyConfigString(mapped, configAny, "command");
+			copyConfigArray(mapped, configAny, "args");
+			copyConfigObject(mapped, configAny, "env");
+			copyConfigArray(mapped, configAny, "env_vars");
+			copyConfigString(mapped, configAny, "cwd");
+			copyConfigString(mapped, configAny, "experimental_environment");
+			copyConfigString(mapped, configAny, "url");
+			copyConfigObject(mapped, configAny, "http_headers");
+			copyConfigObject(mapped, configAny, "headers", "http_headers");
+			copyConfigObject(mapped, configAny, "env_http_headers");
+			copyConfigString(mapped, configAny, "bearer_token_env_var");
+			copyConfigNumber(mapped, configAny, "timeout");
+			copyConfigNumber(mapped, configAny, "startup_timeout_sec");
+			copyConfigNumber(mapped, configAny, "tool_timeout_sec");
+			copyConfigBoolean(mapped, configAny, "enabled");
+			copyConfigBoolean(mapped, configAny, "required");
+			copyConfigArray(mapped, configAny, "enabled_tools");
+			copyConfigArray(mapped, configAny, "disabled_tools");
+			copyConfigString(mapped, configAny, "default_tools_approval_mode");
+			copyConfigObject(mapped, configAny, "tools");
 
 			if (!mapped.command && !mapped.url) {
 				console.warn(

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -489,30 +489,6 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
-function isConfigObject(
-	value: unknown,
-): value is Record<string, CodexConfigValue> {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function setMissingCodexMcpToolApproval(
-	mapped: CodexConfigOverrides,
-	toolName: string,
-): void {
-	const tools = isConfigObject(mapped.tools) ? { ...mapped.tools } : {};
-	const existingToolConfig = tools[toolName];
-	const toolConfig = isConfigObject(existingToolConfig)
-		? { ...existingToolConfig }
-		: {};
-
-	if (!Object.hasOwn(toolConfig, "approval_mode")) {
-		toolConfig.approval_mode = CODEX_MCP_APPROVE_MODE;
-	}
-
-	tools[toolName] = toolConfig;
-	mapped.tools = tools;
-}
-
 function applyCyrusMcpAllowedToolsSemantics(
 	mapped: CodexConfigOverrides,
 	allowedToolsFilter: McpAllowedToolsFilter,
@@ -532,12 +508,6 @@ function applyCyrusMcpAllowedToolsSemantics(
 	// must also be approved for non-interactive Codex exec runs.
 	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
 		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
-	}
-
-	if (shouldGenerateToolFilter) {
-		for (const tool of allowedToolsFilter.tools) {
-			setMissingCodexMcpToolApproval(mapped, tool);
-		}
 	}
 }
 

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -56,6 +56,11 @@ interface ToolProjection {
 	isError: boolean;
 }
 
+interface McpAllowedToolsFilter {
+	allowAll: boolean;
+	tools: string[];
+}
+
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
 
@@ -375,6 +380,56 @@ function loadMcpConfigFromPaths(
 	}
 
 	return mcpServers;
+}
+
+function parseMcpAllowedTool(
+	toolPattern: string,
+): { serverName: string; toolName?: string } | null {
+	const trimmed = toolPattern.trim();
+	if (!trimmed.startsWith("mcp__")) {
+		return null;
+	}
+
+	const parts = trimmed.split("__");
+	const serverName = parts[1]?.trim();
+	if (!serverName) {
+		return null;
+	}
+
+	if (parts.length === 2) {
+		return { serverName };
+	}
+
+	const toolName = parts.slice(2).join("__").trim();
+	return toolName ? { serverName, toolName } : { serverName };
+}
+
+function buildMcpAllowedToolsFilters(
+	allowedTools: string[] | undefined,
+): Map<string, McpAllowedToolsFilter> {
+	const filters = new Map<string, McpAllowedToolsFilter>();
+	for (const allowedTool of allowedTools ?? []) {
+		const parsed = parseMcpAllowedTool(allowedTool);
+		if (!parsed) {
+			continue;
+		}
+
+		const filter = filters.get(parsed.serverName) ?? {
+			allowAll: false,
+			tools: [],
+		};
+
+		if (!parsed.toolName) {
+			filter.allowAll = true;
+			filter.tools = [];
+		} else if (!filter.allowAll && !filter.tools.includes(parsed.toolName)) {
+			filter.tools.push(parsed.toolName);
+		}
+
+		filters.set(parsed.serverName, filter);
+	}
+
+	return filters;
 }
 
 function copyConfigString(
@@ -720,6 +775,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			return undefined;
 		}
 
+		const allowedToolsFilters = buildMcpAllowedToolsFilters(
+			this.config.allowedTools,
+		);
+
 		// Codex MCP configuration reference:
 		// https://platform.openai.com/docs/docs-mcp
 		const codexServers: Record<string, CodexConfigOverrides> = {};
@@ -763,6 +822,24 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				);
 				continue;
 			}
+
+			const allowedToolsFilter = allowedToolsFilters.get(serverName);
+			const hasNativeToolFilter =
+				Object.hasOwn(mapped, "enabled_tools") ||
+				Object.hasOwn(mapped, "disabled_tools");
+			if (
+				allowedToolsFilter &&
+				!allowedToolsFilter.allowAll &&
+				allowedToolsFilter.tools.length > 0 &&
+				!hasNativeToolFilter
+			) {
+				mapped.enabled_tools = allowedToolsFilter.tools;
+			}
+			// If the MCP config already contains Codex-native enabled_tools or
+			// disabled_tools, keep those exact filters. They are more specific to
+			// Codex than Claude-style Cyrus allowedTools entries. A bare
+			// `mcp__server` intentionally emits no enabled_tools filter because it
+			// means "allow every tool exposed by this configured server".
 
 			codexServers[serverName] = mapped;
 		}

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -93,19 +93,14 @@ describe("CodexRunner MCP config mapping", () => {
 			"create_issue",
 		]);
 		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
-		expect(mcpServers.linear.tools).toEqual({
-			list_issues: { approval_mode: "approve" },
-			create_issue: { approval_mode: "approve" },
-		});
+		expect(mcpServers.linear.tools).toBeUndefined();
 		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
 			"linear_agent_session_create_on_comment",
 		]);
 		expect(mcpServers["cyrus-tools"].default_tools_approval_mode).toBe(
 			"approve",
 		);
-		expect(mcpServers["cyrus-tools"].tools).toEqual({
-			linear_agent_session_create_on_comment: { approval_mode: "approve" },
-		});
+		expect(mcpServers["cyrus-tools"].tools).toBeUndefined();
 	});
 
 	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
@@ -149,10 +144,7 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers["slack-fixed"].default_tools_approval_mode).toBe(
 			"approve",
 		);
-		expect(mcpServers["slack-fixed"].tools).toEqual({
-			conversations_replies: { approval_mode: "approve" },
-			attachment_get_data: { approval_mode: "approve" },
-		});
+		expect(mcpServers["slack-fixed"].tools).toBeUndefined();
 	});
 
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -92,9 +92,20 @@ describe("CodexRunner MCP config mapping", () => {
 			"list_issues",
 			"create_issue",
 		]);
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.linear.tools).toEqual({
+			list_issues: { approval_mode: "approve" },
+			create_issue: { approval_mode: "approve" },
+		});
 		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
 			"linear_agent_session_create_on_comment",
 		]);
+		expect(mcpServers["cyrus-tools"].default_tools_approval_mode).toBe(
+			"approve",
+		);
+		expect(mcpServers["cyrus-tools"].tools).toEqual({
+			linear_agent_session_create_on_comment: { approval_mode: "approve" },
+		});
 	});
 
 	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
@@ -112,6 +123,7 @@ describe("CodexRunner MCP config mapping", () => {
 		const mcpServers = (runner as any).buildCodexMcpServersConfig();
 		expect(mcpServers.linear.enabled_tools).toBeUndefined();
 		expect(mcpServers.linear.disabled_tools).toBeUndefined();
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
 	});
 
 	it("matches underscore Cyrus MCP server names to hyphenated Codex MCP server names", () => {
@@ -134,6 +146,13 @@ describe("CodexRunner MCP config mapping", () => {
 			"conversations_replies",
 			"attachment_get_data",
 		]);
+		expect(mcpServers["slack-fixed"].default_tools_approval_mode).toBe(
+			"approve",
+		);
+		expect(mcpServers["slack-fixed"].tools).toEqual({
+			conversations_replies: { approval_mode: "approve" },
+			attachment_get_data: { approval_mode: "approve" },
+		});
 	});
 
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
@@ -159,8 +178,12 @@ describe("CodexRunner MCP config mapping", () => {
 
 		const mcpServers = (runner as any).buildCodexMcpServersConfig();
 		expect(mcpServers.linear.enabled_tools).toEqual(["list_issues"]);
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.linear.tools).toBeUndefined();
 		expect(mcpServers.github.enabled_tools).toBeUndefined();
 		expect(mcpServers.github.disabled_tools).toEqual(["delete_repository"]);
+		expect(mcpServers.github.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.github.tools).toBeUndefined();
 	});
 
 	it("loads hosted file-based MCP configs and preserves Codex MCP options", () => {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { CodexRunner } from "../src/CodexRunner.js";
 
@@ -60,5 +63,84 @@ describe("CodexRunner MCP config mapping", () => {
 			Authorization: "LINEAR_API_TOKEN",
 		});
 		expect(mcpServers.linear.bearer_token_env_var).toBe("LINEAR_API_TOKEN");
+	});
+
+	it("loads hosted file-based MCP configs and preserves Codex MCP options", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "cyrus-codex-mcp-"));
+		try {
+			const mcpConfigPath = join(tmp, "mcp-hosted.json");
+			writeFileSync(
+				mcpConfigPath,
+				JSON.stringify({
+					mcpServers: {
+						hosted: {
+							command: "node",
+							args: ["server.js"],
+							env: { HOSTED_TOKEN: "secret" },
+							env_vars: [
+								"LOCAL_TOKEN",
+								{ name: "REMOTE_TOKEN", source: "remote" },
+							],
+							cwd: "/tmp/hosted",
+							experimental_environment: "remote",
+							startup_timeout_sec: 20,
+							tool_timeout_sec: 45,
+							enabled: true,
+							required: true,
+							enabled_tools: ["search"],
+							disabled_tools: ["delete"],
+							default_tools_approval_mode: "prompt",
+							tools: {
+								search: {
+									approval_mode: "approve",
+								},
+							},
+						},
+						remote: {
+							url: "https://example.com/mcp",
+							bearer_token_env_var: "REMOTE_MCP_TOKEN",
+							http_headers: { "X-Region": "us-east-1" },
+							env_http_headers: { Authorization: "AUTH_HEADER" },
+						},
+					},
+				}),
+				"utf8",
+			);
+
+			const runner = new CodexRunner({
+				workingDirectory: process.cwd(),
+				mcpConfigPath,
+			});
+
+			const mcpServers = (runner as any).buildCodexMcpServersConfig();
+			expect(mcpServers.hosted).toMatchObject({
+				command: "node",
+				args: ["server.js"],
+				env: { HOSTED_TOKEN: "secret" },
+				env_vars: ["LOCAL_TOKEN", { name: "REMOTE_TOKEN", source: "remote" }],
+				cwd: "/tmp/hosted",
+				experimental_environment: "remote",
+				startup_timeout_sec: 20,
+				tool_timeout_sec: 45,
+				enabled: true,
+				required: true,
+				enabled_tools: ["search"],
+				disabled_tools: ["delete"],
+				default_tools_approval_mode: "prompt",
+				tools: {
+					search: {
+						approval_mode: "approve",
+					},
+				},
+			});
+			expect(mcpServers.remote).toMatchObject({
+				url: "https://example.com/mcp",
+				bearer_token_env_var: "REMOTE_MCP_TOKEN",
+				http_headers: { "X-Region": "us-east-1" },
+				env_http_headers: { Authorization: "AUTH_HEADER" },
+			});
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -65,6 +65,82 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers.linear.bearer_token_env_var).toBe("LINEAR_API_TOKEN");
 	});
 
+	it("translates per-tool Cyrus MCP allowedTools to Codex enabled_tools", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"Read",
+				"mcp__linear__list_issues",
+				"mcp__linear__create_issue",
+				"mcp__linear__list_issues",
+				"mcp__cyrus-tools__linear_agent_session_create_on_comment",
+			],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+				},
+				"cyrus-tools": {
+					type: "http",
+					url: "http://127.0.0.1:4444/mcp/cyrus-tools",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toEqual([
+			"list_issues",
+			"create_issue",
+		]);
+		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
+			"linear_agent_session_create_on_comment",
+		]);
+	});
+
+	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: ["mcp__linear", "mcp__linear__list_issues"],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toBeUndefined();
+		expect(mcpServers.linear.disabled_tools).toBeUndefined();
+	});
+
+	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"mcp__linear__create_issue",
+				"mcp__github__create_pull_request",
+			],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+					enabled_tools: ["list_issues"],
+				} as any,
+				github: {
+					type: "http",
+					url: "https://example.com/github/mcp",
+					disabled_tools: ["delete_repository"],
+				} as any,
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toEqual(["list_issues"]);
+		expect(mcpServers.github.enabled_tools).toBeUndefined();
+		expect(mcpServers.github.disabled_tools).toEqual(["delete_repository"]);
+	});
+
 	it("loads hosted file-based MCP configs and preserves Codex MCP options", () => {
 		const tmp = mkdtempSync(join(tmpdir(), "cyrus-codex-mcp-"));
 		try {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -114,6 +114,28 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers.linear.disabled_tools).toBeUndefined();
 	});
 
+	it("matches underscore Cyrus MCP server names to hyphenated Codex MCP server names", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"mcp__slack_fixed__conversations_replies",
+				"mcp__slack_fixed__attachment_get_data",
+			],
+			mcpConfig: {
+				"slack-fixed": {
+					type: "http",
+					url: "https://example.com/slack-fixed/mcp",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers["slack-fixed"].enabled_tools).toEqual([
+			"conversations_replies",
+			"attachment_get_data",
+		]);
+	});
+
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
 		const runner = new CodexRunner({
 			workingDirectory: process.cwd(),

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -164,7 +164,10 @@ import {
 	RepositoryRouter,
 	type RepositoryRouterDeps,
 } from "./RepositoryRouter.js";
-import { RunnerConfigBuilder } from "./RunnerConfigBuilder.js";
+import {
+	RunnerConfigBuilder,
+	resolveIssueMcpConfigPath,
+} from "./RunnerConfigBuilder.js";
 import { RunnerSelectionService } from "./RunnerSelectionService.js";
 import { SharedApplicationServer } from "./SharedApplicationServer.js";
 import {
@@ -6732,16 +6735,13 @@ ${input.userComment}
 					// mcpConfigPath stays scoped to that repo, otherwise the
 					// team-level `linearMcpConfigs` list applies. Same coupling
 					// the live `buildIssueConfig` path uses.
-					const repoHasAllowedToolsOverride =
-						Array.isArray(repo.allowedTools) && repo.allowedTools.length > 0;
-					const mcpConfigPath = repoHasAllowedToolsOverride
-						? this.mcpConfigService.buildMergedMcpConfigPath(repo)
-						: this.config.linearMcpConfigs &&
-								this.config.linearMcpConfigs.length > 0
-							? this.config.linearMcpConfigs.length === 1
-								? this.config.linearMcpConfigs[0]
-								: [...this.config.linearMcpConfigs]
-							: undefined;
+					const mcpConfigPath = resolveIssueMcpConfigPath(
+						repo,
+						this.config.linearMcpConfigs,
+						this.mcpConfigService.buildMergedMcpConfigPath.bind(
+							this.mcpConfigService,
+						),
+					);
 					let mcpServers: Record<string, McpServerConfig> = { ...mcpConfig };
 					if (mcpConfigPath) {
 						const paths = Array.isArray(mcpConfigPath)

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -151,6 +151,31 @@ export interface IssueRunnerConfigInput {
 	egressCaCertPath?: string;
 }
 
+export function resolveIssueMcpConfigPath(
+	repository: RepositoryConfig,
+	platformMcpConfigOverrides: readonly string[] | undefined,
+	buildMergedMcpConfigPath: (
+		repositories: RepositoryConfig | RepositoryConfig[],
+	) => string | string[] | undefined,
+): string | string[] | undefined {
+	const repoHasAllowedToolsOverride =
+		Array.isArray(repository.allowedTools) &&
+		repository.allowedTools.length > 0;
+	if (repoHasAllowedToolsOverride) {
+		return buildMergedMcpConfigPath(repository);
+	}
+
+	if (!platformMcpConfigOverrides || platformMcpConfigOverrides.length === 0) {
+		return undefined;
+	}
+
+	if (platformMcpConfigOverrides.length === 1) {
+		return platformMcpConfigOverrides[0];
+	}
+
+	return [...platformMcpConfigOverrides];
+}
+
 /**
  * Shared runner config assembly for both issue and chat sessions.
  *
@@ -346,17 +371,13 @@ export class RunnerConfigBuilder {
 		//     (`linearMcpConfigs` / `githubMcpConfigs`).
 		// This guarantees the agent's permission rules and the loaded MCP
 		// server set always come from the same scope.
-		const repoHasAllowedToolsOverride =
-			Array.isArray(input.repository.allowedTools) &&
-			input.repository.allowedTools.length > 0;
-		const mcpConfigPath = repoHasAllowedToolsOverride
-			? this.mcpConfigProvider.buildMergedMcpConfigPath(input.repository)
-			: input.platformMcpConfigOverrides &&
-					input.platformMcpConfigOverrides.length > 0
-				? input.platformMcpConfigOverrides.length === 1
-					? input.platformMcpConfigOverrides[0]
-					: [...input.platformMcpConfigOverrides]
-				: undefined;
+		const mcpConfigPath = resolveIssueMcpConfigPath(
+			input.repository,
+			input.platformMcpConfigOverrides,
+			this.mcpConfigProvider.buildMergedMcpConfigPath.bind(
+				this.mcpConfigProvider,
+			),
+		);
 
 		// Multi-repo sessions place each repo in a sibling sub-worktree of the
 		// cwd (the workspace container). Register those sub-worktrees as

--- a/packages/edge-worker/test/EgressProxy.test.ts
+++ b/packages/edge-worker/test/EgressProxy.test.ts
@@ -439,8 +439,9 @@ function connectViaProxy(proxyPort: number, target: string): Promise<number> {
 			method: "CONNECT",
 			path: target,
 		});
-		req.on("connect", (res) => {
+		req.on("connect", (res, socket) => {
 			resolve(res.statusCode || 0);
+			socket.destroy();
 			req.destroy();
 		});
 		req.on("error", () => resolve(0));

--- a/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
@@ -5,6 +5,7 @@ import {
 	type IMcpConfigProvider,
 	type IRunnerSelector,
 	RunnerConfigBuilder,
+	resolveIssueMcpConfigPath,
 } from "../src/RunnerConfigBuilder.js";
 
 const silentLogger: ILogger = {
@@ -118,5 +119,33 @@ describe("RunnerConfigBuilder additionalDirectories (multi-repo skill discovery)
 		const { config } = buildIssueConfig(session);
 
 		expect(config.additionalDirectories).toEqual(["/ws/root/repo-b"]);
+	});
+});
+
+describe("resolveIssueMcpConfigPath", () => {
+	it("uses platform-level MCP configs when the repo inherits platform tools", () => {
+		const repository = makeRepository();
+		const result = resolveIssueMcpConfigPath(
+			repository,
+			["/home/user/.cyrus/mcp-configs/mcp-supabase.json"],
+			() => "/repo/.mcp.json",
+		);
+
+		expect(result).toBe("/home/user/.cyrus/mcp-configs/mcp-supabase.json");
+	});
+
+	it("uses repo MCP config when the repo owns an allowedTools override", () => {
+		const repository = {
+			...makeRepository(),
+			allowedTools: ["Read(**)", "mcp__repo"],
+			mcpConfigPath: "/repo/.mcp.json",
+		} as unknown as RepositoryConfig;
+		const result = resolveIssueMcpConfigPath(
+			repository,
+			["/home/user/.cyrus/mcp-configs/mcp-supabase.json"],
+			(repo) => (repo as RepositoryConfig).mcpConfigPath,
+		);
+
+		expect(result).toBe("/repo/.mcp.json");
 	});
 });


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary
- Preserve Codex-supported MCP server options when converting Cyrus `.mcp.json` files into Codex `mcp_servers` config.
- Share issue-session MCP config path resolution between live sessions and warmup so platform-level hosted configs and repo-level overrides stay coupled to their tool scope.
- Merged #1292 to translate Cyrus MCP `allowedTools` entries into Codex `enabled_tools` filters and non-interactive MCP approvals.
- Add regression coverage and F1 validation notes for the Codex runner path.

## Linear
- https://linear.app/ceedar/issue/CYPACK-1286/make-the-mcp-configs-available-to-the-codex-runner

## Related PRs
- Merged into this branch: #1292 Fix Codex MCP allowedTools translation

## Testing
- `pnpm --filter cyrus-codex-runner test:run -- CodexRunner.mcp-config.test.ts`
- `pnpm --dir packages/edge-worker exec vitest run test/RunnerConfigBuilder.additional-directories.test.ts`
- `pnpm --dir packages/edge-worker exec vitest run test/EgressProxy.test.ts`
- `pnpm -r --filter ./packages/* build`
- `pnpm --filter cyrus-codex-runner typecheck`
- `pnpm --filter cyrus-edge-worker typecheck`
- `pnpm lint`
- `pnpm test:packages:run`
- `pnpm typecheck`
- F1 smoke documented in `apps/f1/test-drives/2026-06-04-cypack-1286-codex-mcp-config.md`

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->