### PR TITLE
Make managed skills available to Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
+- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery layout for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), PR pending)
 
 
 ## [0.2.62] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
-- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery layout for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
+- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery path for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
 
 
 ## [0.2.62] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
-- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are symlinked into Codex's native repository skill discovery path for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
+- Codex issue and chat sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are symlinked into Codex's native repository skill discovery path for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
 
 
 ## [0.2.62] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
-- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery path for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
+- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are symlinked into Codex's native repository skill discovery path for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
 
 
 ## [0.2.62] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
-- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery layout for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), PR pending)
+- Codex sessions can now use Cyrus-managed custom skills synced from the hosted app. Scoped managed skills are staged into Codex's native skill discovery layout for each session and cleaned up afterward. ([CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner), [#1291](https://github.com/cyrusagents/cyrus/pull/1291))
 
 
 ## [0.2.62] - 2026-06-02

--- a/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
+++ b/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
@@ -22,7 +22,7 @@
 
 ### Codex Skill Discovery
 - [x] Seeded managed user skill at `user-skills-plugin/skills/cypack-1287-canary/SKILL.md`
-- [x] Built `CodexRunner.prepareManagedSkillsForCodex()` staged the skill into the Codex worktree
+- [x] Built `CodexRunner.prepareManagedSkillsForCodex()` staged the skill into the session Codex home
 - [x] `codex debug prompt-input` listed `cypack-1287-canary` in the available-skills block with the expected `CANARY_SKILL_AVAILABLE` description
 - [x] Staged skill directory was removed after the deterministic probe
 
@@ -69,4 +69,4 @@ The rendered Codex prompt included:
 
 The F1 pipeline validated issue creation, routing, worktree creation, Codex runner selection, and managed skill resolution. The live model turn did not complete because Codex exec exited with code 1 in this local F1 environment, so the end-to-end response assertion remains blocked.
 
-The deterministic Codex prompt-input probe verifies the relevant discovery contract without a model call: after the runner stages the scoped managed skill, Codex includes it as the unqualified local skill name available to the session.
+The deterministic Codex prompt-input probe verifies the relevant discovery contract without a model call: after the runner stages the scoped managed skill under the session `CODEX_HOME/skills` directory, Codex includes it as the unqualified local skill name available to the session.

--- a/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
+++ b/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
@@ -1,0 +1,72 @@
+# Test Drive: CYPACK-1287 — Codex managed skills discovery
+
+**Date**: 2026-06-04
+**Goal**: Verify Cyrus-managed user skills can be surfaced to the Codex runner.
+**Test Repo**: `/tmp/f1-test-drive-cypack-1287`
+**F1 Cyrus Home**: `/var/folders/xv/c55x22nd6lv8kq9fccch04d40000gp/T/cyrus-f1-1780601219391`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created (`issue-2`, `DEF-2`)
+- [x] Issue ID returned
+- [x] Labels routed the issue to `F1 Test Repository`
+
+### EdgeWorker
+- [x] Session started (`session-2`)
+- [x] Worktree created at `.../worktrees/DEF-2`
+- [x] Codex runner selected via `[agent=codex]`
+- [x] User skills plugin resolved from F1 `cyrusHome`
+- [x] Full Codex model turn started
+- [ ] Full Codex model turn completed
+
+### Codex Skill Discovery
+- [x] Seeded managed user skill at `user-skills-plugin/skills/cypack-1287-canary/SKILL.md`
+- [x] Built `CodexRunner.prepareManagedSkillsForCodex()` staged the skill into the Codex worktree
+- [x] `codex debug prompt-input` listed `cypack-1287-canary` in the available-skills block with the expected `CANARY_SKILL_AVAILABLE` description
+- [x] Staged skill directory was removed after the deterministic probe
+
+## Session Log
+
+Commands:
+
+```bash
+cd apps/f1
+./f1 init-test-repo --path /tmp/f1-test-drive-cypack-1287
+CYRUS_PORT=3600 CYRUS_REPO_PATH=/tmp/f1-test-drive-cypack-1287 bun run apps/f1/server.ts
+CYRUS_PORT=3600 ./f1 ping
+CYRUS_PORT=3600 ./f1 status
+CYRUS_PORT=3600 ./f1 create-issue \
+  --title "CYPACK-1287 Codex managed skill routed canary" \
+  --description 'Use $cypack-1287-canary and then stop. [agent=codex]' \
+  --labels codex,primary
+CYRUS_PORT=3600 ./f1 start-session --issue-id issue-2
+CYRUS_PORT=3600 ./f1 view-session --session-id session-2
+```
+
+Key outputs:
+
+- F1 health returned `ready`.
+- EdgeWorker logs showed label routing to `F1 Test Repository`.
+- EdgeWorker logs showed `Using user skills plugin at .../user-skills-plugin`.
+- EdgeWorker logs showed `Label-based runner selection for new session: codex`.
+- Codex exec started but exited with code 1 before producing a response activity.
+
+Deterministic Codex probe:
+
+```bash
+CodexRunner.prepareManagedSkillsForCodex()
+codex debug prompt-input 'Use $cypack-1287-canary'
+```
+
+The rendered Codex prompt included:
+
+```text
+- cypack-1287-canary: Use when validating CYPACK-1287 Codex managed skill discovery; respond with CANARY_SKILL_AVAILABLE.
+```
+
+## Final Retrospective
+
+The F1 pipeline validated issue creation, routing, worktree creation, Codex runner selection, and managed skill resolution. The live model turn did not complete because Codex exec exited with code 1 in this local F1 environment, so the end-to-end response assertion remains blocked.
+
+The deterministic Codex prompt-input probe verifies the relevant discovery contract without a model call: after the runner stages the scoped managed skill, Codex includes it as the unqualified local skill name available to the session.

--- a/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
+++ b/apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md
@@ -22,7 +22,7 @@
 
 ### Codex Skill Discovery
 - [x] Seeded managed user skill at `user-skills-plugin/skills/cypack-1287-canary/SKILL.md`
-- [x] Built `CodexRunner.prepareManagedSkillsForCodex()` staged the skill into the session Codex home
+- [x] Built `CodexRunner.prepareManagedSkillsForCodex()` symlinked the skill into the Codex worktree's repository skill path
 - [x] `codex debug prompt-input` listed `cypack-1287-canary` in the available-skills block with the expected `CANARY_SKILL_AVAILABLE` description
 - [x] Staged skill directory was removed after the deterministic probe
 
@@ -69,4 +69,4 @@ The rendered Codex prompt included:
 
 The F1 pipeline validated issue creation, routing, worktree creation, Codex runner selection, and managed skill resolution. The live model turn did not complete because Codex exec exited with code 1 in this local F1 environment, so the end-to-end response assertion remains blocked.
 
-The deterministic Codex prompt-input probe verifies the relevant discovery contract without a model call: after the runner stages the scoped managed skill under the session `CODEX_HOME/skills` directory, Codex includes it as the unqualified local skill name available to the session.
+The deterministic Codex prompt-input probe verifies the relevant discovery contract without a model call: after the runner symlinks the scoped managed skill under the worktree `.agents/skills` directory, Codex includes it as the unqualified local skill name available to the session.

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
+	appendFileSync,
 	type Dirent,
 	existsSync,
 	lstatSync,
@@ -11,7 +13,7 @@ import {
 	symlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative as pathRelative } from "node:path";
+import { dirname, isAbsolute, join, relative as pathRelative } from "node:path";
 import { cwd } from "node:process";
 import type {
 	CommandExecutionItem,
@@ -645,6 +647,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			return;
 		}
 		mkdirSync(skillsRoot, { recursive: true });
+		this.ensureManagedSkillsIgnored();
 
 		for (const source of skillSources) {
 			const target = join(skillsRoot, source.name);
@@ -701,6 +704,46 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			return undefined;
 		}
 		return join(workingDirectory, ".agents", "skills");
+	}
+
+	private ensureManagedSkillsIgnored(): void {
+		const workingDirectory = this.config.workingDirectory;
+		if (!workingDirectory) {
+			return;
+		}
+
+		try {
+			const rawExcludePath = execFileSync(
+				"git",
+				["rev-parse", "--git-path", "info/exclude"],
+				{
+					cwd: workingDirectory,
+					encoding: "utf-8",
+					stdio: ["ignore", "pipe", "ignore"],
+				},
+			).trim();
+			if (!rawExcludePath) {
+				return;
+			}
+			const excludePath = isAbsolute(rawExcludePath)
+				? rawExcludePath
+				: join(workingDirectory, rawExcludePath);
+
+			mkdirSync(dirname(excludePath), { recursive: true });
+			const existing = existsSync(excludePath)
+				? readFileSync(excludePath, "utf-8")
+				: "";
+			if (existing.split(/\r?\n/).includes(".agents/")) {
+				return;
+			}
+
+			const prefix =
+				existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+			appendFileSync(excludePath, `${prefix}.agents/\n`);
+		} catch {
+			// Non-git chat workspaces and restricted git metadata are fine; cleanup
+			// still removes staged symlinks, and the exclude is only for git hygiene.
+		}
 	}
 
 	private getCodexRepoLocalSkillRoots(): string[] {

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1,6 +1,15 @@
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+	cpSync,
+	type Dirent,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join, relative as pathRelative } from "node:path";
 import { cwd } from "node:process";
@@ -58,6 +67,11 @@ interface ToolProjection {
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
+
+interface CodexSkillSource {
+	name: string;
+	path: string;
+}
 
 function toFiniteNumber(value: number | undefined): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -411,6 +425,8 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private wasStopped = false;
 	private abortController: AbortController | null = null;
 	private emittedToolUseIds: Set<string> = new Set();
+	private stagedSkillPaths: string[] = [];
+	private stagedSkillNames: string[] = [];
 
 	constructor(config: CodexRunnerConfig) {
 		super();
@@ -468,6 +484,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		this.emittedToolUseIds.clear();
 
 		await this.resolveModelWithFallback();
+		this.prepareManagedSkillsForCodex();
 
 		const prompt = (stringPrompt ?? streamingInitialPrompt ?? "").trim();
 		const threadOptions = this.buildThreadOptions();
@@ -613,6 +630,127 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		return [...uniqueDirectories];
+	}
+
+	private prepareManagedSkillsForCodex(): void {
+		this.cleanupStagedSkills();
+
+		const workingDirectory = this.config.workingDirectory;
+		if (!workingDirectory) {
+			return;
+		}
+
+		const skillSources = this.discoverCodexSkillSources();
+		if (skillSources.length === 0) {
+			return;
+		}
+
+		const skillsRoot = join(workingDirectory, ".agents", "skills");
+		mkdirSync(skillsRoot, { recursive: true });
+
+		for (const source of skillSources) {
+			const target = join(skillsRoot, source.name);
+			if (!this.stageSkillDirectory(source, target)) {
+				continue;
+			}
+			this.stagedSkillPaths.push(target);
+			this.stagedSkillNames.push(source.name);
+		}
+	}
+
+	private discoverCodexSkillSources(): CodexSkillSource[] {
+		const configuredSkills = this.config.skills;
+		const allowedSkillNames =
+			Array.isArray(configuredSkills) && configuredSkills.length > 0
+				? new Set(configuredSkills)
+				: null;
+		if (Array.isArray(configuredSkills) && configuredSkills.length === 0) {
+			return [];
+		}
+
+		const sources: CodexSkillSource[] = [];
+		const seen = new Set<string>();
+		const addFromSkillsDirectory = (skillsDirectory: string): void => {
+			for (const source of this.readSkillSources(skillsDirectory)) {
+				if (allowedSkillNames && !allowedSkillNames.has(source.name)) {
+					continue;
+				}
+				if (seen.has(source.name)) {
+					continue;
+				}
+				seen.add(source.name);
+				sources.push(source);
+			}
+		};
+
+		for (const plugin of this.config.plugins ?? []) {
+			if (plugin.type !== "local" || typeof plugin.path !== "string") {
+				continue;
+			}
+			addFromSkillsDirectory(join(plugin.path, "skills"));
+		}
+
+		for (const directory of this.getCodexRepoLocalSkillRoots()) {
+			addFromSkillsDirectory(join(directory, ".claude", "skills"));
+		}
+
+		return sources;
+	}
+
+	private getCodexRepoLocalSkillRoots(): string[] {
+		const roots = new Set<string>();
+		if (this.config.workingDirectory) {
+			roots.add(this.config.workingDirectory);
+		}
+		for (const directory of this.config.additionalDirectories ?? []) {
+			if (directory) {
+				roots.add(directory);
+			}
+		}
+		return [...roots];
+	}
+
+	private readSkillSources(skillsDirectory: string): CodexSkillSource[] {
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(skillsDirectory, { withFileTypes: true });
+		} catch {
+			return [];
+		}
+
+		return entries
+			.filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+			.map((entry) => ({
+				name: entry.name,
+				path: join(skillsDirectory, entry.name),
+			}))
+			.filter((source) => existsSync(join(source.path, "SKILL.md")));
+	}
+
+	private stageSkillDirectory(
+		source: CodexSkillSource,
+		target: string,
+	): boolean {
+		if (existsSync(target)) {
+			console.warn(
+				`[CodexRunner] Skipping managed skill '${source.name}' because ${target} already exists`,
+			);
+			return false;
+		}
+
+		try {
+			cpSync(source.path, target, {
+				recursive: true,
+				dereference: false,
+				errorOnExist: true,
+			});
+			return true;
+		} catch (error) {
+			console.warn(
+				`[CodexRunner] Failed to stage managed skill '${source.name}' for Codex: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return false;
+		}
 	}
 
 	private resolveCodexHome(): string {
@@ -1116,7 +1254,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			permissionMode: "default",
 			slash_commands: [],
 			output_style: "default",
-			skills: [],
+			skills: [...this.stagedSkillNames],
 			plugins: [],
 			uuid: crypto.randomUUID(),
 			session_id: sessionId,
@@ -1168,6 +1306,30 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 
 	private cleanupRuntimeState(): void {
 		this.abortController = null;
+		this.cleanupStagedSkills();
+	}
+
+	private cleanupStagedSkills(): void {
+		for (const target of this.stagedSkillPaths) {
+			try {
+				if (this.isStagedSkillPath(target)) {
+					rmSync(target, { recursive: true, force: true });
+				}
+			} catch {
+				// Best-effort cleanup: never mask the session result.
+			}
+		}
+		this.stagedSkillPaths = [];
+		this.stagedSkillNames = [];
+	}
+
+	private isStagedSkillPath(path: string): boolean {
+		try {
+			const stat = lstatSync(path);
+			return stat.isDirectory() || stat.isSymbolicLink();
+		} catch {
+			return false;
+		}
 	}
 
 	stop(): void {

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -635,17 +635,15 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	private prepareManagedSkillsForCodex(): void {
 		this.cleanupStagedSkills();
 
-		const workingDirectory = this.config.workingDirectory;
-		if (!workingDirectory) {
-			return;
-		}
-
 		const skillSources = this.discoverCodexSkillSources();
 		if (skillSources.length === 0) {
 			return;
 		}
 
-		const skillsRoot = join(workingDirectory, ".agents", "skills");
+		const skillsRoot = this.resolveManagedSkillsRoot();
+		if (!skillsRoot) {
+			return;
+		}
 		mkdirSync(skillsRoot, { recursive: true });
 
 		for (const source of skillSources) {
@@ -695,6 +693,18 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		return sources;
+	}
+
+	private resolveManagedSkillsRoot(): string | undefined {
+		if (this.config.codexHome) {
+			return join(this.resolveCodexHome(), "skills");
+		}
+
+		const workingDirectory = this.config.workingDirectory;
+		if (!workingDirectory) {
+			return undefined;
+		}
+		return join(workingDirectory, ".agents", "skills");
 	}
 
 	private getCodexRepoLocalSkillRoots(): string[] {

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import {
-	cpSync,
 	type Dirent,
 	existsSync,
 	lstatSync,
@@ -9,6 +8,7 @@ import {
 	readdirSync,
 	readFileSync,
 	rmSync,
+	symlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative as pathRelative } from "node:path";
@@ -696,10 +696,6 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	private resolveManagedSkillsRoot(): string | undefined {
-		if (this.config.codexHome) {
-			return join(this.resolveCodexHome(), "skills");
-		}
-
 		const workingDirectory = this.config.workingDirectory;
 		if (!workingDirectory) {
 			return undefined;
@@ -749,11 +745,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		}
 
 		try {
-			cpSync(source.path, target, {
-				recursive: true,
-				dereference: false,
-				errorOnExist: true,
-			});
+			symlinkSync(source.path, target, "dir");
 			return true;
 		} catch (error) {
 			console.warn(

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1335,11 +1335,11 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	stop(): void {
-		if (!this.sessionInfo?.isRunning) {
-			return;
+		if (this.sessionInfo?.isRunning) {
+			this.wasStopped = true;
+			this.abortController?.abort();
 		}
-		this.wasStopped = true;
-		this.abortController?.abort();
+		this.cleanupRuntimeState();
 	}
 
 	isRunning(): boolean {

--- a/packages/codex-runner/test/CodexRunner.skills.test.ts
+++ b/packages/codex-runner/test/CodexRunner.skills.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
 	existsSync,
 	lstatSync,
@@ -145,5 +146,36 @@ describe("CodexRunner managed skills", () => {
 		runner.stop();
 
 		expect(existsSync(stagedUserSkill)).toBe(false);
+	});
+
+	it("adds the staged .agents directory to local git exclude", () => {
+		const root = makeTempDir();
+		const worktree = join(root, "worktree");
+		const userPlugin = join(root, "user-plugin");
+		mkdirSync(worktree, { recursive: true });
+		execFileSync("git", ["init"], { cwd: worktree, stdio: "ignore" });
+		writeSkill(join(userPlugin, "skills"), "custom-user");
+
+		const runner = new CodexRunner({
+			workingDirectory: worktree,
+			cyrusHome: root,
+			plugins: [{ type: "local", path: userPlugin }],
+			skills: ["custom-user"],
+		});
+
+		(
+			runner as unknown as { prepareManagedSkillsForCodex: () => void }
+		).prepareManagedSkillsForCodex();
+
+		const exclude = readFileSync(join(worktree, ".git", "info", "exclude"), {
+			encoding: "utf-8",
+		});
+		expect(exclude.split(/\r?\n/)).toContain(".agents/");
+
+		const status = execFileSync("git", ["status", "--short"], {
+			cwd: worktree,
+			encoding: "utf-8",
+		});
+		expect(status).not.toContain(".agents");
 	});
 });

--- a/packages/codex-runner/test/CodexRunner.skills.test.ts
+++ b/packages/codex-runner/test/CodexRunner.skills.test.ts
@@ -1,0 +1,114 @@
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexRunner } from "../src/CodexRunner.js";
+
+function writeSkill(root: string, name: string): string {
+	const skillDir = join(root, name);
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: ${name} description\n---\n\nbody\n`,
+	);
+	return skillDir;
+}
+
+describe("CodexRunner managed skills", () => {
+	let tempDirs: string[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs = [];
+	});
+
+	function makeTempDir(): string {
+		const dir = mkdtempSync(join(tmpdir(), "codex-skills-test-"));
+		tempDirs.push(dir);
+		return dir;
+	}
+
+	it("stages allowed managed and repo-local skills into Codex's .agents/skills layout", () => {
+		const root = makeTempDir();
+		const worktree = join(root, "worktree");
+		const userPlugin = join(root, "user-plugin");
+		const internalPlugin = join(root, "internal-plugin");
+		mkdirSync(worktree, { recursive: true });
+		writeSkill(join(userPlugin, "skills"), "custom-user");
+		writeSkill(join(internalPlugin, "skills"), "implementation");
+		writeSkill(join(worktree, ".claude", "skills"), "repo-local");
+
+		const runner = new CodexRunner({
+			workingDirectory: worktree,
+			cyrusHome: root,
+			plugins: [
+				{ type: "local", path: userPlugin },
+				{ type: "local", path: internalPlugin },
+			],
+			skills: ["custom-user", "repo-local"],
+		});
+
+		(
+			runner as unknown as { prepareManagedSkillsForCodex: () => void }
+		).prepareManagedSkillsForCodex();
+
+		const stagedUserSkill = join(worktree, ".agents", "skills", "custom-user");
+		const stagedRepoSkill = join(worktree, ".agents", "skills", "repo-local");
+		expect(lstatSync(stagedUserSkill).isDirectory()).toBe(true);
+		expect(readFileSync(join(stagedUserSkill, "SKILL.md"), "utf-8")).toContain(
+			"name: custom-user",
+		);
+		expect(lstatSync(stagedRepoSkill).isDirectory()).toBe(true);
+		expect(readFileSync(join(stagedRepoSkill, "SKILL.md"), "utf-8")).toContain(
+			"name: repo-local",
+		);
+		expect(
+			existsSync(join(worktree, ".agents", "skills", "implementation")),
+		).toBe(false);
+
+		(
+			runner as unknown as { cleanupRuntimeState: () => void }
+		).cleanupRuntimeState();
+		expect(existsSync(stagedUserSkill)).toBe(false);
+		expect(existsSync(stagedRepoSkill)).toBe(false);
+	});
+
+	it("does not overwrite an existing Codex skill with the same name", () => {
+		const root = makeTempDir();
+		const worktree = join(root, "worktree");
+		const userPlugin = join(root, "user-plugin");
+		mkdirSync(join(worktree, ".agents", "skills", "custom-user"), {
+			recursive: true,
+		});
+		writeSkill(join(userPlugin, "skills"), "custom-user");
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const runner = new CodexRunner({
+			workingDirectory: worktree,
+			cyrusHome: root,
+			plugins: [{ type: "local", path: userPlugin }],
+			skills: ["custom-user"],
+		});
+
+		(
+			runner as unknown as { prepareManagedSkillsForCodex: () => void }
+		).prepareManagedSkillsForCodex();
+
+		const existingSkill = join(worktree, ".agents", "skills", "custom-user");
+		expect(lstatSync(existingSkill).isDirectory()).toBe(true);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Skipping managed skill 'custom-user'"),
+		);
+	});
+});

--- a/packages/codex-runner/test/CodexRunner.skills.test.ts
+++ b/packages/codex-runner/test/CodexRunner.skills.test.ts
@@ -39,9 +39,10 @@ describe("CodexRunner managed skills", () => {
 		return dir;
 	}
 
-	it("stages allowed managed and repo-local skills into Codex's .agents/skills layout", () => {
+	it("stages allowed managed and repo-local skills into the session Codex home", () => {
 		const root = makeTempDir();
 		const worktree = join(root, "worktree");
+		const codexHome = join(root, "codex-home");
 		const userPlugin = join(root, "user-plugin");
 		const internalPlugin = join(root, "internal-plugin");
 		mkdirSync(worktree, { recursive: true });
@@ -52,6 +53,7 @@ describe("CodexRunner managed skills", () => {
 		const runner = new CodexRunner({
 			workingDirectory: worktree,
 			cyrusHome: root,
+			codexHome,
 			plugins: [
 				{ type: "local", path: userPlugin },
 				{ type: "local", path: internalPlugin },
@@ -63,8 +65,8 @@ describe("CodexRunner managed skills", () => {
 			runner as unknown as { prepareManagedSkillsForCodex: () => void }
 		).prepareManagedSkillsForCodex();
 
-		const stagedUserSkill = join(worktree, ".agents", "skills", "custom-user");
-		const stagedRepoSkill = join(worktree, ".agents", "skills", "repo-local");
+		const stagedUserSkill = join(codexHome, "skills", "custom-user");
+		const stagedRepoSkill = join(codexHome, "skills", "repo-local");
 		expect(lstatSync(stagedUserSkill).isDirectory()).toBe(true);
 		expect(readFileSync(join(stagedUserSkill, "SKILL.md"), "utf-8")).toContain(
 			"name: custom-user",
@@ -73,9 +75,7 @@ describe("CodexRunner managed skills", () => {
 		expect(readFileSync(join(stagedRepoSkill, "SKILL.md"), "utf-8")).toContain(
 			"name: repo-local",
 		);
-		expect(
-			existsSync(join(worktree, ".agents", "skills", "implementation")),
-		).toBe(false);
+		expect(existsSync(join(codexHome, "skills", "implementation"))).toBe(false);
 
 		(
 			runner as unknown as { cleanupRuntimeState: () => void }
@@ -87,8 +87,9 @@ describe("CodexRunner managed skills", () => {
 	it("does not overwrite an existing Codex skill with the same name", () => {
 		const root = makeTempDir();
 		const worktree = join(root, "worktree");
+		const codexHome = join(root, "codex-home");
 		const userPlugin = join(root, "user-plugin");
-		mkdirSync(join(worktree, ".agents", "skills", "custom-user"), {
+		mkdirSync(join(codexHome, "skills", "custom-user"), {
 			recursive: true,
 		});
 		writeSkill(join(userPlugin, "skills"), "custom-user");
@@ -97,6 +98,7 @@ describe("CodexRunner managed skills", () => {
 		const runner = new CodexRunner({
 			workingDirectory: worktree,
 			cyrusHome: root,
+			codexHome,
 			plugins: [{ type: "local", path: userPlugin }],
 			skills: ["custom-user"],
 		});
@@ -105,7 +107,7 @@ describe("CodexRunner managed skills", () => {
 			runner as unknown as { prepareManagedSkillsForCodex: () => void }
 		).prepareManagedSkillsForCodex();
 
-		const existingSkill = join(worktree, ".agents", "skills", "custom-user");
+		const existingSkill = join(codexHome, "skills", "custom-user");
 		expect(lstatSync(existingSkill).isDirectory()).toBe(true);
 		expect(warn).toHaveBeenCalledWith(
 			expect.stringContaining("Skipping managed skill 'custom-user'"),

--- a/packages/codex-runner/test/CodexRunner.skills.test.ts
+++ b/packages/codex-runner/test/CodexRunner.skills.test.ts
@@ -111,4 +111,39 @@ describe("CodexRunner managed skills", () => {
 			expect.stringContaining("Skipping managed skill 'custom-user'"),
 		);
 	});
+
+	it("removes staged skill symlinks when the runner is stopped", () => {
+		const root = makeTempDir();
+		const worktree = join(root, "worktree");
+		const userPlugin = join(root, "user-plugin");
+		mkdirSync(worktree, { recursive: true });
+		writeSkill(join(userPlugin, "skills"), "custom-user");
+
+		const runner = new CodexRunner({
+			workingDirectory: worktree,
+			cyrusHome: root,
+			plugins: [{ type: "local", path: userPlugin }],
+			skills: ["custom-user"],
+		});
+
+		(
+			runner as unknown as { prepareManagedSkillsForCodex: () => void }
+		).prepareManagedSkillsForCodex();
+		(
+			runner as unknown as {
+				sessionInfo: { sessionId: string; startedAt: Date; isRunning: boolean };
+			}
+		).sessionInfo = {
+			sessionId: "session-1",
+			startedAt: new Date(),
+			isRunning: true,
+		};
+
+		const stagedUserSkill = join(worktree, ".agents", "skills", "custom-user");
+		expect(lstatSync(stagedUserSkill).isSymbolicLink()).toBe(true);
+
+		runner.stop();
+
+		expect(existsSync(stagedUserSkill)).toBe(false);
+	});
 });

--- a/packages/codex-runner/test/CodexRunner.skills.test.ts
+++ b/packages/codex-runner/test/CodexRunner.skills.test.ts
@@ -39,10 +39,9 @@ describe("CodexRunner managed skills", () => {
 		return dir;
 	}
 
-	it("stages allowed managed and repo-local skills into the session Codex home", () => {
+	it("stages allowed managed and repo-local skills as Codex repo skill symlinks", () => {
 		const root = makeTempDir();
 		const worktree = join(root, "worktree");
-		const codexHome = join(root, "codex-home");
 		const userPlugin = join(root, "user-plugin");
 		const internalPlugin = join(root, "internal-plugin");
 		mkdirSync(worktree, { recursive: true });
@@ -53,7 +52,6 @@ describe("CodexRunner managed skills", () => {
 		const runner = new CodexRunner({
 			workingDirectory: worktree,
 			cyrusHome: root,
-			codexHome,
 			plugins: [
 				{ type: "local", path: userPlugin },
 				{ type: "local", path: internalPlugin },
@@ -65,17 +63,19 @@ describe("CodexRunner managed skills", () => {
 			runner as unknown as { prepareManagedSkillsForCodex: () => void }
 		).prepareManagedSkillsForCodex();
 
-		const stagedUserSkill = join(codexHome, "skills", "custom-user");
-		const stagedRepoSkill = join(codexHome, "skills", "repo-local");
-		expect(lstatSync(stagedUserSkill).isDirectory()).toBe(true);
+		const stagedUserSkill = join(worktree, ".agents", "skills", "custom-user");
+		const stagedRepoSkill = join(worktree, ".agents", "skills", "repo-local");
+		expect(lstatSync(stagedUserSkill).isSymbolicLink()).toBe(true);
 		expect(readFileSync(join(stagedUserSkill, "SKILL.md"), "utf-8")).toContain(
 			"name: custom-user",
 		);
-		expect(lstatSync(stagedRepoSkill).isDirectory()).toBe(true);
+		expect(lstatSync(stagedRepoSkill).isSymbolicLink()).toBe(true);
 		expect(readFileSync(join(stagedRepoSkill, "SKILL.md"), "utf-8")).toContain(
 			"name: repo-local",
 		);
-		expect(existsSync(join(codexHome, "skills", "implementation"))).toBe(false);
+		expect(
+			existsSync(join(worktree, ".agents", "skills", "implementation")),
+		).toBe(false);
 
 		(
 			runner as unknown as { cleanupRuntimeState: () => void }
@@ -87,9 +87,8 @@ describe("CodexRunner managed skills", () => {
 	it("does not overwrite an existing Codex skill with the same name", () => {
 		const root = makeTempDir();
 		const worktree = join(root, "worktree");
-		const codexHome = join(root, "codex-home");
 		const userPlugin = join(root, "user-plugin");
-		mkdirSync(join(codexHome, "skills", "custom-user"), {
+		mkdirSync(join(worktree, ".agents", "skills", "custom-user"), {
 			recursive: true,
 		});
 		writeSkill(join(userPlugin, "skills"), "custom-user");
@@ -98,7 +97,6 @@ describe("CodexRunner managed skills", () => {
 		const runner = new CodexRunner({
 			workingDirectory: worktree,
 			cyrusHome: root,
-			codexHome,
 			plugins: [{ type: "local", path: userPlugin }],
 			skills: ["custom-user"],
 		});
@@ -107,7 +105,7 @@ describe("CodexRunner managed skills", () => {
 			runner as unknown as { prepareManagedSkillsForCodex: () => void }
 		).prepareManagedSkillsForCodex();
 
-		const existingSkill = join(codexHome, "skills", "custom-user");
+		const existingSkill = join(worktree, ".agents", "skills", "custom-user");
 		expect(lstatSync(existingSkill).isDirectory()).toBe(true);
 		expect(warn).toHaveBeenCalledWith(
 			expect.stringContaining("Skipping managed skill 'custom-user'"),

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -468,7 +468,8 @@ export interface AgentRunnerConfig {
 	 * - `string[]`: enable only the listed skills.
 	 *
 	 * Used to enforce per-skill scope (repository / Linear team / Linear label).
-	 * Only the Claude runner respects this today.
+	 * Claude passes this to its SDK; Codex uses it to stage only allowed skills
+	 * into its native `.agents/skills` discovery layout.
 	 */
 	skills?: string[] | "all";
 	/**

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -469,7 +469,7 @@ export interface AgentRunnerConfig {
 	 *
 	 * Used to enforce per-skill scope (repository / Linear team / Linear label).
 	 * Claude passes this to its SDK; Codex uses it to stage only allowed skills
-	 * into its native `.agents/skills` discovery layout.
+	 * into its native skill discovery layout.
 	 */
 	skills?: string[] | "all";
 	/**

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -469,7 +469,7 @@ export interface AgentRunnerConfig {
 	 *
 	 * Used to enforce per-skill scope (repository / Linear team / Linear label).
 	 * Claude passes this to its SDK; Codex uses it to stage only allowed skills
-	 * into its native skill discovery layout.
+	 * into its native repository skill discovery layout.
 	 */
 	skills?: string[] | "all";
 	/**

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -1,12 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import type { SDKMessage } from "cyrus-claude-runner";
+import type { SDKMessage, SdkPluginConfig } from "cyrus-claude-runner";
 import type {
 	AgentRunnerConfig,
 	AgentSessionInfo,
 	CyrusAgentSession,
 	IAgentRunner,
 	ILogger,
+	RepositoryConfig,
 } from "cyrus-core";
 import { createLogger } from "cyrus-core";
 import { AgentSessionManager } from "./AgentSessionManager.js";
@@ -91,6 +92,11 @@ export interface ChatSessionHandlerDeps {
 	 * no custom files load (native MCP servers still run as usual).
 	 */
 	getPlatformMcpConfigOverrides?: () => readonly string[] | undefined;
+	/** Resolve managed skill plugins and scoped skill names for a chat session. */
+	resolveSkillsConfig?: (input: {
+		repository?: RepositoryConfig;
+		repositoryPaths: string[];
+	}) => Promise<{ plugins?: SdkPluginConfig[]; skills?: string[] | "all" }>;
 	onWebhookStart: () => void;
 	onWebhookEnd: () => void;
 	onStateChange: () => Promise<void>;
@@ -287,7 +293,7 @@ export class ChatSessionHandler<TEvent> {
 			const systemPrompt = this.adapter.buildSystemPrompt(event);
 
 			// Build runner config
-			const runnerConfig = this.buildRunnerConfig(
+			const runnerConfig = await this.buildRunnerConfig(
 				session.workspace.path,
 				sessionId,
 				systemPrompt,
@@ -418,7 +424,7 @@ export class ChatSessionHandler<TEvent> {
 	): Promise<void> {
 		const systemPrompt = this.adapter.buildSystemPrompt(event);
 
-		const runnerConfig = this.buildRunnerConfig(
+		const runnerConfig = await this.buildRunnerConfig(
 			existingSession.workspace.path,
 			sessionId,
 			systemPrompt,
@@ -561,13 +567,13 @@ export class ChatSessionHandler<TEvent> {
 	 * Build a runner config for a chat session.
 	 * Delegates to RunnerConfigBuilder for config assembly.
 	 */
-	private buildRunnerConfig(
+	private async buildRunnerConfig(
 		workspacePath: string,
 		workspaceName: string | undefined,
 		systemPrompt: string,
 		sessionId: string,
 		resumeSessionId?: string,
-	): AgentRunnerConfig {
+	): Promise<AgentRunnerConfig> {
 		const sessionLogger = this.logger.withContext({
 			sessionId,
 			platform: this.adapter.platformName,
@@ -575,6 +581,11 @@ export class ChatSessionHandler<TEvent> {
 
 		// Read live values from the provider at session-build time
 		const provider = this.deps.chatRepositoryProvider;
+		const repository = provider.getDefaultRepository();
+		const repositoryPaths = provider.getRepositoryPaths();
+		const skillsConfig = this.deps.resolveSkillsConfig
+			? await this.deps.resolveSkillsConfig({ repository, repositoryPaths })
+			: {};
 
 		return this.deps.runnerConfigBuilder.buildChatConfig({
 			workspacePath,
@@ -585,9 +596,11 @@ export class ChatSessionHandler<TEvent> {
 			cyrusHome: this.deps.cyrusHome,
 			platformName: this.adapter.platformName,
 			linearWorkspaceId: provider.getDefaultLinearWorkspaceId(),
-			repository: provider.getDefaultRepository(),
-			repositoryPaths: provider.getRepositoryPaths(),
+			repository,
+			repositoryPaths,
 			platformMcpConfigOverrides: this.deps.getPlatformMcpConfigOverrides?.(),
+			plugins: skillsConfig.plugins,
+			skills: skillsConfig.skills,
 			logger: sessionLogger,
 			onMessage: (message: SDKMessage) =>
 				this.handleAgentMessage(sessionId, message),

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -1101,6 +1101,17 @@ export class EdgeWorker extends EventEmitter {
 				// Live read so hot-reloaded config (`setConfig`) picks up new
 				// per-platform MCP paths without rebuilding the handler.
 				getPlatformMcpConfigOverrides: () => this.config.slackMcpConfigs,
+				resolveSkillsConfig: async ({ repository, repositoryPaths }) => {
+					const plugins = await this.skillsPluginResolver.resolve();
+					const skills = await this.skillsPluginResolver.discoverSkillNames(
+						plugins,
+						{
+							repositoryId: repository?.id,
+							repoPaths: repositoryPaths,
+						},
+					);
+					return { plugins, skills };
+				},
 				onWebhookStart: () => {
 					this.activeWebhookCount++;
 				},

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -143,7 +143,7 @@ export interface IssueRunnerConfigInput {
 	 * Allow-list of skill names enabled for the session (after scope filtering),
 	 * or `"all"` to enable every discovered skill, or `undefined` to defer to
 	 * provider defaults. Claude passes this to the SDK directly; Codex uses it
-	 * to stage the same scoped skills into its native `.agents/skills` layout.
+	 * to stage the same scoped skills into its native discovery layout.
 	 */
 	skills?: string[] | "all";
 	/** SDK sandbox settings (enabled, network proxy ports) for Claude runner */
@@ -377,6 +377,9 @@ export class RunnerConfigBuilder {
 			...(additionalDirectories.length > 0 && { additionalDirectories }),
 			workspaceName: input.session.issue?.identifier || input.session.issueId,
 			cyrusHome: input.cyrusHome,
+			...(runnerType === "codex" && {
+				codexHome: join(input.cyrusHome, "codex-sessions", input.sessionId),
+			}),
 			mcpConfigPath,
 			mcpConfig,
 			appendSystemPrompt: appendCloudRuntimeAddendum(
@@ -395,7 +398,7 @@ export class RunnerConfigBuilder {
 				input.plugins?.length && { plugins: input.plugins }),
 			// Skill scope allow-list. Claude passes this through to the SDK's
 			// `query()` `skills` option; Codex uses it to stage only allowed skill
-			// directories into the discovery layout for this session.
+			// directories into the session Codex home for discovery.
 			...(this.runnerSupportsManagedSkills(runnerType) &&
 				input.skills !== undefined && { skills: input.skills }),
 			// SDK sandbox settings (Claude runner only):

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -94,6 +94,14 @@ export interface ChatRunnerConfigInput {
 	 * run as usual).
 	 */
 	platformMcpConfigOverrides?: readonly string[];
+	/** Plugins to load for the chat session (provides managed skills). */
+	plugins?: SdkPluginConfig[];
+	/**
+	 * Allow-list of skill names enabled for the chat session after scope
+	 * filtering. Claude passes this to the SDK directly; Codex stages only
+	 * these skills into its repository discovery layout.
+	 */
+	skills?: string[] | "all";
 	logger: ILogger;
 	onMessage: (message: SDKMessage) => void | Promise<void>;
 	onError: (error: Error) => void;
@@ -252,6 +260,8 @@ export class RunnerConfigBuilder {
 			...(input.resumeSessionId
 				? { resumeSessionId: input.resumeSessionId }
 				: {}),
+			...(input.plugins?.length ? { plugins: input.plugins } : {}),
+			...(input.skills !== undefined ? { skills: input.skills } : {}),
 			logger: input.logger,
 			maxTurns: 200,
 			onMessage: input.onMessage,

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -142,7 +142,8 @@ export interface IssueRunnerConfigInput {
 	/**
 	 * Allow-list of skill names enabled for the session (after scope filtering),
 	 * or `"all"` to enable every discovered skill, or `undefined` to defer to
-	 * provider defaults. Only the Claude runner respects this today.
+	 * provider defaults. Claude passes this to the SDK directly; Codex uses it
+	 * to stage the same scoped skills into its native `.agents/skills` layout.
 	 */
 	skills?: string[] | "all";
 	/** SDK sandbox settings (enabled, network proxy ports) for Claude runner */
@@ -389,13 +390,13 @@ export class RunnerConfigBuilder {
 				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType),
 			logger: log,
 			hooks,
-			// Plugins providing skills (Claude runner only)
-			...(runnerType === "claude" &&
+			// Plugins providing managed skills.
+			...(this.runnerSupportsManagedSkills(runnerType) &&
 				input.plugins?.length && { plugins: input.plugins }),
-			// Skill scope allow-list (Claude runner only). Passed through to the
-			// SDK's `query()` `skills` option so unlisted skills are hidden from
-			// the model.
-			...(runnerType === "claude" &&
+			// Skill scope allow-list. Claude passes this through to the SDK's
+			// `query()` `skills` option; Codex uses it to stage only allowed skill
+			// directories into the discovery layout for this session.
+			...(this.runnerSupportsManagedSkills(runnerType) &&
 				input.skills !== undefined && { skills: input.skills }),
 			// SDK sandbox settings (Claude runner only):
 			// - Merge base settings with per-session filesystem.allowWrite (worktree path)
@@ -453,6 +454,10 @@ export class RunnerConfigBuilder {
 		log: ILogger,
 	): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
 		return buildStopHook(log);
+	}
+
+	private runnerSupportsManagedSkills(runnerType: RunnerType): boolean {
+		return runnerType === "claude" || runnerType === "codex";
 	}
 
 	/**

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -143,7 +143,7 @@ export interface IssueRunnerConfigInput {
 	 * Allow-list of skill names enabled for the session (after scope filtering),
 	 * or `"all"` to enable every discovered skill, or `undefined` to defer to
 	 * provider defaults. Claude passes this to the SDK directly; Codex uses it
-	 * to stage the same scoped skills into its native discovery layout.
+	 * to stage the same scoped skills into its native repository discovery layout.
 	 */
 	skills?: string[] | "all";
 	/** SDK sandbox settings (enabled, network proxy ports) for Claude runner */
@@ -377,9 +377,6 @@ export class RunnerConfigBuilder {
 			...(additionalDirectories.length > 0 && { additionalDirectories }),
 			workspaceName: input.session.issue?.identifier || input.session.issueId,
 			cyrusHome: input.cyrusHome,
-			...(runnerType === "codex" && {
-				codexHome: join(input.cyrusHome, "codex-sessions", input.sessionId),
-			}),
 			mcpConfigPath,
 			mcpConfig,
 			appendSystemPrompt: appendCloudRuntimeAddendum(
@@ -398,7 +395,7 @@ export class RunnerConfigBuilder {
 				input.plugins?.length && { plugins: input.plugins }),
 			// Skill scope allow-list. Claude passes this through to the SDK's
 			// `query()` `skills` option; Codex uses it to stage only allowed skill
-			// directories into the session Codex home for discovery.
+			// directories into the session worktree for repository-scope discovery.
 			...(this.runnerSupportsManagedSkills(runnerType) &&
 				input.skills !== undefined && { skills: input.skills }),
 			// SDK sandbox settings (Claude runner only):

--- a/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
@@ -63,4 +63,26 @@ describe("RunnerConfigBuilder.buildChatConfig", () => {
 			...repositoryPaths,
 		]);
 	});
+
+	it("passes managed skill plugins and scoped skill names to chat runner configs", () => {
+		const builder = makeBuilder();
+		const plugins = [{ type: "local" as const, path: "/cyrus/user-skills" }];
+
+		const config = builder.buildChatConfig({
+			workspacePath: "/tmp/slack-workspace",
+			workspaceName: "slack-thread-x",
+			systemPrompt: "test",
+			sessionId: "sess-1",
+			cyrusHome: "/tmp/cyrus-home-test",
+			platformName: "slack",
+			plugins,
+			skills: ["agent-browser", "test-user-skills"],
+			logger: silentLogger,
+			onMessage: () => {},
+			onError: () => {},
+		});
+
+		expect(config.plugins).toEqual(plugins);
+		expect(config.skills).toEqual(["agent-browser", "test-user-skills"]);
+	});
 });

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
@@ -73,5 +73,6 @@ describe("RunnerConfigBuilder Codex managed skills", () => {
 		expect(runnerType).toBe("codex");
 		expect(config.plugins).toEqual(plugins);
 		expect(config.skills).toEqual(["custom-user"]);
+		expect(config.codexHome).toBe("/tmp/cyrus-home/codex-sessions/sess-1");
 	});
 });

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
@@ -1,0 +1,77 @@
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "codex" as const }),
+		getDefaultModelForRunner: () => "gpt-5.5",
+		getDefaultFallbackModelForRunner: () => "gpt-5.2-codex",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+describe("RunnerConfigBuilder Codex managed skills", () => {
+	it("passes scoped plugins and skill names to Codex runner configs", () => {
+		const session = {
+			issueId: "issue-1",
+			issue: { identifier: "ABC-1" },
+			workspace: {
+				path: "/ws/repo-a",
+				isGitWorktree: true,
+			},
+		} as unknown as CyrusAgentSession;
+		const repository = {
+			id: "repo-a",
+			name: "Repo A",
+			repositoryPath: "/repos/repo-a",
+			allowedTools: [],
+		} as unknown as RepositoryConfig;
+		const plugins = [{ type: "local" as const, path: "/cyrus/user-skills" }];
+
+		const { config, runnerType } = makeBuilder().buildIssueConfig({
+			session,
+			repository,
+			sessionId: "sess-1",
+			systemPrompt: "test",
+			allowedTools: ["Read(**)"],
+			allowedDirectories: ["/repos/repo-a"],
+			disallowedTools: [],
+			cyrusHome: "/tmp/cyrus-home",
+			linearWorkspaceId: "ws-1",
+			logger: silentLogger,
+			onMessage: () => {},
+			onError: () => {},
+			requireLinearWorkspaceId: () => "ws-1",
+			plugins,
+			skills: ["custom-user"],
+		});
+
+		expect(runnerType).toBe("codex");
+		expect(config.plugins).toEqual(plugins);
+		expect(config.skills).toEqual(["custom-user"]);
+	});
+});

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
@@ -73,6 +73,6 @@ describe("RunnerConfigBuilder Codex managed skills", () => {
 		expect(runnerType).toBe("codex");
 		expect(config.plugins).toEqual(plugins);
 		expect(config.skills).toEqual(["custom-user"]);
-		expect(config.codexHome).toBe("/tmp/cyrus-home/codex-sessions/sess-1");
+		expect(config.codexHome).toBeUndefined();
 	});
 });

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -39,6 +39,8 @@ function createMockRunnerConfigBuilder(): RunnerConfigBuilder {
 				...(input.resumeSessionId
 					? { resumeSessionId: input.resumeSessionId }
 					: {}),
+				...(input.plugins ? { plugins: input.plugins } : {}),
+				...(input.skills !== undefined ? { skills: input.skills } : {}),
 				logger: input.logger,
 				maxTurns: 200,
 				onMessage: input.onMessage,
@@ -157,6 +159,69 @@ describe("ChatSessionHandler chat session permissions", () => {
 		for (const path of chatRepositoryPaths) {
 			expect(capturedConfig.allowedDirectories).toContain(path);
 		}
+	});
+
+	it("passes scoped managed skills to chat runner configs", async () => {
+		const event: TestEvent = {
+			eventId: "test-event",
+			threadKey: "test-thread",
+		};
+		const cyrusHome = TEST_CYRUS_CHAT;
+		const repository = {
+			id: "repo-a",
+			name: "Repo A",
+			repositoryPath: "/repo/chat-one",
+			allowedTools: [],
+		} as unknown as RepositoryConfig;
+		const chatRepositoryPaths = ["/repo/chat-one"];
+		const plugins = [{ type: "local" as const, path: "/cyrus/user-skills" }];
+		let capturedConfig: any;
+
+		const adapter = new TestChatAdapter("thread-key");
+		const createRunner = vi.fn((config: any) => {
+			capturedConfig = config;
+			return {
+				supportsStreamingInput: false,
+				start: vi.fn().mockResolvedValue({ sessionId: "session-1" }),
+				stop: vi.fn(),
+				isRunning: vi.fn().mockReturnValue(false),
+				isStreaming: vi.fn().mockReturnValue(false),
+				addStreamMessage: vi.fn(),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+		const resolveSkillsConfig = vi.fn().mockResolvedValue({
+			plugins,
+			skills: ["agent-browser", "test-user-skills"],
+		});
+
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome,
+			chatRepositoryProvider: createStaticProvider(
+				chatRepositoryPaths,
+				repository,
+				"workspace-1",
+			),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			resolveSkillsConfig,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		await handler.handleEvent(event as any);
+
+		expect(resolveSkillsConfig).toHaveBeenCalledWith({
+			repository,
+			repositoryPaths: chatRepositoryPaths,
+		});
+		expect(capturedConfig.plugins).toEqual(plugins);
+		expect(capturedConfig.skills).toEqual([
+			"agent-browser",
+			"test-user-skills",
+		]);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Stage scoped Cyrus-managed skills into Codex's documented repository skill discovery path with per-session symlinks under `.agents/skills`.
- Pass managed skill plugin and allow-list config through to Codex issue runner configs without changing `CODEX_HOME`, preserving both native Codex login and API-key auth behavior.
- Pass the same managed skill plugin and scoped allow-list through Slack/chat runner configs so Codex chat sessions can see user-managed skills too.
- Keep staged `.agents/` symlinks out of `git status` by adding the runtime directory to the repository-local `.git/info/exclude` instead of modifying project `.gitignore`.
- Clean staged Codex skill symlinks on both normal completion and explicit runner stop requests.
- Add unit coverage for Codex staging, cleanup, stop cleanup, collision handling, local git exclude behavior, issue config propagation, chat config propagation, and ChatSessionHandler skill resolution.
- Add an F1 test-drive report for CYPACK-1287.

## Research Notes
- Official Codex docs list repository skill discovery through `.agents/skills` from CWD up to repo root, plus user/admin/system locations.
- Official Codex docs state symlinked skill folders are supported and followed during scanning.
- Local `codex debug prompt-input` confirmed a symlinked managed skill appears as the expected unqualified skill name.

## Testing
- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter cyrus-codex-runner test:run -- CodexRunner.skills.test.ts`
- `pnpm --filter cyrus-edge-worker test:run -- RunnerConfigBuilder.codex-skills.test.ts`
- `pnpm --filter cyrus-edge-worker test:run -- RunnerConfigBuilder.chat-config.test.ts chat-sessions.test.ts`
- `pnpm exec biome check packages/codex-runner/src/CodexRunner.ts packages/codex-runner/test/CodexRunner.skills.test.ts`
- `pnpm exec biome check apps/f1/test-drives/2026-06-04-cypack-1287-codex-managed-skills.md packages/codex-runner/src/CodexRunner.ts packages/codex-runner/test/CodexRunner.skills.test.ts packages/edge-worker/src/RunnerConfigBuilder.ts packages/edge-worker/src/ChatSessionHandler.ts packages/edge-worker/src/EdgeWorker.ts packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts packages/edge-worker/test/chat-sessions.test.ts packages/core/src/agent-runner-types.ts`
- `git diff --check`
- F1 test drive: issue routing and Codex selection passed; live Codex model turn exited with code 1 in the local F1 environment, so discovery was validated with a deterministic `codex debug prompt-input` probe.

## Linear
- Issue: [CYPACK-1287](https://linear.app/ceedar/issue/CYPACK-1287/make-our-managed-skills-available-to-the-codex-runner)
- Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

Tip: Managed skills are symlinked into the isolated issue/chat worktree and removed during runner cleanup or stop handling, while `.agents/` is ignored locally through `.git/info/exclude` so repositories do not need to commit a Cyrus-specific ignore rule.

<!-- generated-by-cyrus -->
