### PR TITLE
Add GitLab runtime credential support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- GitLab credentials can now be pushed to the runtime through a provider-neutral token store. The git credential helper resolves GitHub and GitLab HTTPS credentials by host/namespace, and sessions receive GitLab tokens as `CYRUS_GITLAB_TOKEN` without clobbering user-managed `GITLAB_TOKEN`. ([CYHOST-1082](https://linear.app/ceedar/issue/CYHOST-1082), [#1311](https://github.com/cyrusagents/cyrus/pull/1311))
 - Cyrus now supports multiple GitHub organizations per team: git and `gh` operations automatically use the right credentials for each repository's org. Tokens are pushed by the Cyrus control plane and a git credential helper picks the matching one per repository, so concurrent sessions across different GitHub orgs no longer share a single login. ([CYHOST-913](https://linear.app/ceedar/issue/CYHOST-913), [#1307](https://github.com/cyrusagents/cyrus/pull/1307))
 
 ## [0.2.63] - 2026-06-09

--- a/packages/config-updater/scripts/git-credential-cyrus.cjs
+++ b/packages/config-updater/scripts/git-credential-cyrus.cjs
@@ -9,12 +9,9 @@
  *   git config --global --replace-all credential."https://github.com".helper ""
  *   git config --global --add credential."https://github.com".helper "!node <this file>"
  *
- * For `get` operations against github.com it looks up the org (first path
- * segment) in `<cyrusHome>/github-tokens.json` — the per-installation
- * GitHub App tokens pushed by cyrus-hosted — and prints credentials for a
- * case-insensitive org match. If no org matches but exactly one non-expired
- * token exists, that token is used. Otherwise it prints nothing and exits 0
- * so git falls through to other helpers / prompts.
+ * For `get` operations it first checks `<cyrusHome>/git-provider-tokens.json`
+ * for provider-neutral GitHub/GitLab credentials. If that file is absent, it
+ * falls back to the CYHOST-913 `<cyrusHome>/github-tokens.json` format.
  */
 "use strict";
 
@@ -41,36 +38,91 @@ function main() {
 		}
 	}
 
-	if ((attrs.host || "").toLowerCase() !== "github.com") return;
+	const host = (attrs.host || "").toLowerCase();
+	if (!host) return;
 
 	// With credential.useHttpPath=true git sends e.g. path=owner/repo.git
-	const org = (attrs.path || "").split("/")[0] || "";
+	const pathParts = (attrs.path || "").replace(/\.git$/i, "").split("/");
+	const repoNamespace = pathParts.slice(0, -1).join("/").toLowerCase();
+	const org = pathParts[0] || "";
 
 	const cyrusHome = process.env.CYRUS_HOME || path.join(os.homedir(), ".cyrus");
-	const tokensFile = path.join(cyrusHome, "github-tokens.json");
+	const providerTokensFile = path.join(cyrusHome, "git-provider-tokens.json");
 
 	let tokens = [];
 	try {
-		const parsed = JSON.parse(fs.readFileSync(tokensFile, "utf8"));
-		if (Array.isArray(parsed.tokens)) tokens = parsed.tokens;
+		const parsed = JSON.parse(fs.readFileSync(providerTokensFile, "utf8"));
+		if (Array.isArray(parsed.tokens)) {
+			tokens = parsed.tokens
+				.filter((t) => t && typeof t.token === "string")
+				.map((t) => ({
+					provider: t.provider,
+					host: String(t.host || "").toLowerCase(),
+					namespace:
+						typeof t.namespace === "string"
+							? t.namespace.replace(/^\/+|\/+$/g, "").toLowerCase()
+							: null,
+					token: t.token,
+					expiresAt: t.expiresAt ?? null,
+					username:
+						typeof t.username === "string" && t.username.length > 0
+							? t.username
+							: t.provider === "gitlab"
+								? "oauth2"
+								: "x-access-token",
+				}));
+		}
 	} catch {
-		return;
+		// Fall back to the older GitHub-only store below.
+	}
+
+	if (tokens.length === 0 && host === "github.com") {
+		try {
+			const parsed = JSON.parse(
+				fs.readFileSync(path.join(cyrusHome, "github-tokens.json"), "utf8"),
+			);
+			if (Array.isArray(parsed.tokens)) {
+				tokens = parsed.tokens
+					.filter((t) => t && typeof t.token === "string")
+					.map((t) => ({
+						provider: "github",
+						host: "github.com",
+						namespace:
+							typeof t.organization === "string"
+								? t.organization.toLowerCase()
+								: null,
+						token: t.token,
+						expiresAt: t.expiresAt,
+						username: "x-access-token",
+					}));
+			}
+		} catch {
+			return;
+		}
 	}
 
 	const now = Date.now();
 	const valid = tokens.filter((t) => {
+		if (t.host !== host) return false;
 		if (!t || typeof t.token !== "string" || t.token.length === 0) return false;
+		if (!t.expiresAt) return true;
 		const expiresAt = Date.parse(t.expiresAt);
 		return !Number.isNaN(expiresAt) && expiresAt > now;
 	});
 
 	let match;
-	if (org) {
-		const lowered = org.toLowerCase();
+	if (repoNamespace) {
 		match = valid.find(
 			(t) =>
-				typeof t.organization === "string" &&
-				t.organization.toLowerCase() === lowered,
+				typeof t.namespace === "string" &&
+				(repoNamespace === t.namespace ||
+					repoNamespace.startsWith(`${t.namespace}/`)),
+		);
+	}
+	if (!match && org) {
+		const lowered = org.toLowerCase();
+		match = valid.find(
+			(t) => typeof t.namespace === "string" && t.namespace === lowered,
 		);
 	}
 	if (!match && valid.length === 1) {
@@ -78,7 +130,7 @@ function main() {
 	}
 	if (!match) return;
 
-	process.stdout.write(`username=x-access-token\npassword=${match.token}\n`);
+	process.stdout.write(`username=${match.username}\npassword=${match.token}\n`);
 }
 
 main();

--- a/packages/config-updater/src/ConfigUpdater.ts
+++ b/packages/config-updater/src/ConfigUpdater.ts
@@ -5,6 +5,7 @@ import { handleConfigureMcp } from "./handlers/configureMcp.js";
 import { handleCyrusConfig } from "./handlers/cyrusConfig.js";
 import { handleCyrusEnv } from "./handlers/cyrusEnv.js";
 import { handleGitHubTokens } from "./handlers/githubTokens.js";
+import { handleGitProviderTokens } from "./handlers/gitProviderTokens.js";
 import {
 	handleRepository,
 	handleRepositoryDelete,
@@ -25,6 +26,7 @@ import type {
 	DeleteRepositoryPayload,
 	DeleteSkillPayload,
 	GitHubTokensPayload,
+	GitProviderTokensPayload,
 	ListSkillsPayload,
 	RepositoryPayload,
 	TestMcpPayload,
@@ -74,6 +76,10 @@ export class ConfigUpdater {
 		this.registerRoute(
 			"/api/update/github-tokens",
 			this.handleGitHubTokensRoute,
+		);
+		this.registerRoute(
+			"/api/update/git-provider-tokens",
+			this.handleGitProviderTokensRoute,
 		);
 		this.registerRoute("/api/check-gh", this.handleCheckGhRoute);
 		this.registerRoute("/api/check-glab", this.handleCheckGlabRoute);
@@ -254,6 +260,15 @@ export class ConfigUpdater {
 		payload: GitHubTokensPayload,
 	): Promise<ApiResponse> {
 		return handleGitHubTokens(payload, this.cyrusHome);
+	}
+
+	/**
+	 * Handle provider-neutral git tokens push
+	 */
+	private async handleGitProviderTokensRoute(
+		payload: GitProviderTokensPayload,
+	): Promise<ApiResponse> {
+		return handleGitProviderTokens(payload, this.cyrusHome);
 	}
 
 	/**

--- a/packages/config-updater/src/handlers/gitProviderTokens.ts
+++ b/packages/config-updater/src/handlers/gitProviderTokens.ts
@@ -1,0 +1,70 @@
+import { dirname } from "node:path";
+import { GitProviderTokenStore } from "cyrus-core";
+import {
+	type ApiResponse,
+	type GitProviderTokensPayload,
+	GitProviderTokensPayloadSchema,
+} from "../types.js";
+import {
+	ensureGitCredentialHelper,
+	ensureGlabWrapperSupportsCyrusToken,
+} from "./githubTokens.js";
+
+export async function handleGitProviderTokens(
+	rawPayload: unknown,
+	cyrusHome: string,
+): Promise<ApiResponse> {
+	const parseResult = GitProviderTokensPayloadSchema.safeParse(rawPayload);
+	if (!parseResult.success) {
+		const firstIssue = parseResult.error.issues[0];
+		const path = firstIssue?.path.join(".") || "unknown";
+		const message = firstIssue?.message || "Invalid payload";
+		return {
+			success: false,
+			error: "Git provider tokens payload validation failed",
+			details: `${path}: ${message}`,
+		};
+	}
+
+	const payload: GitProviderTokensPayload = parseResult.data;
+
+	try {
+		new GitProviderTokenStore(cyrusHome).save(payload.tokens);
+	} catch (error) {
+		return {
+			success: false,
+			error: "Failed to save git provider tokens",
+			details: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	try {
+		ensureGitCredentialHelper(cyrusHome);
+	} catch (error) {
+		return {
+			success: false,
+			error: "Failed to configure git credential helper",
+			details: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	try {
+		ensureGlabWrapperSupportsCyrusToken(dirname(cyrusHome));
+	} catch (error) {
+		console.warn(
+			"[gitProviderTokens] glab wrapper self-heal failed:",
+			error instanceof Error ? error.message : String(error),
+		);
+	}
+
+	return {
+		success: true,
+		message: "Git provider tokens updated successfully",
+		data: {
+			tokensCount: payload.tokens.length,
+			providers: Array.from(
+				new Set(payload.tokens.map((t) => t.provider)),
+			).sort(),
+		},
+	};
+}

--- a/packages/config-updater/src/handlers/githubTokens.ts
+++ b/packages/config-updater/src/handlers/githubTokens.ts
@@ -41,7 +41,7 @@ function bundledHelperPath(): string {
  *
  * Returns the absolute path of the installed helper script.
  */
-export function ensureGitHubCredentialHelper(cyrusHome: string): string {
+export function ensureGitCredentialHelper(cyrusHome: string): string {
 	const scriptDir = join(cyrusHome, "scripts");
 	const scriptDest = join(scriptDir, "git-credential-cyrus.cjs");
 
@@ -49,28 +49,32 @@ export function ensureGitHubCredentialHelper(cyrusHome: string): string {
 	copyFileSync(bundledHelperPath(), scriptDest);
 	chmodSync(scriptDest, 0o755);
 
-	const credentialKey = "credential.https://github.com";
 	const git = (args: string[]): void => {
 		execFileSync("git", args, { stdio: "ignore" });
 	};
 
-	// Pass the repo path to the helper so it can resolve the org.
-	git(["config", "--global", `${credentialKey}.useHttpPath`, "true"]);
-	// Clear inherited helpers (an empty value resets git's helper list for
-	// this key). --replace-all also makes repeated runs idempotent: every
-	// call ends with exactly ["", "!node <script>"].
-	git(["config", "--global", "--replace-all", `${credentialKey}.helper`, ""]);
-	// Quote the script path — helper commands are run through the shell.
-	git([
-		"config",
-		"--global",
-		"--add",
-		`${credentialKey}.helper`,
-		`!node "${scriptDest}"`,
-	]);
+	for (const host of ["github.com", "gitlab.com"]) {
+		const credentialKey = `credential.https://${host}`;
+		// Pass the repo path to the helper so it can resolve org/group namespaces.
+		git(["config", "--global", `${credentialKey}.useHttpPath`, "true"]);
+		// Clear inherited helpers (an empty value resets git's helper list for
+		// this key). --replace-all also makes repeated runs idempotent: every
+		// call ends with exactly ["", "!node <script>"].
+		git(["config", "--global", "--replace-all", `${credentialKey}.helper`, ""]);
+		// Quote the script path — helper commands are run through the shell.
+		git([
+			"config",
+			"--global",
+			"--add",
+			`${credentialKey}.helper`,
+			`!node "${scriptDest}"`,
+		]);
+	}
 
 	return scriptDest;
 }
+
+export const ensureGitHubCredentialHelper = ensureGitCredentialHelper;
 
 /**
  * Self-heal the droplet's `~/.local/bin/gh` wrapper to honor
@@ -105,6 +109,30 @@ fi
 exec env -u GITHUB_TOKEN -u GH_TOKEN /usr/bin/gh "$@"
 `;
 	writeFileSync(wrapperPath, updated, { mode: 0o755 });
+	return true;
+}
+
+export function ensureGlabWrapperSupportsCyrusToken(
+	homeDir: string = homedir(),
+): boolean {
+	if (!existsSync("/usr/bin/glab")) return false;
+
+	const binDir = join(homeDir, ".local", "bin");
+	const wrapperPath = join(binDir, "glab");
+	const desired = `#!/usr/bin/env bash
+if [ -n "\${CYRUS_GITLAB_TOKEN:-}" ]; then
+  exec env GITLAB_TOKEN="$CYRUS_GITLAB_TOKEN" /usr/bin/glab "$@"
+fi
+exec env -u GITLAB_TOKEN /usr/bin/glab "$@"
+`;
+
+	if (existsSync(wrapperPath)) {
+		const current = readFileSync(wrapperPath, "utf8");
+		if (current === desired) return false;
+	}
+
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(wrapperPath, desired, { mode: 0o755 });
 	return true;
 }
 
@@ -170,7 +198,7 @@ export async function handleGitHubTokens(
 	}
 
 	try {
-		ensureGitHubCredentialHelper(cyrusHome);
+		ensureGitCredentialHelper(cyrusHome);
 	} catch (error) {
 		return {
 			success: false,

--- a/packages/config-updater/src/handlers/repository.ts
+++ b/packages/config-updater/src/handlers/repository.ts
@@ -2,7 +2,11 @@ import { exec } from "node:child_process";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import { promisify } from "node:util";
-import { GitHubTokenStore, getDefaultReposDir } from "cyrus-core";
+import {
+	GitHubTokenStore,
+	GitProviderTokenStore,
+	getDefaultReposDir,
+} from "cyrus-core";
 import type {
 	ApiResponse,
 	DeleteRepositoryPayload,
@@ -33,6 +37,23 @@ function getRepoNameFromUrl(repoUrl: string): string {
 	}
 	// Fallback: use last part of URL
 	return basename(repoUrl, ".git");
+}
+
+function isGitHubRepoUrl(repoUrl: string): boolean {
+	const trimmed = repoUrl.trim();
+	const scpMatch = trimmed.match(/^[\w.-]+@([^:]+):/);
+	if (scpMatch?.[1]) {
+		return scpMatch[1].toLowerCase() === "github.com";
+	}
+
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+		? trimmed
+		: `https://${trimmed}`;
+	try {
+		return new URL(withScheme).hostname.toLowerCase() === "github.com";
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -99,20 +120,22 @@ export async function handleRepository(
 			};
 		}
 
-		// Clone the repository. When cyrus-hosted has pushed per-installation
-		// GitHub tokens (cloud runtime), use plain `git clone` so auth flows
-		// through the Cyrus git credential helper, which resolves the token
-		// for the repo's OWN org — `gh repo clone` would authenticate with
-		// gh's stored login (the first org's token) and fail for repos added
-		// from a different org. Without pushed tokens (self-host), fall back
-		// to `gh repo clone` using the user's own gh authentication.
-		const tokenStore = new GitHubTokenStore(cyrusHome);
+		// Clone the repository. When cyrus-hosted has pushed source-control
+		// tokens (cloud runtime), use plain `git clone` so auth flows through
+		// the Cyrus git credential helper. For GitHub self-host setups without
+		// pushed tokens, fall back to `gh repo clone` using the user's local gh
+		// authentication. Non-GitHub providers must use `git clone`.
+		const gitHubTokenStore = new GitHubTokenStore(cyrusHome);
+		const gitProviderTokenStore = new GitProviderTokenStore(cyrusHome);
 		const usePushedTokens = Boolean(
-			tokenStore.getTokenForRepoUrl(payload.repository_url) ??
-				tokenStore.getFallbackToken(),
+			gitHubTokenStore.getTokenForRepoUrl(payload.repository_url) ??
+				gitHubTokenStore.getFallbackToken() ??
+				gitProviderTokenStore.getTokenForRepoUrl(payload.repository_url),
 		);
+		const useGitClone =
+			usePushedTokens || !isGitHubRepoUrl(payload.repository_url);
 		try {
-			const cloneCmd = usePushedTokens
+			const cloneCmd = useGitClone
 				? `git clone "${payload.repository_url}" "${repoPath}"`
 				: `gh repo clone "${payload.repository_url}" "${repoPath}"`;
 			await execAsync(cloneCmd);
@@ -140,8 +163,10 @@ export async function handleRepository(
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
 			const authHint = usePushedTokens
-				? "The pushed GitHub credentials may not include this repository's org — check the team's GitHub installations."
-				: "Please verify the URL is correct, you have access to the repository, and gh is authenticated.";
+				? "The pushed source-control credentials may not include this repository — check the team's connected provider credentials."
+				: useGitClone
+					? "Please verify the URL is correct and local git credentials can access the repository."
+					: "Please verify the URL is correct, you have access to the repository, and gh is authenticated.";
 			return {
 				success: false,
 				error: "Failed to clone repository",

--- a/packages/config-updater/src/types.ts
+++ b/packages/config-updater/src/types.ts
@@ -126,6 +126,29 @@ export const GitHubTokensPayloadSchema = z.object({
 export type GitHubTokensPayload = z.infer<typeof GitHubTokensPayloadSchema>;
 
 /**
+ * Provider-neutral git credential payload. GitHub entries may be short-lived
+ * App installation tokens; GitLab entries may be OAuth, PAT, project, or bot
+ * tokens. A null expiresAt represents a long-lived/revoked-by-provider token.
+ */
+export const GitProviderTokensPayloadSchema = z.object({
+	tokens: z.array(
+		z.object({
+			provider: z.enum(["github", "gitlab"]),
+			host: z.string().min(1),
+			namespace: z.string().nullable().optional().default(null),
+			connectionId: z.string().nullable().optional().default(null),
+			token: z.string().min(1),
+			expiresAt: z.string().nullable().optional().default(null),
+			username: z.string().nullable().optional().default(null),
+		}),
+	),
+});
+
+export type GitProviderTokensPayload = z.infer<
+	typeof GitProviderTokensPayloadSchema
+>;
+
+/**
  * Error response to send back to cyrus-hosted
  */
 export interface ErrorResponse {

--- a/packages/config-updater/test/git-credential-cyrus.test.ts
+++ b/packages/config-updater/test/git-credential-cyrus.test.ts
@@ -45,6 +45,20 @@ function writeTokensFile(
 	);
 }
 
+function writeProviderTokensFile(
+	cyrusHome: string,
+	tokens: Array<Record<string, unknown>>,
+): void {
+	writeFileSync(
+		join(cyrusHome, "git-provider-tokens.json"),
+		JSON.stringify({
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			tokens,
+		}),
+	);
+}
+
 const future = () => new Date(Date.now() + 3600_000).toISOString();
 const past = () => new Date(Date.now() - 3600_000).toISOString();
 
@@ -175,6 +189,52 @@ describe("git-credential-cyrus helper script", () => {
 		expect(result.status).toBe(0);
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toBe("");
+	});
+
+	it("prints GitLab credentials from the provider-neutral token file", () => {
+		writeProviderTokensFile(cyrusHome, [
+			{
+				provider: "gitlab",
+				host: "gitlab.com",
+				namespace: "group/subgroup",
+				token: "glpat_match",
+				expiresAt: null,
+				username: "oauth2",
+			},
+		]);
+
+		const result = runHelper(
+			"get",
+			"protocol=https\nhost=gitlab.com\npath=group/subgroup/repo.git\n",
+			cyrusHome,
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.stdout).toBe("username=oauth2\npassword=glpat_match\n");
+	});
+
+	it("matches self-managed GitLab hosts from the provider-neutral token file", () => {
+		writeProviderTokensFile(cyrusHome, [
+			{
+				provider: "gitlab",
+				host: "gitlab.example.com",
+				namespace: "platform",
+				token: "glpat_self_managed",
+				expiresAt: future(),
+			},
+		]);
+
+		const result = runHelper(
+			"get",
+			"protocol=https\nhost=gitlab.example.com\npath=platform/service.git\n",
+			cyrusHome,
+		);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe(
+			"username=oauth2\npassword=glpat_self_managed\n",
+		);
 	});
 
 	it("does nothing for non-get operations", () => {

--- a/packages/config-updater/test/handlers/gitProviderTokens.test.ts
+++ b/packages/config-updater/test/handlers/gitProviderTokens.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleGitProviderTokens } from "../../src/handlers/gitProviderTokens.js";
+
+vi.mock("node:child_process", () => ({
+	execFileSync: vi.fn(),
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+describe("handleGitProviderTokens", () => {
+	let cyrusHome: string;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		cyrusHome = mkdtempSync(join(tmpdir(), "cyrus-provider-tokens-"));
+	});
+
+	afterEach(() => {
+		rmSync(cyrusHome, { recursive: true, force: true });
+	});
+
+	it("persists provider-neutral tokens and configures the git helper", async () => {
+		const response = await handleGitProviderTokens(
+			{
+				tokens: [
+					{
+						provider: "gitlab",
+						host: "gitlab.com",
+						namespace: "group/subgroup",
+						connectionId: "conn-1",
+						token: "glpat_token",
+						expiresAt: null,
+						username: "oauth2",
+					},
+				],
+			},
+			cyrusHome,
+		);
+
+		expect(response.success).toBe(true);
+		const filePath = join(cyrusHome, "git-provider-tokens.json");
+		expect(existsSync(filePath)).toBe(true);
+		expect(statSync(filePath).mode & 0o777).toBe(0o600);
+		const written = JSON.parse(readFileSync(filePath, "utf8"));
+		expect(written.version).toBe(1);
+		expect(written.tokens[0]).toMatchObject({
+			provider: "gitlab",
+			host: "gitlab.com",
+			namespace: "group/subgroup",
+		});
+		expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
+	});
+
+	it("rejects unsupported providers", async () => {
+		const response = await handleGitProviderTokens(
+			{
+				tokens: [{ provider: "bitbucket", host: "bitbucket.org", token: "x" }],
+			},
+			cyrusHome,
+		);
+
+		expect(response.success).toBe(false);
+		expect(existsSync(join(cyrusHome, "git-provider-tokens.json"))).toBe(false);
+		expect(mockedExecFileSync).not.toHaveBeenCalled();
+	});
+});

--- a/packages/config-updater/test/handlers/githubTokens.test.ts
+++ b/packages/config-updater/test/handlers/githubTokens.test.ts
@@ -82,7 +82,7 @@ describe("handleGitHubTokens", () => {
 		// Executable bit set
 		expect(statSync(scriptPath).mode & 0o111).not.toBe(0);
 
-		expect(mockedExecFileSync).toHaveBeenCalledTimes(4);
+		expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
 		expect(mockedExecFileSync).toHaveBeenNthCalledWith(
 			1,
 			"git",
@@ -128,7 +128,7 @@ describe("handleGitHubTokens", () => {
 			expect(response.data?.ghAuthConfigured).toBe(true);
 		}
 		expect(mockedExecFileSync).toHaveBeenNthCalledWith(
-			4,
+			7,
 			"gh",
 			["auth", "login", "--with-token"],
 			expect.objectContaining({ input: payload.tokens[0].token }),
@@ -153,9 +153,9 @@ describe("handleGitHubTokens", () => {
 		const second = await handleGitHubTokens(validPayload(), cyrusHome);
 		expect(first.success).toBe(true);
 		expect(second.success).toBe(true);
-		// Each push re-runs the same replace-all + add + gh auth sequence
-		// (3 git calls + 1 gh call each)
-		expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
+		// Each push re-runs the same replace-all + add for github.com and
+		// gitlab.com, then refreshes gh auth (6 git calls + 1 gh call each).
+		expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
 	});
 
 	it("rejects a payload without a tokens array", async () => {

--- a/packages/config-updater/test/handlers/repository.test.ts
+++ b/packages/config-updater/test/handlers/repository.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { GitHubTokenStore } from "cyrus-core";
+import { GitHubTokenStore, GitProviderTokenStore } from "cyrus-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRepository } from "../../src/handlers/repository.js";
 
@@ -97,6 +97,46 @@ describe("handleRepository clone auth selection (CYHOST-913)", () => {
 		expect(response.success).toBe(true);
 		expect(executedCommands).toHaveLength(1);
 		expect(executedCommands[0]).toMatch(/^gh repo clone /);
+	});
+
+	it("uses plain git clone when provider tokens cover a GitLab repo", async () => {
+		new GitProviderTokenStore(cyrusHome).save([
+			{
+				provider: "gitlab",
+				host: "gitlab.com",
+				namespace: "acme",
+				connectionId: "connection-1",
+				token: "glpat_token",
+				expiresAt: null,
+				username: "oauth2",
+			},
+		]);
+
+		const response = await handleRepository(
+			{
+				repository_url: "https://gitlab.com/acme/repo-a.git",
+				repository_name: "repo-a",
+			},
+			cyrusHome,
+		);
+
+		expect(response.success).toBe(true);
+		expect(executedCommands).toHaveLength(1);
+		expect(executedCommands[0]).toMatch(/^git clone /);
+	});
+
+	it("uses plain git clone for GitLab repos even when no pushed tokens exist", async () => {
+		const response = await handleRepository(
+			{
+				repository_url: "https://gitlab.com/acme/repo-a.git",
+				repository_name: "repo-a",
+			},
+			cyrusHome,
+		);
+
+		expect(response.success).toBe(true);
+		expect(executedCommands).toHaveLength(1);
+		expect(executedCommands[0]).toMatch(/^git clone /);
 	});
 
 	it("treats expired pushed tokens as absent and uses gh repo clone", async () => {

--- a/packages/core/src/git-provider-token-store.ts
+++ b/packages/core/src/git-provider-token-store.ts
@@ -1,0 +1,196 @@
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+export type GitProvider = "github" | "gitlab";
+
+export interface GitProviderToken {
+	provider: GitProvider;
+	/** Hostname that owns the token, e.g. github.com or gitlab.example.com */
+	host: string;
+	/** Owner/group namespace used for path matching when present */
+	namespace: string | null;
+	/** Optional provider connection identifier from cyrus-hosted */
+	connectionId?: string | null;
+	/** Access token used for HTTPS git/API calls */
+	token: string;
+	/** ISO timestamp when the token expires. Null means non-expiring PAT/bot token. */
+	expiresAt: string | null;
+	/** Username to return to git. GitLab accepts oauth2 for OAuth tokens. */
+	username?: string | null;
+}
+
+export interface GitProviderTokensFile {
+	version: 1;
+	updatedAt: string;
+	tokens: GitProviderToken[];
+}
+
+export const GIT_PROVIDER_TOKENS_FILENAME = "git-provider-tokens.json";
+
+function normalizeHost(host: string): string {
+	return host.trim().toLowerCase();
+}
+
+function normalizeNamespace(
+	namespace: string | null | undefined,
+): string | null {
+	const value = namespace?.trim().replace(/^\/+|\/+$/g, "");
+	return value ? value.toLowerCase() : null;
+}
+
+function isExpired(token: GitProviderToken, now: number): boolean {
+	if (!token.expiresAt) return false;
+	const expiresAt = Date.parse(token.expiresAt);
+	return Number.isNaN(expiresAt) || expiresAt <= now;
+}
+
+export function extractGitProviderRepoParts(url: string): {
+	host: string;
+	namespace: string | null;
+} | null {
+	if (!url || typeof url !== "string") return null;
+	const trimmed = url.trim();
+
+	const scpMatch = trimmed.match(/^[\w.-]+@([^:]+):(.+)$/);
+	if (scpMatch?.[1] && scpMatch[2]) {
+		const segments = scpMatch[2].replace(/\.git$/i, "").split("/");
+		segments.pop();
+		return {
+			host: normalizeHost(scpMatch[1]),
+			namespace: normalizeNamespace(segments.join("/")),
+		};
+	}
+
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+		? trimmed
+		: `https://${trimmed}`;
+	try {
+		const parsed = new URL(withScheme);
+		const segments = parsed.pathname
+			.replace(/\.git$/i, "")
+			.split("/")
+			.filter(Boolean);
+		segments.pop();
+		return {
+			host: normalizeHost(parsed.hostname),
+			namespace: normalizeNamespace(segments.join("/")),
+		};
+	} catch {
+		return null;
+	}
+}
+
+export class GitProviderTokenStore {
+	private cyrusHome: string;
+	private cachedTokens: GitProviderToken[] | null = null;
+	private cachedMtimeMs: number | null = null;
+	private cachedSize: number | null = null;
+
+	constructor(cyrusHome: string) {
+		this.cyrusHome = cyrusHome;
+	}
+
+	get filePath(): string {
+		return join(this.cyrusHome, GIT_PROVIDER_TOKENS_FILENAME);
+	}
+
+	save(tokens: GitProviderToken[]): void {
+		const file: GitProviderTokensFile = {
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			tokens,
+		};
+		const target = this.filePath;
+		mkdirSync(dirname(target), { recursive: true });
+		const tmpPath = `${target}.tmp`;
+		writeFileSync(tmpPath, JSON.stringify(file, null, 2), { mode: 0o600 });
+		chmodSync(tmpPath, 0o600);
+		renameSync(tmpPath, target);
+		this.cachedTokens = null;
+		this.cachedMtimeMs = null;
+		this.cachedSize = null;
+	}
+
+	load(): GitProviderToken[] {
+		const target = this.filePath;
+		if (!existsSync(target)) {
+			this.cachedTokens = null;
+			this.cachedMtimeMs = null;
+			this.cachedSize = null;
+			return [];
+		}
+
+		try {
+			const stat = statSync(target);
+			if (
+				this.cachedTokens !== null &&
+				this.cachedMtimeMs === stat.mtimeMs &&
+				this.cachedSize === stat.size
+			) {
+				return this.cachedTokens;
+			}
+
+			const parsed = JSON.parse(
+				readFileSync(target, "utf-8"),
+			) as Partial<GitProviderTokensFile>;
+			const tokens = Array.isArray(parsed.tokens)
+				? parsed.tokens.filter(
+						(t): t is GitProviderToken =>
+							!!t &&
+							typeof t === "object" &&
+							(t.provider === "github" || t.provider === "gitlab") &&
+							typeof t.host === "string" &&
+							typeof t.token === "string",
+					)
+				: [];
+			this.cachedTokens = tokens;
+			this.cachedMtimeMs = stat.mtimeMs;
+			this.cachedSize = stat.size;
+			return tokens;
+		} catch {
+			return [];
+		}
+	}
+
+	private loadValid(): GitProviderToken[] {
+		const now = Date.now();
+		return this.load().filter((t) => !isExpired(t, now));
+	}
+
+	getTokenForRepoUrl(
+		url: string,
+		provider?: GitProvider,
+	): GitProviderToken | undefined {
+		const parts = extractGitProviderRepoParts(url);
+		if (!parts) return undefined;
+		const host = normalizeHost(parts.host);
+		const namespace = normalizeNamespace(parts.namespace);
+		const candidates = this.loadValid().filter(
+			(t) =>
+				normalizeHost(t.host) === host &&
+				(!provider || t.provider === provider),
+		);
+
+		if (namespace) {
+			const match = candidates.find((t) => {
+				const tokenNamespace = normalizeNamespace(t.namespace);
+				return (
+					tokenNamespace !== null &&
+					(namespace === tokenNamespace ||
+						namespace.startsWith(`${tokenNamespace}/`))
+				);
+			});
+			if (match) return match;
+		}
+
+		return candidates.length === 1 ? candidates[0] : undefined;
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,16 @@ export {
 	getDefaultReposDir,
 	getDefaultWorktreesDir,
 } from "./constants.js";
+export type {
+	GitProvider,
+	GitProviderToken,
+	GitProviderTokensFile,
+} from "./git-provider-token-store.js";
+export {
+	extractGitProviderRepoParts,
+	GIT_PROVIDER_TOKENS_FILENAME,
+	GitProviderTokenStore,
+} from "./git-provider-token-store.js";
 // GitHub App installation token store (multi-org GitHub support)
 export type {
 	GitHubInstallationToken,

--- a/packages/core/test/git-provider-token-store.test.ts
+++ b/packages/core/test/git-provider-token-store.test.ts
@@ -1,0 +1,104 @@
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	extractGitProviderRepoParts,
+	type GitProviderToken,
+	GitProviderTokenStore,
+} from "../src/git-provider-token-store.js";
+
+function token(overrides: Partial<GitProviderToken> = {}): GitProviderToken {
+	return {
+		provider: "gitlab",
+		host: "gitlab.com",
+		namespace: "group/subgroup",
+		token: "glpat_token",
+		expiresAt: null,
+		username: "oauth2",
+		...overrides,
+	};
+}
+
+describe("extractGitProviderRepoParts", () => {
+	it("extracts host and namespace from nested https URLs", () => {
+		expect(
+			extractGitProviderRepoParts(
+				"https://gitlab.com/group/subgroup/project.git",
+			),
+		).toEqual({ host: "gitlab.com", namespace: "group/subgroup" });
+	});
+
+	it("extracts host and namespace from scp-style SSH URLs", () => {
+		expect(
+			extractGitProviderRepoParts("git@gitlab.example.com:platform/app.git"),
+		).toEqual({ host: "gitlab.example.com", namespace: "platform" });
+	});
+});
+
+describe("GitProviderTokenStore", () => {
+	let cyrusHome: string;
+	let store: GitProviderTokenStore;
+
+	beforeEach(() => {
+		cyrusHome = mkdtempSync(join(tmpdir(), "cyrus-provider-store-"));
+		store = new GitProviderTokenStore(cyrusHome);
+	});
+
+	afterEach(() => {
+		rmSync(cyrusHome, { recursive: true, force: true });
+	});
+
+	it("round-trips tokens through a 0600 provider token file", () => {
+		store.save([token()]);
+		const filePath = join(cyrusHome, "git-provider-tokens.json");
+		expect(existsSync(filePath)).toBe(true);
+		expect(statSync(filePath).mode & 0o777).toBe(0o600);
+		const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+		expect(parsed.version).toBe(1);
+		expect(store.load()).toEqual([token()]);
+	});
+
+	it("matches a GitLab token by host and nested namespace", () => {
+		store.save([
+			token({ namespace: "group", token: "glpat_group" }),
+			token({ namespace: "other", token: "glpat_other" }),
+		]);
+
+		expect(
+			store.getTokenForRepoUrl(
+				"https://gitlab.com/group/subgroup/repo",
+				"gitlab",
+			)?.token,
+		).toBe("glpat_group");
+	});
+
+	it("returns the single host token as a fallback", () => {
+		store.save([token({ namespace: null, token: "glpat_single" })]);
+		expect(
+			store.getTokenForRepoUrl("https://gitlab.com/any/group/repo", "gitlab")
+				?.token,
+		).toBe("glpat_single");
+	});
+
+	it("ignores expired tokens", () => {
+		store.save([
+			token({
+				token: "glpat_stale",
+				expiresAt: new Date(Date.now() - 1000).toISOString(),
+			}),
+		]);
+		expect(
+			store.getTokenForRepoUrl(
+				"https://gitlab.com/group/subgroup/repo",
+				"gitlab",
+			),
+		).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -60,6 +60,7 @@ import {
 	createLogger,
 	DEFAULT_PROXY_URL,
 	GitHubTokenStore,
+	GitProviderTokenStore,
 	isAgentSessionCreatedWebhook,
 	isAgentSessionPromptedWebhook,
 	isContentUpdateMessage,
@@ -228,6 +229,8 @@ export class EdgeWorker extends EventEmitter {
 	private cyrusHome: string;
 	/** Per-org GitHub App installation tokens pushed by cyrus-hosted (lazy file-backed reads) */
 	private githubTokenStore: GitHubTokenStore;
+	/** Provider-neutral GitHub/GitLab tokens pushed by cyrus-hosted */
+	private gitProviderTokenStore: GitProviderTokenStore;
 	private globalSessionRegistry: GlobalSessionRegistry; // Centralized session storage across all repositories
 	private configPath?: string; // Path to config.json file
 	/** @internal - Exposed for testing only */
@@ -325,6 +328,7 @@ export class EdgeWorker extends EventEmitter {
 		this.config = EdgeWorker.normalizeConfigPaths(config);
 		this.cyrusHome = config.cyrusHome;
 		this.githubTokenStore = new GitHubTokenStore(this.cyrusHome);
+		this.gitProviderTokenStore = new GitProviderTokenStore(this.cyrusHome);
 		this.logger = createLogger({ component: "EdgeWorker" });
 		this.persistenceManager = new PersistenceManager(
 			join(this.cyrusHome, "state"),
@@ -625,11 +629,14 @@ export class EdgeWorker extends EventEmitter {
 		// If cyrus-hosted has pushed per-org GitHub App tokens previously, make
 		// sure the git credential helper is wired up (idempotent). Covers the
 		// case where the process restarted after the helper config was wiped.
-		if (existsSync(this.githubTokenStore.filePath)) {
+		if (
+			existsSync(this.githubTokenStore.filePath) ||
+			existsSync(this.gitProviderTokenStore.filePath)
+		) {
 			try {
 				ensureGitHubCredentialHelper(this.cyrusHome);
 				this.logger.info(
-					"✅ GitHub credential helper configured from existing token store",
+					"✅ Git credential helper configured from existing token store",
 				);
 			} catch (error) {
 				this.logger.warn(
@@ -6488,6 +6495,12 @@ ${input.userComment}
 			// users without the token file.
 			githubToken: repository.githubUrl
 				? this.githubTokenStore.getTokenForRepoUrl(repository.githubUrl)
+				: undefined,
+			gitlabToken: repository.gitlabUrl
+				? this.gitProviderTokenStore.getTokenForRepoUrl(
+						repository.gitlabUrl,
+						"gitlab",
+					)?.token
 				: undefined,
 			logger: log,
 			plugins,

--- a/packages/edge-worker/src/PromptBuilder.ts
+++ b/packages/edge-worker/src/PromptBuilder.ts
@@ -497,6 +497,8 @@ export class PromptBuilder {
 					routingContext,
 				);
 
+			prompt = this.appendGitLabSourceControlContext(prompt, repositories);
+
 			// Append agent guidance if present
 			prompt += this.formatAgentGuidance(guidance);
 
@@ -942,6 +944,8 @@ IMPORTANT: Focus specifically on addressing the new comment above. This is a new
 				prompt = prompt.replace(/\n*{{#if new_comment}}[\s\S]*?{{\/if}}/g, "");
 			}
 
+			prompt = this.appendGitLabSourceControlContext(prompt, repositories);
+
 			// Append agent guidance if present
 			prompt += this.formatAgentGuidance(guidance);
 
@@ -1000,6 +1004,25 @@ ${newComment ? `New comment to address:\n${newComment.body}\n\n` : ""}Please ana
 
 			return { prompt: fallbackPrompt, version: undefined };
 		}
+	}
+
+	private appendGitLabSourceControlContext(
+		prompt: string,
+		repositories: RepositoryConfig[],
+	): string {
+		const gitLabRepositories = repositories.filter((repo) => repo.gitlabUrl);
+		if (gitLabRepositories.length === 0) {
+			return prompt;
+		}
+
+		const repositoryLines = gitLabRepositories
+			.map(
+				(repo) =>
+					`  <repository name="${repo.name}">\n    <gitlab_url>${repo.gitlabUrl}</gitlab_url>\n    <cli>glab</cli>\n  </repository>`,
+			)
+			.join("\n");
+
+		return `${prompt}\n\n<source_control_context>\n${repositoryLines}\n<instructions>\n- Use \`glab\` for GitLab-specific operations such as merge requests, comments, reviews, and project API lookups.\n- Do not use \`gh\` for GitLab repositories.\n- Plain \`git\` fetch, clone, pull, commit, and push operations are already authenticated by the Cyrus git credential helper.\n</instructions>\n</source_control_context>`;
 	}
 
 	/**

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -160,6 +160,12 @@ export interface IssueRunnerConfigInput {
 	 * `gh auth login` the github-tokens push handler performs.
 	 */
 	githubToken?: string;
+	/**
+	 * GitLab token matched to the session repository. Exposed only as
+	 * CYRUS_GITLAB_TOKEN so customer-owned GITLAB_TOKEN/glab state is not
+	 * overwritten.
+	 */
+	gitlabToken?: string;
 }
 
 /**
@@ -437,6 +443,12 @@ export class RunnerConfigBuilder {
 			config.additionalEnv = {
 				...config.additionalEnv,
 				CYRUS_GH_TOKEN: input.githubToken,
+			};
+		}
+		if (input.gitlabToken) {
+			config.additionalEnv = {
+				...config.additionalEnv,
+				CYRUS_GITLAB_TOKEN: input.gitlabToken,
 			};
 		}
 

--- a/packages/edge-worker/test/RunnerConfigBuilder.github-token-env.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.github-token-env.test.ts
@@ -104,4 +104,27 @@ describe("RunnerConfigBuilder GitHub token session env (CYHOST-913)", () => {
 		expect(env.NODE_EXTRA_CA_CERTS).toBe("/tmp/ca.pem");
 		expect(env.GIT_SSL_CAINFO).toBe("/tmp/ca.pem");
 	});
+
+	it("exposes ONLY CYRUS_GITLAB_TOKEN when a gitlabToken is provided", () => {
+		const { config } = buildIssueConfig({ gitlabToken: "glpat_repo_token" });
+
+		expect(config.additionalEnv).toEqual({
+			CYRUS_GITLAB_TOKEN: "glpat_repo_token",
+		});
+		expect(
+			(config.additionalEnv as Record<string, string>).GITLAB_TOKEN,
+		).toBeUndefined();
+	});
+
+	it("can expose GitHub and GitLab Cyrus-specific tokens together", () => {
+		const { config } = buildIssueConfig({
+			githubToken: "ghs_org_token",
+			gitlabToken: "glpat_repo_token",
+		});
+
+		expect(config.additionalEnv).toEqual({
+			CYRUS_GH_TOKEN: "ghs_org_token",
+			CYRUS_GITLAB_TOKEN: "glpat_repo_token",
+		});
+	});
 });

--- a/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.new-sessions.test.ts
@@ -193,4 +193,80 @@ Analyze the issue description, labels, and any user comments to determine which 
 			.expectComponents("issue-context", "user-comment")
 			.verify();
 	});
+
+	it("assignment-based GitLab repo - should tell the agent to use glab", async () => {
+		const worker = createTestWorker();
+
+		const session = {
+			issueId: "c3d4e5f6-a7b8-9012-cdef-234567890123",
+			workspace: { path: "/test/gitlab-repo" },
+			metadata: {},
+		};
+
+		const issue = {
+			id: "c3d4e5f6-a7b8-9012-cdef-234567890123",
+			identifier: "GL-123",
+			title: "Fix GitLab bug",
+			description: "The GitLab integration needs an update",
+		};
+
+		const repository = {
+			id: "repo-gitlab-123",
+			name: "GitLab Repo",
+			repositoryPath: "/test/gitlab-repo",
+			gitlabUrl: "https://gitlab.com/acme/gitlab-repo",
+		};
+
+		await scenario(worker)
+			.newSession()
+			.assignmentBased()
+			.withSession(session)
+			.withIssue(issue)
+			.withRepository(repository)
+			.withUserComment("")
+			.withLabels()
+			.expectUserPrompt(`<context>
+  <repository>GitLab Repo</repository>
+  <working_directory>/test/gitlab-repo</working_directory>
+  <base_branch>main</base_branch>
+</context>
+
+<linear_issue>
+  <id>c3d4e5f6-a7b8-9012-cdef-234567890123</id>
+  <identifier>GL-123</identifier>
+  <title>Fix GitLab bug</title>
+  <description>
+The GitLab integration needs an update
+  </description>
+  <state>Unknown</state>
+  <priority>None</priority>
+  <url></url>
+  <assignee>
+    <linear_display_name></linear_display_name>
+    <linear_profile_url></linear_profile_url>
+    <github_username></github_username>
+    <github_user_id></github_user_id>
+    <github_noreply_email></github_noreply_email>
+  </assignee>
+</linear_issue>
+
+<linear_comments>
+No comments yet.
+</linear_comments>
+
+<source_control_context>
+  <repository name="GitLab Repo">
+    <gitlab_url>https://gitlab.com/acme/gitlab-repo</gitlab_url>
+    <cli>glab</cli>
+  </repository>
+<instructions>
+- Use \`glab\` for GitLab-specific operations such as merge requests, comments, reviews, and project API lookups.
+- Do not use \`gh\` for GitLab repositories.
+- Plain \`git\` fetch, clone, pull, commit, and push operations are already authenticated by the Cyrus git credential helper.
+</instructions>
+</source_control_context>`)
+			.expectPromptType("fallback")
+			.expectComponents("issue-context")
+			.verify();
+	});
 });

--- a/packages/edge-worker/test/prompt-assembly.routing-context.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.routing-context.test.ts
@@ -89,6 +89,96 @@ Orchestrate this task
 			.verify();
 	});
 
+	it("should include GitLab source-control context for single-repository label-based prompts", async () => {
+		const repository = {
+			id: "repo-gitlab-single-123",
+			name: "GitLab Single Repo",
+			repositoryPath: "/test/gitlab-single-repo",
+			workspaceBaseDir: "/test/workspace",
+			linearWorkspaceId: "test-gitlab-workspace-1",
+
+			baseBranch: "main",
+			gitlabUrl: "https://gitlab.com/acme/gitlab-single-repo",
+			routingLabels: ["backend"],
+			teamKeys: ["BACK"],
+			labelPrompts: {
+				orchestrator: { labels: ["Orchestrator"] },
+			},
+		};
+
+		const worker = createTestWorker([repository]);
+
+		const session = {
+			issueId: "issue-gitlab-123",
+			workspace: { path: "/test" },
+			metadata: {},
+		};
+
+		const issue = {
+			id: "issue-gitlab-123",
+			identifier: "GL-100",
+			title: "Single GitLab orchestration",
+			description: "Test GitLab issue",
+		};
+
+		await scenario(worker)
+			.newSession()
+			.assignmentBased()
+			.withSession(session)
+			.withIssue(issue)
+			.withRepository(repository)
+			.withUserComment("Orchestrate this GitLab task")
+			.withLabels("Orchestrator")
+			.expectUserPrompt(`<git_context>
+<repository>GitLab Single Repo</repository>
+<base_branch>main</base_branch>
+</git_context>
+
+<linear_issue>
+<id>issue-gitlab-123</id>
+<identifier>GL-100</identifier>
+<title>Single GitLab orchestration</title>
+<description>Test GitLab issue</description>
+<url></url>
+<assignee>
+<linear_id></linear_id>
+<linear_display_name></linear_display_name>
+<linear_profile_url></linear_profile_url>
+<github_username></github_username>
+<github_user_id></github_user_id>
+<github_noreply_email></github_noreply_email>
+</assignee>
+</linear_issue>
+
+<workspace_context>
+<teams>
+
+</teams>
+<labels>
+
+</labels>
+</workspace_context>
+
+<source_control_context>
+  <repository name="GitLab Single Repo">
+    <gitlab_url>https://gitlab.com/acme/gitlab-single-repo</gitlab_url>
+    <cli>glab</cli>
+  </repository>
+<instructions>
+- Use \`glab\` for GitLab-specific operations such as merge requests, comments, reviews, and project API lookups.
+- Do not use \`gh\` for GitLab repositories.
+- Plain \`git\` fetch, clone, pull, commit, and push operations are already authenticated by the Cyrus git credential helper.
+</instructions>
+</source_control_context>
+
+<user_comment>
+Orchestrate this GitLab task
+</user_comment>`)
+			.expectPromptType("label-based")
+			.expectComponents("issue-context", "user-comment")
+			.verify();
+	});
+
 	it("should include routing context for multi-repository setup", async () => {
 		const frontendRepo = {
 			id: "repo-frontend-123",


### PR DESCRIPTION
Assignee: @PaytonWebber ([payton](https://linear.app/ceedar/profiles/payton))

## Summary
- Adds a provider-neutral git token store for GitHub/GitLab credentials.
- Extends the ConfigUpdater with /api/update/git-provider-tokens and keeps /api/update/github-tokens backward compatible.
- Updates the git credential helper to resolve GitLab HTTPS credentials by host/namespace and injects CYRUS_GITLAB_TOKEN into sessions without clobbering user GITLAB_TOKEN.

## Testing
- pnpm --filter cyrus-core exec vitest run --passWithNoTests git-provider-token-store github-token-store
- pnpm --filter cyrus-config-updater exec vitest run --passWithNoTests handlers/gitProviderTokens handlers/githubTokens git-credential-cyrus
- pnpm --filter cyrus-edge-worker exec vitest run RunnerConfigBuilder.github-token-env
- pnpm --filter cyrus-core typecheck
- pnpm --filter cyrus-config-updater typecheck
- pnpm --filter cyrus-edge-worker typecheck
- pnpm exec biome check <touched runtime files>

Linear: https://linear.app/ceedar/issue/CYHOST-1082/add-gitlab-as-an-alternative-source-control-provider

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->