### PR TITLE
Remove stale preview-init Slack reference

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Removed stale Slack setup skill guidance that pointed agents back to the retired hosted preview initialization workflow. ([CYHOST-1078](https://linear.app/ceedar/issue/CYHOST-1078/remove-legacy-agent-led-deploy-preview-skills-and-references), [#1310](https://github.com/cyrusagents/cyrus/pull/1310))
+
 ## [0.2.63] - 2026-06-09
 
 ### Fixed

--- a/skills/cyrus-setup-slack/SKILL.md
+++ b/skills/cyrus-setup-slack/SKILL.md
@@ -38,7 +38,7 @@ Construct the manifest, substituting `<AGENT_NAME>`, `<AGENT_DESCRIPTION>`, and 
 
 **IMPORTANT: Use the manifest template EXACTLY as shown below.** The event subscription path MUST be `/slack-webhook` (not `/slack/events` or any other path). This matches the route registered by `SlackEventTransport` in the Cyrus codebase.
 
-**NOTE: this list of 'scopes' must be kept in sync with the list of scopes in the skill defined at: [https://github.com/cyrusagents/cyrus-hosted/blob/main/.claude/skills/preview-init/SKILL.md](https://github.com/cyrusagents/cyrus-hosted/blob/main/.claude/skills/preview-init/SKILL.md) , as well as the list of scopes defined at [https://github.com/cyrusagents/cyrus-hosted/blob/main/apps/app/src/lib/slack/constants.ts](https://github.com/cyrusagents/cyrus-hosted/blob/main/apps/app/src/lib/slack/constants.ts). If you change here you must also propose changes in those locations.**
+**NOTE: this list of scopes must be kept in sync with the Slack App configuration and the list of scopes defined at [https://github.com/cyrusagents/cyrus-hosted/blob/main/apps/app/src/lib/slack/constants.ts](https://github.com/cyrusagents/cyrus-hosted/blob/main/apps/app/src/lib/slack/constants.ts). If you change scopes here, propose matching changes there and update any live Slack App configuration that relies on this manifest.**
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Remove the stale cyrus-hosted preview-init reference from the Slack setup skill.
- Keep the Slack scope synchronization note pointed at the live Slack App configuration and hosted Slack scope constants.

## Verification
- `pnpm lint` (passes with existing unrelated Biome warnings)
- `pnpm build`
- `pnpm typecheck`
- `pnpm -r --if-present test:run`

Linear: https://linear.app/ceedar/issue/CYHOST-1078/remove-legacy-agent-led-deploy-preview-skills-and-references

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->