### PR TITLE
Fix Codex MCP allowedTools translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
-- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters and approvals, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools without requiring interactive approval. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
-- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288))
+- Codex sessions now translate Cyrus MCP allow-list entries into Codex MCP tool filters, so `mcp__server__tool` permissions restrict Codex sessions to the configured tools. ([CYPACK-1288](https://linear.app/ceedar/issue/CYPACK-1288), [#1292](https://github.com/cyrusagents/cyrus/pull/1292))
 - Codex sessions now load Cyrus-hosted custom MCP configs with Codex-specific MCP options preserved, so configured MCP servers are available when using the Codex runner. ([CYPACK-1286](https://linear.app/ceedar/issue/CYPACK-1286), [#1290](https://github.com/cyrusagents/cyrus/pull/1290))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -489,11 +489,13 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
-function isConfigObject(value: unknown): value is CodexConfigOverrides {
-	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+function isConfigObject(
+	value: unknown,
+): value is Record<string, CodexConfigValue> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function ensureCodexMcpToolApproval(
+function setMissingCodexMcpToolApproval(
 	mapped: CodexConfigOverrides,
 	toolName: string,
 ): void {
@@ -511,21 +513,30 @@ function ensureCodexMcpToolApproval(
 	mapped.tools = tools;
 }
 
-function applyCyrusMcpApprovalSemantics(
+function applyCyrusMcpAllowedToolsSemantics(
 	mapped: CodexConfigOverrides,
 	allowedToolsFilter: McpAllowedToolsFilter,
-	options: { approveListedTools: boolean },
+	options: { hasNativeToolFilter: boolean },
 ): void {
+	const shouldGenerateToolFilter =
+		!allowedToolsFilter.allowAll &&
+		allowedToolsFilter.tools.length > 0 &&
+		!options.hasNativeToolFilter;
+
+	if (shouldGenerateToolFilter) {
+		mapped.enabled_tools = allowedToolsFilter.tools;
+	}
+
+	// Codex separates tool visibility (`enabled_tools`) from MCP approval. Cyrus
+	// allowedTools are already the operator's allow-list, so generated allowances
+	// must also be approved for non-interactive Codex exec runs.
 	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
 		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
 	}
 
-	// Codex separates tool visibility (`enabled_tools`) from approval. Cyrus
-	// allowedTools are already the operator's allow-list, so generated MCP
-	// allowances must also be pre-approved for non-interactive Codex exec runs.
-	if (options.approveListedTools && !allowedToolsFilter.allowAll) {
+	if (shouldGenerateToolFilter) {
 		for (const tool of allowedToolsFilter.tools) {
-			ensureCodexMcpToolApproval(mapped, tool);
+			setMissingCodexMcpToolApproval(mapped, tool);
 		}
 	}
 }
@@ -928,17 +939,9 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			const hasNativeToolFilter =
 				Object.hasOwn(mapped, "enabled_tools") ||
 				Object.hasOwn(mapped, "disabled_tools");
-			if (
-				allowedToolsFilter &&
-				!allowedToolsFilter.allowAll &&
-				allowedToolsFilter.tools.length > 0 &&
-				!hasNativeToolFilter
-			) {
-				mapped.enabled_tools = allowedToolsFilter.tools;
-			}
 			if (allowedToolsFilter) {
-				applyCyrusMcpApprovalSemantics(mapped, allowedToolsFilter, {
-					approveListedTools: !hasNativeToolFilter,
+				applyCyrusMcpAllowedToolsSemantics(mapped, allowedToolsFilter, {
+					hasNativeToolFilter,
 				});
 			}
 			// If the MCP config already contains Codex-native enabled_tools or

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -63,6 +63,7 @@ interface McpAllowedToolsFilter {
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
+const CODEX_MCP_APPROVE_MODE = "approve";
 
 function toFiniteNumber(value: number | undefined): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -488,6 +489,47 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
+function isConfigObject(value: unknown): value is CodexConfigOverrides {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function ensureCodexMcpToolApproval(
+	mapped: CodexConfigOverrides,
+	toolName: string,
+): void {
+	const tools = isConfigObject(mapped.tools) ? { ...mapped.tools } : {};
+	const existingToolConfig = tools[toolName];
+	const toolConfig = isConfigObject(existingToolConfig)
+		? { ...existingToolConfig }
+		: {};
+
+	if (!Object.hasOwn(toolConfig, "approval_mode")) {
+		toolConfig.approval_mode = CODEX_MCP_APPROVE_MODE;
+	}
+
+	tools[toolName] = toolConfig;
+	mapped.tools = tools;
+}
+
+function applyCyrusMcpApprovalSemantics(
+	mapped: CodexConfigOverrides,
+	allowedToolsFilter: McpAllowedToolsFilter,
+	options: { approveListedTools: boolean },
+): void {
+	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
+		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
+	}
+
+	// Codex separates tool visibility (`enabled_tools`) from approval. Cyrus
+	// allowedTools are already the operator's allow-list, so generated MCP
+	// allowances must also be pre-approved for non-interactive Codex exec runs.
+	if (options.approveListedTools && !allowedToolsFilter.allowAll) {
+		for (const tool of allowedToolsFilter.tools) {
+			ensureCodexMcpToolApproval(mapped, tool);
+		}
+	}
+}
+
 function copyConfigString(
 	target: CodexConfigOverrides,
 	source: Record<string, unknown>,
@@ -893,6 +935,11 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				!hasNativeToolFilter
 			) {
 				mapped.enabled_tools = allowedToolsFilter.tools;
+			}
+			if (allowedToolsFilter) {
+				applyCyrusMcpApprovalSemantics(mapped, allowedToolsFilter, {
+					approveListedTools: !hasNativeToolFilter,
+				});
 			}
 			// If the MCP config already contains Codex-native enabled_tools or
 			// disabled_tools, keep those exact filters. They are more specific to

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -432,6 +432,62 @@ function buildMcpAllowedToolsFilters(
 	return filters;
 }
 
+function normalizeMcpServerFilterName(serverName: string): string {
+	return serverName.replace(/[-_]+/g, "").toLowerCase();
+}
+
+function mergeMcpAllowedToolsFilters(
+	filters: McpAllowedToolsFilter[],
+): McpAllowedToolsFilter | undefined {
+	if (filters.length === 0) {
+		return undefined;
+	}
+
+	const merged: McpAllowedToolsFilter = {
+		allowAll: false,
+		tools: [],
+	};
+
+	for (const filter of filters) {
+		if (filter.allowAll) {
+			return { allowAll: true, tools: [] };
+		}
+
+		for (const tool of filter.tools) {
+			if (!merged.tools.includes(tool)) {
+				merged.tools.push(tool);
+			}
+		}
+	}
+
+	return merged;
+}
+
+function getMcpAllowedToolsFilter(
+	filters: Map<string, McpAllowedToolsFilter>,
+	serverName: string,
+): McpAllowedToolsFilter | undefined {
+	const matchingFilters: McpAllowedToolsFilter[] = [];
+	const exact = filters.get(serverName);
+	if (exact) {
+		matchingFilters.push(exact);
+	}
+
+	const normalizedServerName = normalizeMcpServerFilterName(serverName);
+	for (const [allowedServerName, filter] of filters.entries()) {
+		if (allowedServerName === serverName) {
+			continue;
+		}
+		if (
+			normalizeMcpServerFilterName(allowedServerName) === normalizedServerName
+		) {
+			matchingFilters.push(filter);
+		}
+	}
+
+	return mergeMcpAllowedToolsFilters(matchingFilters);
+}
+
 function copyConfigString(
 	target: CodexConfigOverrides,
 	source: Record<string, unknown>,
@@ -823,7 +879,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				continue;
 			}
 
-			const allowedToolsFilter = allowedToolsFilters.get(serverName);
+			const allowedToolsFilter = getMcpAllowedToolsFilter(
+				allowedToolsFilters,
+				serverName,
+			);
 			const hasNativeToolFilter =
 				Object.hasOwn(mapped, "enabled_tools") ||
 				Object.hasOwn(mapped, "disabled_tools");

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -489,30 +489,6 @@ function getMcpAllowedToolsFilter(
 	return mergeMcpAllowedToolsFilters(matchingFilters);
 }
 
-function isConfigObject(
-	value: unknown,
-): value is Record<string, CodexConfigValue> {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function setMissingCodexMcpToolApproval(
-	mapped: CodexConfigOverrides,
-	toolName: string,
-): void {
-	const tools = isConfigObject(mapped.tools) ? { ...mapped.tools } : {};
-	const existingToolConfig = tools[toolName];
-	const toolConfig = isConfigObject(existingToolConfig)
-		? { ...existingToolConfig }
-		: {};
-
-	if (!Object.hasOwn(toolConfig, "approval_mode")) {
-		toolConfig.approval_mode = CODEX_MCP_APPROVE_MODE;
-	}
-
-	tools[toolName] = toolConfig;
-	mapped.tools = tools;
-}
-
 function applyCyrusMcpAllowedToolsSemantics(
 	mapped: CodexConfigOverrides,
 	allowedToolsFilter: McpAllowedToolsFilter,
@@ -532,12 +508,6 @@ function applyCyrusMcpAllowedToolsSemantics(
 	// must also be approved for non-interactive Codex exec runs.
 	if (!Object.hasOwn(mapped, "default_tools_approval_mode")) {
 		mapped.default_tools_approval_mode = CODEX_MCP_APPROVE_MODE;
-	}
-
-	if (shouldGenerateToolFilter) {
-		for (const tool of allowedToolsFilter.tools) {
-			setMissingCodexMcpToolApproval(mapped, tool);
-		}
 	}
 }
 

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -56,6 +56,11 @@ interface ToolProjection {
 	isError: boolean;
 }
 
+interface McpAllowedToolsFilter {
+	allowAll: boolean;
+	tools: string[];
+}
+
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
 
@@ -375,6 +380,56 @@ function loadMcpConfigFromPaths(
 	}
 
 	return mcpServers;
+}
+
+function parseMcpAllowedTool(
+	toolPattern: string,
+): { serverName: string; toolName?: string } | null {
+	const trimmed = toolPattern.trim();
+	if (!trimmed.startsWith("mcp__")) {
+		return null;
+	}
+
+	const parts = trimmed.split("__");
+	const serverName = parts[1]?.trim();
+	if (!serverName) {
+		return null;
+	}
+
+	if (parts.length === 2) {
+		return { serverName };
+	}
+
+	const toolName = parts.slice(2).join("__").trim();
+	return toolName ? { serverName, toolName } : { serverName };
+}
+
+function buildMcpAllowedToolsFilters(
+	allowedTools: string[] | undefined,
+): Map<string, McpAllowedToolsFilter> {
+	const filters = new Map<string, McpAllowedToolsFilter>();
+	for (const allowedTool of allowedTools ?? []) {
+		const parsed = parseMcpAllowedTool(allowedTool);
+		if (!parsed) {
+			continue;
+		}
+
+		const filter = filters.get(parsed.serverName) ?? {
+			allowAll: false,
+			tools: [],
+		};
+
+		if (!parsed.toolName) {
+			filter.allowAll = true;
+			filter.tools = [];
+		} else if (!filter.allowAll && !filter.tools.includes(parsed.toolName)) {
+			filter.tools.push(parsed.toolName);
+		}
+
+		filters.set(parsed.serverName, filter);
+	}
+
+	return filters;
 }
 
 function copyConfigString(
@@ -720,6 +775,10 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			return undefined;
 		}
 
+		const allowedToolsFilters = buildMcpAllowedToolsFilters(
+			this.config.allowedTools,
+		);
+
 		// Codex MCP configuration reference:
 		// https://platform.openai.com/docs/docs-mcp
 		const codexServers: Record<string, CodexConfigOverrides> = {};
@@ -763,6 +822,24 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 				);
 				continue;
 			}
+
+			const allowedToolsFilter = allowedToolsFilters.get(serverName);
+			const hasNativeToolFilter =
+				Object.hasOwn(mapped, "enabled_tools") ||
+				Object.hasOwn(mapped, "disabled_tools");
+			if (
+				allowedToolsFilter &&
+				!allowedToolsFilter.allowAll &&
+				allowedToolsFilter.tools.length > 0 &&
+				!hasNativeToolFilter
+			) {
+				mapped.enabled_tools = allowedToolsFilter.tools;
+			}
+			// If the MCP config already contains Codex-native enabled_tools or
+			// disabled_tools, keep those exact filters. They are more specific to
+			// Codex than Claude-style Cyrus allowedTools entries. A bare
+			// `mcp__server` intentionally emits no enabled_tools filter because it
+			// means "allow every tool exposed by this configured server".
 
 			codexServers[serverName] = mapped;
 		}

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -93,19 +93,14 @@ describe("CodexRunner MCP config mapping", () => {
 			"create_issue",
 		]);
 		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
-		expect(mcpServers.linear.tools).toEqual({
-			list_issues: { approval_mode: "approve" },
-			create_issue: { approval_mode: "approve" },
-		});
+		expect(mcpServers.linear.tools).toBeUndefined();
 		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
 			"linear_agent_session_create_on_comment",
 		]);
 		expect(mcpServers["cyrus-tools"].default_tools_approval_mode).toBe(
 			"approve",
 		);
-		expect(mcpServers["cyrus-tools"].tools).toEqual({
-			linear_agent_session_create_on_comment: { approval_mode: "approve" },
-		});
+		expect(mcpServers["cyrus-tools"].tools).toBeUndefined();
 	});
 
 	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
@@ -149,10 +144,7 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers["slack-fixed"].default_tools_approval_mode).toBe(
 			"approve",
 		);
-		expect(mcpServers["slack-fixed"].tools).toEqual({
-			conversations_replies: { approval_mode: "approve" },
-			attachment_get_data: { approval_mode: "approve" },
-		});
+		expect(mcpServers["slack-fixed"].tools).toBeUndefined();
 	});
 
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -92,9 +92,20 @@ describe("CodexRunner MCP config mapping", () => {
 			"list_issues",
 			"create_issue",
 		]);
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.linear.tools).toEqual({
+			list_issues: { approval_mode: "approve" },
+			create_issue: { approval_mode: "approve" },
+		});
 		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
 			"linear_agent_session_create_on_comment",
 		]);
+		expect(mcpServers["cyrus-tools"].default_tools_approval_mode).toBe(
+			"approve",
+		);
+		expect(mcpServers["cyrus-tools"].tools).toEqual({
+			linear_agent_session_create_on_comment: { approval_mode: "approve" },
+		});
 	});
 
 	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
@@ -112,6 +123,7 @@ describe("CodexRunner MCP config mapping", () => {
 		const mcpServers = (runner as any).buildCodexMcpServersConfig();
 		expect(mcpServers.linear.enabled_tools).toBeUndefined();
 		expect(mcpServers.linear.disabled_tools).toBeUndefined();
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
 	});
 
 	it("matches underscore Cyrus MCP server names to hyphenated Codex MCP server names", () => {
@@ -134,6 +146,13 @@ describe("CodexRunner MCP config mapping", () => {
 			"conversations_replies",
 			"attachment_get_data",
 		]);
+		expect(mcpServers["slack-fixed"].default_tools_approval_mode).toBe(
+			"approve",
+		);
+		expect(mcpServers["slack-fixed"].tools).toEqual({
+			conversations_replies: { approval_mode: "approve" },
+			attachment_get_data: { approval_mode: "approve" },
+		});
 	});
 
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
@@ -159,8 +178,12 @@ describe("CodexRunner MCP config mapping", () => {
 
 		const mcpServers = (runner as any).buildCodexMcpServersConfig();
 		expect(mcpServers.linear.enabled_tools).toEqual(["list_issues"]);
+		expect(mcpServers.linear.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.linear.tools).toBeUndefined();
 		expect(mcpServers.github.enabled_tools).toBeUndefined();
 		expect(mcpServers.github.disabled_tools).toEqual(["delete_repository"]);
+		expect(mcpServers.github.default_tools_approval_mode).toBe("approve");
+		expect(mcpServers.github.tools).toBeUndefined();
 	});
 
 	it("loads hosted file-based MCP configs and preserves Codex MCP options", () => {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -65,6 +65,82 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers.linear.bearer_token_env_var).toBe("LINEAR_API_TOKEN");
 	});
 
+	it("translates per-tool Cyrus MCP allowedTools to Codex enabled_tools", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"Read",
+				"mcp__linear__list_issues",
+				"mcp__linear__create_issue",
+				"mcp__linear__list_issues",
+				"mcp__cyrus-tools__linear_agent_session_create_on_comment",
+			],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+				},
+				"cyrus-tools": {
+					type: "http",
+					url: "http://127.0.0.1:4444/mcp/cyrus-tools",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toEqual([
+			"list_issues",
+			"create_issue",
+		]);
+		expect(mcpServers["cyrus-tools"].enabled_tools).toEqual([
+			"linear_agent_session_create_on_comment",
+		]);
+	});
+
+	it("leaves Codex MCP servers unrestricted for server-wide Cyrus MCP allowedTools", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: ["mcp__linear", "mcp__linear__list_issues"],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toBeUndefined();
+		expect(mcpServers.linear.disabled_tools).toBeUndefined();
+	});
+
+	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"mcp__linear__create_issue",
+				"mcp__github__create_pull_request",
+			],
+			mcpConfig: {
+				linear: {
+					type: "http",
+					url: "https://mcp.linear.app/mcp",
+					enabled_tools: ["list_issues"],
+				} as any,
+				github: {
+					type: "http",
+					url: "https://example.com/github/mcp",
+					disabled_tools: ["delete_repository"],
+				} as any,
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers.linear.enabled_tools).toEqual(["list_issues"]);
+		expect(mcpServers.github.enabled_tools).toBeUndefined();
+		expect(mcpServers.github.disabled_tools).toEqual(["delete_repository"]);
+	});
+
 	it("loads hosted file-based MCP configs and preserves Codex MCP options", () => {
 		const tmp = mkdtempSync(join(tmpdir(), "cyrus-codex-mcp-"));
 		try {

--- a/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
+++ b/packages/codex-runner/test/CodexRunner.mcp-config.test.ts
@@ -114,6 +114,28 @@ describe("CodexRunner MCP config mapping", () => {
 		expect(mcpServers.linear.disabled_tools).toBeUndefined();
 	});
 
+	it("matches underscore Cyrus MCP server names to hyphenated Codex MCP server names", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			allowedTools: [
+				"mcp__slack_fixed__conversations_replies",
+				"mcp__slack_fixed__attachment_get_data",
+			],
+			mcpConfig: {
+				"slack-fixed": {
+					type: "http",
+					url: "https://example.com/slack-fixed/mcp",
+				},
+			},
+		});
+
+		const mcpServers = (runner as any).buildCodexMcpServersConfig();
+		expect(mcpServers["slack-fixed"].enabled_tools).toEqual([
+			"conversations_replies",
+			"attachment_get_data",
+		]);
+	});
+
 	it("keeps Codex-native MCP tool filters ahead of Cyrus allowedTools translation", () => {
 		const runner = new CodexRunner({
 			workingDirectory: process.cwd(),

--- a/packages/edge-worker/test/EgressProxy.test.ts
+++ b/packages/edge-worker/test/EgressProxy.test.ts
@@ -439,8 +439,9 @@ function connectViaProxy(proxyPort: number, target: string): Promise<number> {
 			method: "CONNECT",
 			path: target,
 		});
-		req.on("connect", (res) => {
+		req.on("connect", (res, socket) => {
 			resolve(res.statusCode || 0);
+			socket.destroy();
 			req.destroy();
 		});
 		req.on("error", () => resolve(0));


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary
- Translate Cyrus MCP `allowedTools` entries into Codex MCP config for the Codex runner.
- Generate Codex `enabled_tools` for per-tool entries such as `mcp__server__tool_name`.
- Preserve server-wide `mcp__server` semantics by leaving that server unrestricted.
- Pre-approve Cyrus-allowed MCP servers with Codex `default_tools_approval_mode = "approve"`, so non-interactive Codex exec runs do not stop at an MCP approval prompt.
- Keep Codex-native `enabled_tools`, `disabled_tools`, and `tools` config from MCP config ahead of generated Cyrus translations.
- Match hyphen/underscore MCP server-name aliases so entries like `mcp__slack_fixed__attachment_get_data` filter a Codex server configured as `slack-fixed`.

## Root Cause Found
The local `@openai/codex-sdk` serializes the `config` object into Codex CLI `--config dotted.path=value` overrides. Codex MCP config supports `enabled_tools` and `disabled_tools`, but those only control tool visibility. The Codex CLI also has an MCP approval layer (`default_tools_approval_mode`, with optional per-tool `approval_mode`). Without approval settings, a headless/non-interactive MCP call can surface as `user cancelled MCP tool call` even when the tool is visible.

For Cyrus-generated per-tool allow-lists, `enabled_tools` narrows visibility to the allowed tools and `default_tools_approval_mode = "approve"` approves those visible tools. We do not generate redundant `tools.<tool>.approval_mode` entries; existing Codex-native per-tool approval config from `.mcp.json` is preserved when provided.

## Testing
- `pnpm --filter cyrus-codex-runner test:run`
- `pnpm --filter cyrus-codex-runner typecheck`
- `pnpm --filter cyrus-codex-runner build`
- Runtime config probe for `slack-fixed` confirmed Codex receives:
  - `enabled_tools: ["conversations_replies", "attachment_get_data"]`
  - `default_tools_approval_mode: "approve"`
  - no generated `tools` approval object
- Direct `slack_fixed.conversations_replies` reproduction against the reported channel/thread returned `user cancelled MCP tool call`, which matches the missing-approval failure mode observed by the user.
- `pnpm --filter cyrus-edge-worker exec vitest run test/EgressProxy.test.ts`
- `pnpm --filter cyrus-edge-worker test:run`
- `pnpm --filter cyrus-edge-worker exec vitest run test/RunnerConfigBuilder.additional-directories.test.ts`
- `pnpm test:packages:run` (one unrelated edge-worker prompt assembly test timed out in the full run; passed on direct rerun)
- `pnpm --filter cyrus-edge-worker exec vitest run test/prompt-assembly.system-prompt-behavior.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with pre-existing warnings)
- Commit hooks also ran repository-wide `pnpm build` and `pnpm typecheck` successfully.
- GitHub Actions passed for Node 20 and Node 22 after closing the leaked CONNECT socket in the EgressProxy test helper.

Linear: https://linear.app/ceedar/issue/CYPACK-1288/fix-allowedtools-translation-for-codex-runner

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
