### PR TITLE
fix(slack): only add the receipt reaction when the event will engage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Slack: only add the receipt (eyes) reaction when Cyrus will actually engage — a thread it's bound to, or a session-initiating event like an @mention — instead of reacting to every message in any channel it can see and never clearing it. ([#1374](https://github.com/cyrusagents/cyrus/pull/1374))
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -170,18 +170,28 @@ export class ChatSessionHandler<TEvent> {
 				`Processing ${this.adapter.platformName} webhook: ${this.adapter.getEventId(event)}`,
 			);
 
-			// Fire-and-forget acknowledgement (e.g., emoji reaction)
-			this.adapter.acknowledgeReceipt(event).catch((err: unknown) => {
-				this.logger.warn(
-					`Failed to acknowledge ${this.adapter.platformName} event: ${err instanceof Error ? err.message : err}`,
-				);
-			});
-
 			const taskInstructions = this.adapter.extractTaskInstructions(event);
 			const threadKey = this.adapter.getThreadKey(event);
 
 			// Check if there's already an active session for this thread
 			const existingSessionId = this.threadSessions.get(threadKey);
+
+			// Fire-and-forget acknowledgement (e.g., emoji reaction) — only when
+			// this event will actually engage: a follow-up in a thread we're already
+			// bound to, or a session-initiating event (e.g. a Slack @mention).
+			// Non-initiating events return below without ever reaching
+			// acknowledgeProcessed(), so acking them leaves a receipt reaction on
+			// every message in any channel Cyrus can see that is never cleared.
+			if (
+				existingSessionId ||
+				this.adapter.isSessionInitiatingEvent?.(event) !== false
+			) {
+				this.adapter.acknowledgeReceipt(event).catch((err: unknown) => {
+					this.logger.warn(
+						`Failed to acknowledge ${this.adapter.platformName} event: ${err instanceof Error ? err.message : err}`,
+					);
+				});
+			}
 			if (existingSessionId) {
 				const existingSession =
 					this.sessionManager.getSession(existingSessionId);

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -287,6 +287,100 @@ describe("ChatSessionHandler session-initiation gate", () => {
 	});
 });
 
+describe("ChatSessionHandler receipt acknowledgement gate", () => {
+	function buildHandler(adapter: ChatPlatformAdapter<TestEvent>) {
+		const createRunner = vi.fn(
+			() =>
+				({
+					supportsStreamingInput: false,
+					start: vi.fn().mockResolvedValue({ sessionId: "session-1" }),
+					stop: vi.fn(),
+					isRunning: vi.fn().mockReturnValue(false),
+					isStreaming: vi.fn().mockReturnValue(false),
+					addStreamMessage: vi.fn(),
+					getMessages: vi.fn().mockReturnValue([]),
+				}) as any,
+		);
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+		return { handler, createRunner };
+	}
+
+	it("does NOT acknowledge a non-initiating event in an unbound thread", async () => {
+		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
+			"unbound-thread",
+		);
+		adapter.isSessionInitiatingEvent = () => false;
+		const acknowledgeReceipt = vi
+			.spyOn(adapter, "acknowledgeReceipt")
+			.mockResolvedValue(undefined);
+
+		const { handler, createRunner } = buildHandler(adapter);
+		await handler.handleEvent({
+			eventId: "chatter",
+			threadKey: "unbound-thread",
+		} as any);
+
+		// No 👀 left on an unrelated channel message, and the event is ignored.
+		expect(acknowledgeReceipt).not.toHaveBeenCalled();
+		expect(createRunner).not.toHaveBeenCalled();
+		expect(handler.listThreads()).toHaveLength(0);
+	});
+
+	it("acknowledges an initiating event (e.g. an @mention)", async () => {
+		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
+			"mention-thread",
+		);
+		adapter.isSessionInitiatingEvent = () => true;
+		const acknowledgeReceipt = vi
+			.spyOn(adapter, "acknowledgeReceipt")
+			.mockResolvedValue(undefined);
+
+		const { handler } = buildHandler(adapter);
+		const event = { eventId: "mention", threadKey: "mention-thread" };
+		await handler.handleEvent(event as any);
+
+		expect(acknowledgeReceipt).toHaveBeenCalledTimes(1);
+		expect(acknowledgeReceipt).toHaveBeenCalledWith(event);
+	});
+
+	it("acknowledges a non-initiating follow-up in an already-bound thread", async () => {
+		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(
+			"engaged-thread",
+		);
+		// The initiating @mention binds the thread to a session.
+		adapter.isSessionInitiatingEvent = () => true;
+		const acknowledgeReceipt = vi
+			.spyOn(adapter, "acknowledgeReceipt")
+			.mockResolvedValue(undefined);
+
+		const { handler } = buildHandler(adapter);
+		await handler.handleEvent({
+			eventId: "mention",
+			threadKey: "engaged-thread",
+		} as any);
+		expect(handler.listThreads()).toHaveLength(1);
+		acknowledgeReceipt.mockClear();
+
+		// A plain follow-up (non-initiating) in that bound thread still engages,
+		// so it should be acknowledged.
+		adapter.isSessionInitiatingEvent = () => false;
+		const followUp = { eventId: "follow-up", threadKey: "engaged-thread" };
+		await handler.handleEvent(followUp as any);
+
+		expect(acknowledgeReceipt).toHaveBeenCalledTimes(1);
+		expect(acknowledgeReceipt).toHaveBeenCalledWith(followUp);
+	});
+});
+
 describe("ChatSessionHandler processed acknowledgement", () => {
 	it("calls acknowledgeProcessed when the runner emits a result", async () => {
 		const adapter: ChatPlatformAdapter<TestEvent> = new TestChatAdapter(


### PR DESCRIPTION
## Problem

In Slack, Cyrus adds a 👀 (`RECEIPT_REACTION`) to **every** message in any channel it's a member of, and the reaction is never cleared.

`ChatSessionHandler.handleEvent()` calls `this.adapter.acknowledgeReceipt(event)` unconditionally at the top — before the guard that ignores non-initiating events:

- The Slack app subscribes to `message.channels` / `message.groups`, so Cyrus receives an event for every message in channels it's in.
- Each event is acked with 👀 immediately, then dropped as non-initiating.
- The drop `return`s *before* `acknowledgeProcessed()` (the 👀→✅ swap), so the 👀 is never cleared.
- `SlackChatAdapter.isSessionInitiatingEvent` only returns true for `app_mention` / `upstreamGated`, so every ordinary channel message is acked-then-ignored.

Net effect: Cyrus 👀-reacts to unrelated conversations in any channel it's in.

## Fix

Move the acknowledgement below where `threadKey` / `existingSessionId` are computed, and gate it so it only fires when the event will actually engage — a follow-up in a bound thread, or a session-initiating event:

```ts
if (existingSessionId || this.adapter.isSessionInitiatingEvent?.(event) !== false) {
  this.adapter.acknowledgeReceipt(event).catch(...);
}
```

| Event | Before | After |
|---|---|---|
| @mention (initiating) | 👀 | 👀 |
| Follow-up in a bound thread | 👀 | 👀 |
| Ordinary message, unbound thread | 👀 (never cleared) | no reaction |

Platforms whose adapter doesn't implement `isSessionInitiatingEvent` are unaffected — `?.(...) !== false` is true when the method is absent — so GitHub/Linear behavior is unchanged.

## Testing

- `pnpm --filter cyrus-edge-worker exec vitest run test/chat-sessions.test.ts` → **PASS** (33 tests, including the 3 new ones below)
- `pnpm --filter cyrus-edge-worker test:run` (full package suite) → 728 passed / 8 failed. The 8 failures are **pre-existing on `main`** and unrelated to this change — they live in `EdgeWorker.runner-selection.test.ts` (2) and `EdgeWorker.screenshot-upload-hooks.test.ts` (6). With this branch's changes stashed, the same suite reports the identical 8 failures (725 passed); this PR adds exactly +3 passing tests and 0 new failures.
- `pnpm typecheck` → **PASS** (all packages, `tsc --noEmit`)
- `pnpm biome check` on the changed files → **PASS** (no fixes needed)
- Added unit tests (in `packages/edge-worker/test/chat-sessions.test.ts`, `ChatSessionHandler receipt acknowledgement gate`):
  - `acknowledgeReceipt` is **not** called for a non-initiating event in an unbound thread (and the event is ignored — no runner created, no thread bound).
  - `acknowledgeReceipt` **is** called for an initiating event (e.g. an @mention).
  - `acknowledgeReceipt` **is** called for a non-initiating follow-up in an already-bound thread.
