### PR TITLE
[codex] Block crawlers on team tunnels

### DIFF
--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -3,6 +3,9 @@ import { CloudflareTunnelClient } from "cyrus-cloudflare-tunnel-client";
 import { createLogger, type ILogger } from "cyrus-core";
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 
+const ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
+const ROBOTS_HEADER = "noindex, nofollow";
+
 /**
  * OAuth callback state for tracking flows
  */
@@ -77,6 +80,18 @@ export class SharedApplicationServer {
 		this.app = Fastify({
 			logger: false,
 			trustProxy: true,
+		});
+
+		this.app.addHook("onRequest", (_request, reply, done) => {
+			reply.header("X-Robots-Tag", ROBOTS_HEADER);
+			done();
+		});
+
+		this.app.get("/robots.txt", async (_request, reply) => {
+			return reply
+				.type("text/plain; charset=utf-8")
+				.header("Cache-Control", "public, max-age=3600")
+				.send(ROBOTS_TXT);
 		});
 
 		// Preserve raw request body for webhook signature verification (GitHub HMAC-SHA256).

--- a/packages/edge-worker/test/SharedApplicationServer.robots.test.ts
+++ b/packages/edge-worker/test/SharedApplicationServer.robots.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+
+describe("SharedApplicationServer crawler controls", () => {
+	it("serves robots.txt that disallows crawling", async () => {
+		const server = new SharedApplicationServer();
+		const app = server.getFastifyInstance();
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/robots.txt",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["content-type"]).toContain("text/plain");
+		expect(response.headers["x-robots-tag"]).toBe("noindex, nofollow");
+		expect(response.body).toBe("User-agent: *\nDisallow: /\n");
+	});
+
+	it("adds a noindex header to application responses", async () => {
+		const server = new SharedApplicationServer();
+		const app = server.getFastifyInstance();
+
+		app.get("/status-check", async () => ({ ok: true }));
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/status-check",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["x-robots-tag"]).toBe("noindex, nofollow");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `X-Robots-Tag: noindex, nofollow` to shared application server responses.
- Serve `/robots.txt` with `Disallow: /` for team tunnel subdomains.
- Add coverage for the robots response and noindex header.

## Validation
- `pnpm exec vitest run test/SharedApplicationServer.robots.test.ts`
- Commit hook also ran `pnpm -r --filter='!@cyrus/electron' build` and `pnpm -r typecheck` successfully.
