### PR TITLE
Customize Slack in-flight response status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependency directories
 node_modules
 **/node_modules
+.pnpm-store
 
 # This monorepo uses pnpm — npm/yarn lockfiles should never be committed
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Slack chat sessions now show Cyrus-branded in-flight status while work is underway, clear that status when the turn finishes or errors, and include guardrails for Slack streaming replies so a stream cannot mix text and task/progress modes. ([CYPACK-1367](https://linear.app/ceedar/issue/CYPACK-1367), [#1362](https://github.com/cyrusagents/cyrus/pull/1362))
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/apps/f1/test-drives/2026-07-03-cypack-1367-slack-inflight-status.md
+++ b/apps/f1/test-drives/2026-07-03-cypack-1367-slack-inflight-status.md
@@ -1,0 +1,46 @@
+# Test Drive: CYPACK-1367 Slack In-Flight Status
+
+**Date**: 2026-07-03
+**Goal**: Verify the Slack chat session path still starts and completes after adding in-flight response status hooks.
+**Test Repo**: `/tmp/f1-test-drive-cypack-1367`
+
+## Verification Results
+
+### F1 Setup
+- [x] Test repository created with `apps/f1/f1 init-test-repo --path /tmp/f1-test-drive-cypack-1367`
+- [x] F1 server started on `CYRUS_PORT=3600`
+- [x] `apps/f1/f1 ping` and `apps/f1/f1 status` passed
+
+### Slack Chat Path
+- [x] Synthetic Slack chat event dispatched with `apps/f1/f1 start-chat-session`
+- [x] Slack workspace directory created under `/tmp/cyrus-f1-*/slack-workspaces/`
+- [x] Runner session started for the Slack event
+- [x] Runner emitted a final `result`
+- [x] No-token Slack status/reply paths skipped without blocking session completion
+
+## Session Log
+
+Initial run inherited a real `SLACK_BOT_TOKEN`, so the synthetic channel produced expected Slack API `channel_not_found` warnings for status, reaction, final reply, and status cleanup. The session still started, emitted `result`, and cleanup ran.
+
+Clean no-token run:
+
+```bash
+env -u SLACK_BOT_TOKEN CYRUS_PORT=3600 CYRUS_REPO_PATH=/tmp/f1-test-drive-cypack-1367 bun run apps/f1/server.ts
+CYRUS_PORT=3600 apps/f1/f1 start-chat-session --channel C_TEST_CHAN --user U_TEST_USER --text "Cyrus, give a one sentence reply"
+```
+
+Key observed events:
+
+```text
+Processing slack webhook: f1-1783118377.305
+Cannot set Slack status: no slackBotToken available
+[event:session_started]
+[event:claude_session_id_assigned]
+[event:message_emitted] {"messageType":"result"}
+Session completed (subtype: success)
+Cannot post Slack reply: no slackBotToken available
+```
+
+## Final Retrospective
+
+F1 validates that the Slack ChatSessionHandler path remains functional and that missing Slack credentials do not prevent session startup or completion. F1 cannot visually verify Slack's rendered assistant status because it uses synthetic channels; the final acceptance criterion for branded Slack presentation still needs a live Slack thread with a real channel.

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -52,6 +52,12 @@ export interface ChatPlatformAdapter<TEvent> {
 	/** Fetch thread context as formatted string. Returns "" if not applicable */
 	fetchThreadContext(event: TEvent): Promise<string>;
 
+	/** Mark a platform thread as actively being handled, if supported. */
+	startInFlightResponse?(event: TEvent): Promise<void>;
+
+	/** Clear any active in-flight indicator for the platform thread, if supported. */
+	clearInFlightResponse?(event: TEvent): Promise<void>;
+
 	/** Post the agent's final response back to the platform */
 	postReply(event: TEvent, runner: IAgentRunner): Promise<void>;
 
@@ -198,6 +204,7 @@ export class ChatSessionHandler<TEvent> {
 							`Injecting follow-up prompt into running session ${existingSessionId} (thread ${threadKey})`,
 						);
 						this.enqueueReply(existingSessionId, event);
+						await this.startInFlightResponse(event);
 						existingRunner.addStreamMessage(taskInstructions);
 					} else {
 						// Runner can't accept mid-turn input (e.g. exec Codex). Queue the
@@ -339,6 +346,7 @@ export class ChatSessionHandler<TEvent> {
 			// stays open and the start() promise doesn't resolve until the
 			// whole session ends.
 			this.enqueueReply(sessionId, event);
+			await this.startInFlightResponse(event);
 			const startPromise =
 				runner.supportsStreamingInput && runner.startStreaming
 					? runner.startStreaming(userPrompt)
@@ -349,7 +357,7 @@ export class ChatSessionHandler<TEvent> {
 						`${this.adapter.platformName} session started: ${sessionInfo.sessionId}`,
 					);
 				})
-				.catch((error: unknown) => {
+				.catch(async (error: unknown) => {
 					this.logger.error(
 						`${this.adapter.platformName} session error for event ${eventId}`,
 						error instanceof Error ? error : new Error(String(error)),
@@ -357,7 +365,8 @@ export class ChatSessionHandler<TEvent> {
 					// Runner died before emitting a final `result`. Drop any
 					// still-queued reply events for this session so a later
 					// resumeSession() doesn't pair them with a future turn.
-					this.clearPendingReplies(sessionId);
+					const clearedEvents = this.clearPendingReplies(sessionId);
+					await this.clearInFlightResponses(clearedEvents);
 				})
 				.finally(() => {
 					this.deps.onStateChange().catch((error: unknown) => {
@@ -452,6 +461,7 @@ export class ChatSessionHandler<TEvent> {
 		// warm sessions hold the streaming prompt open across turns so the
 		// start() promise only resolves when the whole session ends.
 		this.enqueueReply(sessionId, event);
+		await this.startInFlightResponse(event);
 		const startPromise =
 			runner.supportsStreamingInput && runner.startStreaming
 				? runner.startStreaming(taskInstructions)
@@ -462,12 +472,13 @@ export class ChatSessionHandler<TEvent> {
 					`${this.adapter.platformName} session resumed: ${sessionInfo.sessionId} (was ${resumeSessionId})`,
 				);
 			})
-			.catch((error: unknown) => {
+			.catch(async (error: unknown) => {
 				this.logger.error(
 					`${this.adapter.platformName} resume session error for ${sessionId}`,
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				this.clearPendingReplies(sessionId);
+				const clearedEvents = this.clearPendingReplies(sessionId);
+				await this.clearInFlightResponses(clearedEvents);
 			});
 	}
 
@@ -498,6 +509,10 @@ export class ChatSessionHandler<TEvent> {
 					this.logger.error(
 						`Failed to post ${this.adapter.platformName} reply for session ${sessionId}`,
 						error instanceof Error ? error : new Error(String(error)),
+					);
+				} finally {
+					await this.clearInFlightResponses(
+						events.length > 0 ? events : [replyEvent],
 					);
 				}
 				// Fire-and-forget processed acknowledgement for every drained
@@ -573,6 +588,40 @@ export class ChatSessionHandler<TEvent> {
 		this.lastReplyEvent.set(sessionId, event);
 	}
 
+	private async startInFlightResponse(event: TEvent): Promise<void> {
+		if (!this.adapter.startInFlightResponse) {
+			return;
+		}
+		try {
+			await this.adapter.startInFlightResponse(event);
+		} catch (error) {
+			this.logger.warn(
+				`Failed to start ${this.adapter.platformName} in-flight response status: ${error instanceof Error ? error.message : error}`,
+			);
+		}
+	}
+
+	private async clearInFlightResponses(events: TEvent[]): Promise<void> {
+		if (!this.adapter.clearInFlightResponse || events.length === 0) {
+			return;
+		}
+		const seen = new Set<string>();
+		for (const event of events) {
+			const key = this.adapter.getThreadKey(event);
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			try {
+				await this.adapter.clearInFlightResponse(event);
+			} catch (error) {
+				this.logger.warn(
+					`Failed to clear ${this.adapter.platformName} in-flight response status: ${error instanceof Error ? error.message : error}`,
+				);
+			}
+		}
+	}
+
 	private drainReplies(sessionId: string): TEvent[] {
 		const queue = this.pendingReplyEvents.get(sessionId);
 		if (!queue || queue.length === 0) return [];
@@ -586,14 +635,15 @@ export class ChatSessionHandler<TEvent> {
 	 * resumeSession() on the same sessionId would pair the stale events with
 	 * the first `result` of the new runner.
 	 */
-	private clearPendingReplies(sessionId: string): void {
+	private clearPendingReplies(sessionId: string): TEvent[] {
 		this.lastReplyEvent.delete(sessionId);
 		const queue = this.pendingReplyEvents.get(sessionId);
-		if (!queue || queue.length === 0) return;
+		if (!queue || queue.length === 0) return [];
 		this.logger.warn(
 			`Discarding ${queue.length} pending ${this.adapter.platformName} reply event(s) for session ${sessionId} after runner error`,
 		);
 		this.pendingReplyEvents.delete(sessionId);
+		return queue;
 	}
 
 	/**

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -34,6 +34,17 @@ export const RECEIPT_REACTION = "eyes";
 /** Reaction that replaces the receipt one once the agent finished its turn (✅) */
 export const PROCESSED_REACTION = "white_check_mark";
 
+/** Status Slack renders as "<App Name> <status>" while Cyrus is working. */
+export const CYRUS_SLACK_ASSISTANT_STATUS = "is working through the request...";
+
+/** Loading messages shown by Slack's assistant thread status indicator. */
+export const CYRUS_SLACK_LOADING_MESSAGES = [
+	"Reading the thread...",
+	"Checking the workspace context...",
+	"Working through the request...",
+	"Verifying the result...",
+] as const;
+
 /**
  * Slack implementation of ChatPlatformAdapter.
  *
@@ -336,6 +347,38 @@ Supported mrkdwn syntax:
 				error instanceof Error ? error : new Error(String(error)),
 			);
 		}
+	}
+
+	async startInFlightResponse(event: SlackWebhookEvent): Promise<void> {
+		const token = this.getSlackBotToken(event);
+		if (!token) {
+			this.logger.warn("Cannot set Slack status: no slackBotToken available");
+			return;
+		}
+
+		const threadTs = event.payload.thread_ts || event.payload.ts;
+		await new SlackMessageService().setAssistantThreadStatus({
+			token,
+			channel_id: event.payload.channel,
+			thread_ts: threadTs,
+			status: CYRUS_SLACK_ASSISTANT_STATUS,
+			loading_messages: [...CYRUS_SLACK_LOADING_MESSAGES],
+		});
+	}
+
+	async clearInFlightResponse(event: SlackWebhookEvent): Promise<void> {
+		const token = this.getSlackBotToken(event);
+		if (!token) {
+			return;
+		}
+
+		const threadTs = event.payload.thread_ts || event.payload.ts;
+		await new SlackMessageService().setAssistantThreadStatus({
+			token,
+			channel_id: event.payload.channel,
+			thread_ts: threadTs,
+			status: "",
+		});
 	}
 
 	async acknowledgeReceipt(event: SlackWebhookEvent): Promise<void> {

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -15,6 +15,8 @@ import { ChatSessionHandler } from "../src/ChatSessionHandler.js";
 import type { RunnerConfigBuilder } from "../src/RunnerConfigBuilder.js";
 import {
 	BEHAVIOURS_PAGE_ROUTE,
+	CYRUS_SLACK_ASSISTANT_STATUS,
+	CYRUS_SLACK_LOADING_MESSAGES,
 	PROCESSED_REACTION,
 	RECEIPT_REACTION,
 	SLACK_NO_RESPONSE_SENTINEL,
@@ -407,6 +409,101 @@ describe("ChatSessionHandler processed acknowledgement", () => {
 	});
 });
 
+describe("ChatSessionHandler in-flight response status", () => {
+	it("starts status when a turn is queued and clears it when the runner emits a result", async () => {
+		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
+			"status-thread",
+		);
+		const startInFlightResponse = vi.fn().mockResolvedValue(undefined);
+		const clearInFlightResponse = vi.fn().mockResolvedValue(undefined);
+		adapter.startInFlightResponse = startInFlightResponse;
+		adapter.clearInFlightResponse = clearInFlightResponse;
+
+		let capturedConfig: any;
+		const createRunner = vi.fn((config: any) => {
+			capturedConfig = config;
+			return {
+				supportsStreamingInput: false,
+				start: vi.fn().mockResolvedValue({ sessionId: "session-1" }),
+				stop: vi.fn(),
+				isRunning: vi.fn().mockReturnValue(false),
+				isStreaming: vi.fn().mockReturnValue(false),
+				addStreamMessage: vi.fn(),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		const event = { eventId: "mention", threadKey: "status-thread" };
+		await handler.handleEvent(event as any);
+
+		expect(startInFlightResponse).toHaveBeenCalledTimes(1);
+		expect(startInFlightResponse).toHaveBeenCalledWith(event);
+		expect(clearInFlightResponse).not.toHaveBeenCalled();
+
+		await capturedConfig.onMessage({
+			type: "result",
+			subtype: "success",
+			is_error: false,
+			result: "done",
+			session_id: "session-1",
+		});
+
+		expect(clearInFlightResponse).toHaveBeenCalledTimes(1);
+		expect(clearInFlightResponse).toHaveBeenCalledWith(event);
+	});
+
+	it("clears status if the runner rejects before emitting a result", async () => {
+		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
+			"error-thread",
+		);
+		const startInFlightResponse = vi.fn().mockResolvedValue(undefined);
+		const clearInFlightResponse = vi.fn().mockResolvedValue(undefined);
+		adapter.startInFlightResponse = startInFlightResponse;
+		adapter.clearInFlightResponse = clearInFlightResponse;
+
+		const createRunner = vi.fn(
+			() =>
+				({
+					supportsStreamingInput: false,
+					start: vi.fn().mockRejectedValue(new Error("runner failed")),
+					stop: vi.fn(),
+					isRunning: vi.fn().mockReturnValue(false),
+					isStreaming: vi.fn().mockReturnValue(false),
+					addStreamMessage: vi.fn(),
+					getMessages: vi.fn().mockReturnValue([]),
+				}) as any,
+		);
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		const event = { eventId: "mention", threadKey: "error-thread" };
+		await handler.handleEvent(event as any);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(startInFlightResponse).toHaveBeenCalledWith(event);
+		expect(clearInFlightResponse).toHaveBeenCalledTimes(1);
+		expect(clearInFlightResponse).toHaveBeenCalledWith(event);
+	});
+});
+
 describe("ChatSessionHandler busy follow-up queueing", () => {
 	it("queues a follow-up that can't be streamed and delivers it after the turn", async () => {
 		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
@@ -676,6 +773,67 @@ describe("SlackChatAdapter responding policy", () => {
 		expect(removeSpy.mock.invocationCallOrder[0]).toBeLessThan(
 			addSpy.mock.invocationCallOrder[0] ?? 0,
 		);
+	});
+});
+
+describe("SlackChatAdapter in-flight response status", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const slackEvent = () =>
+		({
+			eventType: "app_mention",
+			eventId: "Ev1",
+			teamId: "T1",
+			slackBotToken: "xoxb-test",
+			payload: {
+				type: "app_mention",
+				user: "U1",
+				channel: "C1",
+				text: "<@U0BOT> help",
+				ts: "1700000000.000200",
+				thread_ts: "1700000000.000100",
+				event_ts: "1700000000.000200",
+			},
+		}) as any;
+
+	it("sets Cyrus-branded status using Slack's installed app identity", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		const statusSpy = vi
+			.spyOn(SlackMessageService.prototype, "setAssistantThreadStatus")
+			.mockResolvedValue(undefined);
+
+		await adapter.startInFlightResponse(slackEvent());
+
+		expect(statusSpy).toHaveBeenCalledTimes(1);
+		expect(statusSpy.mock.calls[0]?.[0]).toEqual({
+			token: "xoxb-test",
+			channel_id: "C1",
+			thread_ts: "1700000000.000100",
+			status: CYRUS_SLACK_ASSISTANT_STATUS,
+			loading_messages: [...CYRUS_SLACK_LOADING_MESSAGES],
+		});
+		expect(statusSpy.mock.calls[0]?.[0].username).toBeUndefined();
+		expect(statusSpy.mock.calls[0]?.[0].icon_emoji).toBeUndefined();
+		expect(statusSpy.mock.calls[0]?.[0].icon_url).toBeUndefined();
+	});
+
+	it("clears active status with an empty status string", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		const statusSpy = vi
+			.spyOn(SlackMessageService.prototype, "setAssistantThreadStatus")
+			.mockResolvedValue(undefined);
+
+		await adapter.clearInFlightResponse(slackEvent());
+
+		expect(statusSpy).toHaveBeenCalledTimes(1);
+		expect(statusSpy.mock.calls[0]?.[0]).toEqual({
+			token: "xoxb-test",
+			channel_id: "C1",
+			thread_ts: "1700000000.000100",
+			status: "",
+		});
 	});
 });
 

--- a/packages/slack-event-transport/src/SlackMessageService.ts
+++ b/packages/slack-event-transport/src/SlackMessageService.ts
@@ -49,6 +49,131 @@ export interface SlackPostMessageParams {
 	thread_ts?: string;
 }
 
+/**
+ * Parameters for setting or clearing a Slack assistant thread status.
+ */
+export interface SlackAssistantThreadStatusParams {
+	/** Slack Bot OAuth token */
+	token: string;
+	/** Channel ID containing the assistant thread */
+	channel_id: string;
+	/** Timestamp of the thread where the status should appear */
+	thread_ts: string;
+	/** Status text. Pass an empty string to clear the active status. */
+	status: string;
+	/** Loading messages Slack rotates while the assistant is working */
+	loading_messages?: string[];
+	/** Optional display override. Prefer omitting to use the installed app identity. */
+	username?: string;
+	/** Optional icon URL override. Prefer omitting to use the installed app icon. */
+	icon_url?: string;
+	/** Optional emoji override. Avoid production placeholders. */
+	icon_emoji?: string;
+}
+
+export type SlackStreamMode = "markdown" | "chunks";
+
+export interface SlackMarkdownTextChunk {
+	type: "markdown_text";
+	text: string;
+}
+
+export interface SlackTaskUpdateChunk {
+	type: "task_update";
+	id: string;
+	title: string;
+	status: "pending" | "in_progress" | "complete" | "error";
+	details?: string;
+	output?: string;
+	sources?: Array<{ type: "url"; text: string; url: string }>;
+}
+
+export interface SlackPlanUpdateChunk {
+	type: "plan_update";
+	title: string;
+}
+
+export interface SlackBlocksChunk {
+	type: "blocks";
+	blocks: unknown[];
+}
+
+export type SlackStreamChunk =
+	| SlackMarkdownTextChunk
+	| SlackTaskUpdateChunk
+	| SlackPlanUpdateChunk
+	| SlackBlocksChunk;
+
+export interface SlackStreamHandle {
+	channel: string;
+	ts: string;
+	mode: SlackStreamMode;
+}
+
+interface SlackStreamPresentationParams {
+	/** Optional display override. Prefer omitting to use the installed app identity. */
+	username?: string;
+	/** Optional icon URL override. Prefer omitting to use the installed app icon. */
+	icon_url?: string;
+	/** Optional emoji override. Avoid production placeholders. */
+	icon_emoji?: string;
+}
+
+interface SlackStartStreamBaseParams extends SlackStreamPresentationParams {
+	token: string;
+	channel: string;
+	thread_ts: string;
+	/** Required by Slack when streaming into channels. */
+	recipient_user_id?: string;
+	/** Required by Slack when streaming into channels. */
+	recipient_team_id?: string;
+	task_display_mode?: "timeline" | "plan" | "dense";
+}
+
+export type SlackStartStreamParams =
+	| (SlackStartStreamBaseParams & {
+			mode: "markdown";
+			markdown_text?: string;
+			chunks?: never;
+	  })
+	| (SlackStartStreamBaseParams & {
+			mode: "chunks";
+			chunks?: SlackStreamChunk[];
+			markdown_text?: never;
+	  });
+
+export type SlackAppendStreamParams =
+	| {
+			token: string;
+			stream: SlackStreamHandle & { mode: "markdown" };
+			markdown_text: string;
+			chunks?: never;
+	  }
+	| {
+			token: string;
+			stream: SlackStreamHandle & { mode: "chunks" };
+			chunks: SlackStreamChunk[];
+			markdown_text?: never;
+	  };
+
+export type SlackStopStreamParams =
+	| {
+			token: string;
+			stream: SlackStreamHandle & { mode: "markdown" };
+			markdown_text?: string;
+			chunks?: never;
+			blocks?: unknown[];
+			metadata?: unknown;
+	  }
+	| {
+			token: string;
+			stream: SlackStreamHandle & { mode: "chunks" };
+			chunks?: SlackStreamChunk[];
+			markdown_text?: never;
+			blocks?: unknown[];
+			metadata?: unknown;
+	  };
+
 export class SlackMessageService {
 	private apiBaseUrl: string;
 
@@ -141,6 +266,135 @@ export class SlackMessageService {
 	}
 
 	/**
+	 * Set or clear the assistant thread status Slack renders while Cyrus works.
+	 *
+	 * @see https://api.slack.com/methods/assistant.threads.setStatus
+	 */
+	async setAssistantThreadStatus(
+		params: SlackAssistantThreadStatusParams,
+	): Promise<void> {
+		const {
+			token,
+			channel_id,
+			thread_ts,
+			status,
+			loading_messages,
+			username,
+			icon_url,
+			icon_emoji,
+		} = params;
+		const url = `${this.apiBaseUrl}/assistant.threads.setStatus`;
+		const body: Record<string, unknown> = {
+			channel_id,
+			thread_ts,
+			status,
+		};
+		if (loading_messages) body.loading_messages = loading_messages;
+		if (username) body.username = username;
+		if (icon_url) body.icon_url = icon_url;
+		if (icon_emoji) body.icon_emoji = icon_emoji;
+
+		await this.postSlackApi(url, token, body, "set assistant thread status");
+	}
+
+	/**
+	 * Start a Slack streamed message in exactly one mode.
+	 *
+	 * The returned handle records the selected mode so append/stop calls cannot
+	 * accidentally mix `markdown_text` and `chunks` for the same stream.
+	 *
+	 * @see https://api.slack.com/methods/chat.startStream
+	 */
+	async startStream(
+		params: SlackStartStreamParams,
+	): Promise<SlackStreamHandle> {
+		this.assertChannelRecipientFields(params.channel, params);
+		const url = `${this.apiBaseUrl}/chat.startStream`;
+		const body: Record<string, unknown> = {
+			channel: params.channel,
+			thread_ts: params.thread_ts,
+		};
+		if (params.recipient_user_id) {
+			body.recipient_user_id = params.recipient_user_id;
+		}
+		if (params.recipient_team_id) {
+			body.recipient_team_id = params.recipient_team_id;
+		}
+		if (params.task_display_mode) {
+			body.task_display_mode = params.task_display_mode;
+		}
+		if (params.username) body.username = params.username;
+		if (params.icon_url) body.icon_url = params.icon_url;
+		if (params.icon_emoji) body.icon_emoji = params.icon_emoji;
+		this.applyStreamContent(body, params, false);
+
+		const response = await this.postSlackApi<{
+			ok: boolean;
+			channel?: string;
+			ts?: string;
+		}>(url, params.token, body, "start stream");
+
+		if (!response.channel || !response.ts) {
+			throw new Error(
+				"[SlackMessageService] Slack API response missing stream handle",
+			);
+		}
+
+		return {
+			channel: response.channel,
+			ts: response.ts,
+			mode: params.mode,
+		};
+	}
+
+	/**
+	 * Append content to a Slack stream. The stream handle's mode determines
+	 * which payload field is valid.
+	 *
+	 * @see https://api.slack.com/methods/chat.appendStream
+	 */
+	async appendStream(
+		params: SlackAppendStreamParams,
+	): Promise<SlackStreamHandle> {
+		const url = `${this.apiBaseUrl}/chat.appendStream`;
+		const body: Record<string, unknown> = {
+			channel: params.stream.channel,
+			ts: params.stream.ts,
+		};
+		this.applyStreamContent(body, params, true, params.stream.mode);
+
+		const response = await this.postSlackApi<{
+			ok: boolean;
+			channel?: string;
+			ts?: string;
+		}>(url, params.token, body, "append stream");
+
+		return {
+			channel: response.channel ?? params.stream.channel,
+			ts: response.ts ?? params.stream.ts,
+			mode: params.stream.mode,
+		};
+	}
+
+	/**
+	 * Stop a Slack stream. Optional final content must match the stream mode.
+	 *
+	 * @see https://api.slack.com/methods/chat.stopStream
+	 */
+	async stopStream(params: SlackStopStreamParams): Promise<void> {
+		const url = `${this.apiBaseUrl}/chat.stopStream`;
+		const body: Record<string, unknown> = {
+			channel: params.stream.channel,
+			ts: params.stream.ts,
+		};
+		this.applyStreamContent(body, params, false, params.stream.mode);
+		if (params.blocks) body.blocks = params.blocks;
+		if (params.metadata) body.metadata = params.metadata;
+
+		await this.postSlackApi(url, params.token, body, "stop stream");
+	}
+
+	/**
 	 * Fetch all messages in a Slack thread using cursor-based pagination.
 	 *
 	 * @see https://api.slack.com/methods/conversations.replies
@@ -206,5 +460,94 @@ export class SlackMessageService {
 
 		// Enforce limit
 		return messages.slice(0, limit);
+	}
+
+	private async postSlackApi<TBody extends { ok?: boolean; error?: string }>(
+		url: string,
+		token: string,
+		body: Record<string, unknown>,
+		action: string,
+	): Promise<TBody> {
+		const response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(body),
+		});
+
+		if (!response.ok) {
+			const errorBody = await response.text();
+			throw new Error(
+				`[SlackMessageService] Failed to ${action}: ${response.status} ${response.statusText} - ${errorBody}`,
+			);
+		}
+
+		const responseBody = (await response.json()) as TBody;
+		if (!responseBody.ok) {
+			throw new Error(
+				`[SlackMessageService] Slack API error: ${responseBody.error ?? "unknown"}`,
+			);
+		}
+		return responseBody;
+	}
+
+	private assertChannelRecipientFields(
+		channel: string,
+		params: {
+			recipient_user_id?: string;
+			recipient_team_id?: string;
+		},
+	): void {
+		if (channel.startsWith("D")) {
+			return;
+		}
+		if (!params.recipient_user_id || !params.recipient_team_id) {
+			throw new Error(
+				"[SlackMessageService] recipient_user_id and recipient_team_id are required when starting a stream in a channel",
+			);
+		}
+	}
+
+	private applyStreamContent(
+		body: Record<string, unknown>,
+		params: {
+			mode?: SlackStreamMode;
+			markdown_text?: string;
+			chunks?: SlackStreamChunk[];
+		},
+		requireContent: boolean,
+		expectedMode = params.mode,
+	): void {
+		const hasMarkdown = params.markdown_text !== undefined;
+		const hasChunks = params.chunks !== undefined;
+
+		if (hasMarkdown && hasChunks) {
+			throw new Error(
+				"[SlackMessageService] Slack streams must use either markdown_text or chunks, not both",
+			);
+		}
+
+		if (expectedMode === "markdown" && hasChunks) {
+			throw new Error(
+				"[SlackMessageService] Cannot append chunks to a markdown Slack stream",
+			);
+		}
+
+		if (expectedMode === "chunks" && hasMarkdown) {
+			throw new Error(
+				"[SlackMessageService] Cannot append markdown_text to a chunks Slack stream",
+			);
+		}
+
+		if (requireContent && !hasMarkdown && !hasChunks) {
+			throw new Error(
+				"[SlackMessageService] Slack stream append requires content for the stream mode",
+			);
+		}
+
+		if (hasMarkdown) body.markdown_text = params.markdown_text;
+		if (hasChunks) body.chunks = params.chunks;
 	}
 }

--- a/packages/slack-event-transport/src/index.ts
+++ b/packages/slack-event-transport/src/index.ts
@@ -1,7 +1,14 @@
 export { SlackEventTransport } from "./SlackEventTransport.js";
 export type {
+	SlackAppendStreamParams,
+	SlackAssistantThreadStatusParams,
 	SlackFetchThreadParams,
 	SlackPostMessageParams,
+	SlackStartStreamParams,
+	SlackStopStreamParams,
+	SlackStreamChunk,
+	SlackStreamHandle,
+	SlackStreamMode,
 	SlackThreadMessage,
 } from "./SlackMessageService.js";
 export { SlackMessageService } from "./SlackMessageService.js";

--- a/packages/slack-event-transport/test/SlackMessageService.test.ts
+++ b/packages/slack-event-transport/test/SlackMessageService.test.ts
@@ -135,6 +135,241 @@ describe("SlackMessageService", () => {
 		});
 	});
 
+	describe("setAssistantThreadStatus", () => {
+		it("sets a branded assistant thread status without presentation placeholders", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ ok: true }),
+			});
+
+			await service.setAssistantThreadStatus({
+				token: "xoxb-test-token",
+				channel_id: "C9876543210",
+				thread_ts: "1704110400.000100",
+				status: "is working through the request...",
+				loading_messages: [
+					"Reading the thread...",
+					"Checking the workspace context...",
+				],
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://slack.com/api/assistant.threads.setStatus",
+				{
+					method: "POST",
+					headers: {
+						Authorization: "Bearer xoxb-test-token",
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({
+						channel_id: "C9876543210",
+						thread_ts: "1704110400.000100",
+						status: "is working through the request...",
+						loading_messages: [
+							"Reading the thread...",
+							"Checking the workspace context...",
+						],
+					}),
+				},
+			);
+
+			const body = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body as string);
+			expect(body.username).toBeUndefined();
+			expect(body.icon_emoji).toBeUndefined();
+			expect(body.icon_url).toBeUndefined();
+		});
+
+		it("clears assistant thread status with an empty status", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ ok: true }),
+			});
+
+			await service.setAssistantThreadStatus({
+				token: "xoxb-test-token",
+				channel_id: "C9876543210",
+				thread_ts: "1704110400.000100",
+				status: "",
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://slack.com/api/assistant.threads.setStatus",
+				expect.objectContaining({
+					body: JSON.stringify({
+						channel_id: "C9876543210",
+						thread_ts: "1704110400.000100",
+						status: "",
+					}),
+				}),
+			);
+		});
+	});
+
+	describe("streaming", () => {
+		it("starts a chunks stream in a channel with recipient fields", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					ok: true,
+					channel: "C9876543210",
+					ts: "1704110400.000300",
+				}),
+			});
+
+			const stream = await service.startStream({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+				recipient_user_id: "U123",
+				recipient_team_id: "T123",
+				mode: "chunks",
+				chunks: [
+					{
+						type: "task_update",
+						id: "read-thread",
+						title: "Reading the thread",
+						status: "in_progress",
+					},
+				],
+			});
+
+			expect(stream).toEqual({
+				channel: "C9876543210",
+				ts: "1704110400.000300",
+				mode: "chunks",
+			});
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://slack.com/api/chat.startStream",
+				expect.objectContaining({
+					body: JSON.stringify({
+						channel: "C9876543210",
+						thread_ts: "1704110400.000100",
+						recipient_user_id: "U123",
+						recipient_team_id: "T123",
+						chunks: [
+							{
+								type: "task_update",
+								id: "read-thread",
+								title: "Reading the thread",
+								status: "in_progress",
+							},
+						],
+					}),
+				}),
+			);
+		});
+
+		it("requires recipient fields when starting a stream in a channel", async () => {
+			await expect(
+				service.startStream({
+					token: "xoxb-test-token",
+					channel: "C9876543210",
+					thread_ts: "1704110400.000100",
+					mode: "chunks",
+				}),
+			).rejects.toThrow("recipient_user_id and recipient_team_id are required");
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it("allows a DM stream without recipient fields", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					ok: true,
+					channel: "D9876543210",
+					ts: "1704110400.000300",
+				}),
+			});
+
+			await service.startStream({
+				token: "xoxb-test-token",
+				channel: "D9876543210",
+				thread_ts: "1704110400.000100",
+				mode: "markdown",
+				markdown_text: "Working through this now.",
+			});
+
+			const body = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body as string);
+			expect(body.recipient_user_id).toBeUndefined();
+			expect(body.recipient_team_id).toBeUndefined();
+			expect(body.markdown_text).toBe("Working through this now.");
+			expect(body.chunks).toBeUndefined();
+		});
+
+		it("rejects a stream start that mixes markdown_text and chunks", async () => {
+			await expect(
+				service.startStream({
+					token: "xoxb-test-token",
+					channel: "D9876543210",
+					thread_ts: "1704110400.000100",
+					mode: "markdown",
+					markdown_text: "Hello",
+					chunks: [{ type: "markdown_text", text: "Hello" }],
+				} as any),
+			).rejects.toThrow(
+				"Slack streams must use either markdown_text or chunks, not both",
+			);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it("rejects appending content that does not match the stream mode", async () => {
+			await expect(
+				service.appendStream({
+					token: "xoxb-test-token",
+					stream: {
+						channel: "C9876543210",
+						ts: "1704110400.000300",
+						mode: "chunks",
+					},
+					markdown_text: "Wrong mode",
+				} as any),
+			).rejects.toThrow("Cannot append markdown_text to a chunks Slack stream");
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+
+		it("stops a chunks stream without switching modes", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ ok: true }),
+			});
+
+			await service.stopStream({
+				token: "xoxb-test-token",
+				stream: {
+					channel: "C9876543210",
+					ts: "1704110400.000300",
+					mode: "chunks",
+				},
+				chunks: [
+					{
+						type: "task_update",
+						id: "verify",
+						title: "Verifying the result",
+						status: "complete",
+					},
+				],
+			});
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://slack.com/api/chat.stopStream",
+				expect.objectContaining({
+					body: JSON.stringify({
+						channel: "C9876543210",
+						ts: "1704110400.000300",
+						chunks: [
+							{
+								type: "task_update",
+								id: "verify",
+								title: "Verifying the result",
+								status: "complete",
+							},
+						],
+					}),
+				}),
+			);
+		});
+	});
+
 	describe("fetchThreadMessages", () => {
 		it("fetches thread messages with correct GET params and Bearer auth", async () => {
 			mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Implements Cyrus-branded Slack in-flight status for chat sessions and adds Slack stream helpers that keep each stream in a single mode.

- Sets `assistant.threads.setStatus` with Cyrus-specific status/loading copy when a Slack turn starts or receives a streamed follow-up.
- Clears the active Slack status on successful result handling and on runner start/resume errors.
- Adds Slack `chat.startStream` / `chat.appendStream` / `chat.stopStream` helpers with runtime guardrails for markdown-vs-chunks mode mixing and required channel recipient fields.
- Removes prototype presentation from production behavior by omitting username/icon overrides by default so Slack uses the installed Cyrus app identity.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:packages:run`
- `pnpm lint`
- `pnpm --dir packages/slack-event-transport exec vitest run test/SlackMessageService.test.ts`
- `pnpm --dir packages/edge-worker exec vitest run test/chat-sessions.test.ts`
- F1 synthetic Slack chat smoke documented in `apps/f1/test-drives/2026-07-03-cypack-1367-slack-inflight-status.md`

## Notes

F1 validates the Slack chat handler path but cannot visually confirm Slack-rendered assistant status because it uses synthetic channels. A live Slack thread remains the final manual presentation check.

Linear: https://linear.app/ceedar/issue/CYPACK-1367/customize-cyrus-slack-in-flight-response-status-and-streaming

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->