### PR TITLE
Show session usage in final messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Security
 - Patched Hono dependency advisories reported by Dependabot so `pnpm audit` is clean for the Cyrus CLI workspace. ([CYPACK-1290](https://linear.app/ceedar/issue/CYPACK-1290), [#1295](https://github.com/cyrusagents/cyrus/pull/1295))
 
+### Added
+- Final agent responses now include session usage when available, including approximate API cost for runners that report it and token counts otherwise. ([CYPACK-1293](https://linear.app/ceedar/issue/CYPACK-1293), [#1299](https://github.com/cyrusagents/cyrus/pull/1299))
+
 ### Changed
 - Codex sessions now default to `gpt-5.5`, and Linear model labels such as `gpt-5.5` are recognized as Codex model overrides alongside the existing `*-codex` labels. ([CYPACK-1282](https://linear.app/ceedar/issue/CYPACK-1282), [#1288](https://github.com/cyrusagents/cyrus/pull/1288))
 

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -37,6 +37,75 @@ import type {
 // biome-ignore lint/complexity/noBannedTypes: Empty events type (events removed in CYPACK-996 skill refactor)
 export type AgentSessionManagerEvents = {};
 
+function toFiniteNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function formatUsd(amount: number): string {
+	if (amount > 0 && amount < 0.0001) {
+		return "<$0.0001";
+	}
+
+	return `$${amount.toFixed(4)}`;
+}
+
+function formatTokenCount(count: number): string {
+	return new Intl.NumberFormat("en-US").format(count);
+}
+
+function formatSessionUsageFooter(resultMessage: SDKResultMessage): string {
+	if (resultMessage.is_error) {
+		return "";
+	}
+
+	const usage = resultMessage.usage;
+	const totalCostUsd = toFiniteNumber(resultMessage.total_cost_usd);
+	const inputTokens = toFiniteNumber(usage?.input_tokens);
+	const outputTokens = toFiniteNumber(usage?.output_tokens);
+	const cacheWriteTokens = toFiniteNumber(usage?.cache_creation_input_tokens);
+	const cacheReadTokens = toFiniteNumber(usage?.cache_read_input_tokens);
+
+	const tokenParts = [
+		inputTokens > 0 ? `${formatTokenCount(inputTokens)} input` : undefined,
+		outputTokens > 0 ? `${formatTokenCount(outputTokens)} output` : undefined,
+		cacheWriteTokens > 0
+			? `${formatTokenCount(cacheWriteTokens)} cache write`
+			: undefined,
+		cacheReadTokens > 0
+			? `${formatTokenCount(cacheReadTokens)} cache read`
+			: undefined,
+	].filter(Boolean);
+
+	if (totalCostUsd <= 0 && tokenParts.length === 0) {
+		return "";
+	}
+
+	const lines = ["---"];
+	if (totalCostUsd > 0) {
+		lines.push(`**Session usage**: ~${formatUsd(totalCostUsd)} API cost`);
+	} else {
+		lines.push("**Session usage**: API cost unavailable from runner");
+	}
+
+	if (tokenParts.length > 0) {
+		lines.push(`**Tokens**: ${tokenParts.join(", ")}`);
+	}
+
+	return lines.join("\n");
+}
+
+function appendSessionUsageFooter(
+	content: string,
+	resultMessage: SDKResultMessage,
+): string {
+	const usageFooter = formatSessionUsageFooter(resultMessage);
+	if (!usageFooter) {
+		return content;
+	}
+
+	return content ? `${content}\n\n${usageFooter}` : usageFooter;
+}
+
 /**
  * Type-safe event emitter interface for AgentSessionManager
  */
@@ -664,6 +733,8 @@ export class AgentSessionManager extends EventEmitter {
 						: ""))
 		).trim();
 
+		const finalContent = appendSessionUsageFooter(content, resultMessage);
+
 		const resultEntry: CyrusAgentSessionEntry = {
 			// Set the appropriate session ID based on runner type
 			...(runnerType === "gemini"
@@ -674,7 +745,7 @@ export class AgentSessionManager extends EventEmitter {
 						? { cursorSessionId: resultMessage.session_id }
 						: { claudeSessionId: resultMessage.session_id }),
 			type: "result",
-			content,
+			content: finalContent,
 			metadata: {
 				timestamp: Date.now(),
 				durationMs: resultMessage.duration_ms,
@@ -1418,7 +1489,7 @@ export class AgentSessionManager extends EventEmitter {
 		const log = this.sessionLog(sessionId);
 		const session = this.sessions.get(sessionId);
 
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			log.debug(
 				`Skipping ${label} - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,
 			);
@@ -1681,7 +1752,7 @@ export class AgentSessionManager extends EventEmitter {
 		message: SDKStatusMessage,
 	): Promise<void> {
 		const session = this.sessions.get(sessionId);
-		if (!session || !session.externalSessionId) {
+		if (!session?.externalSessionId) {
 			const log = this.sessionLog(sessionId);
 			log.debug(
 				`Skipping status message - no external session ID (platform: ${session?.issueContext?.trackerId || "unknown"})`,

--- a/packages/edge-worker/test/AgentSessionManager.session-usage-footer.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.session-usage-footer.test.ts
@@ -1,0 +1,130 @@
+import type { SDKResultMessage } from "cyrus-claude-runner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+import type { IActivitySink } from "../src/sinks/IActivitySink";
+
+describe("AgentSessionManager - session usage footer", () => {
+	let manager: AgentSessionManager;
+	let mockActivitySink: IActivitySink;
+	let postActivitySpy: ReturnType<typeof vi.fn>;
+	const sessionId = "session-usage";
+	const issueId = "issue-usage";
+
+	beforeEach(() => {
+		mockActivitySink = {
+			id: "test-workspace",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "activity-1" }),
+			createAgentSession: vi.fn().mockResolvedValue("session-usage"),
+		};
+		postActivitySpy = mockActivitySink.postActivity as ReturnType<typeof vi.fn>;
+
+		manager = new AgentSessionManager();
+		manager.createCyrusAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "CYPACK-1293",
+				title: "Show session usage in final message",
+				description: "",
+				branchName: "cypack-1293",
+			},
+			{ path: "/tmp/workspace", isGitWorktree: false },
+		);
+		manager.setActivitySink(sessionId, mockActivitySink);
+	});
+
+	function buildResultMessage(
+		overrides: Partial<SDKResultMessage> = {},
+	): SDKResultMessage {
+		return {
+			type: "result",
+			subtype: "success",
+			duration_ms: 1000,
+			duration_api_ms: 900,
+			is_error: false,
+			num_turns: 1,
+			result: "Done.",
+			stop_reason: null,
+			total_cost_usd: 0,
+			usage: {
+				input_tokens: 0,
+				output_tokens: 0,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation: null,
+			},
+			modelUsage: {},
+			permission_denials: [],
+			uuid: "00000000-0000-0000-0000-000000000001",
+			session_id: "runner-session",
+			...overrides,
+		} as SDKResultMessage;
+	}
+
+	it("appends API cost and token counts to the final response", async () => {
+		await manager.completeSession(
+			sessionId,
+			buildResultMessage({
+				total_cost_usd: 0.012345,
+				usage: {
+					input_tokens: 1234,
+					output_tokens: 567,
+					cache_creation_input_tokens: 89,
+					cache_read_input_tokens: 10,
+					cache_creation: null,
+				},
+			}),
+		);
+
+		expect(postActivitySpy).toHaveBeenCalledTimes(1);
+		expect(postActivitySpy.mock.calls[0]![1]).toEqual({
+			type: "response",
+			body: [
+				"Done.",
+				"",
+				"---",
+				"**Session usage**: ~$0.0123 API cost",
+				"**Tokens**: 1,234 input, 567 output, 89 cache write, 10 cache read",
+			].join("\n"),
+		});
+	});
+
+	it("shows token usage when the runner does not provide a cost", async () => {
+		await manager.completeSession(
+			sessionId,
+			buildResultMessage({
+				total_cost_usd: 0,
+				usage: {
+					input_tokens: 100,
+					output_tokens: 50,
+					cache_creation_input_tokens: 0,
+					cache_read_input_tokens: 25,
+					cache_creation: null,
+				},
+			}),
+		);
+
+		expect(postActivitySpy).toHaveBeenCalledTimes(1);
+		expect(postActivitySpy.mock.calls[0]![1]).toEqual({
+			type: "response",
+			body: [
+				"Done.",
+				"",
+				"---",
+				"**Session usage**: API cost unavailable from runner",
+				"**Tokens**: 100 input, 50 output, 25 cache read",
+			].join("\n"),
+		});
+	});
+
+	it("keeps the final response unchanged when no usage is available", async () => {
+		await manager.completeSession(sessionId, buildResultMessage());
+
+		expect(postActivitySpy).toHaveBeenCalledTimes(1);
+		expect(postActivitySpy.mock.calls[0]![1]).toEqual({
+			type: "response",
+			body: "Done.",
+		});
+	});
+});


### PR DESCRIPTION
Assignee: @Connoropolous ([Connor Turland](https://linear.app/ceedar/profiles/connor))

## Summary
- Append a compact session usage footer to successful final response activities when runner usage data is available.
- Show approximate API cost when the runner provides `total_cost_usd`; otherwise show token usage with an explicit cost-unavailable note.
- Keep error result bodies unchanged so usage-limit and other error messages remain exact.

## Testing
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter cyrus-edge-worker exec vitest run test/AgentSessionManager.session-usage-footer.test.ts test/AgentSessionManager.stop-session.test.ts`
- `pnpm test:packages:run`

Linear: https://linear.app/ceedar/issue/CYPACK-1293/show-session-usage-in-final-message

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
