### PR TITLE
Honor Cyrus sandbox setting for Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 
 ### Fixed
+- Codex sessions no longer run under the Codex workspace sandbox unless Cyrus sandboxing is enabled in config. ([CYPACK-1291](https://linear.app/ceedar/issue/CYPACK-1291), [#1296](https://github.com/cyrusagents/cyrus/pull/1296))
 - Git commands (`add`, `commit`, `merge`, etc.) no longer fail with "Operation not permitted" in multi-repo workspaces when running under a sandboxed agent (e.g. the Codex runner). Each repository's git metadata directory is now granted write access, not just the workspace container.
 
 

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -58,6 +58,7 @@ interface ToolProjection {
 
 const DEFAULT_CODEX_MODEL = "gpt-5.5";
 const CODEX_MCP_DOCS_URL = "https://platform.openai.com/docs/docs-mcp";
+const DEFAULT_CODEX_SANDBOX_MODE = "danger-full-access" as const;
 
 function toFiniteNumber(value: number | undefined): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -589,7 +590,7 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 
 		const threadOptions: ThreadOptions = {
 			model: this.config.model,
-			sandboxMode: this.config.sandbox || "workspace-write",
+			sandboxMode: this.config.sandbox ?? DEFAULT_CODEX_SANDBOX_MODE,
 			workingDirectory: this.config.workingDirectory,
 			skipGitRepoCheck: this.config.skipGitRepoCheck ?? true,
 			approvalPolicy: this.config.askForApproval || "never",
@@ -775,23 +776,24 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 			}
 		}
 
-		const sandboxWorkspaceWrite = configOverrides.sandbox_workspace_write;
-		// Keep workspace-write as the default sandbox, but enable outbound network so
-		// common remote workflows (for example `git`/`gh` against GitHub) work without
-		// requiring danger-full-access.
-		if (
-			sandboxWorkspaceWrite &&
-			typeof sandboxWorkspaceWrite === "object" &&
-			!Array.isArray(sandboxWorkspaceWrite)
-		) {
-			configOverrides.sandbox_workspace_write = {
-				...sandboxWorkspaceWrite,
-				network_access:
-					(sandboxWorkspaceWrite as { network_access?: boolean })
-						.network_access ?? true,
-			};
-		} else if (!sandboxWorkspaceWrite) {
-			configOverrides.sandbox_workspace_write = { network_access: true };
+		if (this.config.sandbox === "workspace-write") {
+			const sandboxWorkspaceWrite = configOverrides.sandbox_workspace_write;
+			// When Cyrus explicitly enables the Codex workspace sandbox, keep outbound
+			// network available so common remote workflows like git/gh continue to work.
+			if (
+				sandboxWorkspaceWrite &&
+				typeof sandboxWorkspaceWrite === "object" &&
+				!Array.isArray(sandboxWorkspaceWrite)
+			) {
+				configOverrides.sandbox_workspace_write = {
+					...sandboxWorkspaceWrite,
+					network_access:
+						(sandboxWorkspaceWrite as { network_access?: boolean })
+							.network_access ?? true,
+				};
+			} else if (!sandboxWorkspaceWrite) {
+				configOverrides.sandbox_workspace_write = { network_access: true };
+			}
 		}
 
 		if (!appendSystemPrompt) {

--- a/packages/codex-runner/test/CodexRunner.sandbox.test.ts
+++ b/packages/codex-runner/test/CodexRunner.sandbox.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { CodexRunner } from "../src/CodexRunner.js";
+
+describe("CodexRunner sandbox mode", () => {
+	it("defaults to unsandboxed execution when no sandbox mode is configured", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+		});
+
+		const threadOptions = (runner as any).buildThreadOptions();
+		const configOverrides = (runner as any).buildConfigOverrides();
+
+		expect(threadOptions.sandboxMode).toBe("danger-full-access");
+		expect(configOverrides?.sandbox_workspace_write).toBeUndefined();
+	});
+
+	it("passes workspace-write sandbox config only when workspace sandbox is configured", () => {
+		const runner = new CodexRunner({
+			workingDirectory: process.cwd(),
+			sandbox: "workspace-write",
+		});
+
+		const threadOptions = (runner as any).buildThreadOptions();
+		const configOverrides = (runner as any).buildConfigOverrides();
+
+		expect(threadOptions.sandboxMode).toBe("workspace-write");
+		expect(configOverrides?.sandbox_workspace_write).toEqual({
+			network_access: true,
+		});
+	});
+});

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -10,6 +10,7 @@ import type {
 	SdkPluginConfig,
 	StopHookInput,
 } from "cyrus-claude-runner";
+import type { CodexRunnerConfig } from "cyrus-codex-runner";
 import type {
 	AgentRunnerConfig,
 	CyrusAgentSession,
@@ -431,6 +432,10 @@ export class RunnerConfigBuilder {
 			}
 		}
 
+		if (runnerType === "codex") {
+			config.sandbox = this.buildCodexSandboxMode(input);
+		}
+
 		if (input.resumeSessionId) {
 			config.resumeSessionId = input.resumeSessionId;
 		}
@@ -440,6 +445,14 @@ export class RunnerConfigBuilder {
 		}
 
 		return { config, runnerType };
+	}
+
+	private buildCodexSandboxMode(
+		input: IssueRunnerConfigInput,
+	): NonNullable<CodexRunnerConfig["sandbox"]> {
+		return input.sandboxSettings?.enabled === true
+			? "workspace-write"
+			: "danger-full-access";
 	}
 
 	/**

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
@@ -1,0 +1,97 @@
+import type { SandboxSettings } from "cyrus-claude-runner";
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "codex" as const }),
+		getDefaultModelForRunner: () => "gpt-5.5",
+		getDefaultFallbackModelForRunner: () => "gpt-5.2-codex",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(): RepositoryConfig {
+	return {
+		id: "repo-a",
+		name: "Repo A",
+		repositoryPath: "/repos/repo-a",
+		allowedTools: [],
+	} as unknown as RepositoryConfig;
+}
+
+function makeSession(): CyrusAgentSession {
+	return {
+		issueId: "issue-1",
+		issue: { identifier: "ABC-1" },
+		workspace: {
+			path: "/ws/repo-a-worktree",
+			isGitWorktree: true,
+		},
+	} as unknown as CyrusAgentSession;
+}
+
+function buildCodexIssueConfig(sandboxSettings?: SandboxSettings) {
+	return makeBuilder().buildIssueConfig({
+		session: makeSession(),
+		repository: makeRepository(),
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+		sandboxSettings,
+	});
+}
+
+describe("RunnerConfigBuilder Codex sandbox mapping", () => {
+	it("disables Codex sandbox when Cyrus sandbox settings are absent", () => {
+		const { config, runnerType } = buildCodexIssueConfig();
+
+		expect(runnerType).toBe("codex");
+		expect(config.sandbox).toBe("danger-full-access");
+	});
+
+	it("enables Codex workspace sandbox when Cyrus sandbox is enabled", () => {
+		const { config, runnerType } = buildCodexIssueConfig({
+			enabled: true,
+			network: {
+				httpProxyPort: 9080,
+				socksProxyPort: 9081,
+			},
+		});
+
+		expect(runnerType).toBe("codex");
+		expect(config.sandbox).toBe("workspace-write");
+	});
+});


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary
- Map Cyrus sandbox enablement into Codex runner sandbox mode: enabled uses workspace-write, disabled/absent uses danger-full-access.
- Stop Codex from injecting workspace sandbox config unless workspace-write is explicitly selected.
- Add regression coverage at the Codex runner and edge-worker config-builder layers.

## Linear
- https://linear.app/ceedar/issue/CYPACK-1291/dont-have-sandbox-applied-on-codex-when-sandbox-config-per-cyrus-is

## Verification
- pnpm build
- pnpm test:packages:run
- pnpm typecheck
- pnpm lint (exits 0; reports existing warnings outside this change)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->