### PR TITLE
feat: per-repository settingSources override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Repositories can now override the Claude Agent SDK's `settingSources` option per-repo via `repositoryConfig.settingSources` (e.g. `["project"]` to skip loading user-scope settings). Useful on multi-repo self-host machines where a repo wants context hygiene from the operator's global `~/.claude` settings. Must be a non-empty array of `"user"` | `"project"` | `"local"`; an unset or invalid override falls back to the existing default (`["user", "project", "local"]`), so behavior is unchanged unless you opt in. ([PR link pending])
+
 ### Fixed
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -26,8 +26,10 @@ import {
 	createLogger,
 	type IAgentRunner,
 	type ILogger,
+	isValidSettingSourcesOverride,
 	LogLevel,
 	StreamingPrompt,
+	VALID_SETTING_SOURCES,
 } from "cyrus-core";
 import dotenv from "dotenv";
 import { ClaudeMessageFormatter, type IMessageFormatter } from "./formatter.js";
@@ -666,7 +668,15 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					// load file based settings, to maintain more backwards compatibility,
 					// particularly with CLAUDE.md files, settings files, and custom slash commands,
 					// see: https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default
-					settingSources: ["user", "project", "local"],
+					// A per-repository config.settingSources override (validated via
+					// isValidSettingSourcesOverride) lets a repo opt out of loading
+					// user-scope settings; an unset/invalid override falls back to
+					// the stock default below.
+					settingSources: isValidSettingSourcesOverride(
+						this.config.settingSources,
+					)
+						? this.config.settingSources
+						: [...VALID_SETTING_SOURCES],
 					env: {
 						...buildBaseSessionEnv(),
 						// CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is intentionally NOT set while

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -14,7 +14,11 @@ import type {
 	SessionStore,
 	WarmQuery,
 } from "@anthropic-ai/claude-agent-sdk";
-import type { ILogger, OnAskUserQuestion } from "cyrus-core";
+import type {
+	ILogger,
+	OnAskUserQuestion,
+	SettingSourceOverride,
+} from "cyrus-core";
 
 export type { OnAskUserQuestion } from "cyrus-core";
 
@@ -44,6 +48,13 @@ export interface ClaudeRunnerConfig {
 	mcpConfig?: Record<string, McpServerConfig>; // Additional/override MCP servers
 	model?: string; // Claude model to use (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
+	/**
+	 * Override for the SDK's settingSources option. Validated via
+	 * isValidSettingSourcesOverride (cyrus-core) before use; an unset or
+	 * invalid value falls back to VALID_SETTING_SOURCES
+	 * (["user", "project", "local"]).
+	 */
+	settingSources?: SettingSourceOverride[];
 	maxTurns?: number; // Maximum number of turns before completing the session
 	tools?: string[]; // Built-in tools available in model context (empty array disables all tools)
 	cyrusHome: string; // Cyrus home directory

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -220,6 +220,84 @@ describe("ClaudeRunner", () => {
 			});
 		});
 
+		it("should use a valid config.settingSources override instead of the stock default", async () => {
+			const runnerWithOverride = new ClaudeRunner({
+				...defaultConfig,
+				settingSources: ["project"],
+			});
+
+			mockQuery.mockImplementation(async function* () {
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "Hello!" }] },
+					parent_tool_use_id: null,
+					session_id: "test-session",
+				} as any;
+			});
+
+			await runnerWithOverride.start("test");
+
+			expect(mockQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						settingSources: ["project"],
+					}),
+				}),
+			);
+		});
+
+		it("should fall back to the stock default when config.settingSources is invalid", async () => {
+			const runnerWithInvalidOverride = new ClaudeRunner({
+				...defaultConfig,
+				settingSources: ["not-a-real-source"] as any,
+			});
+
+			mockQuery.mockImplementation(async function* () {
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "Hello!" }] },
+					parent_tool_use_id: null,
+					session_id: "test-session",
+				} as any;
+			});
+
+			await runnerWithInvalidOverride.start("test");
+
+			expect(mockQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						settingSources: ["user", "project", "local"],
+					}),
+				}),
+			);
+		});
+
+		it("should fall back to the stock default when config.settingSources is an empty array", async () => {
+			const runnerWithEmptyOverride = new ClaudeRunner({
+				...defaultConfig,
+				settingSources: [],
+			});
+
+			mockQuery.mockImplementation(async function* () {
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "Hello!" }] },
+					parent_tool_use_id: null,
+					session_id: "test-session",
+				} as any;
+			});
+
+			await runnerWithEmptyOverride.start("test");
+
+			expect(mockQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						settingSources: ["user", "project", "local"],
+					}),
+				}),
+			);
+		});
+
 		it("should throw error if session already running", async () => {
 			// Mock a long-running query
 			mockQuery.mockImplementation(async function* () {

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -99,6 +99,13 @@
 					"fallbackModel": {
 						"type": "string"
 					},
+					"settingSources": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["user", "project", "local"]
+						}
+					},
 					"labelPrompts": {
 						"type": "object",
 						"properties": {

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -99,6 +99,13 @@
 					"fallbackModel": {
 						"type": "string"
 					},
+					"settingSources": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["user", "project", "local"]
+						}
+					},
 					"labelPrompts": {
 						"type": "object",
 						"properties": {

--- a/packages/core/schemas/RepositoryConfig.json
+++ b/packages/core/schemas/RepositoryConfig.json
@@ -94,6 +94,13 @@
 		"fallbackModel": {
 			"type": "string"
 		},
+		"settingSources": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": ["user", "project", "local"]
+			}
+		},
 		"labelPrompts": {
 			"type": "object",
 			"properties": {

--- a/packages/core/schemas/RepositoryConfigPayload.json
+++ b/packages/core/schemas/RepositoryConfigPayload.json
@@ -94,6 +94,13 @@
 		"fallbackModel": {
 			"type": "string"
 		},
+		"settingSources": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": ["user", "project", "local"]
+			}
+		},
 		"labelPrompts": {
 			"type": "object",
 			"properties": {

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -11,6 +11,7 @@ import type {
 // Import the AskUserQuestionInput type from the SDK's tool input types
 // This ensures we use the SDK's official type definitions
 import type { AskUserQuestionInput as SDKAskUserQuestionInput } from "@anthropic-ai/claude-agent-sdk/sdk-tools";
+import type { SettingSourceOverride } from "./config-schemas.js";
 import type { ILogger } from "./logging/ILogger.js";
 
 // ============================================================================
@@ -473,6 +474,14 @@ export interface AgentRunnerConfig {
 	model?: string;
 	/** Fallback model if primary is unavailable */
 	fallbackModel?: string;
+	/**
+	 * Per-repository override of the Claude Agent SDK's settingSources
+	 * option (Claude runner only). Validated via
+	 * isValidSettingSourcesOverride before use; falls back to
+	 * VALID_SETTING_SOURCES (["user", "project", "local"]) when unset or
+	 * invalid.
+	 */
+	settingSources?: SettingSourceOverride[];
 	/** Maximum number of turns before completing session */
 	maxTurns?: number;
 	/** Built-in tools available in model context (empty array disables all tools) */

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -7,6 +7,33 @@ export const RunnerTypeSchema = z.enum(["claude", "gemini", "codex", "cursor"]);
 export type RunnerType = z.infer<typeof RunnerTypeSchema>;
 
 /**
+ * Stock default for the Claude Agent SDK's settingSources option — loads
+ * user, project, and local (`.claude/settings.local.json`) settings for
+ * backwards compatibility. See:
+ * https://docs.claude.com/en/docs/claude-code/sdk/migration-guide#settings-sources-no-longer-loaded-by-default
+ */
+export const VALID_SETTING_SOURCES = ["user", "project", "local"] as const;
+export type SettingSourceOverride = (typeof VALID_SETTING_SOURCES)[number];
+
+/**
+ * Validate a per-repository / per-runner settingSources override before it
+ * reaches the Claude Agent SDK: must be a non-empty array whose entries are
+ * all valid setting sources. An invalid override (empty, wrong type, unknown
+ * entry) should fall back to VALID_SETTING_SOURCES rather than being passed
+ * through as-is — this keeps a malformed config from silently disabling all
+ * settings loading.
+ */
+export function isValidSettingSourcesOverride(
+	value: unknown,
+): value is SettingSourceOverride[] {
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every((s) => (VALID_SETTING_SOURCES as readonly string[]).includes(s))
+	);
+}
+
+/**
  * User identifier for access control matching.
  * Supports multiple formats for flexibility:
  * - String: treated as user ID (e.g., "usr_abc123")
@@ -305,6 +332,14 @@ export const RepositoryConfigSchema = z.object({
 	appendInstruction: z.string().optional(),
 	model: z.string().optional(),
 	fallbackModel: z.string().optional(),
+	/**
+	 * Per-repository override of the Claude Agent SDK's settingSources
+	 * option (see VALID_SETTING_SOURCES / isValidSettingSourcesOverride).
+	 * Lets a repo opt out of loading user-scope settings (e.g. multi-repo
+	 * machines that want per-repo context hygiene). Invalid/empty overrides
+	 * fall back to the stock ["user", "project", "local"] default.
+	 */
+	settingSources: z.array(z.enum(VALID_SETTING_SOURCES)).optional(),
 
 	// Label-based system prompt configuration
 	labelPrompts: LabelPromptsSchema.optional(),

--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -12,6 +12,7 @@ export {
 	type EdgeConfigPayload,
 	EdgeConfigPayloadSchema,
 	EdgeConfigSchema,
+	isValidSettingSourcesOverride,
 	type LinearWorkspaceConfig,
 	LinearWorkspaceConfigSchema,
 	migrateEdgeConfig,
@@ -26,10 +27,12 @@ export {
 	requireLinearWorkspaceId,
 	type SandboxConfig,
 	SandboxConfigSchema,
+	type SettingSourceOverride,
 	type UserAccessControlConfig,
 	UserAccessControlConfigSchema,
 	type UserIdentifier,
 	UserIdentifierSchema,
+	VALID_SETTING_SOURCES,
 } from "./config-schemas.js";
 
 export { TRUSTED_DOMAINS } from "./trusted-domains.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,7 @@ export type {
 	RepositoryConfigPayload,
 	RunnerType,
 	SandboxConfig,
+	SettingSourceOverride,
 	UserAccessControlConfig,
 	UserIdentifier,
 } from "./config-types.js";
@@ -93,6 +94,7 @@ export {
 	EdgeConfigPayloadSchema,
 	// Zod schemas for runtime validation
 	EdgeConfigSchema,
+	isValidSettingSourcesOverride,
 	LinearWorkspaceConfigSchema,
 	migrateEdgeConfig,
 	NetworkPolicySchema,
@@ -105,6 +107,7 @@ export {
 	TRUSTED_DOMAINS,
 	UserAccessControlConfigSchema,
 	UserIdentifierSchema,
+	VALID_SETTING_SOURCES,
 } from "./config-types.js";
 // Constants
 export {

--- a/packages/core/test/setting-sources.test.ts
+++ b/packages/core/test/setting-sources.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the shared settingSources validation helper used to gate a
+ * per-repository / per-runner override of the Claude Agent SDK's
+ * settingSources option (see CYRUS-PATCH history: the option was previously
+ * hardcoded to ["user", "project", "local"] everywhere).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	isValidSettingSourcesOverride,
+	VALID_SETTING_SOURCES,
+} from "../src/config-schemas.js";
+
+describe("isValidSettingSourcesOverride", () => {
+	it("accepts a valid single-entry override", () => {
+		expect(isValidSettingSourcesOverride(["project"])).toBe(true);
+	});
+
+	it("accepts a valid multi-entry override", () => {
+		expect(isValidSettingSourcesOverride(["user", "local"])).toBe(true);
+	});
+
+	it("accepts all valid sources in any order", () => {
+		expect(isValidSettingSourcesOverride(["local", "user", "project"])).toBe(
+			true,
+		);
+	});
+
+	it("rejects an empty array", () => {
+		expect(isValidSettingSourcesOverride([])).toBe(false);
+	});
+
+	it("rejects an array containing an invalid entry", () => {
+		expect(isValidSettingSourcesOverride(["user", "bogus"])).toBe(false);
+	});
+
+	it("rejects a non-array value", () => {
+		expect(isValidSettingSourcesOverride("user")).toBe(false);
+		expect(isValidSettingSourcesOverride(undefined)).toBe(false);
+		expect(isValidSettingSourcesOverride(null)).toBe(false);
+		expect(isValidSettingSourcesOverride(42)).toBe(false);
+	});
+
+	it("exposes the stock default source list", () => {
+		expect(VALID_SETTING_SOURCES).toEqual(["user", "project", "local"]);
+	});
+});

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -72,9 +72,11 @@ import {
 	isStopSignalMessage,
 	isUnassignMessage,
 	isUserPromptMessage,
+	isValidSettingSourcesOverride,
 	PersistenceManager,
 	requireLinearWorkspaceId,
 	resolvePath,
+	VALID_SETTING_SOURCES,
 	WebhookIpValidator,
 } from "cyrus-core";
 import { CursorRunner } from "cyrus-cursor-runner";
@@ -6824,7 +6826,14 @@ ${input.userComment}
 							...(Object.keys(mcpServers).length > 0 && { mcpServers }),
 							...(allowedTools.length > 0 && { allowedTools }),
 							...(disallowedTools.length > 0 && { disallowedTools }),
-							settingSources: ["user", "project", "local"],
+							// Per-repository settingSources override, validated the same
+							// way as RunnerConfigBuilder/ClaudeRunner; falls back to the
+							// stock default when unset or invalid.
+							settingSources: isValidSettingSourcesOverride(
+								repoConfig.settingSources,
+							)
+								? repoConfig.settingSources
+								: [...VALID_SETTING_SOURCES],
 							// CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is intentionally not set here;
 							// see CYPACK-1108 and ClaudeRunner.start() for context.
 							env: buildBaseSessionEnv(),

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -18,6 +18,7 @@ import type {
 	RepositoryConfig,
 	RunnerType,
 } from "cyrus-core";
+import { isValidSettingSourcesOverride } from "cyrus-core";
 import { buildIntentToAddHook } from "./hooks/IntentToAddHook.js";
 import { buildPrMarkerHook } from "./hooks/PrMarkerHook.js";
 import { appendBrowserUseAddendum } from "./prompts/browserUsePromptAddendum.js";
@@ -435,6 +436,15 @@ export class RunnerConfigBuilder {
 			...(runnerType === "claude" &&
 				input.sandboxSettings &&
 				this.buildSandboxConfig(input)),
+			// Per-repository settingSources override (Claude runner only — the
+			// option is specific to the Claude Agent SDK). Validated via
+			// isValidSettingSourcesOverride; an invalid/empty override is
+			// omitted here so ClaudeRunner's own fallback to the stock default
+			// (["user", "project", "local"]) applies.
+			...(runnerType === "claude" &&
+				isValidSettingSourcesOverride(input.repository.settingSources) && {
+					settingSources: input.repository.settingSources,
+				}),
 			// AskUserQuestion callback - only for Claude runner
 			...(runnerType === "claude" &&
 				input.createAskUserQuestionCallback && {

--- a/packages/edge-worker/test/RunnerConfigBuilder.setting-sources.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.setting-sources.test.ts
@@ -1,0 +1,111 @@
+import type { CyrusAgentSession, ILogger, RepositoryConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
+		getDefaultModelForRunner: () => "opus",
+		getDefaultFallbackModelForRunner: () => "sonnet",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(
+	overrides: Partial<RepositoryConfig> = {},
+): RepositoryConfig {
+	return {
+		id: "repo-a",
+		name: "Repo A",
+		repositoryPath: "/repos/repo-a",
+		allowedTools: [],
+		...overrides,
+	} as unknown as RepositoryConfig;
+}
+
+function makeSession(): CyrusAgentSession {
+	return {
+		issueId: "issue-1",
+		issue: { identifier: "ABC-1" },
+		workspace: { path: "/ws/repo-a-worktree", isGitWorktree: true },
+	} as unknown as CyrusAgentSession;
+}
+
+function buildIssueConfig(repository: RepositoryConfig) {
+	return makeBuilder().buildIssueConfig({
+		session: makeSession(),
+		repository,
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	});
+}
+
+describe("RunnerConfigBuilder settingSources (per-repository override, Claude runner only)", () => {
+	it("threads a valid repository.settingSources override into the runner config", () => {
+		const repository = makeRepository({ settingSources: ["project"] });
+
+		const { config } = buildIssueConfig(repository);
+
+		expect(config.settingSources).toEqual(["project"]);
+	});
+
+	it("omits settingSources from the config when repository has no override", () => {
+		const repository = makeRepository();
+
+		const { config } = buildIssueConfig(repository);
+
+		expect(config.settingSources).toBeUndefined();
+	});
+
+	it("omits an invalid repository.settingSources override rather than passing it through", () => {
+		const repository = makeRepository({
+			settingSources: [
+				"bogus",
+			] as unknown as RepositoryConfig["settingSources"],
+		});
+
+		const { config } = buildIssueConfig(repository);
+
+		expect(config.settingSources).toBeUndefined();
+	});
+
+	it("omits an empty repository.settingSources override", () => {
+		const repository = makeRepository({ settingSources: [] });
+
+		const { config } = buildIssueConfig(repository);
+
+		expect(config.settingSources).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What

Adds `repositoryConfig.settingSources` so a self-hosted multi-repo setup can opt a specific repository out of the Claude Agent SDK's default `["user", "project", "local"]` setting sources.

## Why

When one Cyrus install serves several repositories, every session inherits the operator's global `~/.claude` user-scope surface — skills, slash commands, agents, plugin MCP servers. For a repo that ships its own project-scope `.claude/` config, that inherited surface is dead weight in every session's context (in our install: 133 slash commands → 35, 104 skills → 15 after opting the repo down to `["project", "local"]`).

## How

- New optional `settingSources` field on `RepositoryConfig` (JSON schema + types), validated by a shared `isValidSettingSourcesOverride` helper in `cyrus-core`: must be a non-empty array of `"user"`/`"project"`/`"local"`.
- Threaded through `RunnerConfigBuilder` (Claude runner only) and the prewarm path in `EdgeWorker`, mirroring the existing `repository.model` / `repository.fallbackModel` precedence pattern.
- Unset or invalid override falls back to the stock default — behavior is unchanged unless a repo opts in.

## Testing

- 11 new tests (`ClaudeRunner`, `RunnerConfigBuilder`, core validator); full monorepo build + `pnpm test:packages:run` green.
- Running in production on our self-hosted install as a local dist patch; upstreaming as a proper config-schema feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUrjDzWxhuTbN53VT9a13K