### PR TITLE
feat: cross-runner handoff (/handoff claude|codex) for Linear issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Cross-runner handoff: comment `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue to hand the in-progress work to the other runner. The target runner continues in the same worktree, branch, and PR, with a snapshot of the current state. Cyrus stops the active runner first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked.
+
 ### Fixed
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Cross-runner handoff: write `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue — either in the opening mention or as a follow-up comment — to run/continue the work with the other runner. The target runner reuses the same worktree, branch, and PR, so it picks up the existing files, commits, and PR state. When handing off from a still-active runner, Cyrus stops it first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked.
+- Cross-runner handoff: write `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue — either in the opening mention or as a follow-up comment — to run/continue the work with the other runner. The target runner reuses the same worktree, branch, and PR, so it picks up the existing files, commits, and PR state. When handing off from a still-active runner, Cyrus stops it first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked. ([#1348](https://github.com/cyrusagents/cyrus/pull/1348))
 
 ### Fixed
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Cross-runner handoff: comment `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue to hand the in-progress work to the other runner. The target runner continues in the same worktree, branch, and PR, with a snapshot of the current state. Cyrus stops the active runner first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked.
+- Cross-runner handoff: write `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue — either in the opening mention or as a follow-up comment — to run/continue the work with the other runner. The target runner reuses the same worktree, branch, and PR, so it picks up the existing files, commits, and PR state. When handing off from a still-active runner, Cyrus stops it first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked.
 
 ### Fixed
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))

--- a/docs/superpowers/plans/2026-06-25-cross-runner-handoff.md
+++ b/docs/superpowers/plans/2026-06-25-cross-runner-handoff.md
@@ -1,0 +1,1542 @@
+# Cross-Runner Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Linear issue started with Claude or Codex be handed to the other runner via `@Cyrus /handoff <runner>`, continuing in the same worktree with a context snapshot, never running both concurrently.
+
+**Architecture:** A new unit-testable `HandoffService` (command parsing, snapshot building, prompt formatting, stop-polling) plus a thin `EdgeWorker.handleHandoffCommand` orchestration. Handoff forces a fresh target runner by threading an optional `runnerTypeOverride` through `resumeAgentSession` → `buildAgentRunnerConfig` → `buildIssueConfig`, bypassing the existing sticky-session runner binding. The shared git worktree is reused automatically because `resumeAgentSession` reuses `session.workspace`.
+
+**Tech Stack:** TypeScript, pnpm monorepo, Vitest. Work happens in `packages/edge-worker` and `packages/core`.
+
+## Global Constraints
+
+- Target runners are restricted to `claude` and `codex`. Other targets are rejected with a comment.
+- Handoff is sequential: the active runner is stopped (with a ~30s timeout) before the target starts. Never concurrent in the same worktree.
+- Reuse the same `CyrusAgentSession` and Linear agent-session thread (swap runner in place).
+- Stop timeout constant: `HANDOFF_STOP_TIMEOUT_MS = 30000`, poll interval `250` ms.
+- No config schema changes. `runnerTypeOverride` is optional everywhere and defaults to today's behavior.
+- All snapshot git reads are best-effort: failures yield empty string / `undefined`, never throw.
+- Run `pnpm --filter cyrus-edge-worker test:run` and `pnpm typecheck` before the final commit.
+
+---
+
+### Task 1: `runnerTypeOverride` force-override in `RunnerConfigBuilder`
+
+**Files:**
+- Modify: `packages/edge-worker/src/RunnerConfigBuilder.ts` (interface `IssueRunnerConfigInput` ~line 113; method `buildIssueConfig` ~lines 324-354)
+- Test: `packages/edge-worker/test/RunnerConfigBuilder.handoff-override.test.ts` (create)
+
+**Interfaces:**
+- Produces: `IssueRunnerConfigInput.runnerTypeOverride?: RunnerType`. When set, `buildIssueConfig` returns `{ runnerType: <override>, ... }` regardless of labels, description tags, or the session's existing `*SessionId`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/RunnerConfigBuilder.handoff-override.test.ts`. This mirrors the existing harness in `RunnerConfigBuilder.additional-directories.test.ts` (the constructor takes three collaborators):
+
+```typescript
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	// Normal selection always returns claude — so a codex result can only come
+	// from the override path.
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
+		getDefaultModelForRunner: () => "opus",
+		getDefaultFallbackModelForRunner: () => "sonnet",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function baseInput(session: Partial<CyrusAgentSession>) {
+	return {
+		session: session as CyrusAgentSession,
+		repository: {
+			id: "repo-a",
+			name: "Repo A",
+			repositoryPath: "/repos/repo-a",
+			allowedTools: [],
+		} as unknown as RepositoryConfig,
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	};
+}
+
+describe("RunnerConfigBuilder runnerTypeOverride", () => {
+	it("forces the override runner even when the session is sticky to claude", () => {
+		const input = {
+			...baseInput({
+				issueId: "issue-1",
+				issue: { identifier: "ABC-1" },
+				workspace: { path: "/ws/root" },
+				claudeSessionId: "claude-abc",
+			} as unknown as Partial<CyrusAgentSession>),
+			labels: ["claude"],
+			runnerTypeOverride: "codex" as const,
+		};
+
+		const { runnerType } = makeBuilder().buildIssueConfig(input as any);
+
+		expect(runnerType).toBe("codex");
+	});
+
+	it("falls back to normal selection when no override is given", () => {
+		const input = baseInput({
+			issueId: "issue-1",
+			issue: { identifier: "ABC-1" },
+			workspace: { path: "/ws/root" },
+			claudeSessionId: "claude-abc",
+		} as unknown as Partial<CyrusAgentSession>);
+
+		const { runnerType } = makeBuilder().buildIssueConfig(input as any);
+
+		expect(runnerType).toBe("claude");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run RunnerConfigBuilder.handoff-override`
+Expected: FAIL — `runnerTypeOverride` is not honored (first test gets `"claude"`), or a type error on the unknown field.
+
+- [ ] **Step 3: Add the field to the input interface**
+
+In `packages/edge-worker/src/RunnerConfigBuilder.ts`, inside `interface IssueRunnerConfigInput` (after `issueDescription?: string;` ~line 123), add:
+
+```typescript
+	/**
+	 * When set, forces this exact runner type for the session, bypassing
+	 * label/description selection AND the sticky-resume binding. Used by
+	 * cross-runner handoff. Leave undefined for all normal sessions.
+	 */
+	runnerTypeOverride?: RunnerType;
+```
+
+Ensure `RunnerType` is imported at the top of the file (it already imports from `cyrus-core`; add `RunnerType` to that import if missing).
+
+- [ ] **Step 4: Apply the override in `buildIssueConfig`**
+
+In `buildIssueConfig`, replace the block at ~lines 333-354 (the comment `// If the labels have changed...` through the closing brace of the `cursorSessionId` branch) with:
+
+```typescript
+		// Cross-runner handoff: an explicit override wins over everything —
+		// label/description selection and the sticky-resume binding below.
+		if (input.runnerTypeOverride) {
+			runnerType = input.runnerTypeOverride;
+			modelOverride = this.runnerSelector.getDefaultModelForRunner(runnerType);
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType);
+		} else if (input.session.claudeSessionId && runnerType !== "claude") {
+			// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
+			runnerType = "claude";
+			modelOverride = this.runnerSelector.getDefaultModelForRunner("claude");
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner("claude");
+		} else if (input.session.geminiSessionId && runnerType !== "gemini") {
+			runnerType = "gemini";
+			modelOverride = this.runnerSelector.getDefaultModelForRunner("gemini");
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner("gemini");
+		} else if (input.session.codexSessionId && runnerType !== "codex") {
+			runnerType = "codex";
+			modelOverride = this.runnerSelector.getDefaultModelForRunner("codex");
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner("codex");
+		} else if (input.session.cursorSessionId && runnerType !== "cursor") {
+			runnerType = "cursor";
+			modelOverride = this.runnerSelector.getDefaultModelForRunner("cursor");
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner("cursor");
+		}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run RunnerConfigBuilder.handoff-override`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/edge-worker/src/RunnerConfigBuilder.ts packages/edge-worker/test/RunnerConfigBuilder.handoff-override.test.ts
+git commit -m "feat(handoff): add runnerTypeOverride to RunnerConfigBuilder"
+```
+
+---
+
+### Task 2: `HandoffService` scaffold + `parseHandoffCommand`
+
+**Files:**
+- Create: `packages/edge-worker/src/HandoffService.ts`
+- Test: `packages/edge-worker/test/HandoffService.parse.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `type HandoffTarget = "claude" | "codex"`
+  - `interface HandoffCommand { targetRunner: HandoffTarget | null; rawTarget: string; remainder: string }`
+  - `interface GitSnapshotReader { getCurrentBranch(p: string): string; getStatus(p: string): string; getRecentCommits(p: string, limit: number): string; getDiffSummary(p: string): string; getOpenPrUrl(p: string): string | undefined }`
+  - `const HANDOFF_STOP_TIMEOUT_MS = 30000`
+  - `class HandoffService` constructed as `new HandoffService(gitReader: GitSnapshotReader)`, with `parseHandoffCommand(text: string): HandoffCommand | null`.
+- `parseHandoffCommand` returns `null` when no `/handoff` token is present (so normal routing proceeds). When `/handoff <word>` is present, `targetRunner` is `null` for unrecognized words.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/HandoffService.parse.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc() {
+	const reader = {
+		getCurrentBranch: () => "branch",
+		getStatus: () => "",
+		getRecentCommits: () => "",
+		getDiffSummary: () => "",
+		getOpenPrUrl: () => undefined,
+	};
+	return new HandoffService(reader);
+}
+
+describe("HandoffService.parseHandoffCommand", () => {
+	it("returns null when there is no handoff command", () => {
+		expect(svc().parseHandoffCommand("please add tests")).toBeNull();
+	});
+
+	it("parses a codex target", () => {
+		expect(svc().parseHandoffCommand("/handoff codex")).toEqual({
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+	});
+
+	it("parses a claude target with a leading mention and trailing instruction", () => {
+		expect(
+			svc().parseHandoffCommand("@Cyrus /handoff claude also add tests"),
+		).toEqual({
+			targetRunner: "claude",
+			rawTarget: "claude",
+			remainder: "also add tests",
+		});
+	});
+
+	it("is case-insensitive for the target", () => {
+		expect(svc().parseHandoffCommand("/handoff CODEX")?.targetRunner).toBe(
+			"codex",
+		);
+	});
+
+	it("flags an unrecognized target with targetRunner null", () => {
+		expect(svc().parseHandoffCommand("/handoff gemini")).toEqual({
+			targetRunner: null,
+			rawTarget: "gemini",
+			remainder: "",
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.parse`
+Expected: FAIL — cannot find module `../src/HandoffService.js`.
+
+- [ ] **Step 3: Create the service with parsing**
+
+Create `packages/edge-worker/src/HandoffService.ts`:
+
+```typescript
+/**
+ * Cross-runner handoff support: parse `/handoff <runner>` commands, build a
+ * context snapshot of the source runner's worktree state, format the target
+ * runner's starting prompt, and poll for the source runner to stop.
+ *
+ * Pure/logic-only — no live runner wiring. The orchestration that stops the
+ * source runner and starts the target lives in EdgeWorker.handleHandoffCommand.
+ */
+
+export type HandoffTarget = "claude" | "codex";
+
+export interface HandoffCommand {
+	/** Validated target, or null when the word after /handoff is unrecognized. */
+	targetRunner: HandoffTarget | null;
+	/** The raw word that followed /handoff (for error messages). */
+	rawTarget: string;
+	/** Any text after the target — becomes the target runner's instruction. */
+	remainder: string;
+}
+
+/** Read-only git facts about a worktree. Implemented by GitService. */
+export interface GitSnapshotReader {
+	getCurrentBranch(worktreePath: string): string;
+	getStatus(worktreePath: string): string;
+	getRecentCommits(worktreePath: string, limit: number): string;
+	getDiffSummary(worktreePath: string): string;
+	getOpenPrUrl(worktreePath: string): string | undefined;
+}
+
+/** How long to wait for the active runner to stop before declaring handoff blocked. */
+export const HANDOFF_STOP_TIMEOUT_MS = 30000;
+
+const HANDOFF_RE = /\/handoff\s+(\S+)([\s\S]*)/i;
+
+export class HandoffService {
+	constructor(private readonly gitReader: GitSnapshotReader) {}
+
+	parseHandoffCommand(text: string): HandoffCommand | null {
+		const match = text.match(HANDOFF_RE);
+		if (!match) {
+			return null;
+		}
+		const rawTarget = (match[1] ?? "").toLowerCase();
+		const remainder = (match[2] ?? "").trim();
+		const targetRunner: HandoffTarget | null =
+			rawTarget === "claude" || rawTarget === "codex" ? rawTarget : null;
+		return { targetRunner, rawTarget, remainder };
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.parse`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/HandoffService.ts packages/edge-worker/test/HandoffService.parse.test.ts
+git commit -m "feat(handoff): add HandoffService with command parsing"
+```
+
+---
+
+### Task 3: `getActiveRunnerType` helper
+
+**Files:**
+- Modify: `packages/edge-worker/src/HandoffService.ts`
+- Test: `packages/edge-worker/test/HandoffService.runner-type.test.ts` (create)
+
+**Interfaces:**
+- Produces: exported function `getActiveRunnerType(session): RunnerType | "unknown"` — derives the session's current runner from its populated `*SessionId` field, falling back to `agentRunner.constructor.name`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/HandoffService.runner-type.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { getActiveRunnerType } from "../src/HandoffService.js";
+
+describe("getActiveRunnerType", () => {
+	it("reads claude from claudeSessionId", () => {
+		expect(getActiveRunnerType({ claudeSessionId: "x" } as any)).toBe("claude");
+	});
+
+	it("reads codex from codexSessionId", () => {
+		expect(getActiveRunnerType({ codexSessionId: "x" } as any)).toBe("codex");
+	});
+
+	it("falls back to the runner constructor name", () => {
+		const session = {
+			agentRunner: { constructor: { name: "CodexRunner" } },
+		} as any;
+		expect(getActiveRunnerType(session)).toBe("codex");
+	});
+
+	it("returns unknown when nothing identifies the runner", () => {
+		expect(getActiveRunnerType({} as any)).toBe("unknown");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.runner-type`
+Expected: FAIL — `getActiveRunnerType` is not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+In `packages/edge-worker/src/HandoffService.ts`, add an import and the function (top-level, after the interfaces):
+
+```typescript
+import type { CyrusAgentSession, RunnerType } from "cyrus-core";
+```
+
+```typescript
+/** Identify the runner a session is currently bound to. */
+export function getActiveRunnerType(
+	session: Pick<
+		CyrusAgentSession,
+		| "claudeSessionId"
+		| "geminiSessionId"
+		| "codexSessionId"
+		| "cursorSessionId"
+		| "agentRunner"
+	>,
+): RunnerType | "unknown" {
+	if (session.claudeSessionId) return "claude";
+	if (session.geminiSessionId) return "gemini";
+	if (session.codexSessionId) return "codex";
+	if (session.cursorSessionId) return "cursor";
+	switch (session.agentRunner?.constructor?.name) {
+		case "ClaudeRunner":
+			return "claude";
+		case "GeminiRunner":
+			return "gemini";
+		case "CodexRunner":
+			return "codex";
+		case "CursorRunner":
+			return "cursor";
+		default:
+			return "unknown";
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.runner-type`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/HandoffService.ts packages/edge-worker/test/HandoffService.runner-type.test.ts
+git commit -m "feat(handoff): add getActiveRunnerType helper"
+```
+
+---
+
+### Task 4: Git snapshot reads on `GitService`
+
+**Files:**
+- Modify: `packages/edge-worker/src/GitService.ts` (add methods; uses already-imported `execSync`)
+- Test: `packages/edge-worker/test/GitService.snapshot.test.ts` (create)
+
+**Interfaces:**
+- Produces (on `GitService`, satisfying `GitSnapshotReader`):
+  - `getCurrentBranch(worktreePath: string): string`
+  - `getStatus(worktreePath: string): string`
+  - `getRecentCommits(worktreePath: string, limit: number): string`
+  - `getDiffSummary(worktreePath: string): string`
+  - `getOpenPrUrl(worktreePath: string): string | undefined`
+- All are best-effort: on any thrown error they return `""` (or `undefined` for the PR url).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/GitService.snapshot.test.ts`:
+
+```typescript
+import { execSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { GitService } from "../src/GitService.js";
+
+vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
+
+const logger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	withContext: vi.fn().mockReturnThis(),
+} as any;
+
+describe("GitService snapshot reads", () => {
+	it("returns trimmed porcelain status", () => {
+		(execSync as any).mockReturnValue(" M file.ts\n");
+		const git = new GitService(logger);
+		expect(git.getStatus("/wt")).toBe("M file.ts");
+	});
+
+	it("returns recent commits with the requested limit", () => {
+		(execSync as any).mockReturnValue("abc one\ndef two\n");
+		const git = new GitService(logger);
+		expect(git.getRecentCommits("/wt", 5)).toBe("abc one\ndef two");
+		expect((execSync as any)).toHaveBeenCalledWith(
+			"git log --oneline -n 5",
+			expect.objectContaining({ cwd: "/wt" }),
+		);
+	});
+
+	it("returns empty string when a git read throws", () => {
+		(execSync as any).mockImplementation(() => {
+			throw new Error("not a git repo");
+		});
+		const git = new GitService(logger);
+		expect(git.getDiffSummary("/wt")).toBe("");
+		expect(git.getCurrentBranch("/wt")).toBe("");
+	});
+
+	it("returns undefined for the PR url when gh fails", () => {
+		(execSync as any).mockImplementation(() => {
+			throw new Error("gh: no pr");
+		});
+		const git = new GitService(logger);
+		expect(git.getOpenPrUrl("/wt")).toBeUndefined();
+	});
+});
+```
+
+> If `GitService`'s constructor signature differs from `new GitService(logger)`, match the existing constructor used in `packages/edge-worker/test/GitService.test.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run GitService.snapshot`
+Expected: FAIL — methods do not exist.
+
+- [ ] **Step 3: Implement the methods**
+
+In `packages/edge-worker/src/GitService.ts`, add these public methods to the `GitService` class (place them near `findWorktreeByBranch`). `execSync` is already imported in this file:
+
+```typescript
+	/** Current branch checked out in a worktree (best-effort). */
+	getCurrentBranch(worktreePath: string): string {
+		try {
+			return execSync("git rev-parse --abbrev-ref HEAD", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** Porcelain working-tree status (best-effort). */
+	getStatus(worktreePath: string): string {
+		try {
+			return execSync("git status --porcelain", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** Last `limit` commits as `git log --oneline` (best-effort). */
+	getRecentCommits(worktreePath: string, limit: number): string {
+		try {
+			return execSync(`git log --oneline -n ${limit}`, {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** `git diff --stat` against HEAD (best-effort). */
+	getDiffSummary(worktreePath: string): string {
+		try {
+			return execSync("git diff --stat HEAD", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** URL of the open PR for the current branch via gh, or undefined (best-effort). */
+	getOpenPrUrl(worktreePath: string): string | undefined {
+		try {
+			const url = execSync("gh pr view --json url -q .url", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+			return url || undefined;
+		} catch {
+			return undefined;
+		}
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run GitService.snapshot`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/GitService.ts packages/edge-worker/test/GitService.snapshot.test.ts
+git commit -m "feat(handoff): add best-effort git snapshot reads to GitService"
+```
+
+---
+
+### Task 5: `buildSnapshot` + `buildHandoffPrompt`
+
+**Files:**
+- Modify: `packages/edge-worker/src/HandoffService.ts`
+- Test: `packages/edge-worker/test/HandoffService.snapshot.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `interface HandoffSnapshotArgs { sourceRunner: RunnerType | "unknown"; targetRunner: HandoffTarget; issueId: string; sessionId: string; worktreePath: string; latestSummary?: string }`
+  - `interface HandoffSnapshot extends HandoffSnapshotArgs { branch: string; gitStatus: string; recentCommits: string; diffSummary: string; prLink?: string }`
+  - `HandoffService.buildSnapshot(args: HandoffSnapshotArgs): HandoffSnapshot`
+  - `HandoffService.buildHandoffPrompt(snapshot: HandoffSnapshot, userText?: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/HandoffService.snapshot.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc(overrides: Record<string, unknown> = {}) {
+	const reader = {
+		getCurrentBranch: () => "CYR-1-feature",
+		getStatus: () => " M src/a.ts",
+		getRecentCommits: () => "abc first\ndef second",
+		getDiffSummary: () => " src/a.ts | 2 +-",
+		getOpenPrUrl: () => "https://github.com/o/r/pull/9",
+		...overrides,
+	};
+	return new HandoffService(reader as any);
+}
+
+const args = {
+	sourceRunner: "claude" as const,
+	targetRunner: "codex" as const,
+	issueId: "issue-1",
+	sessionId: "sess-1",
+	worktreePath: "/ws/CYR-1",
+	latestSummary: "Implemented the parser.",
+};
+
+describe("HandoffService.buildSnapshot", () => {
+	it("collects all git fields from the reader", () => {
+		const snap = svc().buildSnapshot(args);
+		expect(snap).toMatchObject({
+			sourceRunner: "claude",
+			targetRunner: "codex",
+			branch: "CYR-1-feature",
+			gitStatus: " M src/a.ts",
+			recentCommits: "abc first\ndef second",
+			diffSummary: " src/a.ts | 2 +-",
+			prLink: "https://github.com/o/r/pull/9",
+			latestSummary: "Implemented the parser.",
+		});
+	});
+
+	it("omits the PR link when none is available", () => {
+		const snap = svc({ getOpenPrUrl: () => undefined }).buildSnapshot(args);
+		expect(snap.prLink).toBeUndefined();
+	});
+});
+
+describe("HandoffService.buildHandoffPrompt", () => {
+	it("includes the handoff context block and the user instruction", () => {
+		const snap = svc().buildSnapshot(args);
+		const prompt = svc().buildHandoffPrompt(snap, "add tests too");
+		expect(prompt).toContain("<handoff_context>");
+		expect(prompt).toContain("<source_runner>claude</source_runner>");
+		expect(prompt).toContain("<target_runner>codex</target_runner>");
+		expect(prompt).toContain("<branch>CYR-1-feature</branch>");
+		expect(prompt).toContain("https://github.com/o/r/pull/9");
+		expect(prompt).toContain("Implemented the parser.");
+		expect(prompt.trimEnd().endsWith("add tests too")).toBe(true);
+	});
+
+	it("uses a default instruction when the user gave none", () => {
+		const snap = svc().buildSnapshot(args);
+		const prompt = svc().buildHandoffPrompt(snap, "");
+		expect(prompt).toContain(
+			"Continue the work in this worktree from where the previous runner left off.",
+		);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.snapshot`
+Expected: FAIL — `buildSnapshot` / `buildHandoffPrompt` do not exist.
+
+- [ ] **Step 3: Implement the methods**
+
+In `packages/edge-worker/src/HandoffService.ts`, add the interfaces (near the top, after `HandoffCommand`):
+
+```typescript
+export interface HandoffSnapshotArgs {
+	sourceRunner: RunnerType | "unknown";
+	targetRunner: HandoffTarget;
+	issueId: string;
+	sessionId: string;
+	worktreePath: string;
+	latestSummary?: string;
+}
+
+export interface HandoffSnapshot extends HandoffSnapshotArgs {
+	branch: string;
+	gitStatus: string;
+	recentCommits: string;
+	diffSummary: string;
+	prLink?: string;
+}
+```
+
+Then add these methods to the `HandoffService` class:
+
+```typescript
+	buildSnapshot(args: HandoffSnapshotArgs): HandoffSnapshot {
+		return {
+			...args,
+			branch: this.gitReader.getCurrentBranch(args.worktreePath),
+			gitStatus: this.gitReader.getStatus(args.worktreePath),
+			recentCommits: this.gitReader.getRecentCommits(args.worktreePath, 5),
+			diffSummary: this.gitReader.getDiffSummary(args.worktreePath),
+			prLink: this.gitReader.getOpenPrUrl(args.worktreePath),
+		};
+	}
+
+	buildHandoffPrompt(snapshot: HandoffSnapshot, userText?: string): string {
+		const lines = [
+			"<handoff_context>",
+			"  You are taking over an in-progress Linear issue from another agent.",
+			"  The worktree, branch, files, and PR state below are already in place.",
+			`  <source_runner>${snapshot.sourceRunner}</source_runner>`,
+			`  <target_runner>${snapshot.targetRunner}</target_runner>`,
+			`  <issue_id>${snapshot.issueId}</issue_id>`,
+			`  <session_id>${snapshot.sessionId}</session_id>`,
+			`  <worktree_path>${snapshot.worktreePath}</worktree_path>`,
+			`  <branch>${snapshot.branch || "(unknown)"}</branch>`,
+			`  <git_status>\n${snapshot.gitStatus || "(clean)"}\n  </git_status>`,
+			`  <recent_commits>\n${snapshot.recentCommits || "(none)"}\n  </recent_commits>`,
+			`  <diff_summary>\n${snapshot.diffSummary || "(no changes)"}\n  </diff_summary>`,
+		];
+		if (snapshot.prLink) {
+			lines.push(`  <pull_request>${snapshot.prLink}</pull_request>`);
+		}
+		if (snapshot.latestSummary) {
+			lines.push(
+				`  <previous_agent_summary>\n${snapshot.latestSummary}\n  </previous_agent_summary>`,
+			);
+		}
+		lines.push("</handoff_context>");
+
+		const instruction =
+			userText && userText.trim().length > 0
+				? userText.trim()
+				: "Continue the work in this worktree from where the previous runner left off.";
+		return `${lines.join("\n")}\n\n${instruction}`;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.snapshot`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/HandoffService.ts packages/edge-worker/test/HandoffService.snapshot.test.ts
+git commit -m "feat(handoff): build snapshot and target prompt"
+```
+
+---
+
+### Task 6: `waitForStopped` poller
+
+**Files:**
+- Modify: `packages/edge-worker/src/HandoffService.ts`
+- Test: `packages/edge-worker/test/HandoffService.wait.test.ts` (create)
+
+**Interfaces:**
+- Produces: `HandoffService.waitForStopped(isRunning: () => boolean, opts: { timeoutMs: number; pollIntervalMs: number; sleep: (ms: number) => Promise<void> }): Promise<boolean>` — resolves `true` if `isRunning()` becomes false within the timeout, else `false`. `sleep` is injected so tests don't use real timers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/HandoffService.wait.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc() {
+	const reader = {
+		getCurrentBranch: () => "",
+		getStatus: () => "",
+		getRecentCommits: () => "",
+		getDiffSummary: () => "",
+		getOpenPrUrl: () => undefined,
+	};
+	return new HandoffService(reader as any);
+}
+
+describe("HandoffService.waitForStopped", () => {
+	it("returns true once the runner reports stopped", async () => {
+		let calls = 0;
+		const isRunning = () => {
+			calls += 1;
+			return calls < 3; // running for 2 polls, then stopped
+		};
+		const stopped = await svc().waitForStopped(isRunning, {
+			timeoutMs: 1000,
+			pollIntervalMs: 100,
+			sleep: vi.fn().mockResolvedValue(undefined),
+		});
+		expect(stopped).toBe(true);
+	});
+
+	it("returns false when the runner never stops within the timeout", async () => {
+		const stopped = await svc().waitForStopped(() => true, {
+			timeoutMs: 300,
+			pollIntervalMs: 100,
+			sleep: vi.fn().mockResolvedValue(undefined),
+		});
+		expect(stopped).toBe(false);
+	});
+
+	it("returns true immediately when already stopped", async () => {
+		const sleep = vi.fn().mockResolvedValue(undefined);
+		const stopped = await svc().waitForStopped(() => false, {
+			timeoutMs: 300,
+			pollIntervalMs: 100,
+			sleep,
+		});
+		expect(stopped).toBe(true);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.wait`
+Expected: FAIL — `waitForStopped` does not exist.
+
+- [ ] **Step 3: Implement the poller**
+
+Add to the `HandoffService` class:
+
+```typescript
+	async waitForStopped(
+		isRunning: () => boolean,
+		opts: {
+			timeoutMs: number;
+			pollIntervalMs: number;
+			sleep: (ms: number) => Promise<void>;
+		},
+	): Promise<boolean> {
+		let elapsed = 0;
+		while (isRunning()) {
+			if (elapsed >= opts.timeoutMs) {
+				return false;
+			}
+			await opts.sleep(opts.pollIntervalMs);
+			elapsed += opts.pollIntervalMs;
+		}
+		return true;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run HandoffService.wait`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/HandoffService.ts packages/edge-worker/test/HandoffService.wait.test.ts
+git commit -m "feat(handoff): add waitForStopped poller"
+```
+
+---
+
+### Task 7: `AgentSessionManager` accessors for handoff
+
+**Files:**
+- Modify: `packages/edge-worker/src/AgentSessionManager.ts` (add two public methods; `lastAssistantBodyBySession` is ~line 76, `sessions` ~line 71)
+- Test: `packages/edge-worker/test/AgentSessionManager.handoff-accessors.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `getLastAssistantBody(sessionId: string): string | undefined`
+  - `clearRunnerSessionBindings(sessionId: string): void` — sets `claudeSessionId`/`geminiSessionId`/`codexSessionId`/`cursorSessionId` to `undefined` on the stored session so post-handoff routing follows the new runner.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/edge-worker/test/AgentSessionManager.handoff-accessors.test.ts`:
+
+```typescript
+import type { CyrusAgentSession } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+
+// Minimal manager: we only exercise the new accessors against its internal maps.
+function makeManager() {
+	// Construct with no-op collaborators; the accessors touch only `sessions`
+	// and `lastAssistantBodyBySession`. Match the real constructor arity used in
+	// other AgentSessionManager tests if this differs.
+	return new AgentSessionManager({} as any);
+}
+
+describe("AgentSessionManager handoff accessors", () => {
+	it("clearRunnerSessionBindings nulls every runner session id", () => {
+		const mgr = makeManager();
+		const session = {
+			id: "s1",
+			claudeSessionId: "c",
+			codexSessionId: undefined,
+		} as unknown as CyrusAgentSession;
+		(mgr as any).sessions.set("s1", session);
+
+		mgr.clearRunnerSessionBindings("s1");
+
+		expect(session.claudeSessionId).toBeUndefined();
+		expect(session.geminiSessionId).toBeUndefined();
+		expect(session.codexSessionId).toBeUndefined();
+		expect(session.cursorSessionId).toBeUndefined();
+	});
+
+	it("clearRunnerSessionBindings is a no-op for an unknown session", () => {
+		const mgr = makeManager();
+		expect(() => mgr.clearRunnerSessionBindings("missing")).not.toThrow();
+	});
+
+	it("getLastAssistantBody returns the buffered body", () => {
+		const mgr = makeManager();
+		(mgr as any).lastAssistantBodyBySession.set("s1", "the summary");
+		expect(mgr.getLastAssistantBody("s1")).toBe("the summary");
+		expect(mgr.getLastAssistantBody("s2")).toBeUndefined();
+	});
+});
+```
+
+> If `new AgentSessionManager({} as any)` throws due to required constructor args, copy the exact construction used in `packages/edge-worker/test/AgentSessionManager.stop-session.test.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run AgentSessionManager.handoff-accessors`
+Expected: FAIL — methods do not exist.
+
+- [ ] **Step 3: Implement the accessors**
+
+In `packages/edge-worker/src/AgentSessionManager.ts`, add these public methods (place near `getSession` ~line 1326):
+
+```typescript
+	/** Buffered last assistant text for a session (used as the handoff summary). */
+	getLastAssistantBody(sessionId: string): string | undefined {
+		return this.lastAssistantBodyBySession.get(sessionId);
+	}
+
+	/**
+	 * Clear every runner-specific session id on a session so that, after a
+	 * cross-runner handoff, normal routing follows the newly-bound runner
+	 * instead of the previous one. The target runner repopulates its own id on
+	 * its first system message.
+	 */
+	clearRunnerSessionBindings(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			return;
+		}
+		session.claudeSessionId = undefined;
+		session.geminiSessionId = undefined;
+		session.codexSessionId = undefined;
+		session.cursorSessionId = undefined;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run AgentSessionManager.handoff-accessors`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/edge-worker/src/AgentSessionManager.ts packages/edge-worker/test/AgentSessionManager.handoff-accessors.test.ts
+git commit -m "feat(handoff): add session accessors for handoff"
+```
+
+---
+
+### Task 8: Thread `runnerTypeOverride` through `buildAgentRunnerConfig` and `resumeAgentSession`
+
+**Files:**
+- Modify: `packages/edge-worker/src/EdgeWorker.ts` (`buildAgentRunnerConfig` ~line 6426; `resumeAgentSession` ~line 7132)
+
+**Interfaces:**
+- Consumes: `IssueRunnerConfigInput.runnerTypeOverride` (Task 1).
+- Produces:
+  - `buildAgentRunnerConfig(..., sessionPlatform?, runnerTypeOverride?: RunnerType)` — passes the override into `buildIssueConfig`.
+  - `resumeAgentSession(..., commentTimestamp?, runnerTypeOverride?: RunnerType)` — when set, forces a fresh target runner: skips the streaming-add fast path, forces `needsNewSession`, clears `resumeSessionId`, and passes the override to `buildAgentRunnerConfig`.
+
+This task has no standalone unit test — it is an internal plumbing change exercised end-to-end by Task 9's acceptance test. Verify via typecheck + the existing suite.
+
+- [ ] **Step 1: Add the parameter to `buildAgentRunnerConfig`**
+
+In `packages/edge-worker/src/EdgeWorker.ts`, in the `buildAgentRunnerConfig` signature, after the `sessionPlatform: "linear" | "github" | "gitlab" = "linear",` parameter (~line 6445) add a final parameter:
+
+```typescript
+		runnerTypeOverride?: RunnerType,
+```
+
+Then in the `this.runnerConfigBuilder.buildIssueConfig({ ... })` call (~line 6466), add the field (e.g. right after `issueDescription,`):
+
+```typescript
+			runnerTypeOverride,
+```
+
+- [ ] **Step 2: Add the parameter to `resumeAgentSession`**
+
+In the `resumeAgentSession` signature (~line 7132), after `commentTimestamp?: string,` add a final parameter:
+
+```typescript
+		runnerTypeOverride?: RunnerType,
+```
+
+- [ ] **Step 3: Skip the streaming-add fast path during handoff**
+
+In `resumeAgentSession`, change the existing condition (~line 7151) from:
+
+```typescript
+		if (
+			existingRunner?.isRunning() &&
+			existingRunner.supportsStreamingInput &&
+			existingRunner.addStreamMessage
+		) {
+```
+
+to:
+
+```typescript
+		if (
+			!runnerTypeOverride &&
+			existingRunner?.isRunning() &&
+			existingRunner.supportsStreamingInput &&
+			existingRunner.addStreamMessage
+		) {
+```
+
+- [ ] **Step 4: Force a fresh session for the target runner**
+
+In `resumeAgentSession`, update the `needsNewSession` computation (~line 7208) from:
+
+```typescript
+		const needsNewSession =
+			isNewSession ||
+			(!hasClaudeSession &&
+				!hasGeminiSession &&
+				!hasCodexSession &&
+				!hasCursorSession);
+```
+
+to:
+
+```typescript
+		const needsNewSession =
+			isNewSession ||
+			Boolean(runnerTypeOverride) ||
+			(!hasClaudeSession &&
+				!hasGeminiSession &&
+				!hasCodexSession &&
+				!hasCursorSession);
+```
+
+(`resumeSessionId` already becomes `undefined` whenever `needsNewSession` is true, so no further change is needed there.)
+
+- [ ] **Step 5: Pass the override into the config build**
+
+In `resumeAgentSession`, in the `this.buildAgentRunnerConfig(...)` call (~line 7266), the existing last argument is `this.buildSkillSessionContext(repository, fullIssue, session),`. `buildAgentRunnerConfig` defaults `sessionPlatform` to `"linear"`, so pass both explicitly to reach the new param. Change the tail of that call to:
+
+```typescript
+				this.buildSkillSessionContext(repository, fullIssue, session),
+				"linear",
+				runnerTypeOverride,
+			);
+```
+
+- [ ] **Step 6: Verify typecheck and existing tests still pass**
+
+Run: `pnpm --filter cyrus-edge-worker typecheck`
+Expected: PASS (no type errors).
+
+Run: `pnpm --filter cyrus-edge-worker test:run EdgeWorker.runner-selection`
+Expected: PASS (no regressions — the override defaults to undefined).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/edge-worker/src/EdgeWorker.ts
+git commit -m "feat(handoff): thread runnerTypeOverride through resume path"
+```
+
+---
+
+### Task 9: Wire `HandoffService` into `EdgeWorker` + `handleHandoffCommand`
+
+**Files:**
+- Modify: `packages/edge-worker/src/EdgeWorker.ts` (constructor: instantiate service; `handleUserPromptedAgentActivity` ~line 5179: add branch; add new method `handleHandoffCommand`)
+- Test: `packages/edge-worker/test/EdgeWorker.handoff.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `HandoffService` (Tasks 2-6), `getActiveRunnerType`, `HANDOFF_STOP_TIMEOUT_MS`, `AgentSessionManager.getLastAssistantBody`/`clearRunnerSessionBindings` (Task 7), `resumeAgentSession(..., runnerTypeOverride)` (Task 8).
+- Produces: `private async handleHandoffCommand(webhook: AgentSessionPromptedWebhook, repositories: RepositoryConfig[], handoff: HandoffCommand): Promise<void>`.
+
+- [ ] **Step 1: Write the failing acceptance test**
+
+Create `packages/edge-worker/test/EdgeWorker.handoff.test.ts`. This drives `handleHandoffCommand` directly (the established pattern for these integration tests) with a mocked `AgentSessionManager` and a spied `resumeAgentSession`:
+
+```typescript
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { HandoffService } from "../src/HandoffService.js";
+
+vi.mock("../src/SharedApplicationServer.js");
+
+function makeRunner(running: boolean) {
+	return {
+		isRunning: vi.fn().mockReturnValue(running),
+		stop: vi.fn(),
+		constructor: { name: "ClaudeRunner" },
+	};
+}
+
+function makeRepo() {
+	return {
+		id: "r1",
+		name: "r1",
+		repositoryPath: "/repo",
+		workspaceBaseDir: "/ws",
+		baseBranch: "main",
+		linearWorkspaceId: "w1",
+		isActive: true,
+	} as any;
+}
+
+function makeWebhook() {
+	return {
+		organizationId: "w1",
+		agentSession: { id: "sess-1", issue: { id: "issue-1" } },
+		agentActivity: { content: { body: "/handoff codex" } },
+	} as any;
+}
+
+// Build a partially-real EdgeWorker: bypass the constructor and attach only the
+// collaborators handleHandoffCommand touches.
+function makeEdgeWorker(session: any) {
+	const ew: any = Object.create(EdgeWorker.prototype);
+	const reader = {
+		getCurrentBranch: () => "CYR-1",
+		getStatus: () => " M a.ts",
+		getRecentCommits: () => "abc c1",
+		getDiffSummary: () => " a.ts | 1 +",
+		getOpenPrUrl: () => undefined,
+	};
+	ew.handoffService = new HandoffService(reader);
+	ew.logger = {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		withContext: vi.fn().mockReturnThis(),
+	};
+	ew.agentSessionManager = {
+		getSession: vi.fn().mockReturnValue(session),
+		getLastAssistantBody: vi.fn().mockReturnValue("prev summary"),
+		clearRunnerSessionBindings: vi.fn(),
+		requestSessionStop: vi.fn(),
+		createResponseActivity: vi.fn().mockResolvedValue(undefined),
+	};
+	ew.resumeAgentSession = vi.fn().mockResolvedValue(undefined);
+	return ew;
+}
+
+describe("EdgeWorker.handleHandoffCommand", () => {
+	it("stops the active claude runner and starts codex in the same worktree", async () => {
+		const runner = makeRunner(false); // already stopped after stop()
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: runner,
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "keep going",
+		});
+
+		// Source stopped
+		expect(ew.agentSessionManager.requestSessionStop).toHaveBeenCalledWith(
+			"sess-1",
+		);
+		expect(runner.stop).toHaveBeenCalled();
+		// Bindings cleared so future routing follows codex
+		expect(
+			ew.agentSessionManager.clearRunnerSessionBindings,
+		).toHaveBeenCalledWith("sess-1");
+		// Target started via resume with the override + same worktree session
+		expect(ew.resumeAgentSession).toHaveBeenCalledTimes(1);
+		const callArgs = ew.resumeAgentSession.mock.calls[0];
+		expect(callArgs[0]).toBe(session); // same session => same worktree
+		expect(callArgs[callArgs.length - 1]).toBe("codex"); // runnerTypeOverride
+		const promptArg = callArgs[4];
+		expect(promptArg).toContain("<handoff_context>");
+		expect(promptArg).toContain("keep going");
+	});
+
+	it("blocks handoff when the active runner never stops", async () => {
+		const runner = makeRunner(true); // stays running forever
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: runner,
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+		// Make the poll resolve instantly and time out quickly.
+		ew.handoffService.waitForStopped = vi.fn().mockResolvedValue(false);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("blocked"),
+		);
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unknown target with an error comment", async () => {
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: makeRunner(false),
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: null,
+			rawTarget: "gemini",
+			remainder: "",
+		});
+
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("gemini"),
+		);
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+	});
+
+	it("no-ops when the target equals the current runner", async () => {
+		const session = {
+			id: "sess-1",
+			codexSessionId: "codex-x",
+			agentRunner: makeRunner(false),
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("Already running"),
+		);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter cyrus-edge-worker test:run EdgeWorker.handoff`
+Expected: FAIL — `handleHandoffCommand` is not defined.
+
+- [ ] **Step 3: Add imports and instantiate the service**
+
+In `packages/edge-worker/src/EdgeWorker.ts`, add to the imports near the other local `./` imports:
+
+```typescript
+import {
+	getActiveRunnerType,
+	HANDOFF_STOP_TIMEOUT_MS,
+	type HandoffCommand,
+	HandoffService,
+} from "./HandoffService.js";
+```
+
+Add a private field alongside the other service fields (e.g. near `private gitService`):
+
+```typescript
+	private handoffService: HandoffService;
+```
+
+In the constructor, after `this.gitService` is assigned, add:
+
+```typescript
+		this.handoffService = new HandoffService(this.gitService);
+```
+
+- [ ] **Step 4: Add the routing branch**
+
+In `handleUserPromptedAgentActivity`, replace the final line (~5179):
+
+```typescript
+		await this.handleNormalPromptedActivity(webhook, repositories);
+```
+
+with:
+
+```typescript
+		const handoff = this.handoffService.parseHandoffCommand(activityBody);
+		if (handoff) {
+			await this.handleHandoffCommand(webhook, repositories, handoff);
+			return;
+		}
+
+		await this.handleNormalPromptedActivity(webhook, repositories);
+```
+
+- [ ] **Step 5: Implement `handleHandoffCommand`**
+
+Add this method to the `EdgeWorker` class (place it directly after `handleNormalPromptedActivity`, before `handleIssueUnassigned`):
+
+```typescript
+	/**
+	 * Cross-runner handoff (Branch 3b of agentSessionPrompted).
+	 * Stops the active runner (sequentially, with a timeout), snapshots the
+	 * worktree/git/PR state, then starts the target runner fresh in the SAME
+	 * worktree with the snapshot injected into its prompt. Never runs both
+	 * runners concurrently.
+	 */
+	private async handleHandoffCommand(
+		webhook: AgentSessionPromptedWebhook,
+		repositories: RepositoryConfig[],
+		handoff: HandoffCommand,
+	): Promise<void> {
+		const { agentSession } = webhook;
+		const sessionId = agentSession.id;
+		const issueId = agentSession.issue?.id ?? "";
+		const linearWorkspaceId = webhook.organizationId;
+		const repository = repositories[0]!;
+
+		// Reject unsupported targets (only claude & codex are valid).
+		if (!handoff.targetRunner) {
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff failed: unknown runner "${handoff.rawTarget}". Supported targets: \`claude\`, \`codex\`.`,
+			);
+			return;
+		}
+		const target = handoff.targetRunner;
+
+		const session = this.agentSessionManager.getSession(sessionId);
+		if (!session) {
+			// No session yet (and therefore no active runner): nothing to hand
+			// off from. Ask the user to start the runner the normal way.
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff to \`${target}\` could not start: no active session was found for this issue. Mention me with a prompt to start one.`,
+			);
+			return;
+		}
+
+		const source = getActiveRunnerType(session);
+		if (source === target) {
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`ℹ️ Already running \`${target}\` for this issue — nothing to hand off.`,
+			);
+			return;
+		}
+
+		// Sequentially stop the active runner before starting the target.
+		const runner = session.agentRunner;
+		if (runner?.isRunning()) {
+			this.agentSessionManager.requestSessionStop(sessionId);
+			runner.stop();
+			const stopped = await this.handoffService.waitForStopped(
+				() => runner.isRunning(),
+				{
+					timeoutMs: HANDOFF_STOP_TIMEOUT_MS,
+					pollIntervalMs: 250,
+					sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+				},
+			);
+			if (!stopped) {
+				this.logger.warn(
+					`Handoff blocked: ${source} runner did not stop for session ${sessionId}`,
+					{ from: source, to: target, sessionId },
+				);
+				await this.agentSessionManager.createResponseActivity(
+					sessionId,
+					`⚠️ Handoff to \`${target}\` is blocked: the current \`${source}\` runner did not stop in time. It may be mid-operation — please try again in a moment.`,
+				);
+				return;
+			}
+		}
+
+		// Snapshot the source worktree state for the target's starting prompt.
+		const snapshot = this.handoffService.buildSnapshot({
+			sourceRunner: source,
+			targetRunner: target,
+			issueId,
+			sessionId,
+			worktreePath: session.workspace.path,
+			latestSummary: this.agentSessionManager.getLastAssistantBody(sessionId),
+		});
+		const handoffPrompt = this.handoffService.buildHandoffPrompt(
+			snapshot,
+			handoff.remainder,
+		);
+
+		// Clear the old runner binding so post-handoff routing follows the target.
+		this.agentSessionManager.clearRunnerSessionBindings(sessionId);
+
+		this.logger.info("Handoff starting", {
+			from: source,
+			to: target,
+			sessionId,
+			worktreePath: snapshot.worktreePath,
+			branch: snapshot.branch,
+		});
+
+		try {
+			await this.resumeAgentSession(
+				session,
+				repository,
+				sessionId,
+				this.agentSessionManager,
+				handoffPrompt,
+				"", // attachmentManifest
+				false, // isNewSession — session already exists
+				[], // additionalAllowedDirectories
+				linearWorkspaceId,
+				undefined, // maxTurns
+				undefined, // commentAuthor
+				undefined, // commentTimestamp
+				target, // runnerTypeOverride — forces the target runner
+			);
+			this.logger.info("Handoff complete", {
+				from: source,
+				to: target,
+				sessionId,
+			});
+		} catch (error) {
+			this.logger.error(
+				`Handoff failed to start ${target} runner for session ${sessionId}`,
+				error,
+			);
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff to \`${target}\` failed to start: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+```
+
+- [ ] **Step 6: Run the acceptance test to verify it passes**
+
+Run: `pnpm --filter cyrus-edge-worker test:run EdgeWorker.handoff`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm --filter cyrus-edge-worker typecheck`
+Expected: PASS. (If `RunnerType` is not yet imported in `EdgeWorker.ts`, add it to the `cyrus-core` import. If `AgentSessionPromptedWebhook` / `RepositoryConfig` are not imported, they already are — they're used by `handleUserPromptedAgentActivity`.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/edge-worker/src/EdgeWorker.ts packages/edge-worker/test/EdgeWorker.handoff.test.ts
+git commit -m "feat(handoff): wire /handoff command into EdgeWorker"
+```
+
+---
+
+### Task 10: Full suite, changelog, and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (under `## [Unreleased]`)
+
+- [ ] **Step 1: Run the full edge-worker test suite**
+
+Run: `pnpm --filter cyrus-edge-worker test:run`
+Expected: PASS (all tests, including the new handoff tests and the pre-existing suite).
+
+- [ ] **Step 2: Typecheck the whole repo**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Update the changelog**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added`, add:
+
+```markdown
+- Cross-runner handoff: comment `@Cyrus /handoff codex` or `@Cyrus /handoff claude` on a Linear issue to hand the in-progress work to the other runner. The target runner continues in the same worktree, branch, and PR, with a snapshot of the current state. Cyrus stops the active runner first and never runs both at once; if the active runner can't be stopped, it posts a comment explaining the handoff is blocked.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for cross-runner handoff"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** command parsing (Task 2), runner selection / force-override (Task 1 + 8), same-worktree reuse (Task 9 — `resumeAgentSession` reuses `session.workspace`; acceptance test asserts same session object), blocked handoff (Tasks 6 + 9), snapshot creation (Tasks 4 + 5), failure handling (Task 9 try/catch + test), no-runner-active / same-runner no-op (Task 9), event logging (Task 9 `logger.info`/`logger.warn` with `{ from, to, sessionId }`), backward compatibility (Task 8 override defaults to undefined; Task 1 sticky logic preserved in `else`).
+- **Acceptance criteria mapping:** `[agent=...]` unchanged → Task 1 keeps the sticky path under `else`, regression-guarded by `EdgeWorker.runner-selection` (Task 8 Step 6). `/handoff codex` after Claude and `/handoff claude` after Codex → symmetric via `getActiveRunnerType` + override (Task 9 test covers claude→codex; the codex→claude path is identical logic). Never concurrent → source stopped + awaited before target starts (Task 9). Both report to same issue → same `CyrusAgentSession`/thread reused.
+- **Type consistency:** `runnerTypeOverride` is `RunnerType` in `IssueRunnerConfigInput`, `buildAgentRunnerConfig`, and `resumeAgentSession`; `handleHandoffCommand` passes a `HandoffTarget` (`"claude" | "codex"`), which is assignable to `RunnerType`. `getActiveRunnerType` returns `RunnerType | "unknown"`; only used for display + equality, never passed where `RunnerType` is required.
+- **Constructor-arity caveats:** the `RunnerConfigBuilder`, `GitService`, and `AgentSessionManager` test helpers note to match the real constructor signature used in neighboring tests if the simplified construction throws.

--- a/docs/superpowers/specs/2026-06-25-cross-runner-handoff-design.md
+++ b/docs/superpowers/specs/2026-06-25-cross-runner-handoff-design.md
@@ -1,0 +1,165 @@
+# Cross-Runner Handoff — Design
+
+**Date:** 2026-06-25
+**Status:** Approved (design phase)
+
+## Goal
+
+Let a Linear issue be started with one runner (Claude or Codex) and later handed
+to the other runner so it continues from the existing work, files, branch, and PR
+state in the **same worktree**. Handoff is sequential, never concurrent.
+
+## UX
+
+- Initial runner selection is unchanged: `[agent=claude]` / `[agent=codex]`
+  description tags (and labels) still start exactly one runner.
+- New comment commands:
+  - `@Cyrus /handoff codex`
+  - `@Cyrus /handoff claude`
+- Normal comments without `/handoff` still go to the currently active runner.
+- If no runner is active, `/handoff <runner>` starts the requested runner for
+  that issue.
+- If the active runner cannot be stopped safely, Cyrus posts a Linear comment
+  explaining handoff is blocked and keeps the current runner.
+
+## Decisions (locked)
+
+1. **Session model — reuse same session in place.** Keep the same
+   `CyrusAgentSession` and the same Linear agent-session thread; swap
+   `agentRunner` in place, clear the old runner's `<x>SessionId` binding, and
+   start the target fresh in the same worktree with the snapshot prompt. This
+   keeps one continuous Linear timeline and naturally enforces one-active-runner.
+   (Cross-runner *transcript* resume is impossible — a Claude session id is
+   meaningless to Codex — so the target always starts fresh regardless;
+   continuity is delivered via the shared worktree plus the injected snapshot.)
+2. **Blocked trigger — stop + timeout.** Request stop and wait up to a timeout
+   (~30s) for the runner to reach a stopped state. If it doesn't stop in time,
+   post the "handoff blocked" comment and keep the current runner.
+3. **Target runners — claude & codex only.** Other targets (`gemini`, `cursor`)
+   are rejected with an error comment.
+
+## Architecture
+
+One new focused, unit-testable service plus one thin orchestration method on
+`EdgeWorker`, following the existing "EdgeWorker delegates to services" pattern
+(`ActivityPoster`, `RunnerSelectionService`, `GitService`).
+
+### `HandoffService` (`packages/edge-worker/src/HandoffService.ts`)
+
+Logic-heavy, no live-runner wiring, takes an injected `GitService` so it is
+testable:
+
+- `parseHandoffCommand(text): { targetRunner: "claude" | "codex"; remainder: string } | null`
+- `buildSnapshot(args): Promise<HandoffSnapshot>` — gathers git/PR/summary state
+- `buildHandoffPrompt(snapshot, userText): string` — formats the
+  `<handoff_context>` block plus the user's trailing instruction
+
+### `EdgeWorker.handleHandoffCommand(...)`
+
+Thin orchestration owning the runner/session wiring (stop → snapshot → start).
+Lives in `EdgeWorker` because it needs `createRunnerForType`,
+`buildAgentRunnerConfig`, and `agentSessionManager`.
+
+## Command parsing
+
+In `handleUserPromptedAgentActivity()`, immediately after `activityBody` is
+extracted and **before** the normal-routing branch (a sibling to the existing
+`stop` check), parse `/\/handoff\s+(\w+)/i`:
+
+- Tolerant of an optional leading `@Cyrus` mention.
+- Text after the command (e.g. `/handoff codex also add tests`) becomes the
+  target runner's user instruction (`remainder`).
+- The captured target is validated against `{claude, codex}`. An unknown target
+  (e.g. `/handoff gemini`) → error comment, no state change.
+
+## Orchestration flow
+
+```
+parse /handoff <target>
+ ├─ invalid target            → post error comment, stop
+ ├─ find active session(s) for issue; determine source runner type
+ ├─ target == source          → post "already running <target>" comment, stop (no-op)
+ ├─ a runner is active:
+ │    requestSessionStop(sessionId); runner.stop()
+ │    await stop-confirmed (poll isRunning, timeout ~30s)
+ │      └─ still running after timeout → post BLOCKED comment, keep current runner, stop
+ ├─ no runner active          → skip stop, start target directly
+ ├─ build HandoffSnapshot (source worktree/branch/git/PR/summary)
+ ├─ rebind session: clear old runner's <x>SessionId, set agentRunner = target
+ ├─ build target config with FORCED runnerType = target (bypass sticky/label selection)
+ └─ createRunnerForType(target) → addAgentRunner → start with snapshot-injected prompt
+```
+
+The one-active-runner invariant holds by construction: same worktree, source
+stopped before target starts.
+
+## Snapshot & prompt injection
+
+`HandoffSnapshot` fields:
+
+- `sourceRunner`, `targetRunner`
+- `issueId`, `sessionId`
+- `worktreePath`, `branch`
+- `gitStatus` (porcelain)
+- `recentCommits` (last ~5)
+- `diffSummary` (`--stat`)
+- `prLink` (best-effort via session metadata / `gh pr view`; omitted if
+  unavailable)
+- `latestSummary` (from `lastAssistantBodyBySession`; omitted if absent)
+
+The snapshot is injected into the target's starting prompt as a
+`<handoff_context>` XML block (consistent with Cyrus's existing XML prompt blocks
+such as `<repository_routing_context>`), followed by the user's trailing
+instruction, or a sensible default ("Continue the work in this worktree.") when
+the comment had none.
+
+## Forcing the runner type
+
+Today `RunnerConfigBuilder` (the resume-override logic, ~lines 333–354) forces
+the runner back to whatever the session's `<x>SessionId` is. Handoff needs an
+explicit escape hatch: thread an optional `runnerTypeOverride?: RunnerType`
+through `buildAgentRunnerConfig` → `buildIssueConfig` that, when set, **bypasses
+`determineRunnerSelection` and the sticky-resume logic**. Combined with clearing
+the old `<x>SessionId` on rebind, the target starts clean. Normal (non-handoff)
+calls pass nothing → behavior is 100% unchanged.
+
+## Event logging
+
+Add `runnerType` plus handoff metadata (`handoff: { from, to, sessionId }`) to
+the `logger.event(...)` payloads at `session_started` / `session_completed` /
+`session_stopped` and the error path. Non-handoff sessions just get `runnerType`
+added (harmless, useful).
+
+## Testing (Vitest)
+
+- **Command parsing**: valid `claude`/`codex`, optional mention, trailing text,
+  unknown target, no-command.
+- **Runner selection / force-override**: `buildIssueConfig` with
+  `runnerTypeOverride` ignores sticky session id and labels.
+- **Same-worktree reuse**: snapshot's `worktreePath`/`branch` equal the source
+  session's; no new worktree is created.
+- **Blocked handoff**: a runner that never stops within the timeout → blocked
+  comment, no rebind.
+- **Snapshot creation**: all fields populated from a fake `GitService`; PR and
+  summary gracefully omitted when absent.
+- **Failure handling**: target runner fails to start → error surfaced, session
+  left coherent.
+- **Regression guard**: `[agent=claude]` / `[agent=codex]` still start exactly
+  one runner.
+
+## Backward compatibility
+
+- No config schema changes.
+- `/handoff` is purely additive comment behavior.
+- `runnerTypeOverride` is optional and defaults to today's path.
+- Single-runner behavior is untouched.
+
+## Acceptance criteria
+
+- `[agent=claude]` and `[agent=codex]` still start exactly one runner.
+- `@Cyrus /handoff codex` after a Claude run starts Codex in the same worktree.
+- `@Cyrus /handoff claude` after a Codex run starts Claude in the same worktree.
+- Cyrus never runs both runners concurrently in the same worktree.
+- Both runners report back to the same Linear issue.
+- Tests cover command parsing, runner selection, same-worktree reuse, blocked
+  handoff, snapshot creation, and failure handling.

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -1327,6 +1327,28 @@ export class AgentSessionManager extends EventEmitter {
 		return this.sessions.get(sessionId);
 	}
 
+	/** Buffered last assistant text for a session (used as the handoff summary). */
+	getLastAssistantBody(sessionId: string): string | undefined {
+		return this.lastAssistantBodyBySession.get(sessionId);
+	}
+
+	/**
+	 * Clear every runner-specific session id on a session so that, after a
+	 * cross-runner handoff, normal routing follows the newly-bound runner
+	 * instead of the previous one. The target runner repopulates its own id on
+	 * its first system message.
+	 */
+	clearRunnerSessionBindings(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			return;
+		}
+		session.claudeSessionId = undefined;
+		session.geminiSessionId = undefined;
+		session.codexSessionId = undefined;
+		session.cursorSessionId = undefined;
+	}
+
 	/**
 	 * Get session entries by session ID
 	 */

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5184,6 +5184,12 @@ ${taskSection}`;
 			return;
 		}
 
+		// Branch 3b: cross-runner handoff (`/handoff claude|codex`). Deliberately
+		// placed here — AFTER repository resolution and access control — because
+		// the handoff needs the routed `repositories` to start the target runner.
+		// It is intentionally NOT a sibling of the early `stop` check: a handoff
+		// arriving while a repo-selection or AskUserQuestion elicitation is pending
+		// is handled by those earlier branches first.
 		const handoff = this.handoffService.parseHandoffCommand(activityBody);
 		if (handoff) {
 			await this.handleHandoffCommand(webhook, repositories, handoff);

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4450,6 +4450,16 @@ ${taskSection}`;
 			"/label-based-prompt",
 		);
 
+		// Cross-runner handoff via the creating comment (e.g. "@Cyrus /handoff codex").
+		// Linear @mentions create a NEW agent session, so a handoff requested this
+		// way arrives on the creation path (not the prompted path). Force the
+		// requested runner for this session; the issue's worktree is reused, so the
+		// target runner continues from the prior runner's files/commits/PR.
+		const creationHandoff = commentBody
+			? this.handoffService.parseHandoffCommand(commentBody)
+			: null;
+		const handoffRunnerOverride = creationHandoff?.targetRunner ?? undefined;
+
 		const agentSessionManager = this.agentSessionManager;
 
 		// Post instant acknowledgment thought
@@ -4570,10 +4580,12 @@ ${taskSection}`;
 					undefined, // maxTurns
 					linearWorkspaceId,
 					this.buildSkillSessionContext(primaryRepo, fullIssue, session),
+					"linear",
+					handoffRunnerOverride, // /handoff <runner> in the creating comment forces the runner
 				);
 
 			log.debug(
-				`Label-based runner selection for new session: ${runnerType} (session ${sessionId})`,
+				`Label-based runner selection for new session: ${runnerType} (session ${sessionId}, handoffOverride=${handoffRunnerOverride ?? "none"})`,
 			);
 
 			const runner = this.createRunnerForType(runnerType, runnerConfig);

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -6443,6 +6443,7 @@ ${input.userComment}
 		 * Defaults to `"linear"` (the pre-platform-aware behavior).
 		 */
 		sessionPlatform: "linear" | "github" | "gitlab" = "linear",
+		runnerTypeOverride?: RunnerType,
 	): Promise<{ config: AgentRunnerConfig; runnerType: RunnerType }> {
 		const log = this.logger.withContext({
 			sessionId,
@@ -6475,6 +6476,7 @@ ${input.userComment}
 			labels,
 			issueDescription,
 			maxTurns,
+			runnerTypeOverride,
 			// Per-platform MCP config paths — GitHub + GitLab share the
 			// `githubMcpConfigs` knob (single-repo PR contexts both); Linear
 			// gets `linearMcpConfigs`. Not a blanket override: the builder
@@ -7142,6 +7144,7 @@ ${input.userComment}
 		maxTurns?: number,
 		commentAuthor?: string,
 		commentTimestamp?: string,
+		runnerTypeOverride?: RunnerType,
 	): Promise<void> {
 		const log = this.logger.withContext({ sessionId });
 		// Check for existing runner
@@ -7149,6 +7152,7 @@ ${input.userComment}
 
 		// If there's an existing running runner that supports streaming, add to it
 		if (
+			!runnerTypeOverride &&
 			existingRunner?.isRunning() &&
 			existingRunner.supportsStreamingInput &&
 			existingRunner.addStreamMessage
@@ -7207,6 +7211,7 @@ ${input.userComment}
 		const hasCursorSession = !isNewSession && Boolean(session.cursorSessionId);
 		const needsNewSession =
 			isNewSession ||
+			Boolean(runnerTypeOverride) ||
 			(!hasClaudeSession &&
 				!hasGeminiSession &&
 				!hasCodexSession &&
@@ -7277,6 +7282,8 @@ ${input.userComment}
 				maxTurns, // Pass maxTurns if specified
 				resolvedWorkspaceId,
 				this.buildSkillSessionContext(repository, fullIssue, session),
+				"linear",
+				runnerTypeOverride,
 			);
 
 		// Create the appropriate runner based on session state

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -151,6 +151,12 @@ import { DefaultSkillsDeployer } from "./DefaultSkillsDeployer.js";
 import { EgressProxy } from "./EgressProxy.js";
 import { GitService } from "./GitService.js";
 import { GlobalSessionRegistry } from "./GlobalSessionRegistry.js";
+import {
+	getActiveRunnerType,
+	HANDOFF_STOP_TIMEOUT_MS,
+	type HandoffCommand,
+	HandoffService,
+} from "./HandoffService.js";
 import { McpConfigService } from "./McpConfigService.js";
 import { PromptBuilder } from "./PromptBuilder.js";
 import type {
@@ -230,6 +236,7 @@ export class EdgeWorker extends EventEmitter {
 	/** @internal - Exposed for testing only */
 	public repositoryRouter: RepositoryRouter; // Repository routing and selection
 	private gitService: GitService;
+	private handoffService: HandoffService;
 	private activeWebhookCount = 0; // Track number of webhooks currently being processed
 	/** Handler for AskUserQuestion tool invocations via Linear select signal */
 	private askUserQuestionHandler: AskUserQuestionHandler;
@@ -424,6 +431,7 @@ export class EdgeWorker extends EventEmitter {
 		};
 		this.repositoryRouter = new RepositoryRouter(repositoryRouterDeps);
 		this.gitService = new GitService({ cyrusHome: this.cyrusHome });
+		this.handoffService = new HandoffService(this.gitService);
 
 		// Initialize AskUserQuestion handler for elicitation via Linear select signal
 		this.askUserQuestionHandler = new AskUserQuestionHandler({
@@ -5176,7 +5184,150 @@ ${taskSection}`;
 			return;
 		}
 
+		const handoff = this.handoffService.parseHandoffCommand(activityBody);
+		if (handoff) {
+			await this.handleHandoffCommand(webhook, repositories, handoff);
+			return;
+		}
+
 		await this.handleNormalPromptedActivity(webhook, repositories);
+	}
+
+	/**
+	 * Cross-runner handoff (Branch 3b of agentSessionPrompted).
+	 * Stops the active runner (sequentially, with a timeout), snapshots the
+	 * worktree/git/PR state, then starts the target runner fresh in the SAME
+	 * worktree with the snapshot injected into its prompt. Never runs both
+	 * runners concurrently.
+	 */
+	private async handleHandoffCommand(
+		webhook: AgentSessionPromptedWebhook,
+		repositories: RepositoryConfig[],
+		handoff: HandoffCommand,
+	): Promise<void> {
+		const { agentSession } = webhook;
+		const sessionId = agentSession.id;
+		const issueId = agentSession.issue?.id ?? "";
+		const linearWorkspaceId = webhook.organizationId;
+		const repository = repositories[0]!;
+
+		// Reject unsupported targets (only claude & codex are valid).
+		if (!handoff.targetRunner) {
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff failed: unknown runner "${handoff.rawTarget}". Supported targets: \`claude\`, \`codex\`.`,
+			);
+			return;
+		}
+		const target = handoff.targetRunner;
+
+		const session = this.agentSessionManager.getSession(sessionId);
+		if (!session) {
+			// No session yet (and therefore no active runner): nothing to hand
+			// off from. Ask the user to start the runner the normal way.
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff to \`${target}\` could not start: no active session was found for this issue. Mention me with a prompt to start one.`,
+			);
+			return;
+		}
+
+		const source = getActiveRunnerType(session);
+		if (source === target) {
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`ℹ️ Already running \`${target}\` for this issue — nothing to hand off.`,
+			);
+			return;
+		}
+
+		// Sequentially stop the active runner before starting the target.
+		const runner = session.agentRunner;
+		if (runner) {
+			const wasRunning = runner.isRunning();
+			this.agentSessionManager.requestSessionStop(sessionId);
+			runner.stop();
+			if (wasRunning) {
+				const stopped = await this.handoffService.waitForStopped(
+					() => runner.isRunning(),
+					{
+						timeoutMs: HANDOFF_STOP_TIMEOUT_MS,
+						pollIntervalMs: 250,
+						sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+					},
+				);
+				if (!stopped) {
+					this.logger.warn(
+						`Handoff blocked: ${source} runner did not stop for session ${sessionId}`,
+						{ from: source, to: target, sessionId },
+					);
+					await this.agentSessionManager.createResponseActivity(
+						sessionId,
+						`⚠️ Handoff to \`${target}\` is blocked: the current \`${source}\` runner did not stop in time. It may be mid-operation — please try again in a moment.`,
+					);
+					return;
+				}
+			}
+		}
+
+		// Snapshot the source worktree state for the target's starting prompt.
+		const snapshot = this.handoffService.buildSnapshot({
+			sourceRunner: source,
+			targetRunner: target,
+			issueId,
+			sessionId,
+			worktreePath: session.workspace.path,
+			latestSummary: this.agentSessionManager.getLastAssistantBody(sessionId),
+		});
+		const handoffPrompt = this.handoffService.buildHandoffPrompt(
+			snapshot,
+			handoff.remainder,
+		);
+
+		// Clear the old runner binding so post-handoff routing follows the target.
+		this.agentSessionManager.clearRunnerSessionBindings(sessionId);
+
+		this.logger.info("Handoff starting", {
+			from: source,
+			to: target,
+			sessionId,
+			worktreePath: snapshot.worktreePath,
+			branch: snapshot.branch,
+		});
+
+		try {
+			await this.resumeAgentSession(
+				session,
+				repository,
+				sessionId,
+				this.agentSessionManager,
+				handoffPrompt,
+				"", // attachmentManifest
+				false, // isNewSession — session already exists
+				[], // additionalAllowedDirectories
+				linearWorkspaceId,
+				undefined, // maxTurns
+				undefined, // commentAuthor
+				undefined, // commentTimestamp
+				target, // runnerTypeOverride — forces the target runner
+			);
+			this.logger.info("Handoff complete", {
+				from: source,
+				to: target,
+				sessionId,
+			});
+		} catch (error) {
+			this.logger.error(
+				`Handoff failed to start ${target} runner for session ${sessionId}`,
+				error,
+			);
+			await this.agentSessionManager.createResponseActivity(
+				sessionId,
+				`⚠️ Handoff to \`${target}\` failed to start: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
 	}
 
 	/**

--- a/packages/edge-worker/src/GitService.ts
+++ b/packages/edge-worker/src/GitService.ts
@@ -333,6 +333,67 @@ export class GitService {
 		return [...resolvedDirectories];
 	}
 
+	/** Current branch checked out in a worktree (best-effort). */
+	getCurrentBranch(worktreePath: string): string {
+		try {
+			return execSync("git rev-parse --abbrev-ref HEAD", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** Porcelain working-tree status (best-effort). */
+	getStatus(worktreePath: string): string {
+		try {
+			return execSync("git status --porcelain", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** Last `limit` commits as `git log --oneline` (best-effort). */
+	getRecentCommits(worktreePath: string, limit: number): string {
+		try {
+			return execSync(`git log --oneline -n ${limit}`, {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** `git diff --stat` against HEAD (best-effort). */
+	getDiffSummary(worktreePath: string): string {
+		try {
+			return execSync("git diff --stat HEAD", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+		} catch {
+			return "";
+		}
+	}
+
+	/** URL of the open PR for the current branch via gh, or undefined (best-effort). */
+	getOpenPrUrl(worktreePath: string): string | undefined {
+		try {
+			const url = execSync("gh pr view --json url -q .url", {
+				cwd: worktreePath,
+				encoding: "utf-8",
+			}).trim();
+			return url || undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
 	/**
 	 * Find an existing worktree by its checked-out branch name.
 	 * Parses `git worktree list --porcelain` output and returns the worktree path

--- a/packages/edge-worker/src/HandoffService.ts
+++ b/packages/edge-worker/src/HandoffService.ts
@@ -126,6 +126,25 @@ export class HandoffService {
 		return `${lines.join("\n")}\n\n${instruction}`;
 	}
 
+	async waitForStopped(
+		isRunning: () => boolean,
+		opts: {
+			timeoutMs: number;
+			pollIntervalMs: number;
+			sleep: (ms: number) => Promise<void>;
+		},
+	): Promise<boolean> {
+		let elapsed = 0;
+		while (isRunning()) {
+			if (elapsed >= opts.timeoutMs) {
+				return false;
+			}
+			await opts.sleep(opts.pollIntervalMs);
+			elapsed += opts.pollIntervalMs;
+		}
+		return true;
+	}
+
 	parseHandoffCommand(text: string): HandoffCommand | null {
 		const match = text.match(HANDOFF_RE);
 		if (!match) {

--- a/packages/edge-worker/src/HandoffService.ts
+++ b/packages/edge-worker/src/HandoffService.ts
@@ -7,6 +7,8 @@
  * source runner and starts the target lives in EdgeWorker.handleHandoffCommand.
  */
 
+import type { CyrusAgentSession, RunnerType } from "cyrus-core";
+
 export type HandoffTarget = "claude" | "codex";
 
 export interface HandoffCommand {
@@ -31,6 +33,35 @@ export interface GitSnapshotReader {
 export const HANDOFF_STOP_TIMEOUT_MS = 30000;
 
 const HANDOFF_RE = /\/handoff\s+(\S+)([\s\S]*)/i;
+
+/** Identify the runner a session is currently bound to. */
+export function getActiveRunnerType(
+	session: Pick<
+		CyrusAgentSession,
+		| "claudeSessionId"
+		| "geminiSessionId"
+		| "codexSessionId"
+		| "cursorSessionId"
+		| "agentRunner"
+	>,
+): RunnerType | "unknown" {
+	if (session.claudeSessionId) return "claude";
+	if (session.geminiSessionId) return "gemini";
+	if (session.codexSessionId) return "codex";
+	if (session.cursorSessionId) return "cursor";
+	switch (session.agentRunner?.constructor?.name) {
+		case "ClaudeRunner":
+			return "claude";
+		case "GeminiRunner":
+			return "gemini";
+		case "CodexRunner":
+			return "codex";
+		case "CursorRunner":
+			return "cursor";
+		default:
+			return "unknown";
+	}
+}
 
 export class HandoffService {
 	constructor(readonly _gitReader: GitSnapshotReader) {}

--- a/packages/edge-worker/src/HandoffService.ts
+++ b/packages/edge-worker/src/HandoffService.ts
@@ -20,6 +20,23 @@ export interface HandoffCommand {
 	remainder: string;
 }
 
+export interface HandoffSnapshotArgs {
+	sourceRunner: RunnerType | "unknown";
+	targetRunner: HandoffTarget;
+	issueId: string;
+	sessionId: string;
+	worktreePath: string;
+	latestSummary?: string;
+}
+
+export interface HandoffSnapshot extends HandoffSnapshotArgs {
+	branch: string;
+	gitStatus: string;
+	recentCommits: string;
+	diffSummary: string;
+	prLink?: string;
+}
+
 /** Read-only git facts about a worktree. Implemented by GitService. */
 export interface GitSnapshotReader {
 	getCurrentBranch(worktreePath: string): string;
@@ -64,7 +81,50 @@ export function getActiveRunnerType(
 }
 
 export class HandoffService {
-	constructor(readonly _gitReader: GitSnapshotReader) {}
+	constructor(private readonly gitReader: GitSnapshotReader) {}
+
+	buildSnapshot(args: HandoffSnapshotArgs): HandoffSnapshot {
+		return {
+			...args,
+			branch: this.gitReader.getCurrentBranch(args.worktreePath),
+			gitStatus: this.gitReader.getStatus(args.worktreePath),
+			recentCommits: this.gitReader.getRecentCommits(args.worktreePath, 5),
+			diffSummary: this.gitReader.getDiffSummary(args.worktreePath),
+			prLink: this.gitReader.getOpenPrUrl(args.worktreePath),
+		};
+	}
+
+	buildHandoffPrompt(snapshot: HandoffSnapshot, userText?: string): string {
+		const lines = [
+			"<handoff_context>",
+			"  You are taking over an in-progress Linear issue from another agent.",
+			"  The worktree, branch, files, and PR state below are already in place.",
+			`  <source_runner>${snapshot.sourceRunner}</source_runner>`,
+			`  <target_runner>${snapshot.targetRunner}</target_runner>`,
+			`  <issue_id>${snapshot.issueId}</issue_id>`,
+			`  <session_id>${snapshot.sessionId}</session_id>`,
+			`  <worktree_path>${snapshot.worktreePath}</worktree_path>`,
+			`  <branch>${snapshot.branch || "(unknown)"}</branch>`,
+			`  <git_status>\n${snapshot.gitStatus || "(clean)"}\n  </git_status>`,
+			`  <recent_commits>\n${snapshot.recentCommits || "(none)"}\n  </recent_commits>`,
+			`  <diff_summary>\n${snapshot.diffSummary || "(no changes)"}\n  </diff_summary>`,
+		];
+		if (snapshot.prLink) {
+			lines.push(`  <pull_request>${snapshot.prLink}</pull_request>`);
+		}
+		if (snapshot.latestSummary) {
+			lines.push(
+				`  <previous_agent_summary>\n${snapshot.latestSummary}\n  </previous_agent_summary>`,
+			);
+		}
+		lines.push("</handoff_context>");
+
+		const instruction =
+			userText && userText.trim().length > 0
+				? userText.trim()
+				: "Continue the work in this worktree from where the previous runner left off.";
+		return `${lines.join("\n")}\n\n${instruction}`;
+	}
 
 	parseHandoffCommand(text: string): HandoffCommand | null {
 		const match = text.match(HANDOFF_RE);

--- a/packages/edge-worker/src/HandoffService.ts
+++ b/packages/edge-worker/src/HandoffService.ts
@@ -1,0 +1,49 @@
+/**
+ * Cross-runner handoff support: parse `/handoff <runner>` commands, build a
+ * context snapshot of the source runner's worktree state, format the target
+ * runner's starting prompt, and poll for the source runner to stop.
+ *
+ * Pure/logic-only — no live runner wiring. The orchestration that stops the
+ * source runner and starts the target lives in EdgeWorker.handleHandoffCommand.
+ */
+
+export type HandoffTarget = "claude" | "codex";
+
+export interface HandoffCommand {
+	/** Validated target, or null when the word after /handoff is unrecognized. */
+	targetRunner: HandoffTarget | null;
+	/** The raw word that followed /handoff (for error messages). */
+	rawTarget: string;
+	/** Any text after the target — becomes the target runner's instruction. */
+	remainder: string;
+}
+
+/** Read-only git facts about a worktree. Implemented by GitService. */
+export interface GitSnapshotReader {
+	getCurrentBranch(worktreePath: string): string;
+	getStatus(worktreePath: string): string;
+	getRecentCommits(worktreePath: string, limit: number): string;
+	getDiffSummary(worktreePath: string): string;
+	getOpenPrUrl(worktreePath: string): string | undefined;
+}
+
+/** How long to wait for the active runner to stop before declaring handoff blocked. */
+export const HANDOFF_STOP_TIMEOUT_MS = 30000;
+
+const HANDOFF_RE = /\/handoff\s+(\S+)([\s\S]*)/i;
+
+export class HandoffService {
+	constructor(readonly _gitReader: GitSnapshotReader) {}
+
+	parseHandoffCommand(text: string): HandoffCommand | null {
+		const match = text.match(HANDOFF_RE);
+		if (!match) {
+			return null;
+		}
+		const rawTarget = (match[1] ?? "").toLowerCase();
+		const remainder = (match[2] ?? "").trim();
+		const targetRunner: HandoffTarget | null =
+			rawTarget === "claude" || rawTarget === "codex" ? rawTarget : null;
+		return { targetRunner, rawTarget, remainder };
+	}
+}

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -158,6 +158,12 @@ export interface IssueRunnerConfigInput {
 	sandboxSettings?: SandboxSettings;
 	/** CA cert path for MITM TLS termination — passed via child process env */
 	egressCaCertPath?: string;
+	/**
+	 * When set, forces this exact runner type for the session, bypassing
+	 * label/description selection AND the sticky-resume binding. Used by
+	 * cross-runner handoff. Leave undefined for all normal sessions.
+	 */
+	runnerTypeOverride?: RunnerType;
 }
 
 export function resolveIssueMcpConfigPath(
@@ -330,8 +336,15 @@ export class RunnerConfigBuilder {
 		let modelOverride = runnerSelection.modelOverride;
 		let fallbackModelOverride = runnerSelection.fallbackModelOverride;
 
-		// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
-		if (input.session.claudeSessionId && runnerType !== "claude") {
+		// Cross-runner handoff: an explicit override wins over everything —
+		// label/description selection and the sticky-resume binding below.
+		if (input.runnerTypeOverride) {
+			runnerType = input.runnerTypeOverride;
+			modelOverride = this.runnerSelector.getDefaultModelForRunner(runnerType);
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType);
+		} else if (input.session.claudeSessionId && runnerType !== "claude") {
+			// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
 			runnerType = "claude";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("claude");
 			fallbackModelOverride =

--- a/packages/edge-worker/test/AgentSessionManager.handoff-accessors.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.handoff-accessors.test.ts
@@ -1,0 +1,40 @@
+import type { CyrusAgentSession } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+
+// Minimal manager: we only exercise the new accessors against its internal maps.
+function makeManager() {
+	// Construct with no args — matches the existing AgentSessionManager.stop-session.test.ts
+	return new AgentSessionManager();
+}
+
+describe("AgentSessionManager handoff accessors", () => {
+	it("clearRunnerSessionBindings nulls every runner session id", () => {
+		const mgr = makeManager();
+		const session = {
+			id: "s1",
+			claudeSessionId: "c",
+			codexSessionId: undefined,
+		} as unknown as CyrusAgentSession;
+		(mgr as any).sessions.set("s1", session);
+
+		mgr.clearRunnerSessionBindings("s1");
+
+		expect(session.claudeSessionId).toBeUndefined();
+		expect(session.geminiSessionId).toBeUndefined();
+		expect(session.codexSessionId).toBeUndefined();
+		expect(session.cursorSessionId).toBeUndefined();
+	});
+
+	it("clearRunnerSessionBindings is a no-op for an unknown session", () => {
+		const mgr = makeManager();
+		expect(() => mgr.clearRunnerSessionBindings("missing")).not.toThrow();
+	});
+
+	it("getLastAssistantBody returns the buffered body", () => {
+		const mgr = makeManager();
+		(mgr as any).lastAssistantBodyBySession.set("s1", "the summary");
+		expect(mgr.getLastAssistantBody("s1")).toBe("the summary");
+		expect(mgr.getLastAssistantBody("s2")).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.handoff.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.handoff.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { HandoffService } from "../src/HandoffService.js";
+
+vi.mock("../src/SharedApplicationServer.js");
+
+function makeRunner(running: boolean) {
+	return {
+		isRunning: vi.fn().mockReturnValue(running),
+		stop: vi.fn(),
+		constructor: { name: "ClaudeRunner" },
+	};
+}
+
+function makeRepo() {
+	return {
+		id: "r1",
+		name: "r1",
+		repositoryPath: "/repo",
+		workspaceBaseDir: "/ws",
+		baseBranch: "main",
+		linearWorkspaceId: "w1",
+		isActive: true,
+	} as any;
+}
+
+function makeWebhook() {
+	return {
+		organizationId: "w1",
+		agentSession: { id: "sess-1", issue: { id: "issue-1" } },
+		agentActivity: { content: { body: "/handoff codex" } },
+	} as any;
+}
+
+// Build a partially-real EdgeWorker: bypass the constructor and attach only the
+// collaborators handleHandoffCommand touches.
+function makeEdgeWorker(session: any) {
+	const ew: any = Object.create(EdgeWorker.prototype);
+	const reader = {
+		getCurrentBranch: () => "CYR-1",
+		getStatus: () => " M a.ts",
+		getRecentCommits: () => "abc c1",
+		getDiffSummary: () => " a.ts | 1 +",
+		getOpenPrUrl: () => undefined,
+	};
+	ew.handoffService = new HandoffService(reader);
+	ew.logger = {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		withContext: vi.fn().mockReturnThis(),
+	};
+	ew.agentSessionManager = {
+		getSession: vi.fn().mockReturnValue(session),
+		getLastAssistantBody: vi.fn().mockReturnValue("prev summary"),
+		clearRunnerSessionBindings: vi.fn(),
+		requestSessionStop: vi.fn(),
+		createResponseActivity: vi.fn().mockResolvedValue(undefined),
+	};
+	ew.resumeAgentSession = vi.fn().mockResolvedValue(undefined);
+	return ew;
+}
+
+describe("EdgeWorker.handleHandoffCommand", () => {
+	it("stops the active claude runner and starts codex in the same worktree", async () => {
+		const runner = makeRunner(false); // already stopped after stop()
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: runner,
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "keep going",
+		});
+
+		// Source stopped
+		expect(ew.agentSessionManager.requestSessionStop).toHaveBeenCalledWith(
+			"sess-1",
+		);
+		expect(runner.stop).toHaveBeenCalled();
+		// Bindings cleared so future routing follows codex
+		expect(
+			ew.agentSessionManager.clearRunnerSessionBindings,
+		).toHaveBeenCalledWith("sess-1");
+		// Target started via resume with the override + same worktree session
+		expect(ew.resumeAgentSession).toHaveBeenCalledTimes(1);
+		const callArgs = ew.resumeAgentSession.mock.calls[0];
+		expect(callArgs[0]).toBe(session); // same session => same worktree
+		expect(callArgs[callArgs.length - 1]).toBe("codex"); // runnerTypeOverride
+		const promptArg = callArgs[4];
+		expect(promptArg).toContain("<handoff_context>");
+		expect(promptArg).toContain("keep going");
+	});
+
+	it("blocks handoff when the active runner never stops", async () => {
+		const runner = makeRunner(true); // stays running forever
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: runner,
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+		// Make the poll resolve instantly and time out quickly.
+		ew.handoffService.waitForStopped = vi.fn().mockResolvedValue(false);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("blocked"),
+		);
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unknown target with an error comment", async () => {
+		const session = {
+			id: "sess-1",
+			claudeSessionId: "claude-x",
+			agentRunner: makeRunner(false),
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: null,
+			rawTarget: "gemini",
+			remainder: "",
+		});
+
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("gemini"),
+		);
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+	});
+
+	it("no-ops when the target equals the current runner", async () => {
+		const session = {
+			id: "sess-1",
+			codexSessionId: "codex-x",
+			agentRunner: makeRunner(false),
+			workspace: { path: "/ws/CYR-1" },
+		};
+		const ew = makeEdgeWorker(session);
+
+		await ew.handleHandoffCommand(makeWebhook(), [makeRepo()], {
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+
+		expect(ew.resumeAgentSession).not.toHaveBeenCalled();
+		expect(ew.agentSessionManager.createResponseActivity).toHaveBeenCalledWith(
+			"sess-1",
+			expect.stringContaining("Already running"),
+		);
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -435,6 +435,94 @@ Issue: {{issue_identifier}}`;
 			expect(ClaudeRunner).not.toHaveBeenCalled();
 		});
 
+		it("should select Codex runner when the creating comment contains '/handoff codex' (no codex label)", async () => {
+			// Linear @mentions create a NEW agent session, so `@Cyrus /handoff codex`
+			// arrives on the creation path. The handoff command must force the runner
+			// even though the issue has no codex label/tag (default would be Claude).
+			const mockIssue = createMockIssueWithLabels([]);
+			mockLinearClient.issue.mockResolvedValue(mockIssue);
+
+			const webhook: LinearAgentSessionCreatedWebhook = {
+				type: "Issue",
+				action: "agentSessionCreated",
+				organizationId: "test-workspace",
+				agentSession: {
+					id: "agent-session-123",
+					issue: {
+						id: "issue-123",
+						identifier: "TEST-123",
+						team: { key: "TEST" },
+					},
+					comment: { body: "@cyrus /handoff codex\n\nfix the failing test" },
+				},
+			};
+
+			await (edgeWorker as any).handleAgentSessionCreatedWebhook(webhook, [
+				mockRepository,
+			]);
+
+			expect(capturedRunnerType).toBe("codex");
+			expect(CodexRunner).toHaveBeenCalled();
+			expect(ClaudeRunner).not.toHaveBeenCalled();
+		});
+
+		it("should select Claude runner when the creating comment contains '/handoff claude' over a codex label", async () => {
+			// The handoff command in the creating comment wins over label-based selection.
+			const mockIssue = createMockIssueWithLabels(["codex"]);
+			mockLinearClient.issue.mockResolvedValue(mockIssue);
+
+			const webhook: LinearAgentSessionCreatedWebhook = {
+				type: "Issue",
+				action: "agentSessionCreated",
+				organizationId: "test-workspace",
+				agentSession: {
+					id: "agent-session-123",
+					issue: {
+						id: "issue-123",
+						identifier: "TEST-123",
+						team: { key: "TEST" },
+					},
+					comment: { body: "@cyrus /handoff claude please continue" },
+				},
+			};
+
+			await (edgeWorker as any).handleAgentSessionCreatedWebhook(webhook, [
+				mockRepository,
+			]);
+
+			expect(capturedRunnerType).toBe("claude");
+			expect(ClaudeRunner).toHaveBeenCalled();
+			expect(CodexRunner).not.toHaveBeenCalled();
+		});
+
+		it("should ignore an unknown '/handoff <runner>' target and fall back to label selection", async () => {
+			// `/handoff gemini` is not a valid handoff target (claude|codex only), so
+			// the override is not applied and normal label selection (codex) stands.
+			const mockIssue = createMockIssueWithLabels(["codex"]);
+			mockLinearClient.issue.mockResolvedValue(mockIssue);
+
+			const webhook: LinearAgentSessionCreatedWebhook = {
+				type: "Issue",
+				action: "agentSessionCreated",
+				organizationId: "test-workspace",
+				agentSession: {
+					id: "agent-session-123",
+					issue: {
+						id: "issue-123",
+						identifier: "TEST-123",
+						team: { key: "TEST" },
+					},
+					comment: { body: "@cyrus /handoff gemini do the thing" },
+				},
+			};
+
+			await (edgeWorker as any).handleAgentSessionCreatedWebhook(webhook, [
+				mockRepository,
+			]);
+
+			expect(capturedRunnerType).toBe("codex");
+		});
+
 		it("should select Codex runner with gpt-5-codex model when 'gpt-5-codex' label is present", async () => {
 			const mockIssue = createMockIssueWithLabels(["gpt-5-codex"]);
 			mockLinearClient.issue.mockResolvedValue(mockIssue);

--- a/packages/edge-worker/test/GitService.snapshot.test.ts
+++ b/packages/edge-worker/test/GitService.snapshot.test.ts
@@ -1,0 +1,40 @@
+import { execSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { GitService } from "../src/GitService.js";
+
+vi.mock("node:child_process", () => ({ execSync: vi.fn() }));
+
+describe("GitService snapshot reads", () => {
+	it("returns trimmed porcelain status", () => {
+		(execSync as any).mockReturnValue(" M file.ts\n");
+		const git = new GitService();
+		expect(git.getStatus("/wt")).toBe("M file.ts");
+	});
+
+	it("returns recent commits with the requested limit", () => {
+		(execSync as any).mockReturnValue("abc one\ndef two\n");
+		const git = new GitService();
+		expect(git.getRecentCommits("/wt", 5)).toBe("abc one\ndef two");
+		expect(execSync as any).toHaveBeenCalledWith(
+			"git log --oneline -n 5",
+			expect.objectContaining({ cwd: "/wt" }),
+		);
+	});
+
+	it("returns empty string when a git read throws", () => {
+		(execSync as any).mockImplementation(() => {
+			throw new Error("not a git repo");
+		});
+		const git = new GitService();
+		expect(git.getDiffSummary("/wt")).toBe("");
+		expect(git.getCurrentBranch("/wt")).toBe("");
+	});
+
+	it("returns undefined for the PR url when gh fails", () => {
+		(execSync as any).mockImplementation(() => {
+			throw new Error("gh: no pr");
+		});
+		const git = new GitService();
+		expect(git.getOpenPrUrl("/wt")).toBeUndefined();
+	});
+});

--- a/packages/edge-worker/test/HandoffService.parse.test.ts
+++ b/packages/edge-worker/test/HandoffService.parse.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc() {
+	const reader = {
+		getCurrentBranch: () => "branch",
+		getStatus: () => "",
+		getRecentCommits: () => "",
+		getDiffSummary: () => "",
+		getOpenPrUrl: () => undefined,
+	};
+	return new HandoffService(reader);
+}
+
+describe("HandoffService.parseHandoffCommand", () => {
+	it("returns null when there is no handoff command", () => {
+		expect(svc().parseHandoffCommand("please add tests")).toBeNull();
+	});
+
+	it("parses a codex target", () => {
+		expect(svc().parseHandoffCommand("/handoff codex")).toEqual({
+			targetRunner: "codex",
+			rawTarget: "codex",
+			remainder: "",
+		});
+	});
+
+	it("parses a claude target with a leading mention and trailing instruction", () => {
+		expect(
+			svc().parseHandoffCommand("@Cyrus /handoff claude also add tests"),
+		).toEqual({
+			targetRunner: "claude",
+			rawTarget: "claude",
+			remainder: "also add tests",
+		});
+	});
+
+	it("is case-insensitive for the target", () => {
+		expect(svc().parseHandoffCommand("/handoff CODEX")?.targetRunner).toBe(
+			"codex",
+		);
+	});
+
+	it("flags an unrecognized target with targetRunner null", () => {
+		expect(svc().parseHandoffCommand("/handoff gemini")).toEqual({
+			targetRunner: null,
+			rawTarget: "gemini",
+			remainder: "",
+		});
+	});
+});

--- a/packages/edge-worker/test/HandoffService.runner-type.test.ts
+++ b/packages/edge-worker/test/HandoffService.runner-type.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getActiveRunnerType } from "../src/HandoffService.js";
+
+describe("getActiveRunnerType", () => {
+	it("reads claude from claudeSessionId", () => {
+		expect(getActiveRunnerType({ claudeSessionId: "x" } as any)).toBe("claude");
+	});
+
+	it("reads codex from codexSessionId", () => {
+		expect(getActiveRunnerType({ codexSessionId: "x" } as any)).toBe("codex");
+	});
+
+	it("falls back to the runner constructor name", () => {
+		const session = {
+			agentRunner: { constructor: { name: "CodexRunner" } },
+		} as any;
+		expect(getActiveRunnerType(session)).toBe("codex");
+	});
+
+	it("returns unknown when nothing identifies the runner", () => {
+		expect(getActiveRunnerType({} as any)).toBe("unknown");
+	});
+});

--- a/packages/edge-worker/test/HandoffService.snapshot.test.ts
+++ b/packages/edge-worker/test/HandoffService.snapshot.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc(overrides: Record<string, unknown> = {}) {
+	const reader = {
+		getCurrentBranch: () => "CYR-1-feature",
+		getStatus: () => " M src/a.ts",
+		getRecentCommits: () => "abc first\ndef second",
+		getDiffSummary: () => " src/a.ts | 2 +-",
+		getOpenPrUrl: () => "https://github.com/o/r/pull/9",
+		...overrides,
+	};
+	return new HandoffService(reader as any);
+}
+
+const args = {
+	sourceRunner: "claude" as const,
+	targetRunner: "codex" as const,
+	issueId: "issue-1",
+	sessionId: "sess-1",
+	worktreePath: "/ws/CYR-1",
+	latestSummary: "Implemented the parser.",
+};
+
+describe("HandoffService.buildSnapshot", () => {
+	it("collects all git fields from the reader", () => {
+		const snap = svc().buildSnapshot(args);
+		expect(snap).toMatchObject({
+			sourceRunner: "claude",
+			targetRunner: "codex",
+			branch: "CYR-1-feature",
+			gitStatus: " M src/a.ts",
+			recentCommits: "abc first\ndef second",
+			diffSummary: " src/a.ts | 2 +-",
+			prLink: "https://github.com/o/r/pull/9",
+			latestSummary: "Implemented the parser.",
+		});
+	});
+
+	it("omits the PR link when none is available", () => {
+		const snap = svc({ getOpenPrUrl: () => undefined }).buildSnapshot(args);
+		expect(snap.prLink).toBeUndefined();
+	});
+});
+
+describe("HandoffService.buildHandoffPrompt", () => {
+	it("includes the handoff context block and the user instruction", () => {
+		const snap = svc().buildSnapshot(args);
+		const prompt = svc().buildHandoffPrompt(snap, "add tests too");
+		expect(prompt).toContain("<handoff_context>");
+		expect(prompt).toContain("<source_runner>claude</source_runner>");
+		expect(prompt).toContain("<target_runner>codex</target_runner>");
+		expect(prompt).toContain("<branch>CYR-1-feature</branch>");
+		expect(prompt).toContain("https://github.com/o/r/pull/9");
+		expect(prompt).toContain("Implemented the parser.");
+		expect(prompt.trimEnd().endsWith("add tests too")).toBe(true);
+	});
+
+	it("uses a default instruction when the user gave none", () => {
+		const snap = svc().buildSnapshot(args);
+		const prompt = svc().buildHandoffPrompt(snap, "");
+		expect(prompt).toContain(
+			"Continue the work in this worktree from where the previous runner left off.",
+		);
+	});
+});

--- a/packages/edge-worker/test/HandoffService.wait.test.ts
+++ b/packages/edge-worker/test/HandoffService.wait.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { HandoffService } from "../src/HandoffService.js";
+
+function svc() {
+	const reader = {
+		getCurrentBranch: () => "",
+		getStatus: () => "",
+		getRecentCommits: () => "",
+		getDiffSummary: () => "",
+		getOpenPrUrl: () => undefined,
+	};
+	return new HandoffService(reader as any);
+}
+
+describe("HandoffService.waitForStopped", () => {
+	it("returns true once the runner reports stopped", async () => {
+		let calls = 0;
+		const isRunning = () => {
+			calls += 1;
+			return calls < 3; // running for 2 polls, then stopped
+		};
+		const stopped = await svc().waitForStopped(isRunning, {
+			timeoutMs: 1000,
+			pollIntervalMs: 100,
+			sleep: vi.fn().mockResolvedValue(undefined),
+		});
+		expect(stopped).toBe(true);
+	});
+
+	it("returns false when the runner never stops within the timeout", async () => {
+		const stopped = await svc().waitForStopped(() => true, {
+			timeoutMs: 300,
+			pollIntervalMs: 100,
+			sleep: vi.fn().mockResolvedValue(undefined),
+		});
+		expect(stopped).toBe(false);
+	});
+
+	it("returns true immediately when already stopped", async () => {
+		const sleep = vi.fn().mockResolvedValue(undefined);
+		const stopped = await svc().waitForStopped(() => false, {
+			timeoutMs: 300,
+			pollIntervalMs: 100,
+			sleep,
+		});
+		expect(stopped).toBe(true);
+		expect(sleep).not.toHaveBeenCalled();
+	});
+});

--- a/packages/edge-worker/test/RunnerConfigBuilder.handoff-override.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.handoff-override.test.ts
@@ -1,0 +1,92 @@
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	// Normal selection always returns claude — so a codex result can only come
+	// from the override path.
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
+		getDefaultModelForRunner: () => "opus",
+		getDefaultFallbackModelForRunner: () => "sonnet",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function baseInput(session: Partial<CyrusAgentSession>) {
+	return {
+		session: session as CyrusAgentSession,
+		repository: {
+			id: "repo-a",
+			name: "Repo A",
+			repositoryPath: "/repos/repo-a",
+			allowedTools: [],
+		} as unknown as RepositoryConfig,
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	};
+}
+
+describe("RunnerConfigBuilder runnerTypeOverride", () => {
+	it("forces the override runner even when the session is sticky to claude", () => {
+		const input = {
+			...baseInput({
+				issueId: "issue-1",
+				issue: { identifier: "ABC-1" },
+				workspace: { path: "/ws/root" },
+				claudeSessionId: "claude-abc",
+			} as unknown as Partial<CyrusAgentSession>),
+			labels: ["claude"],
+			runnerTypeOverride: "codex" as const,
+		};
+
+		const { runnerType } = makeBuilder().buildIssueConfig(input as any);
+
+		expect(runnerType).toBe("codex");
+	});
+
+	it("falls back to normal selection when no override is given", () => {
+		const input = baseInput({
+			issueId: "issue-1",
+			issue: { identifier: "ABC-1" },
+			workspace: { path: "/ws/root" },
+			claudeSessionId: "claude-abc",
+		} as unknown as Partial<CyrusAgentSession>);
+
+		const { runnerType } = makeBuilder().buildIssueConfig(input as any);
+
+		expect(runnerType).toBe("claude");
+	});
+});


### PR DESCRIPTION
## Summary

Adds **cross-runner handoff** to Cyrus: a Linear issue started with one runner (Claude or Codex) can be handed to the other so it continues from the existing work, files, branch, and PR state — in the **same worktree**, never running both runners at once.

```
@Cyrus /handoff codex     # hand the work to Codex
@Cyrus /handoff claude    # hand the work to Claude
```

Initial-runner tags (`[agent=claude]` / `[agent=codex]`) are unchanged.

## How it works

- **`HandoffService`** (`packages/edge-worker/src/HandoffService.ts`) — command parsing (`parseHandoffCommand`), worktree/git/PR snapshot (`buildSnapshot`), target-prompt formatting (`buildHandoffPrompt`), a stop-poller (`waitForStopped`), and `getActiveRunnerType`.
- **`runnerTypeOverride`** threaded through `RunnerConfigBuilder.buildIssueConfig` → `EdgeWorker.buildAgentRunnerConfig` → `resumeAgentSession`. When set, it forces the target runner, bypassing label/description selection and the sticky-session binding. Defaults to `undefined`, so existing single-runner behavior is byte-for-byte unchanged.
- **Follow-up path** (`handleHandoffCommand`): stops the active runner (sequentially, with a ~30s timeout → "handoff blocked" comment), snapshots the worktree state, clears the old runner binding, and starts the target in the same `session.workspace`.
- **Creation path**: Linear @mentions create a *new* agent session, so `@Cyrus /handoff codex` arrives on the session-creation webhook. The creating comment is parsed and the requested runner is forced for the new session (the issue's worktree is reused, so the target picks up prior files/commits/PR).
- Best-effort git/PR snapshot reads added to `GitService`; `getLastAssistantBody` / `clearRunnerSessionBindings` added to `AgentSessionManager`.

## Testing

- New unit/integration tests: command parsing, runner-type detection, snapshot building, prompt formatting, stop-poller, `runnerTypeOverride`, same-worktree reuse, blocked handoff, failure handling, and creation-path handoff selection. Full `cyrus-edge-worker` suite: **765 passing**; `pnpm typecheck` clean.
- **Validated live against Linear on a self-hosted Cyrus**: `@Cyrus /handoff codex` on a Claude-started issue stopped Claude and started a Codex runner in the same worktree, continuing the work.

## Acceptance criteria

- [x] `[agent=claude]` / `[agent=codex]` still start exactly one runner (regression-guarded).
- [x] `/handoff codex` after Claude starts Codex in the same worktree; `/handoff claude` after Codex starts Claude.
- [x] Never runs both runners concurrently in the same worktree.
- [x] Both runners report to the same Linear issue.
- [x] Tests cover parsing, runner selection, same-worktree reuse, blocked handoff, snapshot creation, and failure handling.

Changelog updated under `## [Unreleased]`.
