### PR TITLE
Release v0.2.66

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,10 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+_No internal-only changes._
+
+## [0.2.66] - 2026-06-19
+
 ### Security
 - Patched open CLI security advisories and documented the F1 dependency smoke validation. Direct bumps were used where available, with root overrides retained only for vulnerable transitives whose owning packages are already at their current npm latest. ([CYPACK-1334](https://linear.app/ceedar/issue/CYPACK-1334), [#1330](https://github.com/cyrusagents/cyrus/pull/1330))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.66] - 2026-06-19
+
 ### Security
 - Patched the Cyrus CLI dependency graph so `pnpm audit` reports no known vulnerabilities, including updated Sentry, Cursor SDK, Axios, Vite/esbuild, Hono, form-data, ws, protobufjs, and OpenTelemetry resolutions. ([CYPACK-1334](https://linear.app/ceedar/issue/CYPACK-1334), [#1330](https://github.com/cyrusagents/cyrus/pull/1330))
 - Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` continues to report no known vulnerabilities. ([CYPACK-1340](https://linear.app/ceedar/issue/CYPACK-1340), [#1335](https://github.com/cyrusagents/cyrus/pull/1335))
@@ -14,6 +16,53 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Repository setup and teardown hooks are now discovered from the issue worktree instead of the persistent checkout Cyrus uses to create worktrees. If a branch adds or updates `cyrus-setup.sh`, Cyrus now runs that exact version for the task, so dependency installs, environment bootstrap, generated config, and other repo-specific preparation no longer get skipped or run from an older checkout. Teardown cleanup likewise uses the `cyrus-teardown.sh` committed with the worktree being removed. ([CYPACK-1337](https://linear.app/ceedar/issue/CYPACK-1337), [#1332](https://github.com/cyrusagents/cyrus/pull/1332))
 - Linear agent sessions now show when a repository `cyrus-setup.sh` starts, succeeds, or fails before Cyrus begins working. Failures include duration, exit status, and a short redacted stdout/stderr tail so users can diagnose setup issues without exposing local paths, environment values, or secrets. ([CYPACK-1338](https://linear.app/ceedar/issue/CYPACK-1338), [#1333](https://github.com/cyrusagents/cyrus/pull/1333))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.66
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.66
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.66
+
+#### cyrus-core
+- cyrus-core@0.2.66
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.66
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.66
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.66
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.66
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.66
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.66
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.66
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.66
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.66
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.66
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.66
 
 ## [0.2.65] - 2026-06-11
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-06-19-cypack-1342-release-v0.2.66.md
+++ b/apps/f1/test-drives/2026-06-19-cypack-1342-release-v0.2.66.md
@@ -1,0 +1,93 @@
+# Test Drive: CYPACK-1342 Release v0.2.66 Smoke
+
+**Date**: 2026-06-19
+**Goal**: Validate the local F1 issue/session/activity flow before publishing v0.2.66.
+**Test Repo**: `/tmp/f1-test-drive-cypack-1342-0.2.66`
+**F1 Port**: `3612` (`3600` was already in use)
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Session started
+- [x] Worktree created after repository-selection response
+- [x] Activities tracked
+- [x] Agent began processing the issue
+
+### Renderer
+- [x] Activity format correct
+- [x] Pagination works
+- [ ] Search works (`view-session` pagination was validated; no search command exists in the F1 CLI)
+
+## Session Log
+
+```bash
+apps/f1/f1 init-test-repo --path /tmp/f1-test-drive-cypack-1342-0.2.66
+```
+
+Result: created a fresh git repository with initial commit on `main`.
+
+```bash
+CYRUS_PORT=3600 CYRUS_REPO_PATH=/tmp/f1-test-drive-cypack-1342-0.2.66 bun run apps/f1/server.ts
+```
+
+Result: failed because port `3600` was already in use.
+
+```bash
+CYRUS_PORT=3612 CYRUS_REPO_PATH=/tmp/f1-test-drive-cypack-1342-0.2.66 bun run apps/f1/server.ts
+CYRUS_PORT=3612 apps/f1/f1 ping
+CYRUS_PORT=3612 apps/f1/f1 status
+```
+
+Result: server started on `http://localhost:3612`; ping returned healthy; status returned `ready`.
+
+```bash
+CYRUS_PORT=3612 apps/f1/f1 create-issue \
+  --title "Release smoke validation" \
+  --description "Validate that Cyrus can create an issue, start a session, and render activities for the v0.2.66 release."
+```
+
+Result: created issue `issue-1` / `DEF-1`.
+
+```bash
+CYRUS_PORT=3612 apps/f1/f1 start-session --issue-id issue-1
+```
+
+Result: started `session-1`.
+
+The first activity was repository-selection elicitation:
+
+```text
+Which repository should I work in for this issue?
+```
+
+Answered with:
+
+```bash
+CYRUS_PORT=3612 apps/f1/f1 prompt-session \
+  --session-id session-1 \
+  --message "Use the configured test repository for this issue."
+```
+
+Result: EdgeWorker selected the F1 test repository, created the worktree, assigned a Claude session id, emitted model notification, thought activities, and tool action activities.
+
+```bash
+CYRUS_PORT=3612 apps/f1/f1 view-session --session-id session-1
+CYRUS_PORT=3612 apps/f1/f1 view-session --session-id session-1 --limit 10 --offset 0
+```
+
+Result: both commands rendered session details and activities. The full view showed 10 activities at the time checked, including `elicitation`, `prompt`, `thought`, and `action` rows.
+
+```bash
+CYRUS_PORT=3612 apps/f1/f1 stop-session --session-id session-1
+```
+
+Result: session stopped successfully.
+
+## Final Retrospective
+
+F1 validated the local server, issue tracker, session start, repository-selection recovery, worktree creation, activity rendering, pagination, and session stop path. The only setup issue was a local port conflict on `3600`; rerunning on `3612` passed.

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Configuration update handlers for Cyrus agent",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Core business logic for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Simple agent runner for enumerated responses",
 	"type": "module",
 	"main": "dist/index.js",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.65",
+	"version": "0.2.66",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Release v0.2.66 to npm
- Update changelogs and package versions
- Add F1 release smoke report for CYPACK-1342
- Create git tag and GitHub release

## Validation
- pnpm build
- pnpm test:packages:run
- pnpm typecheck
- pnpm audit
- F1 smoke: issue creation, session start, repository-selection recovery, worktree creation, activity rendering, pagination, and stop-session path

## Links
- GitHub release: https://github.com/cyrusagents/cyrus/releases/tag/v0.2.66
- Linear issue: https://linear.app/ceedar/issue/CYPACK-1342/run-a-release