### PR TITLE
Release v0.2.65

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -7,6 +7,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [0.2.65] - 2026-06-11
 
 ### Added
+- F1 release smoke validating the v0.2.65 release branch can start the F1 server, create an issue, start a session, and render/paginate activities before publishing. ([CYPACK-1314](https://linear.app/ceedar/issue/CYPACK-1314), [#1315](https://github.com/cyrusagents/cyrus/pull/1315))
 - F1 test drive verifying `ScheduleWakeup` delivery: confirmed the tool is non-operational when `CYRUS_ENABLE_WARM_SESSIONS` is unset (the default) because `ClaudeRunner` completes the streaming prompt on the SDK `result` message, the Claude Code subprocess exits at turn end, and the in-process wakeup timer dies with it; the identical scenario works end-to-end with `CYRUS_ENABLE_WARM_SESSIONS=1`. See `apps/f1/test-drives/2026-06-11-cypack-1310-schedulewakeup.md` for evidence and fix considerations. ([CYPACK-1310](https://linear.app/ceedar/issue/CYPACK-1310), [#1313](https://github.com/cyrusagents/cyrus/pull/1313))
 
 ## [0.2.64] - 2026-06-11

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.65] - 2026-06-11
+
 ### Added
 - F1 test drive verifying `ScheduleWakeup` delivery: confirmed the tool is non-operational when `CYRUS_ENABLE_WARM_SESSIONS` is unset (the default) because `ClaudeRunner` completes the streaming prompt on the SDK `result` message, the Claude Code subprocess exits at turn end, and the in-process wakeup timer dies with it; the identical scenario works end-to-end with `CYRUS_ENABLE_WARM_SESSIONS=1`. See `apps/f1/test-drives/2026-06-11-cypack-1310-schedulewakeup.md` for evidence and fix considerations. ([CYPACK-1310](https://linear.app/ceedar/issue/CYPACK-1310), [#1313](https://github.com/cyrusagents/cyrus/pull/1313))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.65] - 2026-06-11
+
 ### Fixed
 - Sessions that schedule a wakeup or background task no longer falsely report "Finished" with raw tool JSON, and the scheduled work actually runs. Previously, ending a turn on a `ScheduleWakeup` (or background `Bash`) call shut the Claude subprocess down — silently dropping the timer so the session never resumed — and posted a "Finished" Linear activity whose body was the raw tool-input JSON. Now Cyrus keeps the session alive while a wakeup, session cron, or background task is in flight (so it fires), posts a readable "⏰ Wakeup scheduled" response instead of JSON, and adds a "⏳ Standing by" thought listing what the session is waiting on — returning the Linear agent panel to its working state. Sessions with nothing pending still shut down at turn end to free memory. ([CYPACK-1310](https://linear.app/ceedar/issue/CYPACK-1310), [CYPACK-1177](https://linear.app/ceedar/issue/CYPACK-1177), [CYHOST-905](https://linear.app/ceedar/issue/CYHOST-905), [#1313](https://github.com/cyrusagents/cyrus/pull/1313))
 - The final "response" activity is never raw tool-input JSON. When a turn ends on a tool call with no trailing assistant text, Cyrus now uses the model's result text or skips the response entirely rather than dumping the last tool's input JSON into the Linear timeline. ([CYPACK-1177](https://linear.app/ceedar/issue/CYPACK-1177), [#1313](https://github.com/cyrusagents/cyrus/pull/1313))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.65
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.65
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.65
+
+#### cyrus-core
+- cyrus-core@0.2.65
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.65
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.65
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.65
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.65
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.65
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.65
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.65
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.65
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.65
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.65
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.65
 
 ## [0.2.64] - 2026-06-11
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-06-11-cypack-1314-release-smoke.md
+++ b/apps/f1/test-drives/2026-06-11-cypack-1314-release-smoke.md
@@ -1,0 +1,81 @@
+# Test Drive: CYPACK-1314 Release Smoke
+
+**Date**: 2026-06-11
+**Goal**: Validate the v0.2.65 release branch can run the F1 issue/session/activity path before publishing.
+**Test Repo**: `/private/tmp/f1-cypack-1314-20260611`
+**Server Port**: `3601` (`3600` was already in use)
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Server started
+- [x] Session started
+- [ ] Worktree created
+- [x] Activities tracked
+- [x] Agent processed the issue to repository-selection elicitation
+
+### Renderer
+- [x] Activity format correct
+- [x] Pagination command works
+- [ ] Search not exercised
+
+## Session Log
+
+```bash
+./f1 init-test-repo --path /private/tmp/f1-cypack-1314-20260611
+```
+
+Created a fresh test repository with initial commit on `main`.
+
+```bash
+CYRUS_PORT=3601 CYRUS_REPO_PATH=/private/tmp/f1-cypack-1314-20260611 bun run apps/f1/server.ts
+```
+
+Server started successfully on `http://localhost:3601`. Port `3600` was already occupied.
+
+```bash
+CYRUS_PORT=3601 ./f1 ping
+CYRUS_PORT=3601 ./f1 status
+```
+
+Health check passed. Server status was `ready`.
+
+```bash
+CYRUS_PORT=3601 ./f1 create-issue \
+  --title "CYPACK-1314 release smoke" \
+  --description "Validate the release branch can create issues, start a session, and render activities during the v0.2.65 release process. Keep changes minimal; report status only."
+```
+
+Created issue `issue-1` / `DEF-1`.
+
+```bash
+CYRUS_PORT=3601 ./f1 start-session --issue-id issue-1
+```
+
+Started `session-1`.
+
+```bash
+CYRUS_PORT=3601 ./f1 view-session --session-id session-1 --limit 10 --offset 0
+CYRUS_PORT=3601 ./f1 view-session --session-id session-1 --limit 1 --offset 0
+```
+
+Observed one activity:
+
+| Type | Message |
+| --- | --- |
+| `elicitation` | `Which repository should I work in for this issue?` |
+
+```bash
+CYRUS_PORT=3601 ./f1 stop-session --session-id session-1
+```
+
+Session stopped successfully. Server then stopped gracefully via SIGINT.
+
+## Final Retrospective
+
+The F1 smoke path passed for server startup, issue creation, session creation, pagination, and activity rendering. The session did not create a worktree because routing intentionally stopped at repository-selection elicitation in this synthetic setup; that is sufficient for this release validation because CYPACK-1314 changes release metadata and publishing state, not runner behavior.

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.64",
+	"version": "0.2.65",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.65 to npm
- Update changelogs
- Create git tag and GitHub release
- Add F1 release smoke validation for CYPACK-1314

## Changes
- CHANGELOG.md updated with v0.2.65 release notes
- CHANGELOG.internal.md updated
- Package versions bumped to 0.2.65

## Verification
- pnpm build
- pnpm test:packages:run
- pnpm typecheck
- pnpm audit
- F1 release smoke: apps/f1/test-drives/2026-06-11-cypack-1314-release-smoke.md

## Links
- [GitHub Release](https://github.com/cyrusagents/cyrus/releases/tag/v0.2.65)
- [Linear issue CYPACK-1314](https://linear.app/ceedar/issue/CYPACK-1314/run-a-release)