### PR TITLE
chore(deps): update @anthropic-ai/claude-agent-sdk to 0.3.187 (CYPACK-1350)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,7 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
-_No internal-only changes._
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187` across `cyrus-core`, `cyrus-claude-runner`, `cyrus-edge-worker`, and `cyrus-simple-agent-runner`. SDK 0.3.186 added `agent_id` to `can_use_tool` requests and a `rewind_conversation` control; 0.3.187 added `sandbox.credentials` to SDK settings types. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#PR](https://github.com/ceedaragents/cyrus/pull/PRNUM))
+- Removed `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` from `availableTools`, `readOnlyTools`, and the per-platform default allowed-tool lists — these three tools are no longer emitted in the Claude Code init block as of SDK 0.3.187. The `AskUserQuestionHandler` and `onAskUserQuestion` callback remain compiled (the types are still in the SDK) but will no longer be triggered. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#PR](https://github.com/ceedaragents/cyrus/pull/PRNUM))
 
 ## [0.2.66] - 2026-06-19
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,8 +5,8 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Changed
-- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187` across `cyrus-core`, `cyrus-claude-runner`, `cyrus-edge-worker`, and `cyrus-simple-agent-runner`. SDK 0.3.186 added `agent_id` to `can_use_tool` requests and a `rewind_conversation` control; 0.3.187 added `sandbox.credentials` to SDK settings types. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#PR](https://github.com/ceedaragents/cyrus/pull/PRNUM))
-- Removed `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` from `availableTools`, `readOnlyTools`, and the per-platform default allowed-tool lists — these three tools are no longer emitted in the Claude Code init block as of SDK 0.3.187. The `AskUserQuestionHandler` and `onAskUserQuestion` callback remain compiled (the types are still in the SDK) but will no longer be triggered. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#PR](https://github.com/ceedaragents/cyrus/pull/PRNUM))
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187` across `cyrus-core`, `cyrus-claude-runner`, `cyrus-edge-worker`, and `cyrus-simple-agent-runner`. SDK 0.3.186 added `agent_id` to `can_use_tool` requests and a `rewind_conversation` control; 0.3.187 added `sandbox.credentials` to SDK settings types. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#1345](https://github.com/ceedaragents/cyrus/pull/1345))
+- Removed `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` from `availableTools`, `readOnlyTools`, and the per-platform default allowed-tool lists — these three tools are no longer emitted in the Claude Code init block as of SDK 0.3.187. The `AskUserQuestionHandler` and `onAskUserQuestion` callback remain compiled (the types are still in the SDK) but will no longer be triggered. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#1345](https://github.com/ceedaragents/cyrus/pull/1345))
 
 ## [0.2.66] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187`, bringing in the latest Claude Code capabilities including sandbox credential configuration and improved permission control. The Claude Code tool list now has 29 tools; `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` were removed from the available tool set in this SDK version. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350))
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187`, bringing in the latest Claude Code capabilities including sandbox credential configuration and improved permission control. The Claude Code tool list now has 29 tools; `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` were removed from the available tool set in this SDK version. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350), [#1345](https://github.com/ceedaragents/cyrus/pull/1345))
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 - Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187`, bringing in the latest Claude Code capabilities including sandbox credential configuration and improved permission control. The Claude Code tool list now has 29 tools; `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` were removed from the available tool set in this SDK version. ([CYPACK-1350](https://linear.app/ceedar/issue/CYPACK-1350))
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 - Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.185",
+		"@anthropic-ai/claude-agent-sdk": "0.3.187",
 		"@anthropic-ai/sdk": "^0.105.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -42,13 +42,10 @@ export const availableTools = [
 	"Skill",
 
 	// User interaction tools
-	"AskUserQuestion",
 	"SendMessage",
 	"PushNotification",
 
-	// Plan and worktree management
-	"EnterPlanMode",
-	"ExitPlanMode",
+	// Worktree management
 	"EnterWorktree",
 	"ExitWorktree",
 
@@ -95,8 +92,6 @@ export const readOnlyTools: ToolName[] = [
 	"Monitor",
 	"LSP",
 	"TaskOutput",
-	"EnterPlanMode",
-	"ExitPlanMode",
 	"ToolSearch",
 ];
 

--- a/packages/claude-runner/test/config.test.ts
+++ b/packages/claude-runner/test/config.test.ts
@@ -27,11 +27,8 @@ describe("config", () => {
 				"TaskList",
 				"NotebookEdit",
 				"Skill",
-				"AskUserQuestion",
 				"SendMessage",
 				"PushNotification",
-				"EnterPlanMode",
-				"ExitPlanMode",
 				"EnterWorktree",
 				"ExitWorktree",
 				"CronCreate",
@@ -47,7 +44,7 @@ describe("config", () => {
 				"DesignSync",
 				"Workflow",
 			]);
-			expect(availableTools).toHaveLength(32);
+			expect(availableTools).toHaveLength(29);
 		});
 
 		it("should define read-only tools", () => {
@@ -64,11 +61,9 @@ describe("config", () => {
 				"Monitor",
 				"LSP",
 				"TaskOutput",
-				"EnterPlanMode",
-				"ExitPlanMode",
 				"ToolSearch",
 			]);
-			expect(readOnlyTools).toHaveLength(15);
+			expect(readOnlyTools).toHaveLength(13);
 		});
 
 		it("should define write tools", () => {
@@ -135,7 +130,6 @@ describe("config", () => {
 			expect(tools).toContain("TaskCreate");
 			expect(tools).toContain("NotebookEdit");
 			expect(tools).toContain("Skill");
-			expect(tools).toContain("AskUserQuestion");
 			expect(tools).not.toContain("Bash");
 
 			// Should have all tools minus Bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.185",
+		"@anthropic-ai/claude-agent-sdk": "0.3.187",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/core/src/allowed-tools-defaults.ts
+++ b/packages/core/src/allowed-tools-defaults.ts
@@ -43,14 +43,11 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	"WebFetch",
 	"WebSearch",
 
-	// Planning + worktree management
-	"EnterPlanMode",
-	"ExitPlanMode",
+	// Worktree management
 	"EnterWorktree",
 	"ExitWorktree",
 
 	// User interaction
-	"AskUserQuestion",
 	"SendMessage",
 	"PushNotification",
 
@@ -122,8 +119,6 @@ export const SLACK_DEFAULT_ALLOWED_TOOLS = [
 	"TaskList",
 	"TaskOutput",
 	"TaskStop",
-	"EnterPlanMode",
-	"ExitPlanMode",
 
 	// Discovery
 	"Monitor",
@@ -164,14 +159,11 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	"WebFetch",
 	"WebSearch",
 
-	// Planning + worktree management
-	"EnterPlanMode",
-	"ExitPlanMode",
+	// Worktree management
 	"EnterWorktree",
 	"ExitWorktree",
 
 	// User interaction
-	"AskUserQuestion",
 	"SendMessage",
 	"PushNotification",
 

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.185",
+		"@anthropic-ai/claude-agent-sdk": "0.3.187",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.185",
+		"@anthropic-ai/claude-agent-sdk": "0.3.187",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.185
-        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: '>=0.105.0'
         version: 0.105.0(zod@4.3.6)
@@ -268,8 +268,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.185
-        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -318,8 +318,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.185
-        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -543,8 +543,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.185
-        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -598,52 +598,52 @@ packages:
       express:
         optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185':
-    resolution: {integrity: sha512-P2Svxx1IFrS9aw4ylJBtcoJrc/OAOVnDs+o05x4TV7HoHUQUcKZ9XhWOGnadyVT0KLyoktgjyjnaK7Zdtc0Ldg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.187':
+    resolution: {integrity: sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185':
-    resolution: {integrity: sha512-H69m2hIJawzSkCDNO/CPLQCYvDGdlbZdzGTgGF8/IQuB4O81sv8WSAh6TBXwtFXOgEi4HtrUYlxiFDmTHt7hMA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.187':
+    resolution: {integrity: sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185':
-    resolution: {integrity: sha512-1GRpKYrg5foomW+qLrxm/k2R/5PEU7RAuEdX65HV6lFMJR3HsGj8qfBq4KCJHTS3r4YdVrFLvPQ/mUqbY6klIA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.187':
+    resolution: {integrity: sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185':
-    resolution: {integrity: sha512-KtXMCoprGYTSPb/A0/kjrO+PpDJAFbHhDd8rjqA4izU51OYjTDkahsGCcSTFM2jA8krOhPqzx/SNVuAVWmexwA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.187':
+    resolution: {integrity: sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185':
-    resolution: {integrity: sha512-YAky0Oez+YYrlcas/xDiaCm9AUX0z1YwM+pnk+CFxEr/ICmc7MbiFsnEIXFLPHaox9bE5iOzw4LS4b/c1tIJRg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.187':
+    resolution: {integrity: sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185':
-    resolution: {integrity: sha512-8U5wu6dNcyzRkwoae0Gu5ZHs6lRSu8CXqd9yrilX3fHR9kKICrm76bLu5q2auuSc/8dx6VL5ZXqSzFKIMp//zw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.187':
+    resolution: {integrity: sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185':
-    resolution: {integrity: sha512-pJEOaCLQQQWSyBeseR/GAn4eEp4WtMDP/o5yPMuuAsNWeoJXM7cY4j/N3KBE6GZofgnYdWEXILF2uw3SjbtINA==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.187':
+    resolution: {integrity: sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185':
-    resolution: {integrity: sha512-/Kf9XneSuIkSHNwrxOVY0XT7RovAEcx5nDASKzku4994cZz54otU5mT2jT6dwevDLEStfgts5x/A4z0AePwVTQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.187':
+    resolution: {integrity: sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.185':
-    resolution: {integrity: sha512-UDDd0cInvOufmR88btR/Ursnh71sb5scoutNlRS2L0LBdkt7JEqYJ0jt7DnOYHEVhMx8AAcg0eYgvXztcWUnFA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.187':
+    resolution: {integrity: sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.105.0'
@@ -3952,44 +3952,44 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       express: 5.2.1
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.187':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.105.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.185
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.187
 
   '@anthropic-ai/sdk@0.105.0(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/claude-agent-sdk` from `0.3.185` to `0.3.187` across all packages that depend on it (`cyrus-core`, `cyrus-claude-runner`, `cyrus-edge-worker`, `cyrus-simple-agent-runner`)
- `@anthropic-ai/sdk` remains at `^0.105.0` (already at latest)
- Removes `AskUserQuestion`, `EnterPlanMode`, and `ExitPlanMode` from `availableTools`, `readOnlyTools`, and all per-platform allowed-tool defaults — these tools are no longer emitted in the Claude Code init block in this SDK version

**What changed in 0.3.186–0.3.187:**
- 0.3.186: `agent_id` added to `can_use_tool` requests; `ReadMcpResourceDirTool` schema; `rewind_conversation` control request
- 0.3.187: `sandbox.credentials` added to SDK settings types

**Tool list:** 32 → 29 tools. `AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode` removed from available toolset.

SDK changelog: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md

Closes CYPACK-1349 (canceled — superseded by this issue CYPACK-1350)

## Test plan
- [x] `pnpm install` — clean install
- [x] `pnpm build` — all packages build successfully
- [x] `pnpm test:packages:run` — all 728+ tests pass
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm audit` — no known vulnerabilities
- [x] Tool list verified: 29 tools (down from 32), AskUserQuestion/EnterPlanMode/ExitPlanMode removed

<!-- generated-by-cyrus -->