### PR TITLE
Fix repo hook discovery from issue worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Tightened the self-reported failure-mode instructions so agents keep reporting true user-visible failures and repeated stuck loops, but avoid filing failure-mode tickets for normal review iteration, brainstorming, first-pass clarification, or probe/no-op messages. ([PRO-116](https://linear.app/ceedar/issue/PRO-116), [#1329](https://github.com/cyrusagents/cyrus/pull/1329))
 
 ### Fixed
-- Repository setup and teardown hooks are now discovered from the issue worktree, so Cyrus runs the hook version that matches the code checked out for the task instead of a stale persistent checkout. ([CYPACK-1337](https://linear.app/ceedar/issue/CYPACK-1337), [#1332](https://github.com/cyrusagents/cyrus/pull/1332))
+- Repository setup and teardown hooks are now discovered from the issue worktree instead of the persistent checkout Cyrus uses to create worktrees. If a branch adds or updates `cyrus-setup.sh`, Cyrus now runs that exact version for the task, so dependency installs, environment bootstrap, generated config, and other repo-specific preparation no longer get skipped or run from an older checkout. Teardown cleanup likewise uses the `cyrus-teardown.sh` committed with the worktree being removed. ([CYPACK-1337](https://linear.app/ceedar/issue/CYPACK-1337), [#1332](https://github.com/cyrusagents/cyrus/pull/1332))
 
 ## [0.2.65] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Tightened the self-reported failure-mode instructions so agents keep reporting true user-visible failures and repeated stuck loops, but avoid filing failure-mode tickets for normal review iteration, brainstorming, first-pass clarification, or probe/no-op messages. ([PRO-116](https://linear.app/ceedar/issue/PRO-116), [#1329](https://github.com/cyrusagents/cyrus/pull/1329))
 
+### Fixed
+- Repository setup and teardown hooks are now discovered from the issue worktree, so Cyrus runs the hook version that matches the code checked out for the task instead of a stale persistent checkout. ([CYPACK-1337](https://linear.app/ceedar/issue/CYPACK-1337), [#1332](https://github.com/cyrusagents/cyrus/pull/1332))
+
 ## [0.2.65] - 2026-06-11
 
 ### Fixed

--- a/docs/SETUP_SCRIPTS.md
+++ b/docs/SETUP_SCRIPTS.md
@@ -12,7 +12,8 @@ Place a `cyrus-setup.sh` script in your repository root to run repository-specif
 
 1. Place a `cyrus-setup.sh` script in your repository root
 2. When Cyrus processes an issue, it creates a new git worktree
-3. If the setup script exists, Cyrus runs it in the new worktree with these environment variables:
+3. Cyrus discovers the setup script from the newly-created issue worktree, so the script version matches the checked-out code for that task
+4. If the setup script exists, Cyrus runs it in the new worktree with these environment variables:
    - `LINEAR_ISSUE_ID` - The Linear issue ID
    - `LINEAR_ISSUE_IDENTIFIER` - The issue identifier (e.g., "CEA-123")
    - `LINEAR_ISSUE_TITLE` - The issue title
@@ -59,7 +60,7 @@ When creating a new worktree:
 1. **Global script** runs first (if configured)
 2. **Repository script** (`cyrus-setup.sh`) runs second (if exists)
 
-Both scripts receive the same environment variables and run in the worktree directory.
+Both scripts receive the same environment variables and run in the worktree directory. The global script path comes from Cyrus configuration; repository scripts are discovered from the issue worktree after checkout.
 
 ### Use Cases
 
@@ -79,7 +80,7 @@ Make sure the script is executable: `chmod +x /opt/cyrus/bin/global-setup.sh`
 
 ## Repository Teardown Script
 
-Place a `cyrus-teardown.sh` script in your repository root to run repository-specific cleanup when an issue reaches a terminal state (completed, canceled, or deleted). Auto-detected the same way as `cyrus-setup.sh` — no configuration needed.
+Place a `cyrus-teardown.sh` script in your repository root to run repository-specific cleanup when an issue reaches a terminal state (completed, canceled, or deleted). Auto-detected from the issue worktree the same way as `cyrus-setup.sh` — no configuration needed.
 
 ### How it works
 

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -804,11 +804,7 @@ export class GitService {
 			}
 
 			// Then, check for repository setup scripts (cross-platform)
-			await this.runRepoSetupScript(
-				repository.repositoryPath,
-				workspacePath,
-				issue,
-			);
+			await this.runRepoSetupScript(workspacePath, issue);
 
 			return {
 				path: workspacePath,
@@ -968,23 +964,17 @@ export class GitService {
 	}): Promise<void> {
 		const { issueIdentifier, workspacePath, repositories } = opts;
 
-		// Build (repoPath, cwd) tuples. Prefer the explicit list from the caller.
-		const targets: Array<{ repositoryPath: string; cwd: string }> = [];
+		// Build the worktree cwd list. Prefer the explicit list from the caller.
+		const targets: string[] = [];
 
 		if (repositories && repositories.length > 0) {
 			if (repositories.length === 1) {
 				// Single-repo layout: workspace root IS the worktree.
-				targets.push({
-					repositoryPath: repositories[0]!.repositoryPath,
-					cwd: workspacePath,
-				});
+				targets.push(workspacePath);
 			} else {
 				// Multi-repo layout: each repo's worktree is a named subdir.
 				for (const repo of repositories) {
-					targets.push({
-						repositoryPath: repo.repositoryPath,
-						cwd: join(workspacePath, repo.name),
-					});
+					targets.push(join(workspacePath, repo.name));
 				}
 			}
 		}
@@ -997,19 +987,15 @@ export class GitService {
 			return;
 		}
 
-		for (const target of targets) {
+		for (const workspacePath of targets) {
 			try {
-				await this.runRepoTeardownScript(
-					target.repositoryPath,
-					target.cwd,
-					issueIdentifier,
-				);
+				await this.runRepoTeardownScript(workspacePath, issueIdentifier);
 			} catch (error) {
 				// runRepoTeardownScript already swallows execSync failures and
 				// logs them; this catch is defensive against unexpected throws
 				// (e.g. unreadable directory) so one bad repo cannot abort the loop.
 				this.logger.error(
-					`Unexpected error running teardown for ${target.repositoryPath}: ${(error as Error).message}`,
+					`Unexpected error running teardown for ${workspacePath}: ${(error as Error).message}`,
 				);
 			}
 		}
@@ -1093,13 +1079,11 @@ export class GitService {
 	 * Find and run a repository-specific setup script (cyrus-setup.sh/.ps1/.cmd/.bat)
 	 */
 	private async runRepoSetupScript(
-		repositoryPath: string,
 		workspacePath: string,
 		issue: Issue,
 	): Promise<void> {
 		await this.runRepoHookScript({
 			hook: "setup",
-			repositoryPath,
 			workspacePath,
 			env: {
 				LINEAR_ISSUE_ID: issue.id,
@@ -1119,13 +1103,11 @@ export class GitService {
 	 * the terminal-state message bus path does not carry the full Issue object.
 	 */
 	private async runRepoTeardownScript(
-		repositoryPath: string,
 		workspacePath: string,
 		issueIdentifier: string,
 	): Promise<void> {
 		await this.runRepoHookScript({
 			hook: "teardown",
-			repositoryPath,
 			workspacePath,
 			env: {
 				LINEAR_ISSUE_IDENTIFIER: issueIdentifier,
@@ -1136,12 +1118,11 @@ export class GitService {
 
 	/**
 	 * Shared discovery+dispatch for repo-scoped hook scripts (setup and teardown).
-	 * Looks in `repositoryPath` for `cyrus-<hook>.{sh,ps1,cmd,bat}` and runs the
+	 * Looks in `workspacePath` for `cyrus-<hook>.{sh,ps1,cmd,bat}` and runs the
 	 * first compatible variant with `cwd` set to `workspacePath`.
 	 */
 	private async runRepoHookScript(opts: {
 		hook: HookKind;
-		repositoryPath: string;
 		workspacePath: string;
 		env: Record<string, string>;
 		timeoutMs: number;
@@ -1155,7 +1136,7 @@ export class GitService {
 		];
 
 		const available = candidates.find((c) => {
-			const scriptPath = join(opts.repositoryPath, c.file);
+			const scriptPath = join(opts.workspacePath, c.file);
 			const isCompatible = isWindows
 				? c.platform === "windows"
 				: c.platform === "unix";
@@ -1166,7 +1147,7 @@ export class GitService {
 		const fallback =
 			!available && isWindows
 				? candidates.find((c) => {
-						const scriptPath = join(opts.repositoryPath, c.file);
+						const scriptPath = join(opts.workspacePath, c.file);
 						return c.platform === "unix" && existsSync(scriptPath);
 					})
 				: null;
@@ -1174,7 +1155,7 @@ export class GitService {
 		const scriptToRun = available || fallback;
 		if (!scriptToRun) return;
 
-		const scriptPath = join(opts.repositoryPath, scriptToRun.file);
+		const scriptPath = join(opts.workspacePath, scriptToRun.file);
 		await this.runHookScript({
 			scriptPath,
 			hook: opts.hook,

--- a/packages/edge-worker/test/GitService.test.ts
+++ b/packages/edge-worker/test/GitService.test.ts
@@ -469,6 +469,135 @@ describe("GitService", () => {
 		});
 	});
 
+	describe("createGitWorktree - repo setup hook discovery", () => {
+		const setupSuccessfulWorktreeCreate = () => {
+			mockExecSync.mockImplementation((cmd: any) => {
+				const cmdStr = String(cmd);
+				if (cmdStr === "git rev-parse --git-dir") {
+					return Buffer.from(".git\n");
+				}
+				if (cmdStr === "git worktree list --porcelain") {
+					return "";
+				}
+				if (
+					cmdStr.includes(
+						'git rev-parse --verify "cyrustester/eng-97-fix-shader"',
+					)
+				) {
+					throw new Error("branch not found");
+				}
+				if (cmdStr.includes("git fetch origin")) {
+					return Buffer.from("");
+				}
+				if (cmdStr.includes("git ls-remote")) {
+					return Buffer.from("abc123\trefs/heads/main\n");
+				}
+				if (cmdStr.includes("git worktree add")) {
+					return Buffer.from("");
+				}
+				if (cmdStr.includes("cyrus-setup.sh")) {
+					return Buffer.from("");
+				}
+				return Buffer.from("");
+			});
+		};
+
+		it("runs setup from the worktree when the persistent checkout lacks cyrus-setup.sh", async () => {
+			const issue = makeIssue();
+			const repository = makeRepository();
+			setupSuccessfulWorktreeCreate();
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/repo/cyrus-setup.sh") return false;
+				if (p === "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh")
+					return true;
+				return false;
+			});
+			mockStatSync.mockImplementation((path: any) => {
+				if (
+					String(path) === "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh"
+				) {
+					return { mode: 0o755, isFile: () => false } as any;
+				}
+				return { isFile: () => false } as any;
+			});
+
+			const result = await gitService.createGitWorktree(issue, [repository]);
+
+			expect(result.isGitWorktree).toBe(true);
+			expect(mockExecSync).toHaveBeenCalledWith(
+				'bash "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh"',
+				expect.objectContaining({
+					cwd: "/home/user/.cyrus/worktrees/ENG-97",
+					env: expect.objectContaining({
+						LINEAR_ISSUE_ID: "issue-1",
+						LINEAR_ISSUE_IDENTIFIER: "ENG-97",
+						LINEAR_ISSUE_TITLE: "Fix the shader",
+					}),
+					timeout: 5 * 60 * 1000,
+				}),
+			);
+			expect(
+				mockExecSync.mock.calls.some(
+					([cmd]) => String(cmd) === 'bash "/home/user/repo/cyrus-setup.sh"',
+				),
+			).toBe(false);
+		});
+
+		it("runs the worktree setup version when the persistent checkout also has cyrus-setup.sh", async () => {
+			const issue = makeIssue();
+			const repository = makeRepository();
+			setupSuccessfulWorktreeCreate();
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/repo/cyrus-setup.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh")
+					return true;
+				return false;
+			});
+			mockStatSync.mockImplementation((path: any) => {
+				if (
+					String(path) === "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh"
+				) {
+					return { mode: 0o755, isFile: () => false } as any;
+				}
+				throw new Error(`unexpected stat: ${String(path)}`);
+			});
+
+			await gitService.createGitWorktree(issue, [repository]);
+
+			const setupCommands = mockExecSync.mock.calls
+				.map(([cmd]) => String(cmd))
+				.filter((cmd) => cmd.includes("cyrus-setup.sh"));
+			expect(setupCommands).toEqual([
+				'bash "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh"',
+			]);
+		});
+
+		it("skips repo setup without failing worktree creation when the worktree lacks cyrus-setup.sh", async () => {
+			const issue = makeIssue();
+			const repository = makeRepository();
+			setupSuccessfulWorktreeCreate();
+			mockExistsSync.mockImplementation((path: any) => {
+				const p = String(path);
+				if (p === "/home/user/repo/cyrus-setup.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/ENG-97/cyrus-setup.sh")
+					return false;
+				return false;
+			});
+
+			const result = await gitService.createGitWorktree(issue, [repository]);
+
+			expect(result.path).toBe("/home/user/.cyrus/worktrees/ENG-97");
+			expect(result.isGitWorktree).toBe(true);
+			expect(
+				mockExecSync.mock.calls.some(([cmd]) =>
+					String(cmd).includes("cyrus-setup.sh"),
+				),
+			).toBe(false);
+		});
+	});
+
 	describe("createGitWorktree - stale worktree detection", () => {
 		it("prunes and recreates worktree when git lists it but directory has no .git file", async () => {
 			const issue = makeIssue();
@@ -802,7 +931,8 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") return true;
 				if (p === "/home/user/repos/repo-a") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh")
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -810,7 +940,7 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") {
 					return { isFile: () => true } as any;
 				}
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") {
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh") {
 					return { mode: 0o755, isFile: () => false } as any;
 				}
 				return { isFile: () => false } as any;
@@ -824,7 +954,7 @@ describe("GitService", () => {
 
 			// Should run teardown with cwd set to workspace root (single-repo)
 			expect(mockExecSync).toHaveBeenCalledWith(
-				'bash "/home/user/repos/repo-a/cyrus-teardown.sh"',
+				'bash "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh"',
 				expect.objectContaining({
 					cwd: "/home/user/.cyrus/worktrees/DEF-123",
 					env: expect.objectContaining({
@@ -865,7 +995,8 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") return true;
 				if (p === "/home/user/repos/repo-a") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh")
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -873,7 +1004,7 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") {
 					return { isFile: () => true } as any;
 				}
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") {
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh") {
 					return { mode: 0o755, isFile: () => false } as any;
 				}
 				return { isFile: () => false } as any;
@@ -909,7 +1040,8 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") return true;
 				if (p === "/home/user/repos/repo-a") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh")
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -917,7 +1049,7 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") {
 					return { isFile: () => true } as any;
 				}
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") {
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh") {
 					return { mode: 0o644, isFile: () => false } as any;
 				}
 				return { isFile: () => false } as any;
@@ -964,8 +1096,14 @@ describe("GitService", () => {
 					return true;
 				if (p === "/home/user/repos/repo-a") return true;
 				if (p === "/home/user/repos/repo-b") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
-				if (p === "/home/user/repos/repo-b/cyrus-teardown.sh") return true;
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh"
+				)
+					return true;
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-b/cyrus-teardown.sh"
+				)
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -1005,13 +1143,13 @@ describe("GitService", () => {
 			});
 
 			expect(mockExecSync).toHaveBeenCalledWith(
-				'bash "/home/user/repos/repo-a/cyrus-teardown.sh"',
+				'bash "/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh"',
 				expect.objectContaining({
 					cwd: "/home/user/.cyrus/worktrees/DEF-123/repo-a",
 				}),
 			);
 			expect(mockExecSync).toHaveBeenCalledWith(
-				'bash "/home/user/repos/repo-b/cyrus-teardown.sh"',
+				'bash "/home/user/.cyrus/worktrees/DEF-123/repo-b/cyrus-teardown.sh"',
 				expect.objectContaining({
 					cwd: "/home/user/.cyrus/worktrees/DEF-123/repo-b",
 				}),
@@ -1030,7 +1168,10 @@ describe("GitService", () => {
 				if (p === "/home/user/repos/repo-a") return true;
 				if (p === "/home/user/repos/repo-b") return true;
 				// Only repo-a has a teardown script
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh"
+				)
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -1041,7 +1182,9 @@ describe("GitService", () => {
 				) {
 					return { isFile: () => true } as any;
 				}
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") {
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh"
+				) {
 					return { mode: 0o755, isFile: () => false } as any;
 				}
 				return { isFile: () => false } as any;
@@ -1073,7 +1216,9 @@ describe("GitService", () => {
 				.map((c) => String(c[0]))
 				.filter((c) => c.includes("cyrus-teardown.sh"));
 			expect(teardownCalls).toHaveLength(1);
-			expect(teardownCalls[0]).toContain("/home/user/repos/repo-a/");
+			expect(teardownCalls[0]).toContain(
+				"/home/user/.cyrus/worktrees/DEF-123/repo-a/",
+			);
 		});
 
 		it("multi-repo: one teardown failing does not skip the other or block rmSync", async () => {
@@ -1087,8 +1232,14 @@ describe("GitService", () => {
 					return true;
 				if (p === "/home/user/repos/repo-a") return true;
 				if (p === "/home/user/repos/repo-b") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
-				if (p === "/home/user/repos/repo-b/cyrus-teardown.sh") return true;
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh"
+				)
+					return true;
+				if (
+					p === "/home/user/.cyrus/worktrees/DEF-123/repo-b/cyrus-teardown.sh"
+				)
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -1120,7 +1271,11 @@ describe("GitService", () => {
 			] as any);
 
 			mockExecSync.mockImplementation((cmd: any) => {
-				if (String(cmd).includes("/home/user/repos/repo-a/cyrus-teardown.sh")) {
+				if (
+					String(cmd).includes(
+						"/home/user/.cyrus/worktrees/DEF-123/repo-a/cyrus-teardown.sh",
+					)
+				) {
 					throw new Error("repo-a teardown failed");
 				}
 				return Buffer.from("");
@@ -1135,7 +1290,7 @@ describe("GitService", () => {
 
 			// repo-b's teardown was still attempted
 			expect(mockExecSync).toHaveBeenCalledWith(
-				'bash "/home/user/repos/repo-b/cyrus-teardown.sh"',
+				'bash "/home/user/.cyrus/worktrees/DEF-123/repo-b/cyrus-teardown.sh"',
 				expect.anything(),
 			);
 			// rmSync still ran
@@ -1153,7 +1308,8 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") return true;
 				if (p === "/home/user/repos/repo-a") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh")
+					return true;
 				return false;
 			});
 			mockExecSync.mockReturnValue(Buffer.from(""));
@@ -1172,7 +1328,8 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123") return true;
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") return true;
 				if (p === "/home/user/repos/repo-a") return true;
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") return true;
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh")
+					return true;
 				return false;
 			});
 			mockStatSync.mockImplementation((path: any) => {
@@ -1180,7 +1337,7 @@ describe("GitService", () => {
 				if (p === "/home/user/.cyrus/worktrees/DEF-123/.git") {
 					return { isFile: () => true } as any;
 				}
-				if (p === "/home/user/repos/repo-a/cyrus-teardown.sh") {
+				if (p === "/home/user/.cyrus/worktrees/DEF-123/cyrus-teardown.sh") {
 					return { mode: 0o755, isFile: () => false } as any;
 				}
 				return { isFile: () => false } as any;


### PR DESCRIPTION
## Summary
- Discover repository setup and teardown hooks from the issue worktree instead of the persistent checkout.
- Keep global setup script behavior unchanged.
- Add regressions for setup hooks that are missing or stale in the persistent checkout.
- Document that repo hooks are discovered from the issue worktree.

## Testing
- pnpm --filter cyrus-edge-worker exec vitest run test/GitService.test.ts
- pnpm build
- pnpm test:packages:run
- pnpm typecheck
- pnpm lint (passes with existing warnings)

Linear: https://linear.app/ceedar/issue/CYPACK-1337/repo-setup-hooks-should-be-discovered-from-the-issue-worktree-not-the

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->