### PR TITLE
fix(deps): patch undici security advisories (CYPACK-1340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 - Patched the Cyrus CLI dependency graph so `pnpm audit` reports no known vulnerabilities, including updated Sentry, Cursor SDK, Axios, Vite/esbuild, Hono, form-data, ws, protobufjs, and OpenTelemetry resolutions. ([CYPACK-1334](https://linear.app/ceedar/issue/CYPACK-1334), [#1330](https://github.com/cyrusagents/cyrus/pull/1330))
+- Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` continues to report no known vulnerabilities. ([CYPACK-1340](https://linear.app/ceedar/issue/CYPACK-1340), [#1335](https://github.com/cyrusagents/cyrus/pull/1335))
 
 ### Changed
 - Tightened the self-reported failure-mode instructions so agents keep reporting true user-visible failures and repeated stuck loops, but avoid filing failure-mode tickets for normal review iteration, brainstorming, first-pass clarification, or probe/no-op messages. ([PRO-116](https://linear.app/ceedar/issue/PRO-116), [#1329](https://github.com/cyrusagents/cyrus/pull/1329))

--- a/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
+++ b/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
@@ -1,0 +1,50 @@
+# Test Drive: CYPACK-1340 Security Dependency Smoke
+
+**Date**: 2026-06-19
+**Goal**: Verify the F1 CLI server and issue-tracker RPC path still work after security dependency patches.
+**Test Repo**: `/private/tmp/f1-cypack-1340-security`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible
+
+### EdgeWorker
+- [x] Server started
+- [x] CLI RPC server registered
+- [x] Status endpoint reported ready
+- [ ] Agent session not started because this change only patches dependencies and does not alter runner/session behavior
+
+### Renderer
+- [x] CLI output remained readable
+- [ ] Activity pagination not exercised because no agent session was started
+
+## Session Log
+
+```bash
+cd apps/f1 && ./f1 init-test-repo --path /private/tmp/f1-cypack-1340-security
+```
+
+Result: fresh test repository created with an initial `main` commit.
+
+```bash
+CYRUS_PORT=3601 CYRUS_REPO_PATH=/private/tmp/f1-cypack-1340-security bun run apps/f1/server.ts
+```
+
+Result: server started successfully on `http://localhost:3601`. Ports `3600` and `3602` were already in use, so `3601` was selected.
+
+```bash
+CYRUS_PORT=3601 ./apps/f1/f1 ping
+CYRUS_PORT=3601 ./apps/f1/f1 status
+CYRUS_PORT=3601 ./apps/f1/f1 create-issue --title "CYPACK-1340 dependency smoke" --description "Verify F1 issue-tracker RPC still works after security dependency patches."
+```
+
+Result: ping succeeded, status returned `ready`, and issue `DEF-1` was created.
+
+Server shutdown via `SIGINT` saved EdgeWorker state and stopped cleanly.
+
+## Final Retrospective
+
+The dependency updates did not break F1 server startup, CLI RPC health/status, or issue creation. A full agent-session drive was intentionally skipped because CYPACK-1340 does not change runner selection, session lifecycle, worktree behavior, or activity rendering.

--- a/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
+++ b/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
@@ -15,11 +15,11 @@
 - [x] Server started
 - [x] CLI RPC server registered
 - [x] Status endpoint reported ready
-- [ ] Agent session not started because this change only patches dependencies and does not alter runner/session behavior
+- [x] Agent session intentionally skipped because this change only patches dependencies and does not alter runner/session behavior
 
 ### Renderer
 - [x] CLI output remained readable
-- [ ] Activity pagination not exercised because no agent session was started
+- [x] Activity pagination intentionally skipped because no agent session was started
 
 ## Session Log
 

--- a/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
+++ b/apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md
@@ -15,11 +15,11 @@
 - [x] Server started
 - [x] CLI RPC server registered
 - [x] Status endpoint reported ready
-- [x] Agent session intentionally skipped because this change only patches dependencies and does not alter runner/session behavior
+- [ ] Agent session not started because this change only patches dependencies and does not alter runner/session behavior
 
 ### Renderer
 - [x] CLI output remained readable
-- [x] Activity pagination intentionally skipped because no agent session was started
+- [ ] Activity pagination not exercised because no agent session was started
 
 ## Session Log
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 			"nodemon>minimatch": ">=10.2.3",
 			"glob>minimatch": ">=10.2.3",
 			"simple-git": ">=3.32.3",
-			"undici": ">=7.24.0",
+			"undici": "7.28.0",
 			"ajv": ">=8.18.0",
 			"diff": ">=8.0.3",
 			"@tootallnate/once": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 			"nodemon>minimatch": ">=10.2.3",
 			"glob>minimatch": ">=10.2.3",
 			"simple-git": ">=3.32.3",
-			"undici": "7.28.0",
+			"undici": "^7.28.0",
 			"ajv": ">=8.18.0",
 			"diff": ">=8.0.3",
 			"@tootallnate/once": ">=3.0.1",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -25,7 +25,7 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@google/gemini-cli-core": "0.46.0",
+		"@google/gemini-cli-core": "0.47.0",
 		"@types/fs-extra": "^11.0.4",
 		"@types/node": "^20.0.0",
 		"typescript": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   nodemon>minimatch: '>=10.2.3'
   glob>minimatch: '>=10.2.3'
   simple-git: '>=3.32.3'
-  undici: '>=7.24.0'
+  undici: 7.28.0
   ajv: '>=8.18.0'
   diff: '>=8.0.3'
   '@tootallnate/once': '>=3.0.1'
@@ -434,8 +434,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@google/gemini-cli-core':
-        specifier: 0.46.0
-        version: 0.46.0(encoding@0.1.13)(express@5.2.1)
+        specifier: 0.47.0
+        version: 0.47.0(encoding@0.1.13)(express@5.2.1)
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1034,8 +1034,8 @@ packages:
     resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
     engines: {node: '>=14'}
 
-  '@google/gemini-cli-core@0.46.0':
-    resolution: {integrity: sha512-9uPxf1Jf4xnPIAa2QJClNolalZo+W8812t9bvmtLb2mW6tlj6garH0TTpWNksLwmPfI4F8pWHiwi2lK7Pkom5Q==}
+  '@google/gemini-cli-core@0.47.0':
+    resolution: {integrity: sha512-kSzrJePBoitrIrZ3q/2JauiQ5qaNNnFKBbGGWWkkb/4DMg4Uj+FMP7cHCPTgqqHNIyPwG6g0sCY0CONhfPTYpQ==}
     engines: {node: '>=20'}
 
   '@google/genai@1.30.0':
@@ -3681,9 +3681,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
-    engines: {node: '>=22.19.0'}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -4308,7 +4308,7 @@ snapshots:
 
   '@google-cloud/promisify@4.0.0': {}
 
-  '@google/gemini-cli-core@0.46.0(encoding@0.1.13)(express@5.2.1)':
+  '@google/gemini-cli-core@0.47.0(encoding@0.1.13)(express@5.2.1)':
     dependencies:
       '@a2a-js/sdk': 0.3.11(@bufbuild/protobuf@2.12.0)(@grpc/grpc-js@1.14.4)(express@5.2.1)
       '@bufbuild/protobuf': 2.12.0
@@ -4374,7 +4374,7 @@ snapshots:
       strip-json-comments: 3.1.1
       systeminformation: 5.31.7
       tree-sitter-bash: 0.25.1
-      undici: 8.1.0
+      undici: 7.28.0
       uuid: 14.0.0
       web-tree-sitter: 0.25.10
       zod: 4.3.6
@@ -7225,7 +7225,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.1.0: {}
+  undici@7.28.0: {}
 
   unfetch@4.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   nodemon>minimatch: '>=10.2.3'
   glob>minimatch: '>=10.2.3'
   simple-git: '>=3.32.3'
-  undici: 7.28.0
+  undici: ^7.28.0
   ajv: '>=8.18.0'
   diff: '>=8.0.3'
   '@tootallnate/once': '>=3.0.1'


### PR DESCRIPTION
## Summary
- Bump `@google/gemini-cli-core` in `packages/gemini-runner` from 0.46.0 to 0.47.0.
- Tighten the existing root `pnpm.overrides.undici` entry to `7.28.0` so the Gemini core dependency resolves to a patched undici 7.x release instead of vulnerable `undici@8.1.0`.
- Add an F1 dependency-smoke validation note for CYPACK-1340.

## Security
Addresses local `pnpm audit` findings for:
- GHSA-vmh5-mc38-953g
- GHSA-pr7r-676h-xcf6
- GHSA-38rv-x7px-6hhq

No open Dependabot-authored or matching security/dependency PRs were found to close.

## Validation
- `pnpm audit`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:packages:run` (passed after build; the first run hit the known prebuild ordering issue for `cyrus-simple-agent-runner` imports)
- F1 smoke: `apps/f1/test-drives/2026-06-19-cypack-1340-security-dependency-smoke.md`

Linear: CYPACK-1340