### PR TITLE
feat: per-issue Claude reasoning effort via `Effort:` directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- You can now control Claude's reasoning effort per issue by adding an `Effort:` line to a Linear issue or comment — `Effort: low`, `medium`, `high`, `xhigh`, `max`, or `ultra`. It applies to Claude sessions and can be changed mid-session by commenting a new `Effort:` line (the latest one wins). Cyrus posts a note in the session timeline when the effort changes; a mid-session `Effort: max` runs at `xhigh` and notes that `max` takes effect from a new session. `Effort: ultra` enables ultracode — `xhigh` effort plus dynamic workflow orchestration (the agent can fan work out across parallel sub-agents), which uses more tokens.
+
 ### Changed
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 - Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- You can now control Claude's reasoning effort per issue by adding an `Effort:` line to a Linear issue or comment — `Effort: low`, `medium`, `high`, `xhigh`, `max`, or `ultra`. It applies to Claude sessions and can be changed mid-session by commenting a new `Effort:` line (the latest one wins). Cyrus posts a note in the session timeline when the effort changes; a mid-session `Effort: max` runs at `xhigh` and notes that `max` takes effect from a new session. `Effort: ultra` enables ultracode — `xhigh` effort plus dynamic workflow orchestration (the agent can fan work out across parallel sub-agents), which uses more tokens.
+- You can now control Claude's reasoning effort per issue by adding an `Effort:` line to a Linear issue or comment — `Effort: low`, `medium`, `high`, `xhigh`, `max`, or `ultra`. It applies to Claude sessions and can be changed mid-session by commenting a new `Effort:` line (the latest one wins). Cyrus posts a note in the session timeline when the effort changes; a mid-session `Effort: max` runs at `xhigh` and notes that `max` takes effect from a new session. `Effort: ultra` enables ultracode — `xhigh` effort plus dynamic workflow orchestration (the agent can fan work out across parallel sub-agents), which uses more tokens. ([#1343](https://github.com/cyrusagents/cyrus/pull/1343))
 
 ### Changed
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -30,6 +30,11 @@ import {
 	StreamingPrompt,
 } from "cyrus-core";
 import dotenv from "dotenv";
+import {
+	type EffortDirective,
+	type LiveEffort,
+	resolveLiveEffort,
+} from "./effort.js";
 import { ClaudeMessageFormatter, type IMessageFormatter } from "./formatter.js";
 import { buildHomeDirectoryDisallowedTools } from "./home-directory-restrictions.js";
 import {
@@ -440,6 +445,40 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 	}
 
 	/**
+	 * Change the reasoning effort of the LIVE session via the SDK flag layer
+	 * (`Query.applyFlagSettings`). Used when a mid-session comment carries a new
+	 * `Effort:` directive ("latest wins").
+	 *
+	 * Because the live flag layer cannot reach `max`, a `max` directive is
+	 * clamped to `xhigh`; the returned {@link LiveEffort} reports `clampedFromMax`
+	 * so the caller can surface a note. Returns `null` when there is no active
+	 * query to apply settings to (e.g. the session already ended).
+	 */
+	setEffort(directive: EffortDirective): LiveEffort | null {
+		if (!this.activeQuery) {
+			this.logger.warn(
+				`Cannot set effort to "${directive}": no active Claude query`,
+			);
+			return null;
+		}
+		const resolved = resolveLiveEffort(directive);
+		// applyFlagSettings is async and fire-and-forget here; failures are logged
+		// but must not crash the streaming turn. Pass a fresh object literal so it
+		// satisfies the SDK Settings index-signature requirement.
+		this.activeQuery
+			.applyFlagSettings({
+				effortLevel: resolved.flagSettings.effortLevel,
+				ultracode: resolved.flagSettings.ultracode,
+				enableWorkflows: resolved.flagSettings.enableWorkflows,
+			})
+			.catch((err: unknown) => {
+				this.logger.error("Failed to apply effort flag settings:", err);
+			});
+		this.logger.info(`Reasoning effort updated mid-session: ${resolved.label}`);
+		return resolved;
+	}
+
+	/**
 	 * Complete the streaming prompt (no more messages will be added)
 	 */
 	completeStream(): void {
@@ -707,11 +746,23 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					...(this.config.sessionStore && {
 						sessionStore: this.config.sessionStore,
 					}),
-					...(this.config.autoMemoryDirectory && {
+					...((this.config.autoMemoryDirectory || this.config.ultracode) && {
 						settings: {
-							autoMemoryDirectory: this.config.autoMemoryDirectory,
+							...(this.config.autoMemoryDirectory && {
+								autoMemoryDirectory: this.config.autoMemoryDirectory,
+							}),
+							// ultracode (xhigh effort + dynamic-workflow orchestration)
+							// only engages when workflows are also enabled for the
+							// session — the SDK gates the Workflow tool behind
+							// `enableWorkflows`. Setting ultracode alone would apply
+							// xhigh effort but never spawn workflows, so enable both.
+							...(this.config.ultracode && {
+								ultracode: true,
+								enableWorkflows: true,
+							}),
 						},
 					}),
+					...(this.config.effort && { effort: this.config.effort }),
 					...(Object.keys(mcpServers).length > 0 && { mcpServers }),
 					// Only use MCP servers we explicitly pass via `mcpConfig` /
 					// `mcpServers`. The flag is undertyped in the SDK's TS

--- a/packages/claude-runner/src/effort.ts
+++ b/packages/claude-runner/src/effort.ts
@@ -1,0 +1,114 @@
+import type { EffortLevel } from "@anthropic-ai/claude-agent-sdk";
+import type { EffortApplicationResult, EffortDirective } from "cyrus-core";
+
+export type { EffortDirective } from "cyrus-core";
+
+/** All recognized directive tokens, in ascending order. */
+export const EFFORT_DIRECTIVE_VALUES: readonly EffortDirective[] = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+] as const;
+
+/**
+ * The SDK flag-layer effort levels accepted by `Query.applyFlagSettings`.
+ * Note this set deliberately omits `max`: the live flag layer cannot reach
+ * `max` — only session-start `Options.effort` can.
+ */
+export type FlagEffortLevel = "low" | "medium" | "high" | "xhigh";
+
+/**
+ * Resolved effort to apply when a session is STARTING, via the `query()`
+ * `Options.effort` (full range, including `max`) plus the `ultracode` settings
+ * flag for `ultra`.
+ */
+export interface StartEffort {
+	/** Top-level `Options.effort` value (supports the full range incl. `max`). */
+	effort: EffortLevel;
+	/** When true, enable ultracode (xhigh + workflow orchestration) at start. */
+	ultracode?: boolean;
+}
+
+/**
+ * Map a directive to the values used at session start.
+ *
+ * - `low`..`max` → that effort level.
+ * - `ultra` → `xhigh` effort + ultracode enabled.
+ */
+export function resolveStartEffort(directive: EffortDirective): StartEffort {
+	if (directive === "ultra") {
+		return { effort: "xhigh", ultracode: true };
+	}
+	return { effort: directive };
+}
+
+/**
+ * Flag-layer settings to merge into a LIVE session via
+ * `Query.applyFlagSettings`. Every field is set explicitly so the flag layer
+ * fully reflects the latest directive ("latest wins" semantics).
+ */
+export interface LiveEffortFlagSettings {
+	effortLevel: FlagEffortLevel;
+	ultracode: boolean;
+	/**
+	 * Whether the Workflow tool is enabled. Set true only for `ultra` — ultracode
+	 * cannot orchestrate workflows unless workflows are also enabled (the SDK
+	 * gates the Workflow tool behind this). Set explicitly so switching away from
+	 * `ultra` turns it back off ("latest wins").
+	 */
+	enableWorkflows: boolean;
+}
+
+/**
+ * Resolved effort to apply MID-SESSION. Because the live flag layer cannot set
+ * `max`, a mid-session `max` directive is clamped to `xhigh` and `clampedFromMax`
+ * is set so the caller can surface a note explaining `max` needs a fresh session.
+ */
+export interface LiveEffort extends EffortApplicationResult {
+	/** Settings to pass to `Query.applyFlagSettings`. */
+	flagSettings: LiveEffortFlagSettings;
+}
+
+/**
+ * Map a directive to the live (mid-session) flag-layer application.
+ *
+ * - `low`..`xhigh` → that level, ultracode cleared.
+ * - `max` → clamped to `xhigh` (ultracode cleared), `clampedFromMax = true`.
+ * - `ultra` → `xhigh` + ultracode enabled.
+ */
+export function resolveLiveEffort(directive: EffortDirective): LiveEffort {
+	if (directive === "ultra") {
+		return {
+			flagSettings: {
+				effortLevel: "xhigh",
+				ultracode: true,
+				enableWorkflows: true,
+			},
+			clampedFromMax: false,
+			label: "ultracode (xhigh + workflows)",
+		};
+	}
+	if (directive === "max") {
+		return {
+			flagSettings: {
+				effortLevel: "xhigh",
+				ultracode: false,
+				enableWorkflows: false,
+			},
+			clampedFromMax: true,
+			label: "xhigh (clamped from max — max takes effect from a new session)",
+		};
+	}
+	return {
+		flagSettings: {
+			effortLevel: directive,
+			ultracode: false,
+			enableWorkflows: false,
+		},
+		clampedFromMax: false,
+		label: directive,
+	};
+}

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -21,6 +21,16 @@ export {
 	writeTools,
 } from "./config.js";
 export {
+	EFFORT_DIRECTIVE_VALUES,
+	type EffortDirective,
+	type FlagEffortLevel,
+	type LiveEffort,
+	type LiveEffortFlagSettings,
+	resolveLiveEffort,
+	resolveStartEffort,
+	type StartEffort,
+} from "./effort.js";
+export {
 	ClaudeMessageFormatter,
 	type IMessageFormatter,
 } from "./formatter.js";

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+	EffortLevel,
 	HookCallbackMatcher,
 	HookEvent,
 	JsonSchemaOutputFormat,
@@ -44,6 +45,18 @@ export interface ClaudeRunnerConfig {
 	mcpConfig?: Record<string, McpServerConfig>; // Additional/override MCP servers
 	model?: string; // Claude model to use (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
+	/**
+	 * Reasoning effort to apply at session start, forwarded to the SDK's
+	 * `query()` `Options.effort`. Supports the full range including "max".
+	 * When unset, the model's own default effort applies.
+	 */
+	effort?: EffortLevel;
+	/**
+	 * Enable ultracode at session start (xhigh effort + standing
+	 * dynamic-workflow orchestration). Set alongside `effort: "xhigh"` when the
+	 * user requests the "ultra" directive.
+	 */
+	ultracode?: boolean;
 	maxTurns?: number; // Maximum number of turns before completing the session
 	tools?: string[]; // Built-in tools available in model context (empty array disables all tools)
 	cyrusHome: string; // Cyrus home directory

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -142,6 +142,37 @@ describe("ClaudeRunner", () => {
 			});
 		});
 
+		it("applies effort and enables workflows alongside ultracode", async () => {
+			const ultraRunner = new ClaudeRunner({
+				...defaultConfig,
+				effort: "xhigh",
+				ultracode: true,
+			});
+
+			mockQuery.mockImplementation(async function* () {
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "hi" }] },
+					parent_tool_use_id: null,
+					session_id: "s",
+				} as any;
+			});
+
+			await ultraRunner.start("go");
+
+			expect(mockQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						effort: "xhigh",
+						settings: expect.objectContaining({
+							ultracode: true,
+							enableWorkflows: true,
+						}),
+					}),
+				}),
+			);
+		});
+
 		it("should handle workspace configuration properly", async () => {
 			const runnerWithWorkspace = new ClaudeRunner({
 				...defaultConfig,
@@ -386,6 +417,64 @@ describe("ClaudeRunner", () => {
 
 			expect(interruptSpy).toHaveBeenCalledTimes(1);
 			expect(warm.isRunning()).toBe(true);
+		});
+	});
+
+	describe("setEffort()", () => {
+		it("returns null and does not throw when there is no active query", () => {
+			expect(runner.setEffort("high")).toBeNull();
+		});
+
+		it("applies a plain effort level via applyFlagSettings", () => {
+			const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+			(runner as any).activeQuery = { applyFlagSettings };
+
+			const result = runner.setEffort("xhigh");
+
+			expect(applyFlagSettings).toHaveBeenCalledWith({
+				effortLevel: "xhigh",
+				ultracode: false,
+				enableWorkflows: false,
+			});
+			expect(result).toEqual({
+				flagSettings: {
+					effortLevel: "xhigh",
+					ultracode: false,
+					enableWorkflows: false,
+				},
+				clampedFromMax: false,
+				label: "xhigh",
+			});
+		});
+
+		it("clamps max to xhigh mid-session and flags it", () => {
+			const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+			(runner as any).activeQuery = { applyFlagSettings };
+
+			const result = runner.setEffort("max");
+
+			expect(applyFlagSettings).toHaveBeenCalledWith({
+				effortLevel: "xhigh",
+				ultracode: false,
+				enableWorkflows: false,
+			});
+			expect(result?.clampedFromMax).toBe(true);
+			expect(result?.label).toContain("clamped from max");
+		});
+
+		it("enables ultracode for the ultra directive", () => {
+			const applyFlagSettings = vi.fn().mockResolvedValue(undefined);
+			(runner as any).activeQuery = { applyFlagSettings };
+
+			const result = runner.setEffort("ultra");
+
+			expect(applyFlagSettings).toHaveBeenCalledWith({
+				effortLevel: "xhigh",
+				ultracode: true,
+				enableWorkflows: true,
+			});
+			expect(result?.clampedFromMax).toBe(false);
+			expect(result?.label).toContain("ultracode");
 		});
 	});
 

--- a/packages/claude-runner/test/effort.test.ts
+++ b/packages/claude-runner/test/effort.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+	EFFORT_DIRECTIVE_VALUES,
+	resolveLiveEffort,
+	resolveStartEffort,
+} from "../src/effort.js";
+
+describe("resolveStartEffort", () => {
+	it("maps plain levels 1:1 with no ultracode", () => {
+		for (const level of ["low", "medium", "high", "xhigh", "max"] as const) {
+			expect(resolveStartEffort(level)).toEqual({ effort: level });
+		}
+	});
+
+	it("maps ultra to xhigh + ultracode", () => {
+		expect(resolveStartEffort("ultra")).toEqual({
+			effort: "xhigh",
+			ultracode: true,
+		});
+	});
+});
+
+describe("resolveLiveEffort", () => {
+	it("maps plain flag levels and clears ultracode + workflows", () => {
+		for (const level of ["low", "medium", "high", "xhigh"] as const) {
+			expect(resolveLiveEffort(level)).toEqual({
+				flagSettings: {
+					effortLevel: level,
+					ultracode: false,
+					enableWorkflows: false,
+				},
+				clampedFromMax: false,
+				label: level,
+			});
+		}
+	});
+
+	it("clamps max to xhigh and flags it", () => {
+		const result = resolveLiveEffort("max");
+		expect(result.flagSettings).toEqual({
+			effortLevel: "xhigh",
+			ultracode: false,
+			enableWorkflows: false,
+		});
+		expect(result.clampedFromMax).toBe(true);
+		expect(result.label).toContain("clamped from max");
+	});
+
+	it("maps ultra to xhigh + ultracode + workflows enabled", () => {
+		const result = resolveLiveEffort("ultra");
+		expect(result.flagSettings).toEqual({
+			effortLevel: "xhigh",
+			ultracode: true,
+			enableWorkflows: true,
+		});
+		expect(result.clampedFromMax).toBe(false);
+		expect(result.label).toContain("ultracode");
+	});
+});
+
+describe("EFFORT_DIRECTIVE_VALUES", () => {
+	it("lists every recognized directive token", () => {
+		expect([...EFFORT_DIRECTIVE_VALUES]).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		]);
+	});
+});

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -1,5 +1,6 @@
 import type {
 	BackgroundTaskSummary,
+	EffortLevel,
 	HookCallbackMatcher,
 	HookEvent,
 	McpServerConfig,
@@ -220,6 +221,33 @@ export interface IMessageFormatter {
  * @see {@link AgentRunnerConfig} for configuration options
  * @see {@link AgentSessionInfo} for session information structure
  */
+
+/**
+ * Reasoning-effort directive tokens a user can write via a natural
+ * `Effort: <level>` line in a Linear issue or comment.
+ *
+ * `low`/`medium`/`high`/`xhigh`/`max` map to the Claude SDK's effort levels;
+ * `ultra` is shorthand for ultracode (xhigh effort + workflow orchestration).
+ */
+export type EffortDirective =
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max"
+	| "ultra";
+
+/**
+ * Outcome of applying an effort directive to a live session, returned by
+ * {@link IAgentRunner.setEffort}.
+ */
+export interface EffortApplicationResult {
+	/** True when a `max` directive was clamped to `xhigh` (live flag limitation). */
+	clampedFromMax: boolean;
+	/** Human-facing description of the effort actually applied. */
+	label: string;
+}
+
 export interface IAgentRunner {
 	/**
 	 * Indicates whether this runner supports streaming input
@@ -323,6 +351,17 @@ export interface IAgentRunner {
 	 * Only available when `supportsStreamingInput` is true.
 	 */
 	isStreaming?(): boolean;
+
+	/**
+	 * Change the reasoning effort of a LIVE session ("latest wins").
+	 *
+	 * Only meaningful for runners whose underlying SDK exposes a reasoning-effort
+	 * control (Claude). Other runners leave this undefined and the caller treats
+	 * the directive as a no-op. Returns the applied result (so callers can surface
+	 * a note, e.g. when `max` is clamped mid-session), or `null` when there is no
+	 * active session to apply it to.
+	 */
+	setEffort?(directive: EffortDirective): EffortApplicationResult | null;
 
 	/**
 	 * Stop the current agent session
@@ -473,6 +512,16 @@ export interface AgentRunnerConfig {
 	model?: string;
 	/** Fallback model if primary is unavailable */
 	fallbackModel?: string;
+	/**
+	 * Reasoning effort applied at session start (Claude runner only). Maps to
+	 * the SDK `query()` `Options.effort`. Other runners ignore it.
+	 */
+	effort?: EffortLevel;
+	/**
+	 * Enable ultracode at session start (Claude runner only): xhigh effort plus
+	 * standing dynamic-workflow orchestration. Set alongside `effort: "xhigh"`.
+	 */
+	ultracode?: boolean;
 	/** Maximum number of turns before completing session */
 	maxTurns?: number;
 	/** Built-in tools available in model context (empty array disables all tools) */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export type {
 	AskUserQuestionOption,
 	AskUserQuestionResult,
 	BackgroundTaskSummary,
+	EffortApplicationResult,
+	EffortDirective,
 	HookCallbackMatcher,
 	HookEvent,
 	IAgentRunner,

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -148,6 +148,7 @@ import { LiveChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import { ChatSessionHandler } from "./ChatSessionHandler.js";
 import { ConfigManager, type RepositoryChanges } from "./ConfigManager.js";
 import { DefaultSkillsDeployer } from "./DefaultSkillsDeployer.js";
+import { parseEffortDirective } from "./EffortDirective.js";
 import { EgressProxy } from "./EgressProxy.js";
 import { GitService } from "./GitService.js";
 import { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
@@ -7064,6 +7065,16 @@ ${input.userComment}
 				fullPrompt = `${promptBody}\n\n${attachmentManifest}`;
 			}
 
+			// Apply a mid-session reasoning-effort change if the comment carries
+			// an `Effort:` directive (before the message so the next turn uses it).
+			this.applyLiveEffortDirective(
+				existingRunner,
+				promptBody,
+				sessionId,
+				linearWorkspaceId,
+				log,
+			);
+
 			// `addStreamMessage` can reject the message if the turn ended in the
 			// race window between "still running" and "turn finished" (e.g. the
 			// Codex app-server backend, which only steers an active turn). Fall
@@ -7099,6 +7110,50 @@ ${input.userComment}
 		);
 
 		return false; // Session was resumed
+	}
+
+	/**
+	 * Apply a mid-session reasoning-effort change when a user comment carries an
+	 * `Effort: <level>` directive ("latest wins"). Claude runner only — a no-op
+	 * for runners without effort control or when there is no active session.
+	 * Posts a Linear thought activity noting the applied effort (and any
+	 * max→xhigh clamp).
+	 */
+	private applyLiveEffortDirective(
+		runner: IAgentRunner | undefined,
+		commentText: string,
+		sessionId: string,
+		linearWorkspaceId: string | undefined,
+		log: ILogger,
+	): void {
+		const directive = parseEffortDirective(commentText);
+		if (!directive) {
+			return;
+		}
+		if (!runner?.setEffort) {
+			log.debug(
+				`Ignoring "Effort: ${directive}" — runner has no effort control`,
+			);
+			return;
+		}
+		const result = runner.setEffort(directive);
+		if (!result) {
+			return;
+		}
+		log.debug(`Applied mid-session effort "${directive}": ${result.label}`);
+		if (linearWorkspaceId) {
+			this.activityPoster
+				.postThoughtActivity(
+					sessionId,
+					linearWorkspaceId,
+					`Reasoning effort set to **${result.label}**.`,
+				)
+				.catch((err: unknown) => {
+					log.warn("Failed to post effort change activity", {
+						error: err instanceof Error ? err.message : String(err),
+					});
+				});
+		}
 	}
 
 	/**
@@ -7157,6 +7212,16 @@ ${input.userComment}
 			if (attachmentManifest) {
 				fullPrompt = `${promptBody}\n\n${attachmentManifest}`;
 			}
+			// Apply a mid-session reasoning-effort change if the comment carries
+			// an `Effort:` directive (before the message so the next turn uses it).
+			this.applyLiveEffortDirective(
+				existingRunner,
+				promptBody,
+				sessionId,
+				linearWorkspaceId,
+				log,
+			);
+
 			// See handlePromptWithStreamingCheck: a steer-only backend can reject
 			// the message if the turn just ended. Fall through to a fresh resume
 			// turn rather than dropping the comment. No-op for Claude.

--- a/packages/edge-worker/src/EffortDirective.ts
+++ b/packages/edge-worker/src/EffortDirective.ts
@@ -1,0 +1,42 @@
+import type { EffortDirective } from "cyrus-claude-runner";
+
+/**
+ * Matches a natural `Effort: <level>` directive on its own line.
+ *
+ * - Anchored to a whole line (multiline + ignore-case) so prose like
+ *   "the effort was high" never matches.
+ * - Leading/trailing spaces and tabs around the keyword, colon, and value are
+ *   tolerated.
+ * - Only the recognized tokens match; anything else (e.g. `Effort: turbo`)
+ *   yields no match.
+ */
+const EFFORT_DIRECTIVE_REGEX =
+	/^[ \t]*effort[ \t]*:[ \t]*(low|medium|high|xhigh|max|ultra)[ \t]*$/gim;
+
+/**
+ * Parse a Claude reasoning-effort directive out of free text (a Linear issue
+ * description or comment).
+ *
+ * Returns the recognized {@link EffortDirective} token, or `null` when no
+ * directive is present. When multiple `Effort:` lines appear, the LAST one
+ * wins ("latest wins" semantics, consistent across description and comments).
+ */
+export function parseEffortDirective(
+	text: string | null | undefined,
+): EffortDirective | null {
+	if (!text) {
+		return null;
+	}
+	// Reset lastIndex defensively — the regex is global and module-scoped.
+	EFFORT_DIRECTIVE_REGEX.lastIndex = 0;
+	let last: EffortDirective | null = null;
+	let match: RegExpExecArray | null = EFFORT_DIRECTIVE_REGEX.exec(text);
+	while (match !== null) {
+		const value = match[1];
+		if (value) {
+			last = value.toLowerCase() as EffortDirective;
+		}
+		match = EFFORT_DIRECTIVE_REGEX.exec(text);
+	}
+	return last;
+}

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -1,14 +1,15 @@
 import { execSync } from "node:child_process";
 import { join } from "node:path";
-import type {
-	HookCallbackMatcher,
-	HookEvent,
-	McpServerConfig,
-	PostToolUseHookInput,
-	SandboxSettings,
-	SDKMessage,
-	SdkPluginConfig,
-	StopHookInput,
+import {
+	type HookCallbackMatcher,
+	type HookEvent,
+	type McpServerConfig,
+	type PostToolUseHookInput,
+	resolveStartEffort,
+	type SandboxSettings,
+	type SDKMessage,
+	type SdkPluginConfig,
+	type StopHookInput,
 } from "cyrus-claude-runner";
 import type {
 	AgentRunnerConfig,
@@ -18,6 +19,7 @@ import type {
 	RepositoryConfig,
 	RunnerType,
 } from "cyrus-core";
+import { parseEffortDirective } from "./EffortDirective.js";
 import { buildIntentToAddHook } from "./hooks/IntentToAddHook.js";
 import { buildPrMarkerHook } from "./hooks/PrMarkerHook.js";
 import { appendBrowserUseAddendum } from "./prompts/browserUsePromptAddendum.js";
@@ -358,6 +360,24 @@ export class RunnerConfigBuilder {
 			log.debug(`Model override via selector: ${modelOverride}`);
 		}
 
+		// Resolve a session-start reasoning effort from an `Effort: <level>`
+		// directive in the issue description. Claude runner only — the SDK
+		// `effort`/`ultracode` controls are Claude-specific.
+		const effortDirective =
+			runnerType === "claude"
+				? parseEffortDirective(input.issueDescription)
+				: null;
+		const startEffort = effortDirective
+			? resolveStartEffort(effortDirective)
+			: null;
+		if (startEffort) {
+			log.debug(
+				`Reasoning effort via directive: ${effortDirective} -> effort=${startEffort.effort}${
+					startEffort.ultracode ? " + ultracode" : ""
+				}`,
+			);
+		}
+
 		// Determine final model from selectors, repository override, then runner-specific defaults
 		const finalModel =
 			modelOverride ||
@@ -443,6 +463,11 @@ export class RunnerConfigBuilder {
 						resolvedWorkspaceId,
 					),
 				}),
+			// Session-start reasoning effort (Claude runner only).
+			...(startEffort && {
+				effort: startEffort.effort,
+				...(startEffort.ultracode && { ultracode: true }),
+			}),
 			onMessage: input.onMessage,
 			onError: input.onError,
 		};

--- a/packages/edge-worker/test/EffortDirective.test.ts
+++ b/packages/edge-worker/test/EffortDirective.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseEffortDirective } from "../src/EffortDirective.js";
+
+describe("parseEffortDirective", () => {
+	it("returns null for empty/missing input", () => {
+		expect(parseEffortDirective(undefined)).toBeNull();
+		expect(parseEffortDirective(null)).toBeNull();
+		expect(parseEffortDirective("")).toBeNull();
+	});
+
+	it("parses each recognized level on its own line", () => {
+		for (const level of [
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		] as const) {
+			expect(parseEffortDirective(`Effort: ${level}`)).toBe(level);
+		}
+	});
+
+	it("is case-insensitive for keyword and value", () => {
+		expect(parseEffortDirective("EFFORT: HIGH")).toBe("high");
+		expect(parseEffortDirective("effort: Max")).toBe("max");
+	});
+
+	it("tolerates surrounding whitespace and tabs", () => {
+		expect(parseEffortDirective("  effort  :  xhigh  ")).toBe("xhigh");
+		expect(parseEffortDirective("\teffort:\tultra\t")).toBe("ultra");
+	});
+
+	it("finds the directive among other lines in a description", () => {
+		const text = [
+			"Please refactor the auth module.",
+			"Effort: high",
+			"Make sure tests pass.",
+		].join("\n");
+		expect(parseEffortDirective(text)).toBe("high");
+	});
+
+	it("returns the LAST directive when multiple are present (latest wins)", () => {
+		const text = ["Effort: low", "actually,", "Effort: max"].join("\n");
+		expect(parseEffortDirective(text)).toBe("max");
+	});
+
+	it("does not match effort mentioned in prose", () => {
+		expect(parseEffortDirective("The effort was high on this one.")).toBeNull();
+		expect(
+			parseEffortDirective("This needs maximum effort: please."),
+		).toBeNull();
+	});
+
+	it("does not match unknown levels", () => {
+		expect(parseEffortDirective("Effort: turbo")).toBeNull();
+		expect(parseEffortDirective("Effort: extreme")).toBeNull();
+	});
+
+	it("does not match without the colon", () => {
+		expect(parseEffortDirective("Effort high")).toBeNull();
+	});
+});

--- a/packages/edge-worker/test/RunnerConfigBuilder.effort.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.effort.test.ts
@@ -1,0 +1,110 @@
+import type {
+	CyrusAgentSession,
+	ILogger,
+	RepositoryConfig,
+	RunnerType,
+} from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(runnerType: RunnerType): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType }),
+		getDefaultModelForRunner: () => "opus",
+		getDefaultFallbackModelForRunner: () => "sonnet",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(): RepositoryConfig {
+	return {
+		id: "repo-a",
+		name: "Repo A",
+		repositoryPath: "/repos/repo-a",
+		allowedTools: [],
+	} as unknown as RepositoryConfig;
+}
+
+function makeSession(): CyrusAgentSession {
+	return {
+		issueId: "issue-1",
+		issue: { identifier: "ABC-1" },
+		workspace: { path: "/ws/repo-a-worktree", isGitWorktree: true },
+	} as unknown as CyrusAgentSession;
+}
+
+function buildIssueConfig(runnerType: RunnerType, issueDescription?: string) {
+	return makeBuilder(runnerType).buildIssueConfig({
+		session: makeSession(),
+		repository: makeRepository(),
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		issueDescription,
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	});
+}
+
+describe("RunnerConfigBuilder session-start effort directive", () => {
+	it("sets effort from an `Effort:` directive for the Claude runner", () => {
+		const { config } = buildIssueConfig(
+			"claude",
+			"Fix the auth bug.\nEffort: high",
+		);
+		expect(config.effort).toBe("high");
+		expect(config.ultracode).toBeUndefined();
+	});
+
+	it("passes max through at session start (full range)", () => {
+		const { config } = buildIssueConfig("claude", "Effort: max");
+		expect(config.effort).toBe("max");
+	});
+
+	it("maps the ultra directive to xhigh + ultracode", () => {
+		const { config } = buildIssueConfig("claude", "Effort: ultra");
+		expect(config.effort).toBe("xhigh");
+		expect(config.ultracode).toBe(true);
+	});
+
+	it("leaves effort unset when no directive is present", () => {
+		const { config } = buildIssueConfig("claude", "Just fix the bug.");
+		expect(config.effort).toBeUndefined();
+		expect(config.ultracode).toBeUndefined();
+	});
+
+	it("ignores the directive for non-Claude runners", () => {
+		const { config } = buildIssueConfig("codex", "Effort: max");
+		expect(config.effort).toBeUndefined();
+		expect(config.ultracode).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Adds a per-issue **reasoning effort** control for Claude sessions. Users put an `Effort:` line in a Linear issue description or comment to set how much reasoning effort Claude applies:

```
Fix the flaky auth test.

Effort: high
```

Supported levels: `low`, `medium`, `high`, `xhigh`, `max`, and `ultra` (ultracode). Claude runner only — Codex/Gemini/Cursor ignore the directive.

## How it works

- **Parsing** — `parseEffortDirective()` matches a whole-line, case-insensitive `Effort: <level>` (anchored so prose like "the effort was high" never matches). When several lines are present, the last one wins.
- **Session start** — resolved effort is forwarded to the SDK `query()` `Options.effort` (full range incl. `max`). `ultra` maps to `xhigh` + `ultracode: true` + `enableWorkflows: true` (ultracode can't orchestrate workflows unless workflows are also enabled).
- **Mid-session ("latest wins")** — a new `Effort:` comment re-applies live via `Query.applyFlagSettings`. Because the live flag layer can't reach `max`, a mid-session `Effort: max` clamps to `xhigh` and Cyrus posts a timeline note explaining `max` takes effect from a new session.
- **Visibility** — effort changes are surfaced in the Linear session timeline.

| Directive | Session start | Mid-session |
|---|---|---|
| low/medium/high/xhigh | that level | `applyFlagSettings({ effortLevel })` |
| max | `effort: "max"` | clamps to `xhigh` + timeline note |
| ultra | `xhigh` + `ultracode` + `enableWorkflows` | `applyFlagSettings({ effortLevel: "xhigh", ultracode: true, enableWorkflows: true })` |

## Implementation

- `packages/core` — `EffortDirective` / `EffortApplicationResult` types + optional `IAgentRunner.setEffort()`; `effort`/`ultracode` on `AgentRunnerConfig`.
- `packages/claude-runner` — `effort.ts` (start/live resolvers), `ClaudeRunnerConfig.effort`/`ultracode`, query-option wiring, and `ClaudeRunner.setEffort()`.
- `packages/edge-worker` — `EffortDirective.ts` parser, `RunnerConfigBuilder` start-effort wiring (Claude only), and `EdgeWorker` mid-session application at the comment stream sites.

## Testing

- Unit tests: parser (case/whitespace/prose-negatives/latest-wins/unknown tokens), start + live resolvers, `RunnerConfigBuilder` wiring (incl. non-Claude no-op), and `ClaudeRunner.setEffort`.
- `pnpm test:packages:run`, `pnpm typecheck`, `pnpm lint` all pass.
- Verified end-to-end on a live Linear workspace: `Effort: max` → `effort: "max"` and `Effort: ultra` → `effort: "xhigh"` + `settings: { ultracode: true, enableWorkflows: true }` confirmed in the Claude query options.

## Notes

- No global/per-repo default — when no `Effort:` line is present, the model's own default effort applies (no behavior change for existing issues).
- `enableWorkflows` makes the Workflow tool *available* under `ultra`; whether the model orchestrates with it remains its own per-task judgment.
