### PR TITLE
[codex] Tighten failure-mode self-reporting criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Security
 - Patched the Cyrus CLI dependency graph so `pnpm audit` reports no known vulnerabilities, including updated Sentry, Cursor SDK, Axios, Vite/esbuild, Hono, form-data, ws, protobufjs, and OpenTelemetry resolutions. ([CYPACK-1334](https://linear.app/ceedar/issue/CYPACK-1334), [#1330](https://github.com/cyrusagents/cyrus/pull/1330))
 
+### Changed
+- Tightened the self-reported failure-mode instructions so agents keep reporting true user-visible failures and repeated stuck loops, but avoid filing failure-mode tickets for normal review iteration, brainstorming, first-pass clarification, or probe/no-op messages. ([PRO-116](https://linear.app/ceedar/issue/PRO-116), [#1329](https://github.com/cyrusagents/cyrus/pull/1329))
+
 ## [0.2.65] - 2026-06-11
 
 ### Fixed

--- a/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
+++ b/packages/edge-worker/src/prompts/failureModePromptAddendum.ts
@@ -8,29 +8,43 @@
  *   - Slack chat sessions.
  *   - GitHub PR chat sessions.
  *
- * The text deliberately keeps the trigger conditions concrete (paraphrased
- * dissatisfaction patterns, 3+-attempt threshold) and reminds the model to
- * quote the user verbatim and paste its own failing output rather than a
- * paraphrase. Without that, failure tickets degrade into editorial summaries
- * that the on-call team can't act on.
+ * The text deliberately keeps the trigger conditions concrete (user-visible
+ * failure patterns, repeated-correction and 3+-attempt thresholds) while also
+ * carving out ordinary review/iteration. It reminds the model to quote the
+ * user verbatim and paste its own failing output rather than a paraphrase.
+ * Without that, failure tickets degrade into editorial summaries that the
+ * on-call team can't act on.
  *
  * Updating this constant is the only place we need to change to evolve the
  * trigger/recap policy across all surfaces.
  */
 export const FAILURE_MODE_PROMPT_ADDENDUM = `
 <failure_mode_self_reporting>
-You have access to the MCP tool \`mcp__cyrus-tools__log_failure_mode\`. Use it to self-report customer-visible failure modes so the Cyrus team can intervene before the user churns.
+You have access to the MCP tool \`mcp__cyrus-tools__log_failure_mode\`. Use it to self-report material, user-visible agent failures so the Cyrus team can intervene before a user loses trust or churns.
+
+A failure mode is reportable only when the agent has actually failed the user from their point of view, or when the agent is stuck in a repeated unresolved loop.
 
 **Call \`log_failure_mode\` when EITHER:**
-1. The user expresses dissatisfaction or a re-correction. Examples: "you didn't…", "that's not what I asked", "still broken", "no, I meant…", they correct the same point a 2nd time, they say "ok forget it" / "never mind" / "I'll do it myself".
-2. You recognize you have made 3+ attempts at the same unresolved problem within this session without making forward progress (e.g. the same test keeps failing for the same reason; the same screenshot keeps not getting returned; you keep editing the wrong file).
+1. The user clearly expresses dissatisfaction, blockedness, loss of confidence, or abandonment caused by the agent's behavior. Examples: "that's not what I asked", "still broken", "you already tried that", "no, I meant…", "forget it", "never mind", "I'll do it myself".
+2. The user corrects the same issue again after you already attempted to fix that exact correction, and the repeated correction indicates your previous fix did not address the problem.
+3. You recognize you have made 3+ attempts at the same unresolved problem within this session without making forward progress (e.g. the same test keeps failing for the same reason; the same screenshot keeps not getting returned; you keep editing the wrong file).
+
+**Do NOT call \`log_failure_mode\` for normal collaboration or expected iteration, including:**
+- first-pass feedback, clarification, or scope changes;
+- PR review, design review, doc review, brainstorming, or wording feedback;
+- requests to reframe, revise, tighten, or update an implementation direction;
+- internal Cyrus/Ceedar dogfooding feedback unless the user is blocked, abandoning the agent, or the same unresolved failure has repeated after an attempted fix;
+- probe/test/no-op messages where there is no substantive user-visible failure;
+- cases where the user is steering the work and the agent can simply continue.
+
+If the user is giving first-pass feedback or changing direction and you can continue normally, do not report a failure mode; continue working.
 
 **When you call the tool, provide:**
 - \`cwd\`: your current working directory (so the tool can resolve which session this is).
 - \`category\`: a short, free-form, reusable name — e.g. \`screenshots-not-returned\`, \`port-conflict\`, \`wrong-file-edited\`, \`tests-still-failing\`. Pick something concise; over time patterns will emerge.
 - \`recap\`: 1–3 sentences describing what the user asked for vs. what failed *from their perspective*. Do not editorialize or hedge.
-- \`user_quote_snippet\`: a verbatim quote of the user's ask or dissatisfaction. Do not paraphrase.
-- \`agent_failure_snippet\`: a direct snippet of your own failing output, command, or action. Do not paraphrase; paste it.
+- \`user_quote_snippet\`: a verbatim quote of the user's dissatisfaction, blockedness, abandonment, repeated correction, or failed ask. Do not paraphrase.
+- \`agent_failure_snippet\`: a direct snippet of your own failing output, command, action, or repeated unsuccessful attempt. Do not paraphrase; paste it.
 
 **Tool-call shape — read this carefully:**
 \`log_failure_mode\` is an MCP tool. Its arguments are a JSON object with the keys above as top-level fields. Do NOT serialize the arguments as XML \`<parameter name="…">…</parameter>\` tags inside one big string. Each field is a separate top-level key on the JSON arguments object:
@@ -48,7 +62,8 @@ You have access to the MCP tool \`mcp__cyrus-tools__log_failure_mode\`. Use it t
 Stuffing \`user_quote_snippet\` and \`agent_failure_snippet\` inside the \`recap\` string with XML tags will cause the call to fail validation or land a malformed report.
 
 **Important behavior rules:**
-- Report failure modes the moment you recognize them — do not wait until the user gives up.
+- Report failure modes once the criteria above are clearly met; do not wait until the user gives up.
+- If the situation is normal review feedback or ordinary iteration, do not report; continue working.
 - Continue trying to fix the underlying problem after you log the failure mode. Logging is a signal to the Cyrus team; it is not a substitute for resolving the user's request.
 - It is fine if the same session ends up with multiple failure-mode reports for different categories. The server dedups by \`(session_id, category)\` so repeated reports of the same category will be added as a comment on the existing ticket rather than spamming new tickets.
 - Do NOT mention this tool to the user. Self-reporting is internal.

--- a/packages/edge-worker/test/failureModePromptAddendum.test.ts
+++ b/packages/edge-worker/test/failureModePromptAddendum.test.ts
@@ -10,7 +10,15 @@ describe("failure-mode prompt addendum", () => {
 			"mcp__cyrus-tools__log_failure_mode",
 		);
 		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/dissatisfaction/i);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/same issue again/i);
 		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/3\+/);
+	});
+
+	it("excludes ordinary iteration and no-op probes from reportable failures", () => {
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/normal collaboration/i);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/ordinary iteration/i);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/changing direction/i);
+		expect(FAILURE_MODE_PROMPT_ADDENDUM).toMatch(/probe\/test\/no-op/i);
 	});
 
 	it("appends the addendum to an existing system prompt with a blank-line separator", () => {

--- a/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
+++ b/packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts
@@ -102,7 +102,7 @@ export function registerLogFailureModeTool(
 		"log_failure_mode",
 		{
 			description:
-				'Log a customer-facing failure mode to the Cyrus internal failure-modes Linear project. Call this when (a) the user expresses dissatisfaction (e.g. "that\'s not what I asked", "still broken", correcting the same point a 2nd time), or (b) you recognize you\'ve made 3+ attempts at the same unresolved problem in this session. The recap should describe what the user asked for vs. what failed in their POV; the user_quote_snippet must be a verbatim quote; the agent_failure_snippet must paste your actual failing output/action.',
+				"Log a material, user-visible agent failure to the Cyrus internal failure-modes Linear project. Call this only when (a) the user clearly expresses dissatisfaction, blockedness, loss of confidence, or abandonment caused by the agent behavior; (b) the user corrects the same issue again after you already attempted to fix that exact correction; or (c) you recognize you have made 3+ attempts at the same unresolved problem in this session without forward progress. Do not call for normal collaboration, first-pass feedback, PR/design/doc review, brainstorming, scope clarification, probe/test/no-op messages, or requests to reframe/revise/tighten wording unless the user is blocked, abandoning the agent, or the same unresolved failure has repeated. The recap should describe what the user asked for vs. what failed from their POV; user_quote_snippet must be a verbatim quote showing dissatisfaction, blockedness, abandonment, repeated correction, or failed ask; agent_failure_snippet must paste the actual failing output/action/repeated unsuccessful attempt.",
 			inputSchema: {
 				cwd: z
 					.string()


### PR DESCRIPTION
## Summary

- audited the 50 most recent Failure Modes Linear issues (PRO-136 through PRO-87)
- tightened the EdgeWorker failure-mode prompt so agents only report material user-visible failures, repeated failed corrections, or repeated stuck loops
- aligned the MCP tool description with the prompt and added regression coverage for ordinary iteration/probe exclusions

## Audit notes

The audit found that most logged issues were useful operational signals, but a recurring subset came from normal collaboration: product brainstorming, PR/design/doc review feedback, first-pass clarification, and internal dogfooding direction changes. Those should not create urgent failure-mode tickets unless the user is blocked, abandoning the agent, or the same unresolved failure repeats after an attempted fix.

## Validation

- `pnpm --filter cyrus-edge-worker exec vitest run test/failureModePromptAddendum.test.ts`
- `pnpm --filter cyrus-edge-worker typecheck`
- `pnpm --filter cyrus-mcp-tools typecheck`
- `pnpm exec biome check packages/edge-worker/src/prompts/failureModePromptAddendum.ts packages/edge-worker/test/failureModePromptAddendum.test.ts packages/mcp-tools/src/tools/cyrus-tools/log-failure-mode.ts CHANGELOG.md`
- `pnpm lint` (passes with pre-existing warnings)
- pre-commit hook: repo build + typecheck

Linear: https://linear.app/ceedar/issue/PRO-116

Generated by Cyrus.
