### PR TITLE
chore(deps): update @anthropic-ai/claude-agent-sdk to 0.3.167 and @anthropic-ai/sdk to 0.101.0 (CYPACK-1292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated `@anthropic-ai/claude-agent-sdk` from 0.3.159 to 0.3.167 and `@anthropic-ai/sdk` to 0.101.0. Removes `Glob` and `Grep` from the allowed-tool lists (now embedded in Claude Code's native search as of v0.3.162; no longer discrete tools). Adds `RemoteTrigger` to all platform default allowed-tool lists. ([CYPACK-1292](https://linear.app/ceedar/issue/CYPACK-1292), [#PLACEHOLDER](https://github.com/cyrusagents/cyrus/pull/PLACEHOLDER))
+- Updated `@anthropic-ai/claude-agent-sdk` from 0.3.159 to 0.3.167 and `@anthropic-ai/sdk` to 0.101.0. Removes `Glob` and `Grep` from the allowed-tool lists (now embedded in Claude Code's native search as of v0.3.162; no longer discrete tools). Adds `RemoteTrigger` to all platform default allowed-tool lists. ([CYPACK-1292](https://linear.app/ceedar/issue/CYPACK-1292), [#1297](https://github.com/cyrusagents/cyrus/pull/1297))
 
 ### Security
 - Patched Hono dependency advisories reported by Dependabot so `pnpm audit` is clean for the Cyrus CLI workspace. ([CYPACK-1290](https://linear.app/ceedar/issue/CYPACK-1290), [#1295](https://github.com/cyrusagents/cyrus/pull/1295))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from 0.3.159 to 0.3.167 and `@anthropic-ai/sdk` to 0.101.0. Removes `Glob` and `Grep` from the allowed-tool lists (now embedded in Claude Code's native search as of v0.3.162; no longer discrete tools). Adds `RemoteTrigger` to all platform default allowed-tool lists. ([CYPACK-1292](https://linear.app/ceedar/issue/CYPACK-1292), [#PLACEHOLDER](https://github.com/cyrusagents/cyrus/pull/PLACEHOLDER))
+
 ### Security
 - Patched Hono dependency advisories reported by Dependabot so `pnpm audit` is clean for the Cyrus CLI workspace. ([CYPACK-1290](https://linear.app/ceedar/issue/CYPACK-1290), [#1295](https://github.com/cyrusagents/cyrus/pull/1295))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.159",
-		"@anthropic-ai/sdk": "^0.100.1",
+		"@anthropic-ai/claude-agent-sdk": "0.3.167",
+		"@anthropic-ai/sdk": "^0.101.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -19,8 +19,6 @@ export const availableTools = [
 	"Read(**)",
 	"Edit(**)",
 	"Write(**)",
-	"Glob",
-	"Grep",
 
 	// Execution tools
 	"Bash",
@@ -64,6 +62,7 @@ export const availableTools = [
 	"Monitor",
 	"TaskOutput",
 	"TaskStop",
+	"RemoteTrigger",
 
 	// Team management
 	"TeamCreate",
@@ -85,8 +84,6 @@ export type ToolName = (typeof availableTools)[number];
  */
 export const readOnlyTools: ToolName[] = [
 	"Read(**)",
-	"Glob",
-	"Grep",
 	"WebFetch",
 	"WebSearch",
 	"TaskCreate",

--- a/packages/claude-runner/test/config.test.ts
+++ b/packages/claude-runner/test/config.test.ts
@@ -17,8 +17,6 @@ describe("config", () => {
 				"Read(**)",
 				"Edit(**)",
 				"Write(**)",
-				"Glob",
-				"Grep",
 				"Bash",
 				"Task",
 				"WebFetch",
@@ -43,19 +41,18 @@ describe("config", () => {
 				"Monitor",
 				"TaskOutput",
 				"TaskStop",
+				"RemoteTrigger",
 				"TeamCreate",
 				"TeamDelete",
 				"ToolSearch",
 				"Workflow",
 			]);
-			expect(availableTools).toHaveLength(33);
+			expect(availableTools).toHaveLength(32);
 		});
 
 		it("should define read-only tools", () => {
 			expect(readOnlyTools).toEqual([
 				"Read(**)",
-				"Glob",
-				"Grep",
 				"WebFetch",
 				"WebSearch",
 				"TaskCreate",
@@ -70,7 +67,7 @@ describe("config", () => {
 				"ExitPlanMode",
 				"ToolSearch",
 			]);
-			expect(readOnlyTools).toHaveLength(16);
+			expect(readOnlyTools).toHaveLength(14);
 		});
 
 		it("should define write tools", () => {
@@ -131,8 +128,6 @@ describe("config", () => {
 			expect(tools).toContain("Read(**)");
 			expect(tools).toContain("Edit(**)");
 			expect(tools).toContain("Write(**)");
-			expect(tools).toContain("Glob");
-			expect(tools).toContain("Grep");
 			expect(tools).toContain("Task");
 			expect(tools).toContain("WebFetch");
 			expect(tools).toContain("WebSearch");
@@ -151,8 +146,6 @@ describe("config", () => {
 
 			// Should include read and execution tools
 			expect(tools).toContain("Read(**)");
-			expect(tools).toContain("Glob");
-			expect(tools).toContain("Grep");
 			expect(tools).toContain("Bash"); // For running tests/builds
 			expect(tools).toContain("Task");
 			expect(tools).toContain("WebFetch");
@@ -174,8 +167,6 @@ describe("config", () => {
 
 			// Can read files
 			expect(coordinatorTools).toContain("Read(**)");
-			expect(coordinatorTools).toContain("Glob");
-			expect(coordinatorTools).toContain("Grep");
 
 			// Cannot edit files
 			expect(coordinatorTools).not.toContain("Edit(**)");
@@ -250,16 +241,6 @@ describe("config", () => {
 		it("WebSearch should be read-only", () => {
 			expect(readOnlyTools).toContain("WebSearch");
 			expect(writeTools).not.toContain("WebSearch");
-		});
-
-		it("Glob should be read-only", () => {
-			expect(readOnlyTools).toContain("Glob");
-			expect(writeTools).not.toContain("Glob");
-		});
-
-		it("Grep should be read-only", () => {
-			expect(readOnlyTools).toContain("Grep");
-			expect(writeTools).not.toContain("Grep");
 		});
 
 		it("Notebook tools should be categorized correctly", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.159",
+		"@anthropic-ai/claude-agent-sdk": "0.3.167",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/core/src/allowed-tools-defaults.ts
+++ b/packages/core/src/allowed-tools-defaults.ts
@@ -33,8 +33,6 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	"Read",
 	"Edit",
 	"Write",
-	"Glob",
-	"Grep",
 	"NotebookEdit",
 
 	// Execution
@@ -73,6 +71,7 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	// Monitoring + discovery
 	"Monitor",
 	"LSP",
+	"RemoteTrigger",
 	"ToolSearch",
 	"Skill",
 
@@ -105,8 +104,6 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 export const SLACK_DEFAULT_ALLOWED_TOOLS = [
 	// Read access to configured repository paths
 	"Read",
-	"Glob",
-	"Grep",
 	"Bash(git -C * pull)",
 
 	// Web
@@ -131,6 +128,7 @@ export const SLACK_DEFAULT_ALLOWED_TOOLS = [
 
 	// Discovery
 	"Monitor",
+	"RemoteTrigger",
 	"Skill",
 	"ToolSearch",
 
@@ -158,8 +156,6 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	"Read",
 	"Edit",
 	"Write",
-	"Glob",
-	"Grep",
 	"NotebookEdit",
 
 	// Execution
@@ -198,6 +194,7 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	// Monitoring + discovery
 	"Monitor",
 	"LSP",
+	"RemoteTrigger",
 	"ToolSearch",
 	"Skill",
 

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.159",
+		"@anthropic-ai/claude-agent-sdk": "0.3.167",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.159",
+		"@anthropic-ai/claude-agent-sdk": "0.3.167",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,8 +158,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.159
-        version: 0.3.159(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.167
+        version: 0.3.167(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: '>=0.100.0'
         version: 0.100.1(zod@4.3.6)
@@ -261,8 +261,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.159
-        version: 0.3.159(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.167
+        version: 0.3.167(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -311,8 +311,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.159
-        version: 0.3.159(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.167
+        version: 0.3.167(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -536,8 +536,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.159
-        version: 0.3.159(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.167
+        version: 0.3.167(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -576,52 +576,52 @@ importers:
 
 packages:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.159':
-    resolution: {integrity: sha512-3nnH4yUNJVSyaU5DBlGw2yxc4zlnVvAnc9UOe+La47QVG7/dN+rWAgn4zCbqKk9bWFLDQ1Ek0r56EZE1Qo4UKQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.167':
+    resolution: {integrity: sha512-lRdC0lWpRQmoo3geCia/9M0/72BraWwZLxyIQrwWhUCvvlGwqvPLRlPd7Ls20W3py1U4qe2UHt8/NlKMMmoq2g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.159':
-    resolution: {integrity: sha512-iv+NRjz+t4Q1R2+kLdDbccSo3b0wedVJ9jMT3noznOVojZHzgkxVpTvt36/XkXV0rqIDQ5H18bBYIZZzOXu7mg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
+    resolution: {integrity: sha512-24WCqqXc9SBliROFQz+JhO8+u9DARqhmMGWAZwT+/fs9RDJtHd2SZ7o8rWPAVnUicKQCMsjxdhtp/vFWELGenA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.159':
-    resolution: {integrity: sha512-WvwiQBWt3tdu5EwqjpDZszI6p2uetYsw4Cxc6ptO/SmLIYXcDienP8nmirZdsZrS+Gzk6imgY0IY5mmNaRhelQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.167':
+    resolution: {integrity: sha512-g9KB5JIDvcLENitm6+QLnY3YC40FvJroWz65C0etK6ri07SALFxfahSPHQqlbHlAo8a/+ZibSihwjqkvOXQtfg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.159':
-    resolution: {integrity: sha512-FlsS5M4GCpzsQVaNDFF8dRgFGR3QwyAHZFl/xM/2Y2BqVBH+NH17RpKQSJxr1qr41QnsNkinMnu2iSKoc33hKg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
+    resolution: {integrity: sha512-f6269JZ8KngRIHDK9tmQMFWHg8XhOyJww6pbTVHqlUnf70pJPEP7hsmg6OQErRIvqQzHQWBiakQA8VIdRrOrjw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.159':
-    resolution: {integrity: sha512-kFH6RC2YJbPc8XWRNy/wL4YU7LzdJjSwAdH488sVzIif3q+TrvVrV5y/IW0+MLmta+CKIqtFYpGaucsJYvj7Eg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.167':
+    resolution: {integrity: sha512-VA+0oQS8jTl2vyeMt4vjFiHf14F0mOxQbNJ6PLdy4etelYxC0lipPtSxVHbdzrgd0cF91uqUDhUMexNkVqS4MQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.159':
-    resolution: {integrity: sha512-uNPEC/iRzVb4bEdzs0KAz1zV7i1PVGEZZnJTQyi1OtgVa81sAoH/H0CbbzDiTsquKdaESf+1DSSEkUlfZmMUEw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
+    resolution: {integrity: sha512-ecxQI20+Fr+PexMgmHlG9/WrUOUi9uQT9n1laUDn4bQAcQX3xDqgZbiH7RErCuTJW+mBSauSh4X68b4jmf64Bg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.159':
-    resolution: {integrity: sha512-WN1QEZGgWXz9GMl61QU6j9E+LEF5plki87bL2xsGwuCPzK+OeVPQU55pabuP8P+vFBFHUo3Y9OlTVyZHnUzmAQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.167':
+    resolution: {integrity: sha512-uB2E9w0bReXONBbaGM27S60F1h+NI/P2HyYoDy+eJsFhMv1lVbko9NG2Wm3kT5qOooBGRlSE5GgiCAK80xBcTA==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.159':
-    resolution: {integrity: sha512-Ty4seccD+dTDX5hhj89IUELZd/LkxO5O43Uiz5Mo8ZJktoX38SK4XMZlBS935QdqTFLRvPL0hvK4Lt4dTOqzPw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
+    resolution: {integrity: sha512-r2IzO8ADzu4uRorXSs07baXee0LtTUIVDXP2ubYW32oTcAr98eip2VfkxwL9xm0tHXN63rp4fporU0eAy9fLPA==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.159':
-    resolution: {integrity: sha512-Xh1oVMIK6N3KsiNIhqNH8ZK90zjRmAEL9d1Md8ZlGdHJE+HhdMYdBadujc3KEkV0uufsEUvYp+A3fDenfypGSA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.167':
+    resolution: {integrity: sha512-FTwjBkfcJlqDugBp/kR2GtQ7wPE1ekU4IJzIuUni0pVikdrOVmAPel3EE9LMSJ0WVqFVnHvoYIuj4U9z4gC+5w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.100.0'
@@ -4300,44 +4300,44 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.159':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.159(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.167(@anthropic-ai/sdk@0.100.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.100.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.159
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.159
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.167
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.167
 
   '@anthropic-ai/sdk@0.100.1(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/claude-agent-sdk` from `0.3.159` to `0.3.167` in all four packages (`core`, `claude-runner`, `simple-agent-runner`, `edge-worker`)
- Bumps `@anthropic-ai/sdk` from `^0.100.1` to `^0.101.0` in `claude-runner`
- Removes `Glob` and `Grep` from `availableTools`, `readOnlyTools`, and all three platform default allowed-tool lists (`LINEAR_DEFAULT_ALLOWED_TOOLS`, `GITHUB_DEFAULT_ALLOWED_TOOLS`, `SLACK_DEFAULT_ALLOWED_TOOLS`) — these are now embedded in Claude Code's native search as of SDK v0.3.162 and no longer appear as discrete tools in the init block
- Adds `RemoteTrigger` to `availableTools` and all three platform default allowed-tool lists
- Updates `config.test.ts` to match the new tool lists

See the [SDK changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) for full release notes (v0.3.160–v0.3.167).

Supersedes #1294 (0.3.165, now closed).
Closes [CYPACK-1292](https://linear.app/ceedar/issue/CYPACK-1292)

## Test plan
- [x] `pnpm install` — lockfile updated to 0.3.167
- [x] `./scripts/extract-claude-tools.sh` — confirmed 32 tools in 0.3.167 init block; Glob/Grep absent, RemoteTrigger present
- [x] `pnpm build` — all packages compile
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm test:packages:run` — all new failures in config.test.ts resolved; pre-existing debug-logging.test.ts failure is unrelated to this change and was already failing on main

<!-- generated-by-cyrus -->