### PR TITLE
fix(edge-worker): suppress ede_diagnostic error on first-stop interrupt (CYPACK-1352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 - Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 
+### Fixed
+- Sending a single "stop" to interrupt Cyrus mid-turn no longer posts a spurious `An error occurred` activity with internal diagnostic text (e.g. `[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use`). The interrupt acknowledgment is still shown, the session stays alive for your next prompt, and the internal diagnostic is no longer surfaced. ([CYPACK-1352](https://linear.app/ceedar/issue/CYPACK-1352))
+
 ## [0.2.66] - 2026-06-19
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
 
 ### Fixed
-- Sending a single "stop" to interrupt Cyrus mid-turn no longer posts a spurious `An error occurred` activity with internal diagnostic text (e.g. `[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use`). The interrupt acknowledgment is still shown, the session stays alive for your next prompt, and the internal diagnostic is no longer surfaced. ([CYPACK-1352](https://linear.app/ceedar/issue/CYPACK-1352))
+- Sending a single "stop" to interrupt Cyrus mid-turn no longer posts a spurious `An error occurred` activity with internal diagnostic text (e.g. `[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use`). The interrupt acknowledgment is still shown, the session stays alive for your next prompt, and the internal diagnostic is no longer surfaced. ([CYPACK-1352](https://linear.app/ceedar/issue/CYPACK-1352), [#1346](https://github.com/cyrusagents/cyrus/pull/1346))
 
 ## [0.2.66] - 2026-06-19
 

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -82,6 +82,7 @@ export class AgentSessionManager extends EventEmitter {
 	private taskSubjectsById: Map<string, string> = new Map(); // Cache task subjects by task ID (e.g., "1" → "Fix login bug")
 	private activeStatusActivitiesBySession: Map<string, string> = new Map(); // Maps session ID to active compacting status activity ID
 	private stopRequestedSessions: Set<string> = new Set(); // Sessions explicitly stopped by user signal
+	private interruptRequestedSessions: Set<string> = new Set(); // Sessions interrupted (first stop — turn aborts but session stays alive)
 	// Per-session serialization queue for handleClaudeMessage. The EdgeWorker's
 	// onMessage callback is fire-and-forget, so without serialization the async
 	// handlers can interleave — causing tool_result to be processed before its
@@ -362,6 +363,19 @@ export class AgentSessionManager extends EventEmitter {
 		this.activeTasksBySession.delete(sessionId);
 
 		const wasStopRequested = this.consumeStopRequest(sessionId);
+		const wasInterrupted = this.consumeInterruptRequest(sessionId);
+
+		if (wasInterrupted) {
+			// First-stop interrupt: the current turn was aborted via runner.interrupt()
+			// but the session stays warm awaiting the next prompt. The SDK surfaces the
+			// aborted turn as an error_during_execution `result` containing
+			// "[ede_diagnostic] ..." text — swallow it so it isn't posted to Linear as a
+			// spurious "An error occurred" activity (CYPACK-1352). Keep the session
+			// Active (don't update status) so the next prompt resumes normally.
+			log.info(`Session turn was interrupted by user`);
+			return;
+		}
+
 		const status = wasStopRequested
 			? AgentSessionStatus.Error
 			: resultMessage.subtype === "success"
@@ -436,6 +450,27 @@ export class AgentSessionManager extends EventEmitter {
 
 	requestSessionStop(linearAgentActivitySessionId: string): void {
 		this.stopRequestedSessions.add(linearAgentActivitySessionId);
+	}
+
+	/**
+	 * Mark a session as interrupted (first-stop signal on a warm session). The
+	 * session stays alive, but the aborted turn's error_during_execution result
+	 * (which contains "[ede_diagnostic] ..." text) must be swallowed by
+	 * completeSession rather than posted as an error activity (CYPACK-1352).
+	 */
+	requestSessionInterrupt(linearAgentActivitySessionId: string): void {
+		this.interruptRequestedSessions.add(linearAgentActivitySessionId);
+	}
+
+	private consumeInterruptRequest(
+		linearAgentActivitySessionId: string,
+	): boolean {
+		if (!this.interruptRequestedSessions.has(linearAgentActivitySessionId)) {
+			return false;
+		}
+
+		this.interruptRequestedSessions.delete(linearAgentActivitySessionId);
+		return true;
 	}
 
 	/**

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4693,7 +4693,12 @@ ${taskSection}`;
 					: `I've stopped working on ${issueTitle}.\n\n**Stop Signal:** Received from ${senderName}\n**Action Taken:** Session terminated`,
 			);
 		} else {
-			// First stop on a warm session — interrupt current turn, keep session warm
+			// First stop on a warm session — interrupt current turn, keep session warm.
+			// Mark the session as interrupted first so completeSession swallows the
+			// error_during_execution result the SDK emits when the turn aborts (it
+			// contains "[ede_diagnostic] ..." text) instead of posting it to Linear as
+			// a spurious "An error occurred" activity (CYPACK-1352).
+			this.agentSessionManager.requestSessionInterrupt(agentSessionId);
 			await existingRunner!.interrupt!();
 			log.info(
 				`Interrupted current turn for session ${agentSessionId} (send stop again within 10s to fully terminate)`,

--- a/packages/edge-worker/test/AgentSessionManager.stop-session.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.stop-session.test.ts
@@ -100,6 +100,55 @@ describe("AgentSessionManager stop-session behavior", () => {
 		);
 	});
 
+	it("swallows the ede_diagnostic result on a first-stop interrupt (CYPACK-1352)", async () => {
+		const initialStatus = manager.getSession(sessionId)?.status;
+
+		// First-stop on a warm session: EdgeWorker calls requestSessionInterrupt()
+		// before runner.interrupt(). The SDK then surfaces the aborted turn as an
+		// error_during_execution result containing "[ede_diagnostic] ..." text.
+		manager.requestSessionInterrupt(sessionId);
+
+		await manager.completeSession(sessionId, {
+			type: "result",
+			subtype: "error_during_execution",
+			duration_ms: 1,
+			duration_api_ms: 1,
+			is_error: true,
+			num_turns: 1,
+			result:
+				"[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use",
+			stop_reason: null,
+			total_cost_usd: 0,
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation: null,
+			},
+			modelUsage: {},
+			permission_denials: [],
+			uuid: "result-interrupt",
+			session_id: "sdk-session",
+		} as any);
+
+		// No error (or any) activity should be posted to Linear.
+		const errorActivity = postActivitySpy.mock.calls.find(
+			(call: any[]) => call[1]?.type === "error",
+		);
+		expect(errorActivity).toBeUndefined();
+		const leakedDiagnostic = postActivitySpy.mock.calls.find((call: any[]) =>
+			String(call[1]?.body ?? "").includes("ede_diagnostic"),
+		);
+		expect(leakedDiagnostic).toBeUndefined();
+
+		// Session stays alive (not flipped to Error) so the next prompt resumes.
+		expect(manager.getSession(sessionId)?.status).toBe(initialStatus);
+		expect(manager.getSession(sessionId)?.status).not.toBe(
+			AgentSessionStatus.Error,
+		);
+	});
+
 	it("posts actual error message to Linear for usage limit errors (not generic)", async () => {
 		const usageLimitError =
 			"You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Feb 16th, 2026 8:09 PM.";


### PR DESCRIPTION
## Summary

Fixes [CYPACK-1352](https://linear.app/ceedar/issue/CYPACK-1352). When a user sends a single **stop** to interrupt Cyrus mid-turn, Linear showed a spurious red **An error occurred** activity containing internal SDK diagnostic text:

```
[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=tool_use
```

## Root cause (what changed)

PR #1109 (`a7be6096`, "warm sessions, interrupt-on-stop, and buffered response posting") introduced a two-phase stop: the **first** stop on a warm session now calls `runner.interrupt()` (abort the current turn, keep the session alive) instead of `stop()`.

The pre-warm-session flow set a stop-request flag (`requestSessionStop`) so `AgentSessionManager.completeSession()` swallowed any error result. The new first-stop interrupt branch in `EdgeWorker.handleStopSignal()` **never set a flag**, so when the SDK surfaced the aborted turn as an `error_during_execution` `result` containing `[ede_diagnostic] ...`, `consumeStopRequest()` returned `false` and `addResultEntry()` posted it as a visible error.

For warm sessions, `interrupt()` does not throw (the `keepSessionWarm` loop stays alive), so the diagnostic arrives purely as a `result` message — fixing the `completeSession` path is sufficient. (Two prior fixes for this exact issue existed on the `agent-sessions-warmup` and `cypack-1129` branches but were never merged to `main`; this ports the cleaner edge-worker-level approach.)

## Fix

- Add `requestSessionInterrupt()` / `consumeInterruptRequest()` to `AgentSessionManager` (mirrors the existing stop-request mechanism).
- `EdgeWorker.handleStopSignal()` marks the session as interrupted **before** calling `interrupt()`.
- `completeSession()` checks the interrupt flag first: if set, it swallows the error result and keeps the session **Active** (no status change) so the next prompt resumes normally. The interrupt acknowledgment ("Interrupted by …") is still posted.

## Testing

- New unit test in `AgentSessionManager.stop-session.test.ts` asserts that after `requestSessionInterrupt`, an `is_error` `ede_diagnostic` result posts **no** error activity and leaves the session non-Error.
- `pnpm --filter cyrus-edge-worker test` → 729 passed.
- `pnpm typecheck` (full monorepo) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- generated-by-cyrus -->