### PR TITLE
feat: replace oversized cold resumes with a Haiku-summarized fresh session

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,7 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
-_No internal-only changes._
+### Changed
+- Rewrote the `description` frontmatter of the five default workflow skills (`debug`, `implementation`, `investigate`, `summarize`, `verify-and-ship`) per Anthropic's skill-authoring best practices: third-person voice, explicit "use when" triggers, and negative triggers (when not to use / which skill to use instead) to improve skill selection.
 
 ## [0.2.66] - 2026-06-19
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Changed
-- Rewrote the `description` frontmatter of the five default workflow skills (`debug`, `implementation`, `investigate`, `summarize`, `verify-and-ship`) per Anthropic's skill-authoring best practices: third-person voice, explicit "use when" triggers, and negative triggers (when not to use / which skill to use instead) to improve skill selection.
+- Rewrote the five default workflow skills (`debug`, `implementation`, `investigate`, `summarize`, `verify-and-ship`) against Anthropic's skill-authoring best practices, as a consistent suite. Descriptions are now third-person with explicit "use when" triggers and negative triggers (which sibling skill to use instead). Bodies gain copyable progress checklists (rendered in the Linear timeline), fresh-evidence verification gates, and consistent voice/terminology. Skill-specific improvements: `debug` requires the reproduction test to fail for the *right reason* before fixing; `implementation` extracts acceptance criteria up front and handles the no-test-suite case honestly; `investigate` and `summarize` share one explicit delivery contract (output is streamed as the response — do not double-post via a tool); `verify-and-ship` fixes a defect where a branch with failing checks could be marked ready (now keeps the PR/MR a draft and surfaces failures, with an explicit ready-state decision and demote-to-draft on re-run), and folds GitHub/GitLab into a single platform decision point. Skill `name` fields and the resolver's routing prose are unchanged.
 
 ## [0.2.66] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
+
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
+- Refreshed Claude Code tool list: added `DesignSync`, removed deprecated `TeamCreate` and `TeamDelete` tools. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))
+
+### Security
+- Patched the tracked Cyrus CLI Bun lockfile so both `pnpm audit` and `bun audit` report no known vulnerabilities. ([CYPACK-1356](https://linear.app/ceedar/issue/CYPACK-1356), [#1353](https://github.com/cyrusagents/cyrus/pull/1353))
 - Skills committed to a repository are now usable again. Previously, a repo skill (`.claude/skills/<name>/`) added after the repository was registered with Cyrus would load in the session but fail when invoked with "Skill `<name>` is not in this session's skills allowlist". The allow-list is now built from the session worktree — the same place the agent loads skill definitions from — instead of a stale snapshot of the base checkout. ([#1336](https://github.com/cyrusagents/cyrus/issues/1336))
 
 ## [0.2.66] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Very long-running issues no longer degrade when Cyrus picks them back up after a long idle gap. When resuming would otherwise replay an oversized conversation, Cyrus now writes a short summary of the work so far and starts a fresh session from it — keeping responses fast and focused instead of dragging the entire history along. This is opt-in via a new `claudeColdResumeSummarizeThresholdTokens` setting; when it isn't set, resumes behave exactly as before, and if summarizing ever fails Cyrus quietly falls back to a normal resume.
+- Very long-running issues no longer degrade when Cyrus picks them back up after a long idle gap. When resuming would otherwise replay an oversized conversation, Cyrus now writes a short summary of the work so far and starts a fresh session from it — keeping responses fast and focused instead of dragging the entire history along. This is opt-in via a new `claudeColdResumeSummarizeThresholdTokens` setting; when it isn't set, resumes behave exactly as before, and if summarizing ever fails Cyrus quietly falls back to a normal resume. ([#1376](https://github.com/cyrusagents/cyrus/pull/1376))
 
 ### Fixed
 - Cyrus no longer loses its memory of in-progress issues if it is restarted or killed at the wrong moment. Session state is now saved atomically and can never be left half-written; if the state file is ever damaged, Cyrus automatically recovers from a backup instead of silently starting fresh and abandoning every active issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Skills committed to a repository are now usable again. Previously, a repo skill (`.claude/skills/<name>/`) added after the repository was registered with Cyrus would load in the session but fail when invoked with "Skill `<name>` is not in this session's skills allowlist". The allow-list is now built from the session worktree — the same place the agent loads skill definitions from — instead of a stale snapshot of the base checkout. ([#1336](https://github.com/cyrusagents/cyrus/issues/1336))
+
 ## [0.2.66] - 2026-06-19
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Very long-running issues no longer degrade when Cyrus picks them back up after a long idle gap. When resuming would otherwise replay an oversized conversation, Cyrus now writes a short summary of the work so far and starts a fresh session from it — keeping responses fast and focused instead of dragging the entire history along. This is opt-in via a new `claudeColdResumeSummarizeThresholdTokens` setting; when it isn't set, resumes behave exactly as before, and if summarizing ever fails Cyrus quietly falls back to a normal resume.
+
 ### Fixed
 - Cyrus no longer loses its memory of in-progress issues if it is restarted or killed at the wrong moment. Session state is now saved atomically and can never be left half-written; if the state file is ever damaged, Cyrus automatically recovers from a backup instead of silently starting fresh and abandoning every active issue.
 - When a working session crashes unexpectedly (its underlying process dies or the connection breaks mid-task), Cyrus now tells you on the issue that the session ended and how to retry, instead of silently leaving the issue stuck "In Progress" with no explanation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Cyrus no longer loses its memory of in-progress issues if it is restarted or killed at the wrong moment. Session state is now saved atomically and can never be left half-written; if the state file is ever damaged, Cyrus automatically recovers from a backup instead of silently starting fresh and abandoning every active issue.
+- When a working session crashes unexpectedly (its underlying process dies or the connection breaks mid-task), Cyrus now tells you on the issue that the session ended and how to retry, instead of silently leaving the issue stuck "In Progress" with no explanation.
+- After Cyrus restarts, issues that were still being worked on when it stopped no longer appear to hang forever with a spinning "working" indicator. Cyrus now marks each interrupted session on the issue and invites you to comment to resume it from where it left off.
+- Resumed sessions are no longer weaker than fresh ones. When Cyrus continues a recent issue from a pre-warmed session, it now has the same skills available as a brand-new session, and the same protection against reading files outside the working directory (such as SSH keys or cloud credentials) — both of which were previously missing on resumed sessions.
+- When Cyrus asks you a question, replying with your own free-form answer now works reliably, and the misleading "Other" choice has been removed. Previously the "Other" option could only ever send back the literal word "Other" instead of what you meant; now the prompt tells you that you can either pick an option or just reply with your own answer.
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,10 @@ The agent automatically moves issues to the "started" state when assigned. Linea
 
    Symptom of forgetting this: self-host sessions crash with `ENOENT: no such file or directory, open '~/.cyrus/...'` while cloud sessions (which get absolute paths from cyrus-hosted) work fine. This bit us with the three platform MCP config arrays added in CYHOST-967 / v0.2.53 — they were the only path-bearing fields on `EdgeWorkerConfig` that bypassed normalization, and crashed every self-host session that had a connected platform MCP integration.
 
+12. **Cold-resume summarize-and-restart (`claudeColdResumeSummarizeThresholdTokens`)**: When an oversized Claude resume is replaced by a Haiku-summarized fresh session (`EdgeWorker.maybeSummarizeColdResume`), you **must NOT clear `session.claudeSessionId`** on success. Two mechanisms depend on it still being set at fresh-start time: runner pinning in `RunnerConfigBuilder` (a set `claudeSessionId` keeps the runner type pinned to `claude` even though we're building a "new" session), and the init-message rebind in `AgentSessionManager.updateSessionWithClaudeSessionId` (which overwrites `claudeSessionId` with the *new* Claude session's ID once the fresh session initializes). The trigger only sets the local `effectiveResumeSessionId = undefined` (so the SDK doesn't `--resume` the giant transcript) and `buildAsNewSession = true` (so the prompt gets the `<previous_session_summary>` block) — it never touches `session.claudeSessionId`.
+
+    The transcript is located by scanning `~/.claude/projects/*/<sessionId>.jsonl` (`findTranscriptPath`) rather than reconstructing the path from the cwd, because the `projects/<slug>` directory name is derived from an undocumented cwd-sanitization rule that has changed between Claude Code versions — a two-level scan is version-proof.
+
 ## Dependency Security Policy (MANDATE)
 
 Our team's mandated approach for addressing Dependabot advisories and other

--- a/apps/f1/test-drives/2026-06-28-skill-suite-routing-validation.md
+++ b/apps/f1/test-drives/2026-06-28-skill-suite-routing-validation.md
@@ -1,0 +1,56 @@
+# F1 Test Drive — Default Skill Suite Routing & Adherence Validation
+
+**Date:** 2026-06-28
+**Branch:** `improve-skill-descriptions` (PR #1 — rewritten default workflow skills)
+**Goal:** Validate that the rewritten `debug` / `implementation` / `investigate` / `summarize` / `verify-and-ship` skills (a) route correctly from issue content and (b) actually follow the new disciplines (reproduce-first, acceptance-criteria extraction, read-only research, delivery contract).
+
+## Setup
+
+- `pnpm install && pnpm build` from repo root. The build's `cp -rL cyrus-skills-plugin dist/` step dereferences the symlinks, so the **rewritten** skills are staged into `dist/` and deployed by `DefaultSkillsDeployer` into the F1 server's fresh `cyrusHome`. Confirmed the deployed `debug/SKILL.md` contained the new "fails for the right reason" gate.
+- `./f1 init-test-repo --path /tmp/f1-skill-eval-repo` (rate-limiter scaffold). The repo has **no test framework** (`npm test` exits 1) — useful for exercising the no-suite fallback.
+- Planted a deterministic bug for the debug scenario: an off-by-one in `consumeTokenBucket` (`state.tokens - tokensToConsume + 1`) so consumed tokens are never fully deducted.
+- `CYRUS_PORT=3601 CYRUS_REPO_PATH=/tmp/f1-skill-eval-repo bun run server.ts` (CLI platform mode, model `sonnet`).
+- Each session required a one-shot repo-selection prompt (no routing config), after which the runner started.
+
+## Results
+
+| # | Issue (natural language) | Expected skill | Routed to | Verdict |
+|---|---|---|---|---|
+| 1 | "Token bucket lets one extra request through" (bug report) | `debug` | `debug` | ✅ PASS |
+| 2 | "How does refill work, can clients burst?" (question) | `investigate` | `investigate` | ✅ PASS |
+| 3 | "Implement the sliding window algorithm" (feature) | `implementation` → `verify-and-ship` | `implementation` → `verify-and-ship` | ✅ PASS (ship phase limited, see below) |
+
+Routing was observed via the `Skill` action activity (`{"skill":"…"}`) at the start of each session. **All three routed correctly on first try.**
+
+### Scenario 1 — bug → `debug` (deep adherence PASS)
+
+The new reproduce-first discipline was followed exactly:
+1. Routed to `debug`; pasted the progress checklist (rendered with ⏳/🔄/✅ in the timeline).
+2. Read the code, identified the off-by-one — but did **not** fix immediately.
+3. Wrote a reproduction test, ran it (`Bash (Error)` = failed as intended), and the agent's own words: *"Test fails for the exact right reason: `request 4 should be denied (capacity exhausted)`"* — the rewrite's **right-reason gate**, honored verbatim.
+4. No test framework existed → it used the deterministic `npx tsx --test` fallback (the skill's no-suite path), and later wired up the `package.json` test script.
+5. Applied the minimal fix (removed the `+ 1`), re-ran the test (pass), typechecked clean.
+
+Final worktree: `rate-limiter.ts` fixed, `rate-limiter.test.ts` added asserting "request 4 should be denied", `package.json` test script set — a minimal 3-file diff.
+
+### Scenario 2 — question → `investigate` (deep adherence PASS)
+
+1. Routed to `investigate`; only `find` + `Read` actions — **worktree stayed clean (zero edits)**, confirming the read-only guardrail.
+2. Streamed the answer as the final `[response]` activity (the shared **delivery contract** — not posted via a tool).
+3. Answer was grounded with `file:line` citations (`src/rate-limiter.ts:111`, `:123–128`, `:159`) and used a `+++` collapsible section — the skill's citation + format discipline.
+4. It also noticed the planted `consume` bug and correctly said *"this is a code change, so fixing it is out of scope here"* — the rewrite's recommend-the-right-path rule.
+
+### Scenario 3 — feature → `implementation` → `verify-and-ship`
+
+1. Routed to `implementation`; checklist showed the rewrite's exact items (*"Issue read; acceptance criteria extracted"*, *"Existing patterns and test conventions studied"*).
+2. Phase 1 (study patterns) → Phase 2 (implement) → typecheck, then **handed off to `Skill: verify-and-ship`** — the cross-skill chain works.
+3. Implementation was correct and criteria-driven: `checkSlidingWindow`/`consumeSlidingWindow` using `SlidingWindowConfig`, request eviction via `filter(ts => ts > windowStart)`, `check()`/`consume()` routed to it; all four acceptance criteria satisfied.
+4. `verify-and-ship` pasted its checklist, validated each acceptance criterion, and committed — then `git push` failed with `fatal: Could not read from remote repository`.
+
+## Known limitation — verify-and-ship ship phase not exercisable in F1 CLI mode
+
+F1's CLI platform mode has **no real GitHub/GitLab remote**, so `verify-and-ship`'s push + `gh pr create` cannot complete, and the session ended at the push failure (followed by an unrelated bundled-agent-SDK `r.trim` error). Consequently the **red-PR ready-state safety fix** (failing checks ⇒ keep the PR a draft, surface failures, demote-to-draft on re-run) was **not** validated end-to-end here. That logic is covered by code review + the adversarial review pass in PR #1; validating it live requires a scenario with a real remote (a throwaway GitHub repo) — recommended as a follow-up.
+
+## Conclusion
+
+Routing is correct for all three issue shapes, and the headline new disciplines — reproduce-before-fix with the right-reason gate (`debug`), read-only research + delivery contract + file:line citations (`investigate`), acceptance-criteria extraction + clean handoff (`implementation` → `verify-and-ship`) — are demonstrably followed by a live `sonnet` agent. The only unvalidated item is the `verify-and-ship` ship-phase ready-state logic, blocked by F1 CLI mode having no remote.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.1.3",
         "husky": "^9.1.7",
-        "lint-staged": "^16.1.6",
+        "lint-staged": "^16.4.0",
         "typescript": "^5.3.3",
       },
     },
@@ -44,23 +44,19 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-truncate": ["cli-truncate@5.1.0", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
@@ -70,29 +66,21 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
     "isomorphic-unfetch": ["isomorphic-unfetch@3.1.0", "", { "dependencies": { "node-fetch": "^2.6.1", "unfetch": "^4.2.0" } }, "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q=="],
 
-    "lint-staged": ["lint-staged@16.2.3", "", { "dependencies": { "commander": "^14.0.1", "listr2": "^9.0.4", "micromatch": "^4.0.8", "nano-spawn": "^1.0.3", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": "bin/lint-staged.js" }, "sha512-1OnJEESB9zZqsp61XHH2fvpS1es3hRCxMplF/AJUDa8Ho8VrscYDIuxGrj3m8KPXbcWZ8fT9XTMUhEQmOVKpKw=="],
+    "lint-staged": ["lint-staged@16.4.0", "", { "dependencies": { "commander": "^14.0.3", "listr2": "^9.0.5", "picomatch": "^4.0.3", "string-argv": "^0.3.2", "tinyexec": "^1.0.4", "yaml": "^2.8.2" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw=="],
 
-    "listr2": ["listr2@9.0.4", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ=="],
+    "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "pidtree": ["pidtree@0.6.0", "", { "bin": "bin/pidtree.js" }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
@@ -108,7 +96,7 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -122,7 +110,7 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "yaml": ["yaml@2.8.1", "", { "bin": "bin.mjs" }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/docs/CONFIG_FILE.md
+++ b/docs/CONFIG_FILE.md
@@ -382,6 +382,33 @@ Sets default allowed tools for each prompt type across all repositories. Reposit
 
 Path to a script that runs for all repositories when creating new worktrees. See the main README for details on setup scripts.
 
+### `claudeColdResumeSummarizeThresholdTokens` (number)
+
+**Opt-in.** When a Claude session is resumed after its keep-alive window has
+expired (a "cold resume"), resuming the full transcript rewrites the entire
+conversation into the prompt cache — expensive for long sessions. When this
+threshold is set and the resumed transcript's estimated size (in tokens)
+exceeds it, Cyrus instead summarizes the prior transcript with a one-shot
+Haiku call and starts a **fresh** session seeded with that summary, avoiding
+the full-transcript cache rewrite.
+
+- Unset (default) → feature disabled.
+- Recommended value: `60000`.
+- Values below `20000` are ignored with a warning (too small to be useful).
+- Only applies to Claude sessions. On any failure (no transcript found,
+  summarization error or timeout) Cyrus transparently falls back to a normal
+  resume, so enabling it can never break a resume that would otherwise succeed.
+
+```json
+{
+  "claudeColdResumeSummarizeThresholdTokens": 60000
+}
+```
+
+The fresh session's prompt includes a `<previous_session_summary>` block with
+the branch(es) the prior session worked on and a note to check the current git
+/ PR state before redoing work.
+
 ---
 
 ## Tool Configuration Priority

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.1.3",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.1.6",
+		"lint-staged": "^16.4.0",
 		"typescript": "^5.3.3"
 	},
 	"dependencies": {
@@ -59,7 +59,7 @@
 			"form-data@^4.0.0": "4.0.6",
 			"fast-uri": ">=3.1.2",
 			"ip-address": ">=10.1.1",
-			"@anthropic-ai/sdk": ">=0.104.1",
+			"@anthropic-ai/sdk": ">=0.105.0",
 			"@opentelemetry/sdk-node": ">=0.217.0",
 			"@opentelemetry/exporter-prometheus": ">=0.217.0",
 			"@hono/node-server": ">=1.19.10",

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -16,8 +16,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.173",
-		"@anthropic-ai/sdk": "^0.104.1",
+		"@anthropic-ai/claude-agent-sdk": "0.3.185",
+		"@anthropic-ai/sdk": "^0.105.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -65,12 +65,11 @@ export const availableTools = [
 	"TaskOutput",
 	"TaskStop",
 
-	// Team management
-	"TeamCreate",
-	"TeamDelete",
-
 	// Tool discovery
 	"ToolSearch",
+
+	// Design sync
+	"DesignSync",
 
 	// Workflow orchestration
 	"Workflow",

--- a/packages/claude-runner/src/index.ts
+++ b/packages/claude-runner/src/index.ts
@@ -41,6 +41,18 @@ export {
 	CYRUS_SESSION_ENV,
 	normalizeMcpHttpTransport,
 } from "./session-env.js";
+export { findTranscriptPath } from "./transcript-locator.js";
+export {
+	type ParsedTurn,
+	parseTranscript,
+	readRecords,
+	type TranscriptRecord,
+} from "./transcript-parser.js";
+export {
+	renderCompactTurnLog,
+	type SummarizeTranscriptOptions,
+	summarizeTranscript,
+} from "./transcript-summarizer.js";
 export type {
 	APIAssistantMessage,
 	APIUserMessage,

--- a/packages/claude-runner/src/transcript-locator.ts
+++ b/packages/claude-runner/src/transcript-locator.ts
@@ -1,0 +1,49 @@
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Locate the on-disk transcript for a Claude Code session.
+ *
+ * Claude Code writes each session to
+ * `~/.claude/projects/<sanitized-cwd-slug>/<sessionId>.jsonl`. The slug is
+ * derived from the session's working directory via an undocumented
+ * sanitization rule, so rather than reconstruct that path we scan the two-level
+ * `projects/*` tree for the `<sessionId>.jsonl` file directly. This is robust
+ * to the sanitization rule changing between Claude Code versions.
+ *
+ * @param claudeSessionId The Claude session ID (transcript file basename).
+ * @param baseDir Override for `~/.claude` (primarily for tests).
+ * @returns Absolute path to the transcript, or `null` if not found.
+ */
+export async function findTranscriptPath(
+	claudeSessionId: string,
+	baseDir: string = join(homedir(), ".claude"),
+): Promise<string | null> {
+	const projectsDir = join(baseDir, "projects");
+	const target = `${claudeSessionId}.jsonl`;
+
+	let projectDirs: string[];
+	try {
+		const entries = await readdir(projectsDir, { withFileTypes: true });
+		projectDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+	} catch {
+		// projects/ missing or unreadable — nothing to locate.
+		return null;
+	}
+
+	for (const projectDir of projectDirs) {
+		const dirPath = join(projectsDir, projectDir);
+		let files: string[];
+		try {
+			files = await readdir(dirPath);
+		} catch {
+			continue;
+		}
+		if (files.includes(target)) {
+			return join(dirPath, target);
+		}
+	}
+
+	return null;
+}

--- a/packages/claude-runner/src/transcript-parser.ts
+++ b/packages/claude-runner/src/transcript-parser.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Parsing utilities for Claude Code session transcripts (`~/.claude/projects/<slug>/<sessionId>.jsonl`).
+ *
+ * Each line of a transcript file is a standalone JSON record emitted by the
+ * Claude Code CLI. This module turns those raw records into a normalized,
+ * compact list of conversational turns that downstream consumers (e.g. the
+ * cold-resume summarizer) can render without re-implementing the CLI's
+ * on-disk schema.
+ *
+ * The parsing here is intentionally defensive: transcript files can contain
+ * partial lines, tool-result plumbing, meta/system entries, and schema drift
+ * between Claude Code versions. Malformed lines are skipped rather than
+ * throwing so a single bad record never breaks summarization.
+ */
+
+/** A single raw JSON record from a transcript `.jsonl` file. */
+export interface TranscriptRecord {
+	type?: string;
+	message?: {
+		role?: string;
+		content?: unknown;
+	};
+	[key: string]: unknown;
+}
+
+/** A normalized conversational turn extracted from the transcript. */
+export interface ParsedTurn {
+	role: "user" | "assistant";
+	/** Concatenated text blocks for this turn (may be empty for tool-only turns). */
+	text: string;
+	/** Names of tools invoked in this turn, in order (assistant turns only). */
+	toolNames: string[];
+}
+
+/**
+ * Read and JSON-parse every line of a transcript file.
+ *
+ * Blank lines and lines that fail to parse are silently skipped — transcripts
+ * are appended to line-by-line and can be truncated mid-write.
+ */
+export function readRecords(transcriptPath: string): TranscriptRecord[] {
+	const raw = readFileSync(transcriptPath, "utf-8");
+	const records: TranscriptRecord[] = [];
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			records.push(JSON.parse(trimmed) as TranscriptRecord);
+		} catch {
+			// Skip malformed / partial lines.
+		}
+	}
+	return records;
+}
+
+/**
+ * Extract the plain-text portion of a message `content` field.
+ *
+ * Content may be a bare string (older transcripts) or an array of typed
+ * blocks (`text`, `tool_use`, `tool_result`, `thinking`, ...). Only human /
+ * model text is returned here; tool metadata is surfaced separately via
+ * {@link collectToolNames}.
+ */
+function extractText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	const parts: string[] = [];
+	for (const block of content) {
+		if (block && typeof block === "object") {
+			const b = block as { type?: string; text?: unknown };
+			if (b.type === "text" && typeof b.text === "string") {
+				parts.push(b.text);
+			}
+		}
+	}
+	return parts.join("\n").trim();
+}
+
+/** Collect the ordered list of tool names invoked in a message's content. */
+function collectToolNames(content: unknown): string[] {
+	if (!Array.isArray(content)) return [];
+	const names: string[] = [];
+	for (const block of content) {
+		if (block && typeof block === "object") {
+			const b = block as { type?: string; name?: unknown };
+			if (b.type === "tool_use" && typeof b.name === "string") {
+				names.push(b.name);
+			}
+		}
+	}
+	return names;
+}
+
+/**
+ * Normalize raw transcript records into an ordered list of user/assistant
+ * turns. Records that are not user/assistant messages (system, summary, meta,
+ * tool-result-only user turns) are dropped, as are turns that carry neither
+ * text nor a tool call.
+ */
+export function parseTranscript(records: TranscriptRecord[]): ParsedTurn[] {
+	const turns: ParsedTurn[] = [];
+	for (const record of records) {
+		const role = record.message?.role ?? record.type;
+		if (role !== "user" && role !== "assistant") continue;
+
+		const content = record.message?.content;
+		const text = extractText(content);
+		const toolNames = role === "assistant" ? collectToolNames(content) : [];
+
+		if (!text && toolNames.length === 0) continue;
+
+		turns.push({ role, text, toolNames });
+	}
+	return turns;
+}

--- a/packages/claude-runner/src/transcript-summarizer.ts
+++ b/packages/claude-runner/src/transcript-summarizer.ts
@@ -1,0 +1,208 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { createLogger, type ILogger } from "cyrus-core";
+import {
+	type ParsedTurn,
+	parseTranscript,
+	readRecords,
+} from "./transcript-parser.js";
+
+/**
+ * One-shot summarization of a Claude Code session transcript, used by the
+ * cold-resume-summarize-and-restart flow: instead of resuming a giant
+ * transcript (which rewrites the entire thing to the prompt cache), we
+ * summarize it with a cheap Haiku call and seed a fresh session with the
+ * summary.
+ */
+
+export interface SummarizeTranscriptOptions {
+	/** Absolute path to the transcript `.jsonl` file. */
+	transcriptPath: string;
+	/** Model to summarize with. Defaults to `"haiku"`. */
+	model?: string;
+	/** Abort timeout for the summarization query, in ms. Defaults to 90s. */
+	timeoutMs?: number;
+	/**
+	 * Maximum number of characters of rendered turn log to feed the model.
+	 * The tail is kept (most recent turns) with the first user turn preserved
+	 * as a head anchor. Defaults to ~150k chars.
+	 */
+	maxInputChars?: number;
+	/** Logger for diagnostics. Defaults to a module logger. */
+	logger?: ILogger;
+}
+
+/** Per-turn text budget when rendering the compact turn log. */
+const MAX_TURN_TEXT_CHARS = 2000;
+const DEFAULT_MAX_INPUT_CHARS = 150_000;
+const DEFAULT_TIMEOUT_MS = 90_000;
+const DEFAULT_MODEL = "haiku";
+
+const SYSTEM_PROMPT = `You are summarizing a software-engineering agent's work session so a fresh agent can pick up where it left off without re-reading the whole transcript.
+
+Produce a concise handoff summary in markdown (no more than ~800 words) covering:
+- What the user asked for.
+- What was done, in order (key steps and reasoning).
+- Which files were created, modified, or deleted.
+- Branch, pull request, and commit state (names/numbers if known).
+- Decisions made and any constraints or trade-offs agreed on.
+- What is still unfinished, and the concrete next steps to complete it.
+
+Be factual and specific. Do not invent details that are not present in the transcript. Prefer bullet points over prose.`;
+
+/**
+ * Render a single normalized turn into a compact log line, truncating long
+ * text and appending the tool names invoked.
+ */
+function renderTurn(turn: ParsedTurn): string {
+	const role = turn.role === "user" ? "User" : "Assistant";
+	let text = turn.text;
+	if (text.length > MAX_TURN_TEXT_CHARS) {
+		text = `${text.slice(0, MAX_TURN_TEXT_CHARS)}… [truncated]`;
+	}
+	const lines: string[] = [];
+	if (text) {
+		lines.push(`${role}: ${text}`);
+	}
+	if (turn.toolNames.length > 0) {
+		lines.push(`${role} tools: ${turn.toolNames.join(", ")}`);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Build the compact turn-log string fed to the summarizer.
+ *
+ * Keeps the tail (most recent turns) up to `maxInputChars`, always preserving
+ * the very first user turn as a head anchor so the summary knows the original
+ * ask even when the middle of a long session is dropped.
+ */
+export function renderCompactTurnLog(
+	turns: ParsedTurn[],
+	maxInputChars: number = DEFAULT_MAX_INPUT_CHARS,
+): string {
+	if (turns.length === 0) return "";
+
+	const rendered = turns.map(renderTurn).filter(Boolean);
+	const full = rendered.join("\n\n");
+	if (full.length <= maxInputChars) {
+		return full;
+	}
+
+	// Preserve the first turn as a head anchor, then take as much of the tail
+	// as fits in the remaining budget.
+	const head = rendered[0]!;
+	const separator = "\n\n[…earlier turns omitted…]\n\n";
+	const tailBudget = maxInputChars - head.length - separator.length;
+
+	const tailParts: string[] = [];
+	let used = 0;
+	for (let i = rendered.length - 1; i >= 1; i--) {
+		const part = rendered[i]!;
+		if (used + part.length + 2 > tailBudget) break;
+		tailParts.unshift(part);
+		used += part.length + 2;
+	}
+
+	if (tailParts.length === 0) {
+		// Head alone already exceeds budget — hard-truncate it.
+		return head.slice(0, maxInputChars);
+	}
+
+	return `${head}${separator}${tailParts.join("\n\n")}`;
+}
+
+/**
+ * Summarize a Claude Code transcript with a one-shot Haiku query.
+ *
+ * @throws if the transcript is empty/unparseable, or if the query times out or
+ *   returns no text. Callers treat any throw as "fall through to a normal
+ *   resume" — summarization must never break a resume that would have worked.
+ */
+export async function summarizeTranscript(
+	options: SummarizeTranscriptOptions,
+): Promise<string> {
+	const {
+		transcriptPath,
+		model = DEFAULT_MODEL,
+		timeoutMs = DEFAULT_TIMEOUT_MS,
+		maxInputChars = DEFAULT_MAX_INPUT_CHARS,
+		logger = createLogger({ component: "TranscriptSummarizer" }),
+	} = options;
+
+	const records = readRecords(transcriptPath);
+	const turns = parseTranscript(records);
+	const turnLog = renderCompactTurnLog(turns, maxInputChars);
+
+	if (!turnLog.trim()) {
+		throw new Error(
+			`Transcript at ${transcriptPath} produced an empty turn log`,
+		);
+	}
+
+	const prompt = `Here is the compact log of the prior session's turns. Summarize it per your instructions.\n\n<turn_log>\n${turnLog}\n</turn_log>`;
+
+	const abortController = new AbortController();
+	const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+
+	let summary = "";
+	try {
+		const response = query({
+			prompt,
+			options: {
+				model,
+				// A custom string systemPrompt intentionally bypasses the
+				// `claude_code` preset — we want a lightweight summarizer, not a
+				// coding agent with the full tool-use system prompt.
+				systemPrompt: SYSTEM_PROMPT,
+				tools: [],
+				maxTurns: 1,
+				effort: "low",
+				maxBudgetUsd: 0.5,
+				strictMcpConfig: true,
+				abortController,
+			},
+		});
+
+		for await (const message of response) {
+			if (message.type === "result") {
+				if (message.subtype === "success" && "result" in message) {
+					summary = String(message.result ?? "").trim();
+				}
+			} else if (
+				message.type === "assistant" &&
+				Array.isArray(message.message?.content)
+			) {
+				// Fallback: accumulate assistant text if no result payload arrives.
+				if (!summary) {
+					const blocks = message.message.content as Array<{
+						type?: string;
+						text?: string;
+					}>;
+					const text = blocks
+						.filter((b) => b.type === "text")
+						.map((b) => b.text ?? "")
+						.join("");
+					if (text.trim()) summary = text.trim();
+				}
+			}
+		}
+	} catch (error) {
+		if (abortController.signal.aborted) {
+			throw new Error(
+				`Transcript summarization timed out after ${timeoutMs}ms`,
+			);
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	if (!summary) {
+		throw new Error("Transcript summarization returned an empty summary");
+	}
+
+	logger.debug(
+		`Summarized transcript ${transcriptPath} (${turns.length} turns) into ${summary.length} chars`,
+	);
+	return summary;
+}

--- a/packages/claude-runner/test/config.test.ts
+++ b/packages/claude-runner/test/config.test.ts
@@ -43,12 +43,11 @@ describe("config", () => {
 				"RemoteTrigger",
 				"TaskOutput",
 				"TaskStop",
-				"TeamCreate",
-				"TeamDelete",
 				"ToolSearch",
+				"DesignSync",
 				"Workflow",
 			]);
-			expect(availableTools).toHaveLength(33);
+			expect(availableTools).toHaveLength(32);
 		});
 
 		it("should define read-only tools", () => {

--- a/packages/claude-runner/test/transcript-locator.test.ts
+++ b/packages/claude-runner/test/transcript-locator.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { findTranscriptPath } from "../src/transcript-locator.js";
+
+describe("findTranscriptPath", () => {
+	let baseDir: string;
+
+	beforeEach(async () => {
+		baseDir = await mkdtemp(join(tmpdir(), "cyrus-locator-"));
+	});
+
+	afterEach(async () => {
+		await rm(baseDir, { recursive: true, force: true });
+	});
+
+	async function seedProject(slug: string, files: string[]) {
+		const dir = join(baseDir, "projects", slug);
+		await mkdir(dir, { recursive: true });
+		for (const file of files) {
+			await writeFile(join(dir, file), "{}\n");
+		}
+		return dir;
+	}
+
+	test("finds a transcript nested under projects/<slug>/", async () => {
+		const dir = await seedProject("-home-user-repo", [
+			"session-abc.jsonl",
+			"session-def.jsonl",
+		]);
+
+		const found = await findTranscriptPath("session-abc", baseDir);
+		expect(found).toBe(join(dir, "session-abc.jsonl"));
+	});
+
+	test("scans across multiple project directories", async () => {
+		await seedProject("-home-user-repo-a", ["other.jsonl"]);
+		const target = await seedProject("-home-user-repo-b", ["wanted.jsonl"]);
+
+		const found = await findTranscriptPath("wanted", baseDir);
+		expect(found).toBe(join(target, "wanted.jsonl"));
+	});
+
+	test("returns null when the session transcript is absent", async () => {
+		await seedProject("-home-user-repo", ["session-abc.jsonl"]);
+
+		const found = await findTranscriptPath("does-not-exist", baseDir);
+		expect(found).toBeNull();
+	});
+
+	test("returns null when projects/ does not exist", async () => {
+		const found = await findTranscriptPath("anything", baseDir);
+		expect(found).toBeNull();
+	});
+});

--- a/packages/claude-runner/test/transcript-parser.test.ts
+++ b/packages/claude-runner/test/transcript-parser.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	parseTranscript,
+	readRecords,
+	type TranscriptRecord,
+} from "../src/transcript-parser.js";
+
+describe("readRecords", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cyrus-parser-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	test("parses one JSON record per non-empty line and skips malformed lines", async () => {
+		const path = join(dir, "t.jsonl");
+		await writeFile(
+			path,
+			[
+				JSON.stringify({ type: "user", message: { role: "user" } }),
+				"",
+				"   ",
+				"{ not valid json",
+				JSON.stringify({ type: "assistant", message: { role: "assistant" } }),
+			].join("\n"),
+		);
+
+		const records = readRecords(path);
+		expect(records).toHaveLength(2);
+		expect(records[0]?.type).toBe("user");
+		expect(records[1]?.type).toBe("assistant");
+	});
+});
+
+describe("parseTranscript", () => {
+	test("extracts user/assistant text and assistant tool names in order", () => {
+		const records: TranscriptRecord[] = [
+			{
+				type: "user",
+				message: { role: "user", content: "Implement the feature" },
+			},
+			{
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Working on it" },
+						{ type: "tool_use", name: "Edit", input: {} },
+						{ type: "tool_use", name: "Bash", input: {} },
+					],
+				},
+			},
+		];
+
+		const turns = parseTranscript(records);
+		expect(turns).toEqual([
+			{ role: "user", text: "Implement the feature", toolNames: [] },
+			{ role: "assistant", text: "Working on it", toolNames: ["Edit", "Bash"] },
+		]);
+	});
+
+	test("drops non-conversational records and empty turns", () => {
+		const records: TranscriptRecord[] = [
+			{ type: "system", message: { role: "system", content: "boot" } },
+			{ type: "summary", subject: "x" },
+			// tool-result-only user turn (array content with no text) → dropped
+			{
+				type: "user",
+				message: {
+					role: "user",
+					content: [{ type: "tool_result", content: "ok" }],
+				},
+			},
+			{ type: "assistant", message: { role: "assistant", content: [] } },
+			{ type: "user", message: { role: "user", content: "real question" } },
+		];
+
+		const turns = parseTranscript(records);
+		expect(turns).toEqual([
+			{ role: "user", text: "real question", toolNames: [] },
+		]);
+	});
+});

--- a/packages/claude-runner/test/transcript-summarizer.test.ts
+++ b/packages/claude-runner/test/transcript-summarizer.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: vi.fn(),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+	type ParsedTurn,
+	renderCompactTurnLog,
+	summarizeTranscript,
+} from "../src/index.js";
+
+const mockQuery = vi.mocked(query);
+
+/** Build an async iterable that yields the provided messages. */
+async function* messages(items: any[]) {
+	for (const item of items) yield item;
+}
+
+function resultMessage(text: string) {
+	return { type: "result", subtype: "success", result: text };
+}
+
+describe("renderCompactTurnLog", () => {
+	test("returns the full log when under the char budget", () => {
+		const turns: ParsedTurn[] = [
+			{ role: "user", text: "hello", toolNames: [] },
+			{ role: "assistant", text: "hi", toolNames: ["Bash"] },
+		];
+		const out = renderCompactTurnLog(turns, 10_000);
+		expect(out).toBe("User: hello\n\nAssistant: hi\nAssistant tools: Bash");
+	});
+
+	test("keeps first turn as head anchor and takes the tail when over budget", () => {
+		const turns: ParsedTurn[] = [
+			{ role: "user", text: "FIRST ORIGINAL ASK", toolNames: [] },
+		];
+		// Add many bulky middle turns plus a distinctive last turn.
+		for (let i = 0; i < 50; i++) {
+			turns.push({ role: "assistant", text: "x".repeat(500), toolNames: [] });
+		}
+		turns.push({ role: "assistant", text: "LAST TURN MARKER", toolNames: [] });
+
+		const out = renderCompactTurnLog(turns, 2000);
+
+		expect(out.startsWith("User: FIRST ORIGINAL ASK")).toBe(true);
+		expect(out).toContain("[…earlier turns omitted…]");
+		expect(out).toContain("LAST TURN MARKER");
+		expect(out.length).toBeLessThanOrEqual(2000);
+	});
+});
+
+describe("summarizeTranscript", () => {
+	let dir: string;
+	let transcriptPath: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		dir = await mkdtemp(join(tmpdir(), "cyrus-summarizer-"));
+		transcriptPath = join(dir, "session.jsonl");
+		await writeFile(
+			transcriptPath,
+			[
+				JSON.stringify({
+					type: "user",
+					message: { role: "user", content: "Add a feature" },
+				}),
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						role: "assistant",
+						content: [
+							{ type: "text", text: "Done" },
+							{ type: "tool_use", name: "Edit", input: {} },
+						],
+					},
+				}),
+			].join("\n"),
+		);
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	test("calls query with the one-shot Haiku summarizer options and returns the summary", async () => {
+		mockQuery.mockReturnValue(
+			messages([resultMessage("A concise summary")]) as any,
+		);
+
+		const summary = await summarizeTranscript({ transcriptPath });
+		expect(summary).toBe("A concise summary");
+
+		expect(mockQuery).toHaveBeenCalledTimes(1);
+		const opts = (mockQuery.mock.calls[0]![0] as any).options;
+		expect(opts.model).toBe("haiku");
+		expect(opts.maxTurns).toBe(1);
+		expect(opts.effort).toBe("low");
+		expect(opts.maxBudgetUsd).toBe(0.5);
+		expect(opts.tools).toEqual([]);
+		expect(opts.strictMcpConfig).toBe(true);
+		// Custom string systemPrompt — NOT the claude_code preset object.
+		expect(typeof opts.systemPrompt).toBe("string");
+	});
+
+	test("falls back to assistant text when no result payload is emitted", async () => {
+		mockQuery.mockReturnValue(
+			messages([
+				{
+					type: "assistant",
+					message: {
+						role: "assistant",
+						content: [{ type: "text", text: "Assistant summary" }],
+					},
+				},
+			]) as any,
+		);
+
+		const summary = await summarizeTranscript({ transcriptPath });
+		expect(summary).toBe("Assistant summary");
+	});
+
+	test("throws when the query returns an empty summary", async () => {
+		mockQuery.mockReturnValue(messages([resultMessage("   ")]) as any);
+		await expect(summarizeTranscript({ transcriptPath })).rejects.toThrow(
+			/empty summary/,
+		);
+	});
+
+	test("throws a timeout error when the query is aborted by the timeout", async () => {
+		mockQuery.mockImplementation((args: any) => {
+			const signal: AbortSignal = args.options.abortController.signal;
+			async function* hang() {
+				await new Promise((_resolve, reject) => {
+					signal.addEventListener("abort", () =>
+						reject(new Error("The operation was aborted")),
+					);
+				});
+				yield resultMessage("never");
+			}
+			return hang() as any;
+		});
+
+		await expect(
+			summarizeTranscript({ transcriptPath, timeoutMs: 20 }),
+		).rejects.toThrow(/timed out/);
+	});
+
+	test("throws when the transcript has no summarizable turns", async () => {
+		const emptyPath = join(dir, "empty.jsonl");
+		await writeFile(emptyPath, "\n\n");
+		await expect(
+			summarizeTranscript({ transcriptPath: emptyPath }),
+		).rejects.toThrow(/empty turn log/);
+	});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.173",
+		"@anthropic-ai/claude-agent-sdk": "0.3.185",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -527,6 +527,11 @@
 		"claudeDefaultFallbackModel": {
 			"type": "string"
 		},
+		"claudeColdResumeSummarizeThresholdTokens": {
+			"type": "integer",
+			"exclusiveMinimum": 0,
+			"maximum": 9007199254740991
+		},
 		"geminiDefaultModel": {
 			"type": "string"
 		},

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -521,6 +521,11 @@
 		"claudeDefaultFallbackModel": {
 			"type": "string"
 		},
+		"claudeColdResumeSummarizeThresholdTokens": {
+			"type": "integer",
+			"exclusiveMinimum": 0,
+			"maximum": 9007199254740991
+		},
 		"geminiDefaultModel": {
 			"type": "string"
 		},

--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -86,6 +86,13 @@ export class PersistenceManager {
 	private persistencePath: string;
 	private logger: ILogger;
 
+	// Single-flight write coordination. Concurrent callers coalesce onto the
+	// latest state so overlapping fire-and-forget saves can never interleave
+	// writes to the same file (which previously risked a corrupt/partial file).
+	private pendingState: SerializableEdgeWorkerState | undefined;
+	private writeChain: Promise<void> = Promise.resolve();
+	private writing = false;
+
 	constructor(persistencePath?: string, logger?: ILogger) {
 		this.persistencePath =
 			persistencePath || join(homedir(), ".cyrus", "state");
@@ -107,22 +114,84 @@ export class PersistenceManager {
 	}
 
 	/**
-	 * Save EdgeWorker state to disk (single file for all repositories)
+	 * Save EdgeWorker state to disk (single file for all repositories).
+	 *
+	 * Writes are serialized through a single-flight queue and coalesced to the
+	 * most recently requested state, so overlapping callers (including the many
+	 * fire-and-forget savePersistedState() call sites) can never interleave and
+	 * corrupt the file. Each write is atomic: the payload is written to a temp
+	 * file, fsync'd, the previous good file is rotated to `.bak`, then the temp
+	 * file is atomically renamed into place. A crash therefore leaves either the
+	 * previous complete file or the new complete file — never a truncated one.
 	 */
 	async saveEdgeWorkerState(state: SerializableEdgeWorkerState): Promise<void> {
+		this.pendingState = state;
+		if (!this.writing) {
+			this.writing = true;
+			this.writeChain = this.drainWrites();
+		}
+		return this.writeChain;
+	}
+
+	/**
+	 * Drain all pending state writes, one at a time, coalescing to the latest.
+	 */
+	private async drainWrites(): Promise<void> {
 		try {
-			await this.ensurePersistenceDirectory();
-			const stateFile = this.getEdgeWorkerStateFilePath();
-			const stateData = {
-				version: PERSISTENCE_VERSION,
-				savedAt: new Date().toISOString(),
-				state,
-			};
-			await writeFile(stateFile, JSON.stringify(stateData, null, 2), "utf8");
+			while (this.pendingState !== undefined) {
+				const state = this.pendingState;
+				this.pendingState = undefined;
+				await this.writeStateAtomic(state);
+			}
 		} catch (error) {
 			this.logger.error("Failed to save EdgeWorker state:", error);
 			throw error;
+		} finally {
+			this.writing = false;
 		}
+	}
+
+	/**
+	 * Atomically write a single state snapshot to disk (temp + fsync + rename),
+	 * rotating the previous good file to `.bak` for crash recovery.
+	 */
+	private async writeStateAtomic(
+		state: SerializableEdgeWorkerState,
+	): Promise<void> {
+		await this.ensurePersistenceDirectory();
+		const stateFile = this.getEdgeWorkerStateFilePath();
+		const tmpFile = `${stateFile}.tmp`;
+		const bakFile = `${stateFile}.bak`;
+		const payload = JSON.stringify(
+			{
+				version: PERSISTENCE_VERSION,
+				savedAt: new Date().toISOString(),
+				state,
+			},
+			null,
+			2,
+		);
+
+		// Write + fsync to a temp file so the bytes are durable before we swap.
+		const handle = await open(tmpFile, "w");
+		try {
+			await handle.writeFile(payload, "utf8");
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+
+		// Rotate the current good file to `.bak` (atomic), then swap in the new
+		// one (atomic). If a crash lands between these two renames, loadState()
+		// falls back to `.bak`, so no complete snapshot is ever lost.
+		if (existsSync(stateFile)) {
+			try {
+				await rename(stateFile, bakFile);
+			} catch (error) {
+				this.logger.warn("Failed to rotate state backup:", error);
+			}
+		}
+		await rename(tmpFile, stateFile);
 	}
 
 	/**
@@ -132,11 +201,28 @@ export class PersistenceManager {
 	async loadEdgeWorkerState(): Promise<SerializableEdgeWorkerState | null> {
 		try {
 			const stateFile = this.getEdgeWorkerStateFilePath();
-			if (!existsSync(stateFile)) {
-				return null;
+			const bakFile = `${stateFile}.bak`;
+
+			// Try the primary file first; on missing/corrupt fall back to `.bak`.
+			// This covers both a truncated primary and the narrow window between
+			// the two renames in writeStateAtomic() where only `.bak` exists.
+			let stateData = this.tryReadStateFile(stateFile);
+			if (stateData === undefined) {
+				const recovered = this.tryReadStateFile(bakFile);
+				if (recovered !== undefined) {
+					this.logger.warn(
+						"Primary state file unreadable; recovered from .bak backup",
+					);
+					stateData = recovered;
+				}
 			}
 
-			const stateData = JSON.parse(await readFile(stateFile, "utf8"));
+			// undefined => primary absent AND no usable backup. If the primary
+			// file is genuinely absent this is a fresh install (quiet null); if
+			// it existed but was corrupt, tryReadStateFile already logged an error.
+			if (stateData === undefined) {
+				return null;
+			}
 
 			// Validate state structure exists
 			if (!stateData.state) {
@@ -324,6 +410,39 @@ export class PersistenceManager {
 	}
 
 	/**
+	 * Read and JSON-parse a state file.
+	 *
+	 * Returns the parsed object, or `undefined` if the file is absent, empty, or
+	 * corrupt. A present-but-unparseable file is logged at error level (so a real
+	 * corruption event is visible), while an absent or empty file is treated as
+	 * "no state" without noise — distinguishing corruption from a fresh/cleared
+	 * install, which the previous implementation could not do.
+	 */
+	private tryReadStateFile(
+		path: string,
+	): { version?: string; state?: any } | undefined {
+		if (!existsSync(path)) {
+			return undefined;
+		}
+		let raw: string;
+		try {
+			raw = readFileSync(path, "utf8");
+		} catch (error) {
+			this.logger.error(`Failed to read state file ${path}:`, error);
+			return undefined;
+		}
+		if (raw.trim() === "") {
+			return undefined; // intentionally cleared / empty file
+		}
+		try {
+			return JSON.parse(raw);
+		} catch (error) {
+			this.logger.error(`State file ${path} is corrupt (invalid JSON):`, error);
+			return undefined;
+		}
+	}
+
+	/**
 	 * Check if EdgeWorker state file exists
 	 */
 	hasStateFile(): boolean {
@@ -331,16 +450,22 @@ export class PersistenceManager {
 	}
 
 	/**
-	 * Delete EdgeWorker state file
+	 * Delete EdgeWorker state file (and its temp/backup siblings).
+	 *
+	 * The siblings must go too: otherwise loadEdgeWorkerState() would recover the
+	 * just-deleted state from `.bak`, resurrecting sessions the caller meant to
+	 * clear.
 	 */
 	async deleteStateFile(): Promise<void> {
-		try {
-			const stateFile = this.getEdgeWorkerStateFilePath();
-			if (existsSync(stateFile)) {
-				await writeFile(stateFile, "", "utf8"); // Clear file instead of deleting
+		const stateFile = this.getEdgeWorkerStateFilePath();
+		for (const file of [stateFile, `${stateFile}.tmp`, `${stateFile}.bak`]) {
+			try {
+				if (existsSync(file)) {
+					await unlink(file);
+				}
+			} catch (error) {
+				this.logger.error(`Failed to delete state file ${file}:`, error);
 			}
-		} catch (error) {
-			this.logger.error("Failed to delete EdgeWorker state file:", error);
 		}
 	}
 

--- a/packages/core/src/allowed-tools-defaults.ts
+++ b/packages/core/src/allowed-tools-defaults.ts
@@ -75,9 +75,8 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	"ToolSearch",
 	"Skill",
 
-	// Team lifecycle
-	"TeamCreate",
-	"TeamDelete",
+	// Design sync
+	"DesignSync",
 
 	// Workflow orchestration
 	"Workflow",
@@ -197,9 +196,8 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	"ToolSearch",
 	"Skill",
 
-	// Team lifecycle
-	"TeamCreate",
-	"TeamDelete",
+	// Design sync
+	"DesignSync",
 
 	// Workflow orchestration
 	"Workflow",

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -347,6 +347,19 @@ export const EdgeConfigSchema = z.object({
 	/** Default Claude fallback model if primary Claude model is unavailable */
 	claudeDefaultFallbackModel: z.string().optional(),
 
+	/**
+	 * Estimated transcript size (in tokens) above which a cold resume is
+	 * replaced by a Haiku-summarized fresh session instead of resuming the
+	 * whole transcript. Unset = disabled (opt-in rollout). Recommended value:
+	 * 60000. Values below 20000 are warned about and ignored via
+	 * `resolveColdResumeThreshold`.
+	 */
+	claudeColdResumeSummarizeThresholdTokens: z
+		.number()
+		.int()
+		.positive()
+		.optional(),
+
 	/** Default Gemini model to use across all repositories (e.g., "gemini-2.5-pro") */
 	geminiDefaultModel: z.string().optional(),
 

--- a/packages/core/test/PersistenceManager.migration.test.ts
+++ b/packages/core/test/PersistenceManager.migration.test.ts
@@ -1,33 +1,53 @@
 /**
- * Tests for PersistenceManager migrations (v2.0 → v3.0 → v4.0)
+ * Tests for PersistenceManager migrations (v2.0 → v3.0 → v4.0),
+ * plus atomic-write and crash-recovery behavior.
  */
 
-import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	PERSISTENCE_VERSION,
 	PersistenceManager,
 } from "../src/PersistenceManager.js";
 
-// Mock fs modules
+// Mock fs modules. The save path writes atomically via open()+fsync+rename(),
+// and the load path reads synchronously, so we mock those primitives.
 vi.mock("node:fs", () => ({
 	existsSync: vi.fn(),
+	readFileSync: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
 	mkdir: vi.fn(),
-	readFile: vi.fn(),
-	writeFile: vi.fn(),
+	open: vi.fn(),
+	rename: vi.fn(),
+	unlink: vi.fn(),
 }));
 
 describe("PersistenceManager", () => {
 	let persistenceManager: PersistenceManager;
+	// Captures payloads written to the temp file via the atomic write path.
+	let handleWriteFile: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		persistenceManager = new PersistenceManager("/tmp/test-cyrus");
+
+		handleWriteFile = vi.fn().mockResolvedValue(undefined);
+		vi.mocked(open).mockResolvedValue({
+			writeFile: handleWriteFile,
+			sync: vi.fn().mockResolvedValue(undefined),
+			close: vi.fn().mockResolvedValue(undefined),
+		} as unknown as Awaited<ReturnType<typeof open>>);
+		vi.mocked(rename).mockResolvedValue(undefined);
+		vi.mocked(unlink).mockResolvedValue(undefined);
+		vi.mocked(mkdir).mockResolvedValue(undefined as never);
 	});
+
+	/** Parse the payload written by the most recent atomic save. */
+	const lastSavedData = () =>
+		JSON.parse(handleWriteFile.mock.calls[0][0] as string);
 
 	describe("v2.0 to v4.0 Migration (via v3.0)", () => {
 		const v2State = {
@@ -80,9 +100,7 @@ describe("PersistenceManager", () => {
 
 		it("should migrate v2.0 state through v3.0 to v4.0 flat format", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v2State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v2State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -129,25 +147,18 @@ describe("PersistenceManager", () => {
 
 		it("should save migrated state as v4.0", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v2State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v2State));
 
 			await persistenceManager.loadEdgeWorkerState();
 
-			// Verify writeFile was called with v4.0 version
-			expect(writeFile).toHaveBeenCalled();
-			const savedData = JSON.parse(
-				vi.mocked(writeFile).mock.calls[0][1] as string,
-			);
-			expect(savedData.version).toBe(PERSISTENCE_VERSION);
+			// Verify the atomic write happened with v4.0 version
+			expect(handleWriteFile).toHaveBeenCalled();
+			expect(lastSavedData().version).toBe(PERSISTENCE_VERSION);
 		});
 
 		it("should flatten entries and preserve mappings during v2→v4 migration", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v2State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v2State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -179,7 +190,7 @@ describe("PersistenceManager", () => {
 			};
 
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(
+			vi.mocked(readFileSync).mockReturnValue(
 				JSON.stringify(unknownVersionState),
 			);
 
@@ -196,7 +207,7 @@ describe("PersistenceManager", () => {
 			};
 
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(invalidState));
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(invalidState));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -257,9 +268,7 @@ describe("PersistenceManager", () => {
 
 		it("should flatten nested sessions from multiple repos into a flat map", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v3State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v3State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -284,9 +293,7 @@ describe("PersistenceManager", () => {
 
 		it("should populate repositories from repo key during flattening", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v3State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v3State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -301,9 +308,7 @@ describe("PersistenceManager", () => {
 
 		it("should flatten nested entries from multiple repos", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v3State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v3State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -318,9 +323,7 @@ describe("PersistenceManager", () => {
 
 		it("should preserve childToParentAgentSession and issueRepositoryCache", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v3State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v3State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
@@ -336,48 +339,167 @@ describe("PersistenceManager", () => {
 
 		it("should save migrated v3→v4 state with correct version", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v3State));
-			vi.mocked(writeFile).mockResolvedValue(undefined);
-			vi.mocked(mkdir).mockResolvedValue(undefined);
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v3State));
 
 			await persistenceManager.loadEdgeWorkerState();
 
-			expect(writeFile).toHaveBeenCalled();
-			const savedData = JSON.parse(
-				vi.mocked(writeFile).mock.calls[0][1] as string,
-			);
-			expect(savedData.version).toBe("4.0");
+			expect(handleWriteFile).toHaveBeenCalled();
+			expect(lastSavedData().version).toBe("4.0");
 		});
 	});
 
 	describe("v4.0 state (current)", () => {
-		it("should load v4.0 state without migration", async () => {
-			const v4State = {
-				version: "4.0",
-				savedAt: "2025-01-15T12:00:00.000Z",
-				state: {
-					agentSessions: {
-						"session-123": {
-							id: "session-123",
-							externalSessionId: "session-123",
-							issueContext: {
-								trackerId: "linear",
-								issueId: "issue-456",
-								issueIdentifier: "TEST-123",
-							},
+		const v4State = {
+			version: "4.0",
+			savedAt: "2025-01-15T12:00:00.000Z",
+			state: {
+				agentSessions: {
+					"session-123": {
+						id: "session-123",
+						externalSessionId: "session-123",
+						issueContext: {
+							trackerId: "linear",
+							issueId: "issue-456",
+							issueIdentifier: "TEST-123",
 						},
 					},
 				},
-			};
+			},
+		};
 
+		it("should load v4.0 state without migration", async () => {
 			vi.mocked(existsSync).mockReturnValue(true);
-			vi.mocked(readFile).mockResolvedValue(JSON.stringify(v4State));
+			vi.mocked(readFileSync).mockReturnValue(JSON.stringify(v4State));
 
 			const result = await persistenceManager.loadEdgeWorkerState();
 
 			expect(result).toEqual(v4State.state);
-			// Should not call writeFile since no migration needed
-			expect(writeFile).not.toHaveBeenCalled();
+			// Should not write anything since no migration is needed
+			expect(handleWriteFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("atomic write behavior", () => {
+		const v4State = {
+			agentSessions: { "session-1": { id: "session-1" } },
+		};
+
+		it("writes to a temp file then renames it into place (no in-place write)", async () => {
+			vi.mocked(existsSync).mockReturnValue(false); // no prior file to rotate
+
+			await persistenceManager.saveEdgeWorkerState(
+				v4State as unknown as Parameters<
+					typeof persistenceManager.saveEdgeWorkerState
+				>[0],
+			);
+
+			// Payload written via the temp-file handle...
+			expect(open).toHaveBeenCalledWith(
+				expect.stringMatching(/edge-worker-state\.json\.tmp$/),
+				"w",
+			);
+			expect(handleWriteFile).toHaveBeenCalledTimes(1);
+			// ...then atomically renamed onto the real file.
+			expect(rename).toHaveBeenCalledWith(
+				expect.stringMatching(/edge-worker-state\.json\.tmp$/),
+				expect.stringMatching(/edge-worker-state\.json$/),
+			);
+		});
+
+		it("rotates an existing state file to .bak before swapping in the new one", async () => {
+			vi.mocked(existsSync).mockReturnValue(true); // prior file exists
+
+			await persistenceManager.saveEdgeWorkerState(
+				v4State as unknown as Parameters<
+					typeof persistenceManager.saveEdgeWorkerState
+				>[0],
+			);
+
+			// First rename rotates current → .bak
+			expect(rename).toHaveBeenNthCalledWith(
+				1,
+				expect.stringMatching(/edge-worker-state\.json$/),
+				expect.stringMatching(/edge-worker-state\.json\.bak$/),
+			);
+			// Second rename swaps temp → current
+			expect(rename).toHaveBeenNthCalledWith(
+				2,
+				expect.stringMatching(/edge-worker-state\.json\.tmp$/),
+				expect.stringMatching(/edge-worker-state\.json$/),
+			);
+		});
+
+		it("serializes and coalesces concurrent saves (single-flight)", async () => {
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			// Fire several saves without awaiting between them.
+			const p1 = persistenceManager.saveEdgeWorkerState({
+				agentSessions: { a: { id: "a" } },
+			} as never);
+			const p2 = persistenceManager.saveEdgeWorkerState({
+				agentSessions: { b: { id: "b" } },
+			} as never);
+			const p3 = persistenceManager.saveEdgeWorkerState({
+				agentSessions: { c: { id: "c" } },
+			} as never);
+			await Promise.all([p1, p2, p3]);
+
+			// Coalesced: far fewer physical writes than save calls, and the last
+			// state (c) is the one that ends up persisted.
+			expect(handleWriteFile.mock.calls.length).toBeLessThanOrEqual(3);
+			const finalPayload = JSON.parse(
+				handleWriteFile.mock.calls.at(-1)![0] as string,
+			);
+			expect(finalPayload.state.agentSessions).toHaveProperty("c");
+		});
+	});
+
+	describe("crash recovery", () => {
+		const goodState = {
+			version: "4.0",
+			savedAt: "2025-01-15T12:00:00.000Z",
+			state: { agentSessions: { "session-1": { id: "session-1" } } },
+		};
+
+		it("recovers from .bak when the primary file is corrupt", async () => {
+			// Both primary and backup exist; primary is truncated garbage.
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+				const path = String(p);
+				if (path.endsWith(".bak")) return JSON.stringify(goodState);
+				return '{"version":"4.0","state":{"agentSess'; // truncated
+			});
+
+			const result = await persistenceManager.loadEdgeWorkerState();
+
+			expect(result).toEqual(goodState.state);
+		});
+
+		it("returns null (not a resurrected .bak) after an explicit delete", async () => {
+			// deleteStateFile removes primary + .tmp + .bak, so nothing remains.
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			await persistenceManager.deleteStateFile();
+			expect(unlink).toHaveBeenCalledTimes(0); // nothing existed to unlink
+
+			const result = await persistenceManager.loadEdgeWorkerState();
+			expect(result).toBeNull();
+		});
+
+		it("deletes primary, .tmp and .bak on deleteStateFile", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+
+			await persistenceManager.deleteStateFile();
+
+			expect(unlink).toHaveBeenCalledWith(
+				expect.stringMatching(/edge-worker-state\.json$/),
+			);
+			expect(unlink).toHaveBeenCalledWith(
+				expect.stringMatching(/edge-worker-state\.json\.tmp$/),
+			);
+			expect(unlink).toHaveBeenCalledWith(
+				expect.stringMatching(/edge-worker-state\.json\.bak$/),
+			);
 		});
 	});
 

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.173",
+		"@anthropic-ai/claude-agent-sdk": "0.3.185",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -1627,6 +1627,44 @@ export class AgentSessionManager extends EventEmitter {
 	}
 
 	/**
+	 * Mark a session as failed after an unrecoverable runner crash.
+	 *
+	 * The normal terminal path (`completeSession`) only runs when the SDK
+	 * emits a `result` message. When the subprocess dies without one — a
+	 * crash, a non-143 exit, a stream that errors — no result ever arrives,
+	 * so without this the session stays `Active` with no runner and the
+	 * Linear issue sits "In Progress" forever with no user-visible signal.
+	 *
+	 * Posts an `error` activity to the issue tracker so the user knows the
+	 * session died and can retry, then transitions the session to `Error`.
+	 * Idempotent: a no-op when the session is unknown or already terminal,
+	 * so it's safe to call from a crash handler that may race `completeSession`.
+	 */
+	async failSession(sessionId: string, body: string): Promise<void> {
+		const session = this.sessions.get(sessionId);
+		if (!session) return;
+
+		// Don't clobber a session that already reached a terminal state (e.g.
+		// a result message landed just before the error event fired).
+		if (
+			session.status === AgentSessionStatus.Complete ||
+			session.status === AgentSessionStatus.Error
+		) {
+			return;
+		}
+
+		const log = this.sessionLog(sessionId);
+		this.activeTasksBySession.delete(sessionId);
+		await this.updateSessionStatus(sessionId, AgentSessionStatus.Error);
+		try {
+			await this.createErrorActivity(sessionId, body);
+		} catch (error) {
+			log.error("Failed to post crash error activity", error);
+		}
+		log.info("Session marked failed after runner crash");
+	}
+
+	/**
 	 * Remove a session and all associated tracking state.
 	 * Use for immediate cleanup when a session is permanently done
 	 * (e.g., issue moved to terminal state).
@@ -1724,6 +1762,44 @@ export class AgentSessionManager extends EventEmitter {
 		this.logger.debug(
 			`Restored ${this.sessions.size} sessions, ${Object.keys(serializedEntries).length} entry collections`,
 		);
+	}
+
+	/**
+	 * Reconcile sessions that were mid-flight when the process died.
+	 *
+	 * Runners live only in memory and are never serialized, so every session
+	 * restored from disk comes back with no `agentRunner`. A session persisted
+	 * as `Active` (working) or `AwaitingInput` (waiting on a question) is
+	 * therefore a zombie: it still claims to be live, `getActiveSessions()`
+	 * counts it, but its runner is gone — a stop signal is a no-op and the
+	 * Linear issue shows a working indicator that never resolves.
+	 *
+	 * Transition those sessions to `Error` (interrupted) so local state matches
+	 * reality. The `!agentRunner` guard makes this safe to call at any time:
+	 * a session that already has a live runner is left untouched, so calling
+	 * this after startup (once runners exist) can never kill a running session.
+	 *
+	 * Returns the ids of the sessions that were reconciled so the caller can
+	 * notify the user (e.g. post an "interrupted, comment to resume" activity).
+	 */
+	markInterruptedSessions(): string[] {
+		const interrupted: string[] = [];
+		for (const [sessionId, session] of this.sessions.entries()) {
+			const isNonTerminal =
+				session.status === AgentSessionStatus.Active ||
+				session.status === AgentSessionStatus.AwaitingInput;
+			if (isNonTerminal && !session.agentRunner) {
+				session.status = AgentSessionStatus.Error;
+				session.updatedAt = Date.now();
+				interrupted.push(sessionId);
+			}
+		}
+		if (interrupted.length > 0) {
+			this.logger.info(
+				`Reconciled ${interrupted.length} interrupted session(s) with no runner to Error`,
+			);
+		}
+		return interrupted;
 	}
 
 	/**

--- a/packages/edge-worker/src/AskUserQuestionHandler.ts
+++ b/packages/edge-worker/src/AskUserQuestionHandler.ts
@@ -51,9 +51,29 @@ export interface AskUserQuestionHandlerDeps {
  * Configuration for AskUserQuestionHandler
  */
 export interface AskUserQuestionHandlerConfig {
-	/** Placeholder for future configuration. Set to undefined. */
-	_placeholder?: undefined;
+	/**
+	 * Maximum time (in milliseconds) to wait for a user's response before
+	 * giving up and unblocking the agent.
+	 *
+	 * A pending question is otherwise only resolved by a "prompted" webhook or
+	 * by the session's AbortSignal. If that webhook is never delivered — for
+	 * example when the user replies in a way that never produces an
+	 * elicitation-response event — the Claude subprocess stays blocked on the
+	 * tool result indefinitely. This timeout bounds that wait so the agent can
+	 * proceed instead of deadlocking.
+	 *
+	 * Set to `0` to disable the timeout and wait indefinitely (legacy behavior).
+	 * Defaults to {@link DEFAULT_QUESTION_TIMEOUT_MS}.
+	 */
+	timeoutMs?: number;
 }
+
+/**
+ * Default time to wait for a user's response before unblocking the agent.
+ * 30 minutes: long enough for an attentive user, short enough to avoid a
+ * session hanging for hours on a lost response webhook.
+ */
+export const DEFAULT_QUESTION_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Handler for presenting AskUserQuestion tool calls to users via Linear's select signal.
@@ -67,6 +87,7 @@ export interface AskUserQuestionHandlerConfig {
 export class AskUserQuestionHandler {
 	private deps: AskUserQuestionHandlerDeps;
 	private logger: ILogger;
+	private timeoutMs: number;
 
 	/**
 	 * Map of agent session ID to pending question data.
@@ -74,8 +95,13 @@ export class AskUserQuestionHandler {
 	 */
 	private pendingQuestions: Map<string, PendingQuestion> = new Map();
 
-	constructor(deps: AskUserQuestionHandlerDeps, logger?: ILogger) {
+	constructor(
+		deps: AskUserQuestionHandlerDeps,
+		config?: AskUserQuestionHandlerConfig,
+		logger?: ILogger,
+	) {
 		this.deps = deps;
+		this.timeoutMs = config?.timeoutMs ?? DEFAULT_QUESTION_TIMEOUT_MS;
 		this.logger =
 			logger ?? createLogger({ component: "AskUserQuestionHandler" });
 	}
@@ -188,31 +214,68 @@ export class AskUserQuestionHandler {
 			};
 		}
 
-		// Create promise to wait for user response
-		// Cleanup is handled via AbortSignal when the session ends
+		// Create promise to wait for user response.
+		// The promise is resolved by exactly one of three paths, all funneled
+		// through `finalize`: a user response, session abort, or timeout. A
+		// timeout is essential — without it a lost "prompted" webhook leaves the
+		// Claude subprocess blocked on this tool result forever.
 		return new Promise<AskUserQuestionResult>((resolve) => {
+			let settled = false;
+			let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+			// Declared before `finalize` so `finalize` can detach the listener
+			// without a forward reference; assigned below.
+			let abortHandler: () => void;
+
+			// Single resolution path: clear the timeout, detach the abort
+			// listener, drop the pending entry, and resolve exactly once.
+			const finalize = (result: AskUserQuestionResult) => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				if (timeoutId !== undefined) {
+					clearTimeout(timeoutId);
+				}
+				signal.removeEventListener("abort", abortHandler);
+				this.pendingQuestions.delete(linearAgentSessionId);
+				resolve(result);
+			};
+
 			// Setup abort handler for session cancellation
-			const abortHandler = () => {
+			abortHandler = () => {
 				this.logger.debug(
 					`Question cancelled for session ${linearAgentSessionId}`,
 				);
-				this.pendingQuestions.delete(linearAgentSessionId);
-				resolve({
+				finalize({
 					answered: false,
 					message: "Operation was cancelled",
 				});
 			};
 			signal.addEventListener("abort", abortHandler, { once: true });
 
+			// Guard against a never-delivered response webhook deadlocking the
+			// tool call. On timeout, unblock the agent with a denial that tells
+			// it to proceed rather than hang.
+			if (this.timeoutMs > 0) {
+				timeoutId = setTimeout(() => {
+					const minutes = Math.round(this.timeoutMs / 60000);
+					this.logger.warn(
+						`AskUserQuestion for session ${linearAgentSessionId} timed out after ${this.timeoutMs}ms with no response`,
+					);
+					finalize({
+						answered: false,
+						message: `No response was received within ${minutes} minute(s). Proceed using your best judgment (for example, your recommended default), and ask again later if you still need the user's decision.`,
+					});
+				}, this.timeoutMs);
+				// Don't let this timer keep the process alive on its own.
+				timeoutId.unref?.();
+			}
+
 			// Store pending question
 			this.pendingQuestions.set(linearAgentSessionId, {
 				question,
-				resolve: (result: AskUserQuestionResult) => {
-					// Clean up abort handler before resolving
-					signal.removeEventListener("abort", abortHandler);
-					this.pendingQuestions.delete(linearAgentSessionId);
-					resolve(result);
-				},
+				resolve: finalize,
 				signal,
 			});
 		});

--- a/packages/edge-worker/src/AskUserQuestionHandler.ts
+++ b/packages/edge-worker/src/AskUserQuestionHandler.ts
@@ -174,13 +174,19 @@ export class AskUserQuestionHandler {
 			);
 		}
 
-		// Create the options for Linear's select signal
-		// Include an "Other" option to allow free-form input
+		// Create the options for Linear's select signal, one per offered choice.
+		//
+		// We intentionally do NOT append a literal "Other" option. Linear's
+		// select signal returns the chosen option's `value` verbatim, so an
+		// "Other" button could only ever deliver the useless string "Other" —
+		// there is no way to attach the user's typed text to a select option.
+		// Free-form answers are instead handled by the user simply replying with
+		// a comment: any prompted webhook while a question is pending is routed to
+		// handleUserResponse() and its body becomes the answer. We surface that
+		// affordance in the elicitation body below.
 		const options = question.options.map((opt) => ({
 			value: opt.label,
 		}));
-		// Add "Other" option for free-form input
-		options.push({ value: "Other" });
 
 		// Build the elicitation body
 		// Include the question text and option descriptions for context
@@ -188,7 +194,7 @@ export class AskUserQuestionHandler {
 			.map((opt) => `• **${opt.label}**: ${opt.description}`)
 			.join("\n");
 
-		const elicitationBody = `${question.question}\n\n${optionsText}`;
+		const elicitationBody = `${question.question}\n\n${optionsText}\n\n_Select an option above, or reply with your own answer._`;
 
 		// Post elicitation to Linear
 		try {

--- a/packages/edge-worker/src/ConfigManager.ts
+++ b/packages/edge-worker/src/ConfigManager.ts
@@ -215,6 +215,9 @@ export class ConfigManager extends EventEmitter {
 					parsedConfig.defaultFallbackModel ||
 					this.config.claudeDefaultFallbackModel ||
 					this.config.defaultFallbackModel,
+				claudeColdResumeSummarizeThresholdTokens:
+					parsedConfig.claudeColdResumeSummarizeThresholdTokens ??
+					this.config.claudeColdResumeSummarizeThresholdTokens,
 				geminiDefaultModel:
 					parsedConfig.geminiDefaultModel || this.config.geminiDefaultModel,
 				codexDefaultModel:
@@ -340,6 +343,7 @@ export class ConfigManager extends EventEmitter {
 			"defaultRunner",
 			"claudeDefaultModel",
 			"claudeDefaultFallbackModel",
+			"claudeColdResumeSummarizeThresholdTokens",
 			"geminiDefaultModel",
 			"codexDefaultModel",
 			"cursorDefaultModel",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -5294,7 +5294,20 @@ ${taskSection}`;
 	 * should contribute to the skill whitelist for a session.
 	 *
 	 * - Multi-repo sessions: every sub-worktree in `workspace.repoPaths`.
-	 * - Single-repo / GitHub-mention sessions: the active repository's path.
+	 * - Single-repo / GitHub-mention sessions: the session worktree, which is
+	 *   the same path the SDK uses as cwd to load skill definitions.
+	 *
+	 * The single-repo path MUST be the worktree (`session.workspace.path`), not
+	 * `repository.repositoryPath`. Cyrus never advances the base clone's working
+	 * tree (it only `git fetch`es and cuts each worktree from `origin/<base>`),
+	 * so the base clone is a frozen snapshot from whenever the repo was
+	 * registered. Globbing its `.claude/skills/` produces a stale allow-list,
+	 * while the SDK loads skill definitions from the fresh worktree — any skill
+	 * committed after registration loads but is rejected as "not in this
+	 * session's skills allowlist". Keying off the worktree keeps the allow-list
+	 * source and the definition source identical. See cyrusagents/cyrus#1336.
+	 * (v0.2.66 / #1332 fixed the same base-clone-vs-worktree bug for
+	 * cyrus-setup.sh/teardown hooks; skills were missed.)
 	 */
 	private resolveSkillRepoPaths(
 		repository: RepositoryConfig,
@@ -5308,6 +5321,10 @@ ${taskSection}`;
 			if (paths.length > 0) {
 				return [...new Set(paths)];
 			}
+		}
+		const worktreePath = session?.workspace?.path;
+		if (typeof worktreePath === "string" && worktreePath.length > 0) {
+			return [worktreePath];
 		}
 		return [repository.repositoryPath];
 	}

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -13,6 +13,7 @@ import type {
 } from "cyrus-claude-runner";
 import {
 	buildBaseSessionEnv,
+	buildHomeDirectoryDisallowedTools,
 	ClaudeRunner,
 	HttpSessionStore,
 	normalizeMcpHttpTransport,
@@ -626,6 +627,11 @@ export class EdgeWorker extends EventEmitter {
 
 		// Load persisted state for each repository
 		await this.loadPersistedState();
+
+		// Reconcile sessions that were mid-flight when we last shut down. Their
+		// in-memory runners are gone, so they'd otherwise linger as zombies that
+		// show a working indicator in Linear forever and ignore stop signals.
+		await this.reconcileInterruptedSessions();
 
 		// Pre-warm the 30 most recent Claude sessions in the background
 		// so their first query after restart has near-zero cold-start latency.
@@ -5229,7 +5235,11 @@ ${taskSection}`;
 	 * Handle Claude session error
 	 * Silently ignores AbortError (user-initiated stop), logs other errors
 	 */
-	private async handleClaudeError(error: Error): Promise<void> {
+	private async handleClaudeError(
+		error: Error,
+		sessionId?: string,
+		repositoryId?: string,
+	): Promise<void> {
 		// AbortError is expected when user stops Claude process, don't log it
 		// Check by name since the SDK's AbortError class may not match our imported definition
 		const isAbortError =
@@ -5243,7 +5253,36 @@ ${taskSection}`;
 		if (isAbortError || isSigterm) {
 			return;
 		}
-		this.logger.error("Unhandled claude error:", error);
+		this.logger.error("Unhandled claude error:", {
+			error,
+			sessionId,
+			repositoryId,
+		});
+
+		// A genuine runner crash (subprocess died, stream errored, non-143 exit)
+		// never produces a `result` message, so `completeSession` never runs.
+		// Without surfacing it here the Linear issue stays "In Progress" with a
+		// dead runner and the user sees nothing. When we know which session
+		// crashed, tell the user and transition it to a terminal error state.
+		if (!sessionId) {
+			return;
+		}
+		try {
+			await this.agentSessionManager.failSession(
+				sessionId,
+				`The agent session ended unexpectedly and could not continue.\n\n\`${error.message}\`\n\nComment on this issue to start a new session.`,
+			);
+		} catch (failError) {
+			this.logger.error("Failed to surface runner crash to Linear:", failError);
+		}
+
+		// Reclaim the pre-warmed slot so a crashed session doesn't leak a warm
+		// instance or hand a stale one to a later resume.
+		this.warmInstances.delete(sessionId);
+
+		// Persist the Error transition so a restart doesn't resurrect a zombie
+		// Active session with no runner.
+		await this.savePersistedState();
 	}
 
 	/**
@@ -6513,7 +6552,8 @@ ${input.userComment}
 			onMessage: (message: SDKMessage) => {
 				this.handleClaudeMessage(sessionId, message, repository.id);
 			},
-			onError: (error: Error) => this.handleClaudeError(error),
+			onError: (error: Error) =>
+				this.handleClaudeError(error, sessionId, repository.id),
 			createAskUserQuestionCallback: (sid, wid) =>
 				this.createAskUserQuestionCallback(sid, wid)!,
 			requireLinearWorkspaceId,
@@ -6705,6 +6745,46 @@ ${input.userComment}
 	}
 
 	/**
+	 * After restoring persisted state, transition any session that was still
+	 * "working" or "awaiting input" when we shut down to a terminal error
+	 * state (its runner did not survive the restart), tell the user, and
+	 * persist the correction so it can't resurrect on the next boot.
+	 */
+	private async reconcileInterruptedSessions(): Promise<void> {
+		const interrupted = this.agentSessionManager.markInterruptedSessions();
+		if (interrupted.length === 0) {
+			return;
+		}
+
+		// Best-effort user notice. A restart is not a session error per se — the
+		// transcript is preserved and a follow-up comment resumes it — so phrase
+		// it as recoverable. Failures here (network, missing sink) must never
+		// block startup.
+		await Promise.all(
+			interrupted.map(async (sessionId) => {
+				try {
+					await this.agentSessionManager.createErrorActivity(
+						sessionId,
+						"This session was interrupted when the agent restarted and did not finish. Comment on this issue to resume where it left off.",
+					);
+				} catch (error) {
+					this.logger.warn(
+						`Failed to post interruption notice for session ${sessionId}:`,
+						error,
+					);
+				}
+			}),
+		);
+
+		// Persist the reconciled (Error) statuses so a crash before the next
+		// natural save doesn't bring the zombies back.
+		await this.savePersistedState();
+		this.logger.info(
+			`Reconciled ${interrupted.length} interrupted session(s) after restart`,
+		);
+	}
+
+	/**
 	 * Whether the warm-session feature is enabled.
 	 *
 	 * Warm sessions are an opt-in optimization that pre-spawns Claude Code
@@ -6765,6 +6845,13 @@ ${input.userComment}
 		);
 
 		const { startup } = await import("@anthropic-ai/claude-agent-sdk");
+
+		// Resolve the skill plugins once — they are global (same for every
+		// session), so there is no need to re-resolve per candidate. Without
+		// these, warm-resumed sessions get the Skill tool but an empty skill set,
+		// leaving them strictly weaker than a cold session (which resolves skills
+		// in buildAgentRunnerConfig()).
+		const warmPlugins = await this.skillsPluginResolver.resolve();
 
 		await Promise.all(
 			candidates.map(async (session) => {
@@ -6831,7 +6918,49 @@ ${input.userComment}
 					// Without these, startup() inherits the user's defaultMode ("default"),
 					// which causes macOS permission prompts for file writes.
 					const allowedTools = this.buildAllowedTools(repo);
-					const disallowedTools = this.buildDisallowedTools(repo);
+
+					// Reconstruct the home-directory Read denials that ClaudeRunner.start()
+					// computes at query time. Warm sessions run warmSession.query()
+					// directly and never see those query-time options, so without
+					// re-deriving them here a resumed session could read ~/.ssh, ~/.aws,
+					// etc. Mirror the live allowedDirectories composition so the
+					// attachments/repo/git dirs stay readable.
+					const workspaceFolderName = basename(session.workspace.path);
+					const attachmentsDir = join(
+						this.cyrusHome,
+						workspaceFolderName,
+						"attachments",
+					);
+					const allowedDirectories = [
+						...new Set([
+							attachmentsDir,
+							repo.repositoryPath,
+							session.workspace.path,
+							...this.gitService.getGitMetadataDirectoriesForWorkspace(
+								session.workspace,
+							),
+						]),
+					];
+					const disallowedTools = [
+						...new Set([
+							...this.buildDisallowedTools(repo),
+							...buildHomeDirectoryDisallowedTools(
+								session.workspace.path,
+								allowedDirectories,
+							),
+						]),
+					];
+
+					// Skills for this session's repo/worktree — mirrors the live
+					// resolveSkillsConfig() path so warm sessions have the same skill
+					// set (and skill allow-list) as cold ones.
+					const skills = await this.skillsPluginResolver.discoverSkillNames(
+						warmPlugins,
+						{
+							repositoryId: repo.id,
+							repoPaths: [session.workspace.path],
+						},
+					);
 
 					const warm = await startup({
 						options: {
@@ -6841,6 +6970,8 @@ ${input.userComment}
 							...(Object.keys(mcpServers).length > 0 && { mcpServers }),
 							...(allowedTools.length > 0 && { allowedTools }),
 							...(disallowedTools.length > 0 && { disallowedTools }),
+							...(warmPlugins.length > 0 && { plugins: warmPlugins }),
+							...(skills !== undefined && { skills }),
 							settingSources: ["user", "project", "local"],
 							// CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is intentionally not set here;
 							// see CYPACK-1108 and ClaudeRunner.start() for context.

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { execSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { LinearClient } from "@linear/sdk";
 import type {
@@ -15,8 +15,10 @@ import {
 	buildBaseSessionEnv,
 	buildHomeDirectoryDisallowedTools,
 	ClaudeRunner,
+	findTranscriptPath,
 	HttpSessionStore,
 	normalizeMcpHttpTransport,
+	summarizeTranscript,
 } from "cyrus-claude-runner";
 import { getCyrusAppUrl } from "cyrus-cloudflare-tunnel-client";
 import { CodexRunner } from "cyrus-codex-runner";
@@ -6134,6 +6136,7 @@ ${taskSection}`;
 		attachmentManifest?: string,
 		commentAuthor?: string,
 		commentTimestamp?: string,
+		previousSessionSummary?: string,
 	): Promise<string> {
 		// Fetch labels for system prompt determination
 		const labels = await this.fetchIssueLabels(fullIssue);
@@ -6148,6 +6151,7 @@ ${taskSection}`;
 			commentAuthor,
 			commentTimestamp,
 			attachmentManifest,
+			previousSessionSummary,
 			isNewSession,
 			isStreaming: false, // This path is only for non-streaming prompts
 			labels,
@@ -6290,6 +6294,20 @@ ${taskSection}`;
 		parts.push(issueContext.prompt);
 		components.push("issue-context");
 
+		// 5b. Add previous-session summary (cold-resume-summarize restart).
+		// When a resume's transcript exceeded the configured threshold, the prior
+		// session was summarized by Haiku and a fresh session started; seed that
+		// summary here so the new session can continue the work.
+		if (input.previousSessionSummary?.trim()) {
+			parts.push(
+				this.buildPreviousSessionSummaryBlock(
+					input.session,
+					input.previousSessionSummary,
+				),
+			);
+			components.push("session-summary");
+		}
+
 		// 4. Add user comment (if present)
 		// Skip for mention-triggered prompts since the comment is already in the mention block
 		if (input.userComment.trim() && !input.isMentionTriggered) {
@@ -6326,6 +6344,39 @@ ${input.userComment}
 				isStreaming: false,
 			},
 		};
+	}
+
+	/**
+	 * Build a `<previous_session_summary>` block for the cold-resume-summarize
+	 * restart path. Includes the branches the prior session was working on, the
+	 * Haiku-generated summary, and a note reminding the fresh session that work
+	 * may already exist on the branch / a PR may be open.
+	 */
+	private buildPreviousSessionSummaryBlock(
+		session: CyrusAgentSession,
+		summary: string,
+	): string {
+		const branches = Array.from(
+			new Set(
+				(session.repositories ?? [])
+					.map((repo) => repo.branchName)
+					.filter((b): b is string => Boolean(b)),
+			),
+		);
+		const branchLines =
+			branches.length > 0
+				? branches.map((b) => `    <branch>${b}</branch>`).join("\n")
+				: "";
+		const branchesBlock = branchLines
+			? `  <branches>\n${branchLines}\n  </branches>\n`
+			: "";
+
+		return `<previous_session_summary>
+${branchesBlock}  <summary>
+${summary.trim()}
+  </summary>
+  <note>This summary replaces a prior session that grew too large to resume directly. Work may already exist on the branch above and a pull request may already be open — check the current state with git and gh before redoing anything.</note>
+</previous_session_summary>`;
 	}
 
 	/**
@@ -7266,6 +7317,145 @@ ${input.userComment}
 		);
 	}
 
+	/** Minimum sane cold-resume summarize threshold; below this we warn + disable. */
+	private static readonly MIN_COLD_RESUME_THRESHOLD_TOKENS = 20_000;
+
+	/**
+	 * Resolve the effective cold-resume summarize threshold from config.
+	 * Returns undefined when disabled (unset) or when the configured value is
+	 * below the minimum sane value (warn + ignore). Mirrors the resolve-helper
+	 * pattern used for other bounded numeric config knobs.
+	 */
+	private resolveColdResumeThreshold(): number | undefined {
+		const configured = this.config.claudeColdResumeSummarizeThresholdTokens;
+		if (configured === undefined) return undefined;
+		if (configured < EdgeWorker.MIN_COLD_RESUME_THRESHOLD_TOKENS) {
+			this.logger.warn(
+				`claudeColdResumeSummarizeThresholdTokens=${configured} is below the minimum of ${EdgeWorker.MIN_COLD_RESUME_THRESHOLD_TOKENS}; ignoring (cold-resume summarize disabled)`,
+			);
+			return undefined;
+		}
+		return configured;
+	}
+
+	/**
+	 * Estimate the token size of a resume's prior context.
+	 *
+	 * Prefers the last turn's usage signal (input + cache-read + cache-write)
+	 * when present on the session; otherwise falls back to transcript file size
+	 * divided by 4 (a rough bytes-per-token estimate). Returns undefined if
+	 * neither signal is available.
+	 */
+	private async estimateResumeContextTokens(
+		session: CyrusAgentSession,
+		transcriptPath: string,
+	): Promise<number | undefined> {
+		const usage = session.metadata?.usage as
+			| Record<string, unknown>
+			| undefined;
+		if (usage) {
+			const num = (...keys: string[]): number => {
+				for (const key of keys) {
+					const value = usage[key];
+					if (typeof value === "number" && Number.isFinite(value)) {
+						return value;
+					}
+				}
+				return 0;
+			};
+			const fromUsage =
+				num("input_tokens", "inputTokens") +
+				num("cache_read_input_tokens", "cacheReadInputTokens") +
+				num("cache_creation_input_tokens", "cacheCreationInputTokens");
+			if (fromUsage > 0) return fromUsage;
+		}
+
+		try {
+			const { size } = await stat(transcriptPath);
+			return Math.floor(size / 4);
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Cold-resume summarize-and-restart trigger.
+	 *
+	 * When a Claude resume's transcript has grown past the configured threshold,
+	 * summarize it with a one-shot Haiku call and return the summary so the
+	 * caller can start a fresh session seeded with it. Returns undefined (fall
+	 * through to a normal resume) when the feature is disabled, no transcript is
+	 * found, the estimate is under threshold, or summarization fails — the
+	 * feature must never break a resume that would otherwise have succeeded.
+	 */
+	private async maybeSummarizeColdResume(
+		session: CyrusAgentSession,
+		sessionId: string,
+		claudeSessionId: string,
+		workspaceId: string,
+	): Promise<string | undefined> {
+		const threshold = this.resolveColdResumeThreshold();
+		if (threshold === undefined) return undefined;
+
+		let transcriptPath: string | null = null;
+		try {
+			transcriptPath = await findTranscriptPath(claudeSessionId);
+		} catch (error) {
+			this.logger.warn(`Cold-resume: transcript lookup failed`, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+		if (!transcriptPath) {
+			this.logger.debug(
+				`Cold-resume: no transcript found for ${claudeSessionId}; skipping summarize`,
+			);
+			return undefined;
+		}
+
+		const estimatedTokens = await this.estimateResumeContextTokens(
+			session,
+			transcriptPath,
+		);
+		if (estimatedTokens === undefined || estimatedTokens <= threshold) {
+			return undefined;
+		}
+
+		this.logger.info(
+			`Cold-resume: estimated ${estimatedTokens} tokens > threshold ${threshold}; summarizing ${transcriptPath}`,
+		);
+
+		try {
+			await this.activityPoster.postThoughtActivity(
+				sessionId,
+				workspaceId,
+				"Prior conversation exceeds the resume threshold — summarizing and starting fresh.",
+			);
+		} catch (error) {
+			// Best-effort thought; never block summarization on it.
+			this.logger.warn(`Cold-resume: failed to post summarize thought`, {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+
+		try {
+			const summary = await summarizeTranscript({
+				transcriptPath,
+				logger: this.logger,
+			});
+			this.logger.info(
+				`Cold-resume: summarized transcript into ${summary.length} chars; starting fresh session`,
+			);
+			return summary;
+		} catch (error) {
+			this.logger.warn(
+				`Cold-resume: summarization failed; falling through to normal resume`,
+				{ error: error instanceof Error ? error.message : String(error) },
+			);
+			return undefined;
+		}
+	}
+
 	/**
 	 * Resume or create an Agent session with the given prompt
 	 * This is the core logic for handling prompted agent activities
@@ -7407,6 +7597,34 @@ ${input.userComment}
 			`[resumeAgentSession] needsNewSession=${needsNewSession}, resumeSessionId=${resumeSessionId ?? "none"}`,
 		);
 
+		// Cold-resume summarize-and-restart: when a Claude resume's transcript has
+		// grown past the configured threshold, resuming it rewrites the entire
+		// transcript to the prompt cache. Instead, summarize it with a one-shot
+		// Haiku call and start a fresh session seeded with the summary. On any
+		// failure we fall through to a normal resume — this feature must never
+		// break a resume that would otherwise have succeeded.
+		let effectiveResumeSessionId = resumeSessionId;
+		let previousSessionSummary: string | undefined;
+		let buildAsNewSession = isNewSession;
+		if (resumeSessionId && resumeSessionId === session.claudeSessionId) {
+			const summary = await this.maybeSummarizeColdResume(
+				session,
+				sessionId,
+				resumeSessionId,
+				resolvedWorkspaceId,
+			);
+			if (summary) {
+				// Success: build as a fresh session seeded with the summary.
+				// Crucially, do NOT clear session.claudeSessionId — runner pinning
+				// (RunnerConfigBuilder) and the init-message rebind
+				// (AgentSessionManager) both depend on it; the rebind overwrites it
+				// with the new Claude session ID once the fresh session initializes.
+				effectiveResumeSessionId = undefined;
+				previousSessionSummary = summary;
+				buildAsNewSession = true;
+			}
+		}
+
 		// Create runner configuration
 		// buildAgentRunnerConfig determines runner type from labels for new sessions
 		// For existing sessions, we still need labels for model override but ignore runner type
@@ -7419,7 +7637,7 @@ ${input.userComment}
 				allowedTools,
 				allowedDirectories,
 				disallowedTools,
-				resumeSessionId,
+				effectiveResumeSessionId,
 				labels, // Always pass labels to preserve model override
 				fullIssue.description || undefined, // Description tags can override label selectors
 				maxTurns, // Pass maxTurns if specified
@@ -7438,7 +7656,7 @@ ${input.userComment}
 
 		// Prepare the full prompt
 		const fullPrompt = await this.buildSessionPrompt(
-			isNewSession,
+			buildAsNewSession,
 			session,
 			fullIssue,
 			repository,
@@ -7446,6 +7664,7 @@ ${input.userComment}
 			attachmentManifest,
 			commentAuthor,
 			commentTimestamp,
+			previousSessionSummary,
 		);
 
 		// Start session - use streaming mode if supported for ability to add messages later

--- a/packages/edge-worker/src/SharedApplicationServer.ts
+++ b/packages/edge-worker/src/SharedApplicationServer.ts
@@ -3,6 +3,9 @@ import { CloudflareTunnelClient } from "cyrus-cloudflare-tunnel-client";
 import { createLogger, type ILogger } from "cyrus-core";
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 
+const ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
+const ROBOTS_HEADER = "noindex, nofollow";
+
 /**
  * OAuth callback state for tracking flows
  */
@@ -77,6 +80,18 @@ export class SharedApplicationServer {
 		this.app = Fastify({
 			logger: false,
 			trustProxy: true,
+		});
+
+		this.app.addHook("onRequest", (_request, reply, done) => {
+			reply.header("X-Robots-Tag", ROBOTS_HEADER);
+			done();
+		});
+
+		this.app.get("/robots.txt", async (_request, reply) => {
+			return reply
+				.type("text/plain; charset=utf-8")
+				.header("Cache-Control", "public, max-age=3600")
+				.send(ROBOTS_TXT);
 		});
 
 		// Preserve raw request body for webhook signature verification (GitHub HMAC-SHA256).

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -1,11 +1,11 @@
 import type { IAgentRunner, ILogger } from "cyrus-core";
 import { createLogger } from "cyrus-core";
 import {
+	buildPromptText,
 	SlackMessageService,
 	SlackReactionService,
 	type SlackThreadMessage,
 	type SlackWebhookEvent,
-	stripMention as stripSlackMention,
 } from "cyrus-slack-event-transport";
 import type { ChatRepositoryProvider } from "./ChatRepositoryProvider.js";
 import type { ChatPlatformAdapter } from "./ChatSessionHandler.js";
@@ -106,9 +106,7 @@ export class SlackChatAdapter
 	}
 
 	extractTaskInstructions(event: SlackWebhookEvent): string {
-		return (
-			stripSlackMention(event.payload.text) || "Ask the user for more context"
-		);
+		return buildPromptText(event.payload) || "Ask the user for more context";
 	}
 
 	/**

--- a/packages/edge-worker/src/prompt-assembly/types.ts
+++ b/packages/edge-worker/src/prompt-assembly/types.ts
@@ -45,6 +45,7 @@ export interface PromptAssembly {
  */
 export type PromptComponent =
 	| "issue-context" // Issue title, description, comments, history
+	| "session-summary" // Haiku summary of a prior over-threshold session (cold-resume restart)
 	| "user-comment" // User's comment text
 	| "attachment-manifest" // List of attachments
 	| "guidance-rules"; // Linear agent guidance rules
@@ -90,6 +91,15 @@ export interface PromptAssemblyInput {
 
 	/** Attachment manifest string (if any attachments) */
 	attachmentManifest?: string;
+
+	/**
+	 * Haiku-generated summary of a prior session whose transcript exceeded the
+	 * cold-resume threshold. When present on a new-session prompt, a
+	 * `<previous_session_summary>` block is inserted so the fresh session can
+	 * pick up where the summarized session left off. See
+	 * `EdgeWorker.resumeAgentSession` cold-resume-summarize path.
+	 */
+	previousSessionSummary?: string;
 
 	/** Linear agent guidance rules */
 	guidance?: GuidanceRule[];

--- a/packages/edge-worker/test/AgentSessionManager.fail-session.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.fail-session.test.ts
@@ -1,0 +1,123 @@
+import { AgentSessionStatus } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+import type { IActivitySink } from "../src/sinks/IActivitySink";
+
+describe("AgentSessionManager failSession (runner-crash surfacing)", () => {
+	let manager: AgentSessionManager;
+	let mockActivitySink: IActivitySink;
+	let postActivitySpy: any;
+	const sessionId = "test-session-fail";
+	const issueId = "issue-fail";
+
+	const seedSession = () => {
+		manager.createCyrusAgentSession(
+			sessionId,
+			issueId,
+			{
+				id: issueId,
+				identifier: "TEST-FAIL",
+				title: "Fail Session Test",
+				description: "test",
+				branchName: "test-fail",
+			},
+			{
+				path: "/tmp/workspace",
+				isGitWorktree: false,
+			},
+		);
+		manager.setActivitySink(sessionId, mockActivitySink);
+	};
+
+	beforeEach(() => {
+		mockActivitySink = {
+			id: "test-workspace",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "activity-1" }),
+			createAgentSession: vi.fn().mockResolvedValue("session-1"),
+		};
+		postActivitySpy = vi.spyOn(mockActivitySink, "postActivity");
+		manager = new AgentSessionManager();
+	});
+
+	it("posts an error activity and transitions the session to Error", async () => {
+		seedSession();
+
+		await manager.failSession(sessionId, "boom: subprocess exited with code 1");
+
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+
+		const errorActivity = postActivitySpy.mock.calls.find(
+			(call: any[]) => call[1]?.type === "error",
+		);
+		expect(errorActivity).toBeDefined();
+		expect(errorActivity![1].body).toContain(
+			"boom: subprocess exited with code 1",
+		);
+	});
+
+	it("is a no-op for an unknown session (does not throw, posts nothing)", async () => {
+		await expect(
+			manager.failSession("nonexistent-session", "boom"),
+		).resolves.toBeUndefined();
+		expect(postActivitySpy).not.toHaveBeenCalled();
+	});
+
+	it("does not clobber a session that already completed successfully", async () => {
+		seedSession();
+		await manager.completeSession(sessionId, {
+			type: "result",
+			subtype: "success",
+			duration_ms: 1,
+			duration_api_ms: 1,
+			is_error: false,
+			num_turns: 1,
+			result: "done",
+			stop_reason: null,
+			total_cost_usd: 0,
+			usage: {
+				input_tokens: 1,
+				output_tokens: 1,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+				cache_creation: null,
+			},
+			modelUsage: {},
+			permission_denials: [],
+			uuid: "result-1",
+			session_id: "sdk-session",
+		} as any);
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Complete,
+		);
+
+		postActivitySpy.mockClear();
+		await manager.failSession(sessionId, "late crash after success");
+
+		// Terminal status preserved, no additional error activity posted.
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Complete,
+		);
+		expect(postActivitySpy).not.toHaveBeenCalled();
+	});
+
+	it("does not post twice when called repeatedly (idempotent once errored)", async () => {
+		seedSession();
+
+		await manager.failSession(sessionId, "first crash");
+		const callsAfterFirst = postActivitySpy.mock.calls.filter(
+			(call: any[]) => call[1]?.type === "error",
+		).length;
+		expect(callsAfterFirst).toBe(1);
+
+		await manager.failSession(sessionId, "second crash");
+		const callsAfterSecond = postActivitySpy.mock.calls.filter(
+			(call: any[]) => call[1]?.type === "error",
+		).length;
+		expect(callsAfterSecond).toBe(1);
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+	});
+});

--- a/packages/edge-worker/test/AgentSessionManager.interrupted-sessions.test.ts
+++ b/packages/edge-worker/test/AgentSessionManager.interrupted-sessions.test.ts
@@ -1,0 +1,109 @@
+import { AgentSessionStatus } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager";
+import type { IActivitySink } from "../src/sinks/IActivitySink";
+
+/**
+ * Serialized-session shape accepted by restoreState. We only populate the
+ * fields the reconciliation logic reads (status, agentRunner is never
+ * serialized) plus the minimum for the session to be well-formed.
+ */
+const serializedSession = (id: string, status: AgentSessionStatus) => ({
+	id,
+	issueId: `issue-${id}`,
+	status,
+	createdAt: 1,
+	updatedAt: 1,
+	issueContext: {
+		issueId: `issue-${id}`,
+		issueIdentifier: id.toUpperCase(),
+	},
+	metadata: {},
+	repositories: [],
+});
+
+describe("AgentSessionManager.markInterruptedSessions", () => {
+	let manager: AgentSessionManager;
+
+	beforeEach(() => {
+		manager = new AgentSessionManager();
+	});
+
+	it("transitions restored Active and AwaitingInput sessions (no runner) to Error", () => {
+		manager.restoreState(
+			{
+				active1: serializedSession("active1", AgentSessionStatus.Active) as any,
+				awaiting1: serializedSession(
+					"awaiting1",
+					AgentSessionStatus.AwaitingInput,
+				) as any,
+			},
+			{},
+		);
+
+		const interrupted = manager.markInterruptedSessions();
+
+		expect(interrupted.sort()).toEqual(["active1", "awaiting1"]);
+		expect(manager.getSession("active1")?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+		expect(manager.getSession("awaiting1")?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+	});
+
+	it("leaves already-terminal sessions untouched", () => {
+		manager.restoreState(
+			{
+				done: serializedSession("done", AgentSessionStatus.Complete) as any,
+				failed: serializedSession("failed", AgentSessionStatus.Error) as any,
+			},
+			{},
+		);
+
+		const interrupted = manager.markInterruptedSessions();
+
+		expect(interrupted).toEqual([]);
+		expect(manager.getSession("done")?.status).toBe(
+			AgentSessionStatus.Complete,
+		);
+		expect(manager.getSession("failed")?.status).toBe(AgentSessionStatus.Error);
+	});
+
+	it("does not touch an Active session that has a live runner", () => {
+		manager.restoreState(
+			{ live: serializedSession("live", AgentSessionStatus.Active) as any },
+			{},
+		);
+		// Simulate a runner having been (re)attached after restore.
+		const fakeRunner = { isStreaming: () => true } as any;
+		manager.addAgentRunner("live", fakeRunner);
+
+		const interrupted = manager.markInterruptedSessions();
+
+		expect(interrupted).toEqual([]);
+		expect(manager.getSession("live")?.status).toBe(AgentSessionStatus.Active);
+	});
+
+	it("is a no-op when there are no sessions", () => {
+		expect(manager.markInterruptedSessions()).toEqual([]);
+	});
+
+	it("reconciled sessions no longer count as active", () => {
+		const sink: IActivitySink = {
+			id: "ws",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "a1" }),
+			createAgentSession: vi.fn().mockResolvedValue("s1"),
+		};
+		manager.restoreState(
+			{ a: serializedSession("a", AgentSessionStatus.Active) as any },
+			{},
+		);
+		manager.setActivitySink("a", sink);
+		expect(manager.getActiveSessions()).toHaveLength(1);
+
+		manager.markInterruptedSessions();
+
+		expect(manager.getActiveSessions()).toHaveLength(0);
+	});
+});

--- a/packages/edge-worker/test/AskUserQuestionHandler.test.ts
+++ b/packages/edge-worker/test/AskUserQuestionHandler.test.ts
@@ -511,4 +511,110 @@ describe("AskUserQuestionHandler", () => {
 			expect(handler.pendingCount).toBe(0);
 		});
 	});
+
+	describe("timeout handling", () => {
+		const buildInput = (): AskUserQuestionInput => ({
+			questions: [
+				{
+					question: "Which database?",
+					header: "Database",
+					options: [
+						{ label: "PostgreSQL", description: "Open source relational DB" },
+					],
+					multiSelect: false,
+				},
+			],
+		});
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("should resolve with a denial when no response arrives before the timeout", async () => {
+			const timeoutHandler = new AskUserQuestionHandler(
+				{ getIssueTracker: mockGetIssueTracker },
+				{ timeoutMs: 1000 },
+			);
+			const abortController = new AbortController();
+
+			const resultPromise = timeoutHandler.handleAskUserQuestion(
+				buildInput(),
+				"session-timeout",
+				"org-123",
+				abortController.signal,
+			);
+
+			// Flush the elicitation post so the pending question registers
+			await vi.advanceTimersByTimeAsync(0);
+			expect(timeoutHandler.hasPendingQuestion("session-timeout")).toBe(true);
+
+			// Advance past the timeout
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const result = await resultPromise;
+			expect(result.answered).toBe(false);
+			expect(result.message).toContain("No response was received");
+			// Pending entry must be cleaned up
+			expect(timeoutHandler.hasPendingQuestion("session-timeout")).toBe(false);
+		});
+
+		it("should not time out when a response arrives first", async () => {
+			const timeoutHandler = new AskUserQuestionHandler(
+				{ getIssueTracker: mockGetIssueTracker },
+				{ timeoutMs: 1000 },
+			);
+			const abortController = new AbortController();
+
+			const resultPromise = timeoutHandler.handleAskUserQuestion(
+				buildInput(),
+				"session-fast",
+				"org-123",
+				abortController.signal,
+			);
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			const handled = timeoutHandler.handleUserResponse(
+				"session-fast",
+				"PostgreSQL",
+			);
+			expect(handled).toBe(true);
+
+			// Advancing past the timeout must not double-resolve or throw
+			await vi.advanceTimersByTimeAsync(2000);
+
+			const result = await resultPromise;
+			expect(result.answered).toBe(true);
+			expect(result.answers).toEqual({ "Which database?": "PostgreSQL" });
+		});
+
+		it("should wait indefinitely when timeoutMs is 0", async () => {
+			const noTimeoutHandler = new AskUserQuestionHandler(
+				{ getIssueTracker: mockGetIssueTracker },
+				{ timeoutMs: 0 },
+			);
+			const abortController = new AbortController();
+
+			const resultPromise = noTimeoutHandler.handleAskUserQuestion(
+				buildInput(),
+				"session-inf",
+				"org-123",
+				abortController.signal,
+			);
+
+			await vi.advanceTimersByTimeAsync(0);
+			// Even after a long time, the question is still pending
+			await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+			expect(noTimeoutHandler.hasPendingQuestion("session-inf")).toBe(true);
+
+			// Clean up
+			noTimeoutHandler.handleUserResponse("session-inf", "PostgreSQL");
+			const result = await resultPromise;
+			expect(result.answered).toBe(true);
+		});
+	});
 });

--- a/packages/edge-worker/test/AskUserQuestionHandler.test.ts
+++ b/packages/edge-worker/test/AskUserQuestionHandler.test.ts
@@ -181,7 +181,9 @@ describe("AskUserQuestionHandler", () => {
 			// Give it a moment to post the activity
 			await new Promise((resolve) => setTimeout(resolve, 10));
 
-			// Verify the elicitation was posted
+			// Verify the elicitation was posted. Options mirror the offered
+			// choices exactly — no synthetic "Other" option, which could only
+			// deliver the literal string "Other" (see handler for rationale).
 			expect(mockCreateAgentActivity).toHaveBeenCalledWith({
 				agentSessionId: "session-123",
 				content: {
@@ -190,17 +192,57 @@ describe("AskUserQuestionHandler", () => {
 				},
 				signal: "select",
 				signalMetadata: {
-					options: [
-						{ value: "PostgreSQL" },
-						{ value: "MongoDB" },
-						{ value: "Other" }, // Should include Other option
-					],
+					options: [{ value: "PostgreSQL" }, { value: "MongoDB" }],
 				},
 			});
+
+			// The body should tell the user they can reply with a free-form answer.
+			const postedBody = (mockCreateAgentActivity.mock.calls[0][0] as any)
+				.content.body as string;
+			expect(postedBody).toContain("reply with your own answer");
+			expect(postedBody).not.toContain("Other");
 
 			// Clean up by simulating response
 			handler.handleUserResponse("session-123", "PostgreSQL");
 			await resultPromise;
+		});
+
+		it("delivers a free-form (non-option) reply verbatim as the answer", async () => {
+			const input: AskUserQuestionInput = {
+				questions: [
+					{
+						question: "Which database should we use?",
+						header: "Database",
+						options: [
+							{ label: "PostgreSQL", description: "Open source relational DB" },
+							{ label: "MongoDB", description: "Document database" },
+						],
+						multiSelect: false,
+					},
+				],
+			};
+			const abortController = new AbortController();
+
+			const resultPromise = handler.handleAskUserQuestion(
+				input,
+				"session-free",
+				"org-123",
+				abortController.signal,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			// User ignores the buttons and types their own answer.
+			handler.handleUserResponse(
+				"session-free",
+				"Use CockroachDB — we need multi-region",
+			);
+
+			const result = await resultPromise;
+			expect(result.answered).toBe(true);
+			expect(result.answers).toEqual({
+				"Which database should we use?":
+					"Use CockroachDB — we need multi-region",
+			});
 		});
 
 		it("should include option descriptions in elicitation body", async () => {

--- a/packages/edge-worker/test/EdgeWorker.claude-error.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.claude-error.test.ts
@@ -1,0 +1,165 @@
+import { LinearClient } from "@linear/sdk";
+import { LinearEventTransport } from "cyrus-linear-event-transport";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+import type { EdgeWorkerConfig, RepositoryConfig } from "../src/types.js";
+import { TEST_CYRUS_HOME } from "./test-dirs.js";
+
+vi.mock("fs/promises");
+vi.mock("cyrus-claude-runner");
+vi.mock("cyrus-mcp-tools");
+vi.mock("cyrus-codex-runner");
+vi.mock("cyrus-linear-event-transport");
+vi.mock("@linear/sdk");
+vi.mock("../src/SharedApplicationServer.js");
+vi.mock("../src/AgentSessionManager.js");
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
+	};
+});
+
+describe("EdgeWorker - handleClaudeError (runner-crash surfacing)", () => {
+	let edgeWorker: EdgeWorker;
+	let mockConfig: EdgeWorkerConfig;
+	let mockAgentSessionManager: any;
+
+	const mockRepository: RepositoryConfig = {
+		id: "test-repo",
+		name: "Test Repo",
+		repositoryPath: "/test/repo",
+		workspaceBaseDir: "/test/workspaces",
+		baseBranch: "main",
+		linearWorkspaceId: "test-workspace",
+		isActive: true,
+		allowedTools: ["Read", "Edit"],
+		labelPrompts: {},
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		mockAgentSessionManager = {
+			failSession: vi.fn().mockResolvedValue(undefined),
+			on: vi.fn(),
+		};
+
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		} as any);
+
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
+
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return {
+				register: vi.fn(),
+				on: vi.fn(),
+				removeAllListeners: vi.fn(),
+			};
+		} as any);
+
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({ id: "user-123", name: "Test User" }),
+				},
+			};
+		} as any);
+
+		mockConfig = {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: TEST_CYRUS_HOME,
+			repositories: [mockRepository],
+			linearWorkspaces: {
+				"test-workspace": { linearToken: "test-token" },
+			},
+		} as EdgeWorkerConfig;
+
+		edgeWorker = new EdgeWorker(mockConfig);
+		(edgeWorker as any).agentSessionManager = mockAgentSessionManager;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("surfaces a genuine crash to Linear and reclaims the warm slot", async () => {
+		const sessionId = "sess-crash";
+		(edgeWorker as any).warmInstances.set(sessionId, { fake: "warm" });
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+
+		await (edgeWorker as any).handleClaudeError(
+			new Error("Claude Code process exited with code 1"),
+			sessionId,
+			"test-repo",
+		);
+
+		expect(mockAgentSessionManager.failSession).toHaveBeenCalledTimes(1);
+		const [failedSessionId, body] =
+			mockAgentSessionManager.failSession.mock.calls[0];
+		expect(failedSessionId).toBe(sessionId);
+		expect(body).toContain("Claude Code process exited with code 1");
+		expect((edgeWorker as any).warmInstances.has(sessionId)).toBe(false);
+		expect(savedSpy).toHaveBeenCalled();
+	});
+
+	it("ignores user-initiated aborts (no failSession, no state write)", async () => {
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+		const abortErr = new Error("Query aborted by user");
+		abortErr.name = "AbortError";
+
+		await (edgeWorker as any).handleClaudeError(
+			abortErr,
+			"sess-abort",
+			"test-repo",
+		);
+
+		expect(mockAgentSessionManager.failSession).not.toHaveBeenCalled();
+		expect(savedSpy).not.toHaveBeenCalled();
+	});
+
+	it("ignores graceful SIGTERM (exit code 143)", async () => {
+		await (edgeWorker as any).handleClaudeError(
+			new Error("Claude Code process exited with code 143"),
+			"sess-sigterm",
+			"test-repo",
+		);
+		expect(mockAgentSessionManager.failSession).not.toHaveBeenCalled();
+	});
+
+	it("only logs when no session context is available (legacy callers)", async () => {
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+
+		await (edgeWorker as any).handleClaudeError(
+			new Error("some background crash"),
+		);
+
+		expect(mockAgentSessionManager.failSession).not.toHaveBeenCalled();
+		expect(savedSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.cold-resume-summarize.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.cold-resume-summarize.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Cold-resume summarize-and-restart decision logic.
+ *
+ * Exercises the trigger helpers wired into `EdgeWorker.resumeAgentSession`:
+ * - `resolveColdResumeThreshold` (unset = disabled; below-min = warn + ignore)
+ * - `maybeSummarizeColdResume` (above threshold summarizes; below/unset/failure
+ *   fall through to a normal resume by returning undefined)
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("cyrus-claude-runner", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		findTranscriptPath: vi.fn(),
+		summarizeTranscript: vi.fn(),
+	};
+});
+
+import { findTranscriptPath, summarizeTranscript } from "cyrus-claude-runner";
+import { createTestWorker } from "./prompt-assembly-utils.js";
+
+const mockFindTranscriptPath = vi.mocked(findTranscriptPath);
+const mockSummarizeTranscript = vi.mocked(summarizeTranscript);
+
+const CLAUDE_SESSION_ID = "claude-session-123";
+const WORKSPACE_ID = "workspace-1";
+
+function makeSession(usage?: Record<string, number>) {
+	return {
+		id: "session-1",
+		claudeSessionId: CLAUDE_SESSION_ID,
+		repositories: [{ branchName: "feature/x" }],
+		workspace: { path: "/test/repo" },
+		metadata: usage ? { usage } : {},
+	} as any;
+}
+
+function setThreshold(worker: any, value: number | undefined) {
+	worker.config.claudeColdResumeSummarizeThresholdTokens = value;
+}
+
+describe("EdgeWorker cold-resume summarize", () => {
+	let worker: any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		worker = createTestWorker();
+	});
+
+	describe("resolveColdResumeThreshold", () => {
+		it("returns undefined when unset (disabled)", () => {
+			setThreshold(worker, undefined);
+			expect(worker.resolveColdResumeThreshold()).toBeUndefined();
+		});
+
+		it("warns and ignores values below the 20k minimum", () => {
+			setThreshold(worker, 5000);
+			const warn = vi.spyOn(worker.logger, "warn").mockImplementation(() => {});
+			expect(worker.resolveColdResumeThreshold()).toBeUndefined();
+			expect(warn).toHaveBeenCalled();
+		});
+
+		it("returns the configured value when at/above the minimum", () => {
+			setThreshold(worker, 60000);
+			expect(worker.resolveColdResumeThreshold()).toBe(60000);
+		});
+	});
+
+	describe("maybeSummarizeColdResume", () => {
+		it("summarizes and posts a thought when usage exceeds the threshold", async () => {
+			setThreshold(worker, 60000);
+			mockFindTranscriptPath.mockResolvedValue("/tmp/transcript.jsonl");
+			mockSummarizeTranscript.mockResolvedValue("A summary");
+			const postThought = vi
+				.spyOn(worker.activityPoster, "postThoughtActivity")
+				.mockResolvedValue(undefined);
+
+			const session = makeSession({
+				input_tokens: 50000,
+				cache_read_input_tokens: 40000,
+				cache_creation_input_tokens: 10000,
+			});
+
+			const summary = await worker.maybeSummarizeColdResume(
+				session,
+				"linear-session-1",
+				CLAUDE_SESSION_ID,
+				WORKSPACE_ID,
+			);
+
+			expect(summary).toBe("A summary");
+			expect(mockSummarizeTranscript).toHaveBeenCalledTimes(1);
+			expect(postThought).toHaveBeenCalledTimes(1);
+			// Invariant: never clear the Claude session ID on success.
+			expect(session.claudeSessionId).toBe(CLAUDE_SESSION_ID);
+		});
+
+		it("returns undefined without summarizing when disabled (unset)", async () => {
+			setThreshold(worker, undefined);
+			const session = makeSession({ input_tokens: 1_000_000 });
+
+			const summary = await worker.maybeSummarizeColdResume(
+				session,
+				"linear-session-1",
+				CLAUDE_SESSION_ID,
+				WORKSPACE_ID,
+			);
+
+			expect(summary).toBeUndefined();
+			expect(mockFindTranscriptPath).not.toHaveBeenCalled();
+			expect(mockSummarizeTranscript).not.toHaveBeenCalled();
+		});
+
+		it("returns undefined when the estimate is at/below the threshold", async () => {
+			setThreshold(worker, 60000);
+			mockFindTranscriptPath.mockResolvedValue("/tmp/transcript.jsonl");
+			const session = makeSession({ input_tokens: 10000 });
+
+			const summary = await worker.maybeSummarizeColdResume(
+				session,
+				"linear-session-1",
+				CLAUDE_SESSION_ID,
+				WORKSPACE_ID,
+			);
+
+			expect(summary).toBeUndefined();
+			expect(mockSummarizeTranscript).not.toHaveBeenCalled();
+		});
+
+		it("returns undefined when no transcript is found", async () => {
+			setThreshold(worker, 60000);
+			mockFindTranscriptPath.mockResolvedValue(null);
+			const session = makeSession({ input_tokens: 1_000_000 });
+
+			const summary = await worker.maybeSummarizeColdResume(
+				session,
+				"linear-session-1",
+				CLAUDE_SESSION_ID,
+				WORKSPACE_ID,
+			);
+
+			expect(summary).toBeUndefined();
+			expect(mockSummarizeTranscript).not.toHaveBeenCalled();
+		});
+
+		it("falls through (returns undefined) when summarization throws", async () => {
+			setThreshold(worker, 60000);
+			mockFindTranscriptPath.mockResolvedValue("/tmp/transcript.jsonl");
+			mockSummarizeTranscript.mockRejectedValue(new Error("haiku boom"));
+			vi.spyOn(worker.activityPoster, "postThoughtActivity").mockResolvedValue(
+				undefined,
+			);
+			const session = makeSession({ input_tokens: 1_000_000 });
+
+			const summary = await worker.maybeSummarizeColdResume(
+				session,
+				"linear-session-1",
+				CLAUDE_SESSION_ID,
+				WORKSPACE_ID,
+			);
+
+			expect(summary).toBeUndefined();
+		});
+	});
+
+	describe("estimateResumeContextTokens", () => {
+		let dir: string;
+
+		beforeEach(async () => {
+			dir = await mkdtemp(join(tmpdir(), "cyrus-estimate-"));
+		});
+
+		afterEach(async () => {
+			await rm(dir, { recursive: true, force: true });
+		});
+
+		it("falls back to transcript file size / 4 when no usage is present", async () => {
+			const path = join(dir, "t.jsonl");
+			await writeFile(path, "x".repeat(4000));
+			const session = makeSession();
+
+			const estimate = await worker.estimateResumeContextTokens(session, path);
+			expect(estimate).toBe(1000);
+		});
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.dynamic-tools.test.ts
@@ -37,9 +37,8 @@ vi.mock("cyrus-claude-runner", () => ({
 		"Monitor",
 		"TaskOutput",
 		"TaskStop",
-		"TeamCreate",
-		"TeamDelete",
 		"ToolSearch",
+		"DesignSync",
 		"Workflow",
 	]),
 	getReadOnlyTools: vi.fn(() => [
@@ -90,9 +89,8 @@ vi.mock("cyrus-claude-runner", () => ({
 		"Monitor",
 		"TaskOutput",
 		"TaskStop",
-		"TeamCreate",
-		"TeamDelete",
 		"ToolSearch",
+		"DesignSync",
 		"Workflow",
 	]),
 }));

--- a/packages/edge-worker/test/EdgeWorker.multi-repo-tools.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.multi-repo-tools.test.ts
@@ -33,9 +33,8 @@ vi.mock("cyrus-claude-runner", () => ({
 		"Monitor",
 		"TaskOutput",
 		"TaskStop",
-		"TeamCreate",
-		"TeamDelete",
 		"ToolSearch",
+		"DesignSync",
 		"Workflow",
 	]),
 	getReadOnlyTools: vi.fn(() => [
@@ -86,9 +85,8 @@ vi.mock("cyrus-claude-runner", () => ({
 		"Monitor",
 		"TaskOutput",
 		"TaskStop",
-		"TeamCreate",
-		"TeamDelete",
 		"ToolSearch",
+		"DesignSync",
 		"Workflow",
 	]),
 	getCoordinatorTools: vi.fn(() => [
@@ -115,9 +113,8 @@ vi.mock("cyrus-claude-runner", () => ({
 		"Monitor",
 		"TaskOutput",
 		"TaskStop",
-		"TeamCreate",
-		"TeamDelete",
 		"ToolSearch",
+		"DesignSync",
 		"Workflow",
 	]),
 }));

--- a/packages/edge-worker/test/EdgeWorker.reconcile-interrupted.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.reconcile-interrupted.test.ts
@@ -1,0 +1,151 @@
+import { LinearClient } from "@linear/sdk";
+import { LinearEventTransport } from "cyrus-linear-event-transport";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { EdgeWorker } from "../src/EdgeWorker.js";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+import type { EdgeWorkerConfig, RepositoryConfig } from "../src/types.js";
+import { TEST_CYRUS_HOME } from "./test-dirs.js";
+
+vi.mock("fs/promises");
+vi.mock("cyrus-claude-runner");
+vi.mock("cyrus-mcp-tools");
+vi.mock("cyrus-codex-runner");
+vi.mock("cyrus-linear-event-transport");
+vi.mock("@linear/sdk");
+vi.mock("../src/SharedApplicationServer.js");
+vi.mock("../src/AgentSessionManager.js");
+vi.mock("cyrus-core", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PersistenceManager: vi.fn().mockImplementation(function () {
+			return {
+				loadEdgeWorkerState: vi.fn().mockResolvedValue(null),
+				saveEdgeWorkerState: vi.fn().mockResolvedValue(undefined),
+			};
+		}),
+	};
+});
+
+describe("EdgeWorker - reconcileInterruptedSessions", () => {
+	let edgeWorker: EdgeWorker;
+	let mockConfig: EdgeWorkerConfig;
+	let mockAgentSessionManager: any;
+
+	const mockRepository: RepositoryConfig = {
+		id: "test-repo",
+		name: "Test Repo",
+		repositoryPath: "/test/repo",
+		workspaceBaseDir: "/test/workspaces",
+		baseBranch: "main",
+		linearWorkspaceId: "test-workspace",
+		isActive: true,
+		allowedTools: ["Read", "Edit"],
+		labelPrompts: {},
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		mockAgentSessionManager = {
+			markInterruptedSessions: vi.fn().mockReturnValue([]),
+			createErrorActivity: vi.fn().mockResolvedValue(undefined),
+			on: vi.fn(),
+		};
+
+		vi.mocked(AgentSessionManager).mockImplementation(function () {
+			return mockAgentSessionManager;
+		} as any);
+
+		vi.mocked(SharedApplicationServer).mockImplementation(function () {
+			return {
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+				getFastifyInstance: vi.fn().mockReturnValue({ post: vi.fn() }),
+				getWebhookUrl: vi.fn().mockReturnValue("http://localhost:3456/webhook"),
+				registerOAuthCallbackHandler: vi.fn(),
+			};
+		} as any);
+
+		vi.mocked(LinearEventTransport).mockImplementation(function () {
+			return { register: vi.fn(), on: vi.fn(), removeAllListeners: vi.fn() };
+		} as any);
+
+		vi.mocked(LinearClient).mockImplementation(function () {
+			return {
+				users: {
+					me: vi.fn().mockResolvedValue({ id: "user-123", name: "Test User" }),
+				},
+			};
+		} as any);
+
+		mockConfig = {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: TEST_CYRUS_HOME,
+			repositories: [mockRepository],
+			linearWorkspaces: { "test-workspace": { linearToken: "test-token" } },
+		} as EdgeWorkerConfig;
+
+		edgeWorker = new EdgeWorker(mockConfig);
+		(edgeWorker as any).agentSessionManager = mockAgentSessionManager;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("posts a resume notice for each interrupted session and persists once", async () => {
+		mockAgentSessionManager.markInterruptedSessions.mockReturnValue([
+			"s1",
+			"s2",
+		]);
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+
+		await (edgeWorker as any).reconcileInterruptedSessions();
+
+		expect(mockAgentSessionManager.createErrorActivity).toHaveBeenCalledTimes(
+			2,
+		);
+		const notifiedSessions =
+			mockAgentSessionManager.createErrorActivity.mock.calls.map(
+				(c: any[]) => c[0],
+			);
+		expect(notifiedSessions.sort()).toEqual(["s1", "s2"]);
+		expect(
+			mockAgentSessionManager.createErrorActivity.mock.calls[0][1],
+		).toContain("Comment on this issue to resume");
+		expect(savedSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does nothing (no posts, no save) when no sessions were interrupted", async () => {
+		mockAgentSessionManager.markInterruptedSessions.mockReturnValue([]);
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+
+		await (edgeWorker as any).reconcileInterruptedSessions();
+
+		expect(mockAgentSessionManager.createErrorActivity).not.toHaveBeenCalled();
+		expect(savedSpy).not.toHaveBeenCalled();
+	});
+
+	it("still persists even if posting a notice fails (best-effort notice)", async () => {
+		mockAgentSessionManager.markInterruptedSessions.mockReturnValue(["s1"]);
+		mockAgentSessionManager.createErrorActivity.mockRejectedValue(
+			new Error("network down"),
+		);
+		const savedSpy = vi
+			.spyOn(edgeWorker as any, "savePersistedState")
+			.mockResolvedValue(undefined);
+
+		await expect(
+			(edgeWorker as any).reconcileInterruptedSessions(),
+		).resolves.toBeUndefined();
+		expect(savedSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/edge-worker/test/EdgeWorker.skill-repo-paths.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.skill-repo-paths.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { EdgeWorker } from "../src/EdgeWorker";
+import type { EdgeWorkerConfig } from "../src/types";
+import { TEST_CYRUS_HOME } from "./test-dirs.js";
+
+/**
+ * Regression tests for `resolveSkillRepoPaths`, which decides whose
+ * `.claude/skills/` directories feed the per-session skill allow-list.
+ *
+ * The allow-list source MUST match the Agent SDK's cwd (the session worktree),
+ * otherwise repo-committed skills load in the worktree but get rejected as
+ * "not in this session's skills allowlist". See cyrusagents/cyrus#1336.
+ */
+describe("EdgeWorker.resolveSkillRepoPaths", () => {
+	let edgeWorker: EdgeWorker;
+
+	const repository = {
+		id: "test-repo",
+		name: "test-repo",
+		// Stale base clone — Cyrus only fetches into it, never advances its tree.
+		repositoryPath: "/test/repos/test-repo",
+		workspaceBaseDir: "/test/workspaces",
+		linearWorkspaceId: "test-workspace",
+		baseBranch: "main",
+	};
+
+	function makeSession(workspace: Record<string, unknown>) {
+		return { workspace };
+	}
+
+	function resolve(session?: unknown): string[] {
+		// resolveSkillRepoPaths is private; probe it directly.
+		return (
+			edgeWorker as unknown as {
+				resolveSkillRepoPaths: (r: unknown, s?: unknown) => string[];
+			}
+		).resolveSkillRepoPaths(repository, session);
+	}
+
+	beforeEach(() => {
+		const config: EdgeWorkerConfig = {
+			proxyUrl: "http://localhost:3000",
+			cyrusHome: TEST_CYRUS_HOME,
+			repositories: [repository],
+			linearWorkspaces: {
+				"test-workspace": { linearToken: "test-token" },
+			},
+		} as unknown as EdgeWorkerConfig;
+		edgeWorker = new EdgeWorker(config);
+	});
+
+	it("uses the session worktree (SDK cwd), not the stale base clone, for single-repo sessions", () => {
+		const worktreePath = "/test/workspaces/TEST-1";
+		const session = makeSession({ path: worktreePath, isGitWorktree: true });
+		expect(resolve(session)).toEqual([worktreePath]);
+	});
+
+	it("uses every sub-worktree for multi-repo sessions (unchanged)", () => {
+		const session = makeSession({
+			path: "/test/workspaces/TEST-2",
+			isGitWorktree: true,
+			repoPaths: {
+				"repo-a": "/test/workspaces/TEST-2/repo-a",
+				"repo-b": "/test/workspaces/TEST-2/repo-b",
+			},
+		});
+		expect(resolve(session)).toEqual([
+			"/test/workspaces/TEST-2/repo-a",
+			"/test/workspaces/TEST-2/repo-b",
+		]);
+	});
+
+	it("falls back to the repository path when there is no session", () => {
+		expect(resolve(undefined)).toEqual([repository.repositoryPath]);
+	});
+
+	it("falls back to the repository path when the worktree path is empty", () => {
+		const session = makeSession({ path: "", isGitWorktree: false });
+		expect(resolve(session)).toEqual([repository.repositoryPath]);
+	});
+});

--- a/packages/edge-worker/test/SharedApplicationServer.robots.test.ts
+++ b/packages/edge-worker/test/SharedApplicationServer.robots.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { SharedApplicationServer } from "../src/SharedApplicationServer.js";
+
+describe("SharedApplicationServer crawler controls", () => {
+	it("serves robots.txt that disallows crawling", async () => {
+		const server = new SharedApplicationServer();
+		const app = server.getFastifyInstance();
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/robots.txt",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["content-type"]).toContain("text/plain");
+		expect(response.headers["x-robots-tag"]).toBe("noindex, nofollow");
+		expect(response.body).toBe("User-agent: *\nDisallow: /\n");
+	});
+
+	it("adds a noindex header to application responses", async () => {
+		const server = new SharedApplicationServer();
+		const app = server.getFastifyInstance();
+
+		app.get("/status-check", async () => ({ ok: true }));
+
+		const response = await app.inject({
+			method: "GET",
+			url: "/status-check",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["x-robots-tag"]).toBe("noindex, nofollow");
+	});
+});

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -2,8 +2,10 @@ import { join } from "node:path";
 import { getReadOnlyTools } from "cyrus-claude-runner";
 import type { RepositoryConfig } from "cyrus-core";
 import {
+	type SlackMessageAttachment,
 	SlackMessageService,
 	SlackReactionService,
+	type SlackWebhookEvent,
 } from "cyrus-slack-event-transport";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatRepositoryProvider } from "../src/ChatRepositoryProvider.js";
@@ -500,6 +502,63 @@ describe("SlackChatAdapter session initiation", () => {
 				upstreamGated: true,
 			} as any),
 		).toBe(true);
+	});
+});
+
+describe("SlackChatAdapter task instructions", () => {
+	const mentionEvent = (
+		text: string,
+		attachments?: SlackMessageAttachment[],
+	): SlackWebhookEvent => ({
+		eventType: "app_mention",
+		eventId: "Ev1",
+		teamId: "T1",
+		payload: {
+			type: "app_mention",
+			user: "U1",
+			channel: "C1",
+			text,
+			ts: "1700000000.000200",
+			event_ts: "1700000000.000200",
+			attachments,
+		},
+	});
+
+	it("folds a forwarded attachment body in alongside the comment", () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		expect(
+			adapter.extractTaskInstructions(
+				mentionEvent("<@U0BOT> please look", [
+					{
+						is_share: true,
+						author_name: "Sentry",
+						text: "[frontend] Error: page resources not found",
+					},
+				]),
+			),
+		).toBe(
+			"please look\n\n" +
+				"[Attachment from Sentry]\n" +
+				"[frontend] Error: page resources not found",
+		);
+	});
+
+	it("uses the forwarded attachment as the whole prompt when there is no comment", () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		expect(
+			adapter.extractTaskInstructions(
+				mentionEvent("<@U0BOT>", [
+					{ is_share: true, author_name: "Sentry", text: "alert body" },
+				]),
+			),
+		).toBe("[Attachment from Sentry]\nalert body");
+	});
+
+	it("falls back to the placeholder when neither comment nor attachment has content", () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		expect(adapter.extractTaskInstructions(mentionEvent("<@U0BOT>"))).toBe(
+			"Ask the user for more context",
+		);
 	});
 });
 

--- a/packages/edge-worker/test/prompt-assembly-utils.ts
+++ b/packages/edge-worker/test/prompt-assembly-utils.ts
@@ -136,6 +136,11 @@ export class PromptScenario {
 		return this;
 	}
 
+	withPreviousSessionSummary(summary: string) {
+		this.input.previousSessionSummary = summary;
+		return this;
+	}
+
 	withLabels(...labels: string[]) {
 		this.input.labels = labels;
 		return this;

--- a/packages/edge-worker/test/prompt-assembly.session-summary.test.ts
+++ b/packages/edge-worker/test/prompt-assembly.session-summary.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Prompt Assembly Tests - Previous Session Summary (cold-resume restart)
+ *
+ * Asserts that when a new-session prompt carries a `previousSessionSummary`
+ * (produced by the cold-resume summarize-and-restart path), a
+ * `<previous_session_summary>` component is inserted after issue-context and
+ * before user-comment, including the session's branches and the
+ * check-before-redoing note.
+ */
+
+import { describe, it } from "vitest";
+import { createTestWorker, scenario } from "./prompt-assembly-utils.js";
+
+describe("Prompt Assembly - Previous Session Summary", () => {
+	it("inserts the session-summary component after issue context and before the user comment", async () => {
+		const worker = createTestWorker();
+
+		const session = {
+			issueId: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+			workspace: { path: "/test/repo" },
+			repositories: [{ branchName: "feature/cee-789" }],
+			metadata: {},
+		};
+
+		const issue = {
+			id: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+			identifier: "CEE-789",
+			title: "Build new feature",
+		};
+
+		const repository = {
+			id: "repo-uuid-3456-7890-12cd-ef1234567890",
+			path: "/test/repo",
+		};
+
+		await scenario(worker)
+			.newSession()
+			.assignmentBased()
+			.withSession(session)
+			.withIssue(issue)
+			.withRepository(repository)
+			.withUserComment("Add user authentication")
+			.withPreviousSessionSummary("Prior work summary here.")
+			.withLabels()
+			.expectPromptType("fallback")
+			.expectComponents("issue-context", "session-summary", "user-comment")
+			.expectUserPrompt(`<context>
+  <repository>undefined</repository>
+  <working_directory>/test/repo</working_directory>
+  <base_branch>main</base_branch>
+</context>
+
+<linear_issue>
+  <id>c3d4e5f6-a7b8-9012-cdef-123456789012</id>
+  <identifier>CEE-789</identifier>
+  <title>Build new feature</title>
+  <description>
+No description provided
+  </description>
+  <state>Unknown</state>
+  <priority>None</priority>
+  <url></url>
+  <assignee>
+    <linear_display_name></linear_display_name>
+    <linear_profile_url></linear_profile_url>
+    <github_username></github_username>
+    <github_user_id></github_user_id>
+    <github_noreply_email></github_noreply_email>
+  </assignee>
+</linear_issue>
+
+<linear_comments>
+No comments yet.
+</linear_comments>
+
+<previous_session_summary>
+  <branches>
+    <branch>feature/cee-789</branch>
+  </branches>
+  <summary>
+Prior work summary here.
+  </summary>
+  <note>This summary replaces a prior session that grew too large to resume directly. Work may already exist on the branch above and a pull request may already be open — check the current state with git and gh before redoing anything.</note>
+</previous_session_summary>
+
+<user_comment>
+Add user authentication
+</user_comment>`)
+			.verify();
+	});
+});

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -16,7 +16,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.173",
+		"@anthropic-ai/claude-agent-sdk": "0.3.185",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/packages/slack-event-transport/src/SlackMessageTranslator.ts
+++ b/packages/slack-event-transport/src/SlackMessageTranslator.ts
@@ -18,7 +18,13 @@ import type {
 	TranslationResult,
 	UserPromptMessage,
 } from "cyrus-core";
-import type { SlackWebhookEvent } from "./types.js";
+import type {
+	SlackBlock,
+	SlackEventPayload,
+	SlackMessageAttachment,
+	SlackRichTextElement,
+	SlackWebhookEvent,
+} from "./types.js";
 
 /**
  * Strips the @mention from Slack message text.
@@ -26,6 +32,69 @@ import type { SlackWebhookEvent } from "./types.js";
  */
 export function stripMention(text: string): string {
 	return text.replace(/^\s*<@[A-Z0-9]+>\s*/, "").trim();
+}
+
+/** Flatten Slack rich_text / block nodes into plain text. */
+function richTextToPlain(
+	nodes: Array<SlackBlock | SlackRichTextElement> | undefined,
+): string {
+	if (!Array.isArray(nodes)) return "";
+	const out: string[] = [];
+	const walk = (el: SlackBlock | SlackRichTextElement): void => {
+		const node = el as SlackRichTextElement;
+		if (typeof node.text === "string") out.push(node.text);
+		else if (node.type === "link" && typeof node.url === "string")
+			out.push(node.url);
+		else if (node.type === "user" && node.user_id)
+			out.push(`<@${node.user_id}>`);
+		if (Array.isArray(node.elements)) node.elements.forEach(walk);
+	};
+	nodes.forEach(walk);
+	return out.join("");
+}
+
+/**
+ * Pulls each attachment's body out of `payload.attachments[]` (not in `text`)
+ * as a labeled block. Falls back to `blocks`/`message_blocks` when `text` is empty.
+ */
+export function extractAttachmentContent(payload: SlackEventPayload): string {
+	const attachments: SlackMessageAttachment[] = Array.isArray(
+		payload.attachments,
+	)
+		? payload.attachments
+		: [];
+	const parts: string[] = [];
+	for (const att of attachments) {
+		if (!att || typeof att !== "object") continue;
+		let body = typeof att.text === "string" ? att.text.trim() : "";
+		if (!body && Array.isArray(att.blocks)) {
+			body = richTextToPlain(att.blocks).trim();
+		}
+		if (!body && Array.isArray(att.message_blocks)) {
+			for (const mb of att.message_blocks) {
+				const t = richTextToPlain(mb.message?.blocks).trim();
+				if (t) body = body ? `${body}\n${t}` : t;
+			}
+		}
+		if (!body) continue;
+		const author = att.author_name || att.author_subname || att.author_id || "";
+		const source =
+			(att.channel_name && `#${att.channel_name}`) || att.footer || "";
+		const bits: string[] = [];
+		if (author) bits.push(`from ${author}`);
+		if (source) bits.push(`(${source})`);
+		const header = `[Attachment${bits.length ? ` ${bits.join(" ")}` : ""}]`;
+		parts.push(`${header}\n${body}`);
+	}
+	return parts.join("\n\n");
+}
+
+/** User's own text (mention stripped) + any attachment content folded in. */
+export function buildPromptText(payload: SlackEventPayload): string {
+	const own = stripMention(payload.text || "");
+	const attachments = extractAttachmentContent(payload);
+	if (own && attachments) return `${own}\n\n${attachments}`;
+	return attachments || own;
 }
 
 /**
@@ -125,8 +194,8 @@ export class SlackMessageTranslator
 		// Work item identifier uses channel:thread format
 		const workItemIdentifier = `slack:${payload.channel}:${threadTs}`;
 
-		// Strip the @mention from the text to get the actual prompt
-		const promptText = stripMention(payload.text);
+		// Strip the @mention and fold in any attachment content
+		const promptText = buildPromptText(payload);
 
 		const platformData: SlackSessionStartPlatformData = {
 			channel: this.buildChannelRef(payload.channel),
@@ -172,7 +241,7 @@ export class SlackMessageTranslator
 		const threadTs = payload.thread_ts || payload.ts;
 		const sessionKey = `${payload.channel}:${threadTs}`;
 
-		const promptText = stripMention(payload.text);
+		const promptText = buildPromptText(payload);
 
 		const platformData: SlackUserPromptPlatformData = {
 			channel: this.buildChannelRef(payload.channel),

--- a/packages/slack-event-transport/src/index.ts
+++ b/packages/slack-event-transport/src/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "./SlackMessageService.js";
 export { SlackMessageService } from "./SlackMessageService.js";
 export {
+	buildPromptText,
 	SlackMessageTranslator,
 	stripMention,
 } from "./SlackMessageTranslator.js";
@@ -19,6 +20,7 @@ export type {
 	SlackEventTransportConfig,
 	SlackEventTransportEvents,
 	SlackEventType,
+	SlackMessageAttachment,
 	SlackMessageEvent,
 	SlackUser,
 	SlackVerificationMode,

--- a/packages/slack-event-transport/src/types.ts
+++ b/packages/slack-event-transport/src/types.ts
@@ -117,6 +117,76 @@ export interface SlackChannel {
 	name?: string;
 }
 
+/** An element inside a Slack rich_text / layout block. */
+export interface SlackRichTextElement {
+	/** Element kind (e.g. "text", "link", "user", "rich_text_section"). */
+	type: string;
+	/** Literal text content, present on "text" elements. */
+	text?: string;
+	/** Destination URL, present on "link" elements. */
+	url?: string;
+	/** Mentioned user's ID, present on "user" elements. */
+	user_id?: string;
+	/** Nested child elements for container nodes. */
+	elements?: SlackRichTextElement[];
+}
+
+/** A Slack block (rich_text or layout). */
+export interface SlackBlock {
+	/** Block kind (e.g. "rich_text", "section"). */
+	type: string;
+	/** Child elements that make up the block's content. */
+	elements?: SlackRichTextElement[];
+}
+
+/** Original-message snapshot some share/forward formats carry. */
+export interface SlackMessageBlock {
+	/** Team/workspace ID the original message belongs to. */
+	team?: string;
+	/** Channel ID the original message was posted in. */
+	channel?: string;
+	/** Timestamp (unique ID) of the original message. */
+	ts?: string;
+	/** The original message, whose `blocks` hold its rich content. */
+	message?: { blocks?: SlackBlock[] };
+}
+
+/**
+ * A Slack message attachment. The body that matters lives here, NOT in the
+ * event's `text` — `text` (mrkdwn) is the primary body; some formats omit it
+ * and carry the body in `blocks` or `message_blocks`.
+ *
+ * Example: a forwarded/shared message (carrying `is_share`/`is_msg_unfurl`)
+ * puts the original message's content entirely in the attachment. Note that
+ * forwarded shares expose `channel_id`/`footer`, not `channel_name`.
+ */
+export interface SlackMessageAttachment {
+	/** Primary attachment body as mrkdwn; the main source of content. */
+	text?: string;
+	/** Plain-text fallback Slack renders where rich formatting is unsupported. */
+	fallback?: string;
+	/** ID of the original message's author. */
+	author_id?: string;
+	/** Display name of the original message's author (e.g. "Sentry"). */
+	author_name?: string;
+	/** Secondary author label, shown beside `author_name`. */
+	author_subname?: string;
+	/** ID of the channel the original message came from. */
+	channel_id?: string;
+	/** Name of the source channel; absent on forwarded shares. */
+	channel_name?: string;
+	/** Footer line (e.g. the source app/integration name). */
+	footer?: string;
+	/** True when this attachment is a forwarded/shared message. */
+	is_share?: boolean;
+	/** True when this attachment is an unfurled message link. */
+	is_msg_unfurl?: boolean;
+	/** Rich-content blocks; the body when `text` is empty. */
+	blocks?: SlackBlock[];
+	/** Older share shape carrying the original message's blocks. */
+	message_blocks?: SlackMessageBlock[];
+}
+
 /**
  * Slack app_mention event payload
  * @see https://api.slack.com/events/app_mention
@@ -136,6 +206,8 @@ export interface SlackAppMentionEvent {
 	thread_ts?: string;
 	/** Event timestamp */
 	event_ts: string;
+	/** Message attachments (see {@link SlackMessageAttachment}). */
+	attachments?: SlackMessageAttachment[];
 }
 
 /**
@@ -170,6 +242,8 @@ export interface SlackMessageEvent {
 	thread_ts?: string;
 	/** Event timestamp */
 	event_ts: string;
+	/** Message attachments (see {@link SlackMessageAttachment}). */
+	attachments?: SlackMessageAttachment[];
 }
 
 /**

--- a/packages/slack-event-transport/test/SlackMessageTranslator.test.ts
+++ b/packages/slack-event-transport/test/SlackMessageTranslator.test.ts
@@ -1,10 +1,15 @@
 import type { SlackSessionStartPlatformData } from "cyrus-core";
 import { describe, expect, it } from "vitest";
 import {
+	buildPromptText,
 	SlackMessageTranslator,
 	stripMention,
 } from "../src/SlackMessageTranslator.js";
-import type { SlackWebhookEvent } from "../src/types.js";
+import type {
+	SlackEventPayload,
+	SlackMessageAttachment,
+	SlackWebhookEvent,
+} from "../src/types.js";
 import { testThreadedWebhookEvent, testWebhookEvent } from "./fixtures.js";
 
 describe("SlackMessageTranslator", () => {
@@ -312,6 +317,143 @@ describe("stripMention", () => {
 	it("does not strip @mentions in the middle of text", () => {
 		expect(stripMention("hello <@U1234567890> world")).toBe(
 			"hello <@U1234567890> world",
+		);
+	});
+});
+
+describe("buildPromptText (attachment content)", () => {
+	const basePayload = (
+		attachments?: SlackMessageAttachment[],
+		text = "<@U0BOT1234> more info please",
+	): SlackEventPayload =>
+		({
+			type: "app_mention",
+			user: "U1234567890",
+			text,
+			ts: "1704110400.000100",
+			channel: "C9876543210",
+			event_ts: "1704110400.000100",
+			...(attachments ? { attachments } : {}),
+		}) as SlackEventPayload;
+
+	it("folds a flat-text attachment in after the user's comment", () => {
+		const payload = basePayload([
+			{
+				is_share: true,
+				author_name: "Sentry",
+				text: "[frontend] Error: page resources not found",
+			},
+		]);
+
+		expect(buildPromptText(payload)).toBe(
+			"more info please\n\n" +
+				"[Attachment from Sentry]\n" +
+				"[frontend] Error: page resources not found",
+		);
+	});
+
+	it("extracts the body from blocks when `text` is empty", () => {
+		const payload = basePayload([
+			{
+				is_share: true,
+				author_name: "Sentry",
+				text: "",
+				blocks: [
+					{
+						type: "rich_text",
+						elements: [
+							{
+								type: "rich_text_section",
+								elements: [
+									{ type: "text", text: "ping " },
+									{ type: "user", user_id: "U999" },
+									{ type: "text", text: " see " },
+									{ type: "link", url: "https://example.com/x" },
+								],
+							},
+						],
+					},
+				],
+			},
+		]);
+
+		expect(buildPromptText(payload)).toBe(
+			"more info please\n\n" +
+				"[Attachment from Sentry]\n" +
+				"ping <@U999> see https://example.com/x",
+		);
+	});
+
+	it("extracts the body from message_blocks (older share shape)", () => {
+		const payload = basePayload([
+			{
+				is_share: true,
+				author_id: "U555",
+				message_blocks: [
+					{
+						team: "T1",
+						channel: "C1",
+						ts: "123.456",
+						message: {
+							blocks: [
+								{
+									type: "rich_text",
+									elements: [
+										{
+											type: "rich_text_section",
+											elements: [{ type: "text", text: "original body" }],
+										},
+									],
+								},
+							],
+						},
+					},
+				],
+			},
+		]);
+
+		expect(buildPromptText(payload)).toBe(
+			"more info please\n\n[Attachment from U555]\noriginal body",
+		);
+	});
+
+	it("returns just the stripped comment when there are no attachments", () => {
+		const payload = basePayload(undefined, "<@U0BOT1234> plain comment");
+		expect(buildPromptText(payload)).toBe(stripMention(payload.text));
+		expect(buildPromptText(payload)).toBe("plain comment");
+	});
+
+	it("does not throw on empty/undefined text and empty attachments", () => {
+		expect(() =>
+			buildPromptText({ attachments: [] } as unknown as SlackEventPayload),
+		).not.toThrow();
+		expect(
+			buildPromptText({ attachments: [] } as unknown as SlackEventPayload),
+		).toBe("");
+		expect(buildPromptText({} as unknown as SlackEventPayload)).toBe("");
+	});
+
+	it("returns only the attachment block when the comment is empty", () => {
+		const payload = basePayload(
+			[{ is_share: true, author_name: "Sentry", text: "alert body" }],
+			"<@U0BOT1234>",
+		);
+		expect(buildPromptText(payload)).toBe(
+			"[Attachment from Sentry]\nalert body",
+		);
+	});
+
+	it("labels and joins multiple attachments by blank lines", () => {
+		const payload = basePayload(
+			[
+				{ author_name: "Sentry", text: "first" },
+				{ author_name: "Datadog", text: "second" },
+			],
+			"<@U0BOT1234>",
+		);
+		expect(buildPromptText(payload)).toBe(
+			"[Attachment from Sentry]\nfirst\n\n" +
+				"[Attachment from Datadog]\nsecond",
 		);
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   form-data@^4.0.0: 4.0.6
   fast-uri: '>=3.1.2'
   ip-address: '>=10.1.1'
-  '@anthropic-ai/sdk': '>=0.104.1'
+  '@anthropic-ai/sdk': '>=0.105.0'
   '@opentelemetry/sdk-node': '>=0.217.0'
   '@opentelemetry/exporter-prometheus': '>=0.217.0'
   '@hono/node-server': '>=1.19.10'
@@ -55,7 +55,7 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^16.1.6
+        specifier: ^16.4.0
         version: 16.4.0
       typescript:
         specifier: ^5.3.3
@@ -162,11 +162,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.173
-        version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.185
+        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: '>=0.104.1'
-        version: 0.104.1(zod@4.3.6)
+        specifier: '>=0.105.0'
+        version: 0.105.0(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -268,8 +268,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.173
-        version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.185
+        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -318,8 +318,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.173
-        version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.185
+        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -543,8 +543,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.173
-        version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.185
+        version: 0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -598,60 +598,60 @@ packages:
       express:
         optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.173':
-    resolution: {integrity: sha512-McW1toJ4Qdo/i7bHnsiFMm2AtyCiK/5V90WgL7M9ZO9llrJr3riGRdBlRGHvWnS7rKuv5ttj4/SuBkLoL9o75A==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185':
+    resolution: {integrity: sha512-P2Svxx1IFrS9aw4ylJBtcoJrc/OAOVnDs+o05x4TV7HoHUQUcKZ9XhWOGnadyVT0KLyoktgjyjnaK7Zdtc0Ldg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.173':
-    resolution: {integrity: sha512-m2Oh1pQ69IUg6DSH6n1nAAAtRq+G7J2B/CKTbTfDAEmg5t0lzakZV9l28GZrlP21xl+PIg71dkiJ5u94KYgpRw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185':
+    resolution: {integrity: sha512-H69m2hIJawzSkCDNO/CPLQCYvDGdlbZdzGTgGF8/IQuB4O81sv8WSAh6TBXwtFXOgEi4HtrUYlxiFDmTHt7hMA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.173':
-    resolution: {integrity: sha512-uu8MnPwFBc9ayFg5c94aHaqJVLS51oHNVxHwud4nK27GliP5WoME3F7pmm1N/Jyy2ry2E2CLNnsAm5l3zemfYA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185':
+    resolution: {integrity: sha512-1GRpKYrg5foomW+qLrxm/k2R/5PEU7RAuEdX65HV6lFMJR3HsGj8qfBq4KCJHTS3r4YdVrFLvPQ/mUqbY6klIA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.173':
-    resolution: {integrity: sha512-Vb64WJOD2D9tKn/i0ErmLbO6I1187xTwL/kxEANjg4L1FGQnvdYBnZ6J6jU6+x8UgcuIi82imHROQp80gbPW2w==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185':
+    resolution: {integrity: sha512-KtXMCoprGYTSPb/A0/kjrO+PpDJAFbHhDd8rjqA4izU51OYjTDkahsGCcSTFM2jA8krOhPqzx/SNVuAVWmexwA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.173':
-    resolution: {integrity: sha512-ofKxyp/N8+LLSrClt+dJo0laCHDzmBgmN8+Q+zabJ54Jqc1KXee68UsziE7kLCqGbOSY7rsIK9d22T1uQyZkUw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185':
+    resolution: {integrity: sha512-YAky0Oez+YYrlcas/xDiaCm9AUX0z1YwM+pnk+CFxEr/ICmc7MbiFsnEIXFLPHaox9bE5iOzw4LS4b/c1tIJRg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.173':
-    resolution: {integrity: sha512-0l9L5O+Uiw8gq9mu2NqGSYcSmX8RJMAh9GkGacTJqJbkfHCiFxqZmWBWODOt6HP7PTFCV+yMzQK/xJQjnag/jw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185':
+    resolution: {integrity: sha512-8U5wu6dNcyzRkwoae0Gu5ZHs6lRSu8CXqd9yrilX3fHR9kKICrm76bLu5q2auuSc/8dx6VL5ZXqSzFKIMp//zw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.173':
-    resolution: {integrity: sha512-aulIrBYjFDm+S5kl4CxC8A3KUiTDKLHoKV46Mat64E+skGEyBkC7WzZAGbpGKB2y8KZo1WbrwJTGefgyHMpDhw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185':
+    resolution: {integrity: sha512-pJEOaCLQQQWSyBeseR/GAn4eEp4WtMDP/o5yPMuuAsNWeoJXM7cY4j/N3KBE6GZofgnYdWEXILF2uw3SjbtINA==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.173':
-    resolution: {integrity: sha512-HjGkfDlNLI3Kh9NIUfevJ3SZY8Xv3td4zx5Cz3YE0VPrrjIkRvdEv9K6WTjT94tlS0TUXQS/kFT+NCmoGXuvZQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185':
+    resolution: {integrity: sha512-/Kf9XneSuIkSHNwrxOVY0XT7RovAEcx5nDASKzku4994cZz54otU5mT2jT6dwevDLEStfgts5x/A4z0AePwVTQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.173':
-    resolution: {integrity: sha512-BsdL223y7vCUJA9uBW9osSrhufvwIT+J94IBkh83v+wjyjoBIwLXREdacFabair70bGNdtkw6cWCaYNThSQg7A==}
+  '@anthropic-ai/claude-agent-sdk@0.3.185':
+    resolution: {integrity: sha512-UDDd0cInvOufmR88btR/Ursnh71sb5scoutNlRS2L0LBdkt7JEqYJ0jt7DnOYHEVhMx8AAcg0eYgvXztcWUnFA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@anthropic-ai/sdk': '>=0.104.1'
+      '@anthropic-ai/sdk': '>=0.105.0'
       '@modelcontextprotocol/sdk': '>=1.26.0'
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.104.1':
-    resolution: {integrity: sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==}
+  '@anthropic-ai/sdk@0.105.0':
+    resolution: {integrity: sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==}
     hasBin: true
     peerDependencies:
       zod: 4.3.6
@@ -3952,46 +3952,46 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       express: 5.2.1
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.173':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.185(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.104.1(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.105.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.173
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.173
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.185
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.185
 
-  '@anthropic-ai/sdk@0.104.1(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.105.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Full debugging workflow — reproduce the bug with a failing test, perform root cause analysis, then implement a minimal fix.
+description: Debugs a reported issue — reproduces the bug with a failing test, performs root cause analysis, then implements a minimal fix. Use when an issue reports a bug, error, crash, or regression. Not for new features or refactors (use implementation) or questions (use investigate).
 ---
 
 # Debug

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,29 +1,45 @@
 ---
 name: debug
-description: Debugs a reported issue — reproduces the bug with a failing test, performs root cause analysis, then implements a minimal fix. Use when an issue reports a bug, error, crash, or regression. Not for new features or refactors (use implementation) or questions (use investigate).
+description: Debugs a reported issue — reproduces the bug with a failing test, finds the root cause, then ships a minimal fix. Use when an issue reports a bug, error, crash, exception, or regression. Not for new features or refactors (use implementation) or questions about how code works (use investigate).
 ---
 
 # Debug
 
-Debug a reported issue using a structured reproduction-then-fix approach.
+Fix a reported bug with a reproduce-then-fix discipline: prove the bug exists with a failing test, find the root cause, then make the smallest change that resolves it. Work in two phases; complete Phase 1 before proposing any fix.
 
-## Phase 1: Reproduction & Root Cause Analysis
+Paste this checklist into your response and check items off as you go — Cyrus renders it in the Linear timeline:
 
-1. **Investigate** — Analyze the bug report for key symptoms and error messages
-2. **Trace** — Search the codebase for error occurrence patterns, trace from symptom to source
-3. **Root cause** — Identify the root cause through data flow analysis and edge case checking
-4. **Reproduce** — Create a minimal failing test case that reproduces the exact error
-5. **Document** — Clearly document the root cause and reproduction steps
+```
+- [ ] Reproduced the bug
+- [ ] Wrote a test that fails for the right reason
+- [ ] Identified the root cause
+- [ ] Applied the minimal fix
+- [ ] Failing test now passes
+- [ ] Full suite passes (no regressions)
+```
 
-## Phase 2: Fix Implementation
+## Phase 1: Reproduce and find the root cause
 
-1. **Plan** — Analyze the optimal fix approach based on root cause, check for similar fixes in the codebase
-2. **Implement** — Make the minimal, targeted fix that addresses the root cause
-3. **Verify** — Run the failing test to confirm it passes, then run the full test suite to check for regressions
+Goal: a failing test that proves the bug, plus a clear explanation of why it happens.
+
+1. Read the report for the exact symptom: the error message, stack trace, failing input, or steps to reproduce. If detail is thin, fetch the issue with the issue tracker's `get_issue` tool — and read its comments too, not just the description, since maintainers often add the real reproduction steps there after creation.
+2. Trace from symptom to source. Search the codebase for the error string, the failing function, and the data path that produces the bad result. Follow the real code path rather than guessing — read the code on the path before forming a theory.
+3. Write a minimal test that reproduces the bug. Target the smallest unit that exhibits it, asserting the correct behavior the bug currently violates. If an automated test is genuinely impractical — no test framework in the project, or the bug needs integration, timing (a race), or external/prod-only state to surface — reproduce it with the smallest deterministic alternative instead: a one-off script, a REPL snippet, or a documented manual command you run both before and after the fix. Treat that reproduction as the evidence in place of a unit test.
+4. Run the reproduction and read its output. Confirm it fails — and fails for the *right reason*: the assertion or runtime error described in the report, not an unrelated import, setup, fixture, or compile error. If it fails for the wrong reason, fix the test scaffolding and re-run until the failure is the genuine bug. A test that passes, or fails on the wrong line, has not reproduced anything.
+5. State the root cause: the specific line or logic that produces the wrong behavior, and why. Distinguish the root cause from the symptom — fixing where the error surfaces while leaving the real defect in place is the most common debugging mistake. If the evidence does not yet support a single root cause, keep tracing; do not proceed on a guess.
+
+## Phase 2: Apply the minimal fix
+
+Goal: the smallest change that makes the failing reproduction pass without breaking anything else.
+
+1. Decide the fix that addresses the root cause from Phase 1. Scan for similar fixes already in the codebase and follow the existing pattern.
+2. Make the minimal, targeted change. Touch only the code on the root-cause path. Do not bundle in refactors, style changes, or unrelated improvements — note them for later instead.
+3. Run the reproduction and watch it pass, then run the full test suite and read the output to confirm no regressions. Fix any new failures before continuing. Report from fresh command output, never from expectation — no "should work", "probably", or "looks done"; only after seeing the reproduction pass and the suite stay green.
 
 ## Principles
 
-- **Minimal changes** — Fix the bug, nothing more
-- **Targeted** — Only touch affected code paths
-- **Tested** — The fix must make the failing test pass and not break existing tests
-- **No unrelated improvements** — Stay focused on the specific bug
+- Root cause, not symptom — fix the underlying defect, not the place the error happens to surface.
+- Minimal and targeted — fix the bug and nothing more; stay on the root-cause path.
+- Evidence-required — every "fixed" claim is backed by a reproduction that failed before and passes now, plus a green suite.
+
+Code changed, so the workflow continues to verify-and-ship — which runs the full checks, then commits, pushes, and opens the PR/MR — then summarize. Do not commit, push, or open a PR/MR here.

--- a/skills/implementation/SKILL.md
+++ b/skills/implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation
-description: Implement the requested changes. Write production-ready code, follow existing patterns, and run tests to verify your work.
+description: Implements requested code changes — writes production-ready code that follows existing patterns and runs tests to verify the work. Use when an issue requests a feature, refactor, or other code change, or to address PR review feedback. Not for bug reports (use debug) or questions (use investigate).
 ---
 
 # Implementation

--- a/skills/implementation/SKILL.md
+++ b/skills/implementation/SKILL.md
@@ -1,17 +1,48 @@
 ---
 name: implementation
-description: Implements requested code changes — writes production-ready code that follows existing patterns and runs tests to verify the work. Use when an issue requests a feature, refactor, or other code change, or to address PR review feedback. Not for bug reports (use debug) or questions (use investigate).
+description: Implements requested code changes — writes production-ready code that follows existing patterns and verifies it against the issue's acceptance criteria. Use when an issue requests a feature, refactor, new capability, or PR/MR review change. Not for bug reports (use debug) or questions about how the code works (use investigate).
 ---
 
 # Implementation
 
-Implement the requested changes:
+Implement the requested code change so it satisfies the issue's acceptance criteria and matches the surrounding codebase. Work in two phases; complete Phase 1 before writing code.
 
-- Write production-ready code that follows existing patterns and conventions
-- Run tests to verify your implementation works correctly
-- Handle edge cases and error scenarios appropriately
-- Keep changes focused on what was requested — avoid unrelated improvements
+Paste this checklist into your response and check items off as you go — Cyrus renders it in the Linear timeline:
 
-If tests fail, fix them before moving on to the next phase of the workflow.
+```
+- [ ] Issue read; acceptance criteria extracted
+- [ ] Existing patterns and test conventions studied
+- [ ] Change implemented, scoped to the request
+- [ ] Tests added/updated (or no-suite case noted)
+- [ ] Change confirmed working at the unit level (output read)
+- [ ] Each acceptance criterion checked
+```
 
-When implementation is complete, proceed to the verification and shipping phase.
+## Phase 1: Understand and plan
+
+Goal: know exactly what "done" means before changing anything.
+
+1. Read the issue with the issue tracker's `get_issue` tool — description, comments, linked context. For a PR/MR review change, the relevant review comments are already in the session context; read those rather than fetching them.
+2. Extract the acceptance criteria. Pull out every explicit criterion; if none are stated, derive the implied ones from the title, description, and any examples. These are what verify-and-ship validates against.
+3. Study existing patterns. Locate the files to change and read neighboring code: naming, error handling, module structure, test conventions, and the libraries already in use. Match these rather than introducing new ones.
+4. Plan the minimal set of edits that satisfies the criteria. Note which files to touch and how the change will be tested.
+
+## Phase 2: Implement and verify
+
+Goal: working, focused code backed by fresh evidence.
+
+1. Write the change as production-ready code that follows the patterns from Phase 1, handling the edge cases and error paths the criteria imply.
+2. Stay in scope. Change only what the issue requests; skip unrelated refactors, reformatting, and drive-by improvements that widen the diff — note them for later instead.
+3. Add or update tests for the new behavior using the project's existing test conventions, covering the edge cases from the criteria.
+4. Run the tests that cover your change as a self-check and read the output. Report from fresh command output, never from expectation — no "should work", "probably", or "looks done". verify-and-ship runs the authoritative full suite, lint, and typecheck gate, so this step only needs to confirm the change works at the unit level.
+5. Check each acceptance criterion from Phase 1 and note any that cannot be met and why.
+
+If the repository has no test suite, state that plainly and verify the change another concrete way: run the affected command, exercise the code path, or describe the manual check performed. Do not invent passing tests that do not exist.
+
+## Principles
+
+- Criteria-driven — the acceptance criteria define done; check against them, not a vague sense of completion.
+- Pattern-matching — new code reads as if the existing authors wrote it.
+- Focused — the diff contains only what the issue asked for.
+
+Code changed, so the workflow continues to verify-and-ship — which runs the full checks, then commits, pushes, and opens the PR/MR — then summarize. Carry any unmet criteria or failing tests forward rather than stalling here. Do not commit, push, or open a PR/MR here.

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -1,23 +1,33 @@
 ---
 name: investigate
-description: Researches the codebase to answer a question — searches for relevant files, gathers context, and provides a clear, direct answer. Use for questions and research requests where no code change is expected. Not for making code changes (use implementation or debug).
+description: Researches the codebase to answer a question — searches for relevant files, gathers context, and writes a clear, direct answer grounded in the code. Use when an issue asks how something works, why it behaves a certain way, where something lives, or whether something is possible — any question or research request with no code change expected. Not for making code changes (use implementation), fixing a reported bug (use debug), or summarizing finished work (use summarize).
 ---
 
 # Investigate
 
-Research the codebase and provide a clear, direct answer to the question.
+Answer the question by reading the actual code, not from memory. Every claim must be grounded in what the repository really does, with `file:line` references a reader can open and check.
+
+This is research-only. Do not edit, create, or delete files, and do not commit, push, or open a PR/MR. If the question turns out to require a code change, say so and recommend the right path — a bug goes to debug; a feature, refactor, or PR/MR review change goes to implementation — rather than making the change here.
+
+## Delivery contract
+
+Your final assistant message IS the Linear response — it is streamed back to the agent session automatically. Write the answer as your response. Do NOT post or save it with any tool (that double-posts). It must be the LAST thing you output, so it is not buried under other text.
 
 ## Approach
 
-1. **Search** — Search the codebase for relevant files, functions, and patterns
-2. **Read** — Read necessary files to understand the implementation
-3. **Gather context** — Use tools as needed to collect comprehensive information
-4. **Answer** — Provide a clear, direct answer using your findings
+1. Pin down what is actually being asked. If the report is thin or ambiguous, fetch the issue with the issue tracker's `get_issue` tool — and read its comments too, not just the description — before researching.
+2. Search the codebase for the relevant files, functions, types, and call sites. Follow the real code path rather than guessing — read the code on the path before forming a conclusion.
+3. Read enough to be sure. Trace callers and callees until the evidence supports one answer; do not stop at the first plausible match. If the code contradicts an assumption in the question, say so.
+4. Answer directly, citing the code that proves each claim. Distinguish what the code does (fact, with a reference) from inference about it.
 
-## Answer Format
+If the evidence is genuinely inconclusive, say what was found, what remains unknown, and what would resolve it — do not fabricate certainty.
 
-- Present in Linear-compatible markdown
-- Use `+++Section Name\n...\n+++` for collapsible sections with detailed information
-- Include code references with file paths and line numbers
-- For @mentions, use the Linear profile URL format from `<assignee>` context (e.g. `https://linear.app/<workspace>/profiles/<username>`)
-- Be complete but concise — answer the question directly without unnecessary preamble
+## Answer format
+
+Write Linear-compatible markdown. Lead with the direct answer in the first sentence — no preamble, no restating the question. Then support it. The exact shape is a judgment call; adapt to what the question warrants — a one-line factual question deserves a one-line answer.
+
+- Cite code as `path/to/file.ts:42` (forward slashes, real line numbers read from the file in this session — never invented or remembered) so the reference is clickable in the timeline.
+- Push long evidence — call chains, multi-file walkthroughs, quoted snippets — into `+++Section Name` / content / `+++` collapsible sections so the visible answer stays scannable.
+- For @mentions, use the Linear profile URL from the `<assignee>` context: `https://linear.app/<workspace>/profiles/<username>`.
+
+A grounded answer reads like: "Cross-repo routing priority is defined in `packages/edge-worker/src/PromptBuilder.ts` (the `<repository_routing_context>` block): description tag wins, then routing labels, then project, then team — first match wins," with the supporting walkthrough folded into a `+++` section. Read the file for the current line numbers; do not carry them from memory.

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: investigate
-description: Research the codebase to answer questions. Search for relevant files, gather context, and provide clear answers.
+description: Researches the codebase to answer a question — searches for relevant files, gathers context, and provides a clear, direct answer. Use for questions and research requests where no code change is expected. Not for making code changes (use implementation or debug).
 ---
 
 # Investigate

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize
-description: Format a final summary message for Linear. Your output is automatically streamed to the Linear agent session — just format it well, do not post it yourself.
+description: Formats a final summary of completed work for Linear. Use as the last step of any workflow to narrate results. Output is automatically streamed to the Linear agent session — format it well; do not post it with any tool.
 ---
 
 # Summarize

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,47 +1,49 @@
 ---
 name: summarize
-description: Formats a final summary of completed work for Linear. Use as the last step of any workflow to narrate results. Output is automatically streamed to the Linear agent session — format it well; do not post it with any tool.
+description: Formats the final summary of completed work for Linear, narrating what was done, the key changes, and any follow-up. Use as the last step of any workflow once the work is finished. Not for answering questions or research (use investigate).
 ---
 
 # Summarize
 
-Format a final summary of the work completed. Your output will be automatically rendered inside Linear — just write it as your response. Do **not** use any tool to post or save it.
+Write the final summary of the work that was completed. Keep it tight, factual, and grounded in what actually happened this session.
 
-## Content
+## Delivery contract
 
-Cover the following:
-1. **Work Completed** — What was accomplished (1-2 sentences) and key outcome
-2. **Key Details** — Files modified, important changes, PR link if created
-3. **Status** — Completion status and any follow-up needed
+Your final assistant message IS the Linear response — it is streamed back to the agent session automatically. Write the summary as your response. Do NOT post or save it with any tool (that double-posts). It must be the LAST thing you output, so it is not buried under other text.
+
+## What to cover
+
+1. **Outcome** — What was accomplished and the result, in one or two sentences.
+2. **Key changes** — The substantive changes, files touched, and the PR/MR link if one was created by verify-and-ship.
+3. **Status** — Whether the work is complete, plus any follow-up, known limitations, or unresolved failures carried over from earlier work.
 
 ## Format
 
-- Aim for 3-5 paragraphs maximum
-- Use clear, professional language suitable for Linear
-- Use markdown formatting for readability
-- **Collapsible sections**: Wrap "Changes Made" and "Files Modified" in `+++Section Name\n...\n+++`
-- **@mentions**: Use the Linear profile URL format from `<assignee>` context (e.g. `https://linear.app/<workspace>/profiles/<username>`)
+Write Linear-compatible markdown. Lead with the outcome — no preamble. Keep the visible body short and push supporting detail into collapsible sections:
+
+- Wrap long lists (changes made, files modified) in a `+++Section Name` / content / `+++` collapsible block (see the example for the exact shape) so the timeline stays scannable.
+- For @mentions, use the Linear profile URL from the `<assignee>` context: `https://linear.app/<workspace>/profiles/<username>`. If assignee fields are empty, omit the @mention.
+
+Beyond leading with the outcome and using collapsible sections for detail, the exact shape is your judgment — adapt to what the work warrants.
 
 ## Example
+
+The surrounding fence below only shows the shape — do not wrap your actual output in a code fence (that would render the `+++` sections literally instead of as Linear collapsibles).
 
 ```
 ## Summary
 
-[Brief description of what was done]
+Added retry-with-backoff to the webhook client so transient 5xx responses no longer drop events. PR: [#412](https://github.com/org/repo/pull/412)
 
-+++Changes Made
-- [Key change 1]
-- [Key change 2]
++++Changes made
+- New `withBackoff` wrapper around the fetch call (3 retries, jittered delay)
+- Surfaced retry count in the structured log line
 +++
 
-+++Files Modified
-- [File 1]
-- [File 2]
++++Files modified
+- packages/ndjson-client/src/WebhookClient.ts
+- packages/ndjson-client/test/WebhookClient.test.ts
 +++
 
-## Status
-
-[Current status and any next steps]
-
-[PR link if applicable]
+**Status:** Complete and ready for review. The full test suite passes; no follow-up needed.
 ```

--- a/skills/verify-and-ship/SKILL.md
+++ b/skills/verify-and-ship/SKILL.md
@@ -5,82 +5,135 @@ description: Runs all quality checks (tests, lint, typecheck), fixes failures, u
 
 # Verify and Ship
 
-After implementing your changes, follow these steps to verify quality and ship the work.
+Run after code changed, before summarize. Work through the phases in order. Phase 1 gates everything: validate acceptance criteria before shipping. The git/gh/glab and changelog commands below are exact — run them as written. The only flag latitude is the push-recovery escape hatch in Phase 4.
 
-## 1. Acceptance Criteria Validation (CRITICAL)
+Resolve these from context once: the issue identifier and Linear URL from `<linear_issue>` (`<identifier>` / `<url>`); the target branch from `<git_context>` (or `<context>`) as `<base_branch>`.
 
-Use the issue tracker `get_issue` tool to fetch the current issue details. Extract ALL acceptance criteria from the issue description and verify each one is satisfied by the implementation. If no explicit criteria exist, validate against the implied requirements from the issue title and description.
+Paste this checklist into your response and check items off as you go — Cyrus renders it in the Linear timeline (the ready-state decision in Phase 5 depends on the quality-check result):
 
-## 2. Quality Checks
+```
+- [ ] Acceptance criteria validated against the issue
+- [ ] Tests, lint, and typecheck run and read
+- [ ] Changelog updated (dedup against base branch)
+- [ ] Changes committed and pushed
+- [ ] PR/MR created or updated with the cyrus marker
+- [ ] Ready-state decided: mark ready only if checks pass and guidance allows
+```
 
-Run all applicable quality checks:
-- **Tests** — Run the full test suite. If tests fail, fix the issues and re-run. Retry up to 3 times. If you cannot resolve failures after 3 attempts, proceed and note the failures in your summary.
-- **Linting** — Run linting tools and fix any issues found.
-- **Type checking** — Run TypeScript type checking (if applicable) and fix any errors.
-- **Code review** — Review your changes for quality, consistency, and best practices. Remove any debug code, console.logs, or commented-out sections.
+## Phase 1: Validate acceptance criteria
 
-## 3. Changelog Update
+Fetch the current issue with the issue tracker's `get_issue` tool. Extract every acceptance criterion from the description and confirm the implementation satisfies each one. If the issue states no explicit criteria, validate against the implied requirements in the title and description. Treat unmet criteria as a quality failure surfaced in Phase 5.
 
-Check if the project has changelog files:
+## Phase 2: Quality checks
+
+Discover the project's non-interactive check commands first (from package.json, Makefile, or CLAUDE.md) and prefer run-once variants over watch mode — a watch-mode test command never exits and hangs the whole ship. Run each applicable check, read its output, and fix what it reports. Report from fresh command output, never from expectation — no "should pass" or "looks done".
+
+- **Tests** — Run the full suite once (not in watch mode). On failure, fix and re-run. Retry up to 3 times. If failures remain after 3 attempts, stop retrying and carry the failing result into Phase 5 (do not silently ship as passing).
+- **Lint** — Run the linter and fix what it flags.
+- **Typecheck** — Run type checking (if the project has it) and fix every error.
+- **Self-review** — Read the diff. Remove debug code, stray logging, and commented-out blocks.
+
+Record whether checks ended passing or still failing — Phase 5 branches on it.
+
+## Phase 3: Changelog
+
+Inspect state before mutating. Check for changelog files:
+
 ```bash
 ls -la CHANGELOG.md CHANGELOG.internal.md 2>/dev/null || echo "NO_CHANGELOG"
 ```
 
-If changelog files exist, diff against the base branch to detect entries already added by this branch:
+If none exist, skip this phase. Otherwise diff against the base branch (`<base_branch>` from `<git_context>` or `<context>`) to see what this branch already added:
 
 ```bash
-# See what changelog lines this branch has added compared to the base branch
-# Replace <base_branch> with the actual base branch from the issue context
 git diff <base_branch> -- CHANGELOG.md CHANGELOG.internal.md 2>/dev/null
 ```
 
-**Handling existing entries:**
-- If the diff shows this branch already added a changelog entry for the current issue (matching the issue identifier), **update that entry in-place** (e.g., to add the PR/MR link or refine the description). Do NOT add a duplicate entry.
-- If the diff shows this branch added changelog entries for a different issue or no entries at all, add a new entry.
+- If the diff shows this branch already added an entry for the current issue (matching the issue identifier), update that entry in place — add the PR/MR link or refine the wording. Do not add a duplicate.
+- Otherwise add a new entry.
 
-**Adding or updating entries:**
-- Place entries under `## [Unreleased]` in the appropriate subsection (`### Added`, `### Changed`, `### Fixed`, `### Removed`)
-- Focus on end-user impact — be concise but descriptive
-- Include the Linear issue identifier and PR/MR link (format: `([ISSUE-ID](linear_url), [#NUMBER](PR_OR_MR_URL))`)
-- Follow [Keep a Changelog](https://keepachangelog.com/) format
+Place entries under `## [Unreleased]` in the right subsection (`### Added`, `### Changed`, `### Fixed`, `### Removed`), focused on end-user impact, in [Keep a Changelog](https://keepachangelog.com/) format. Include the issue identifier and PR/MR link: `([ISSUE-ID](linear_url), [#NUMBER](pr_or_mr_url))`.
 
-## 4. Commit and Push
+## Phase 4: Commit and push
 
-- Stage all relevant changes (including changelog updates)
-- Commit with clear, descriptive messages following the project's commit conventions
-- Push to the remote repository
-
-## 5. Create or Update PR/MR
-
-Determine the platform from the repository context (`<github_url>` or `<gitlab_url>` in the issue context). Use the appropriate tool for the platform.
-
-### GitHub (when `<github_url>` is present)
+Stage the relevant changes (including the changelog), commit with a clear message following the project's conventions, then push:
 
 ```bash
 git push -u origin HEAD
-gh pr view --json url,number 2>/dev/null || gh pr create --draft --base [base_branch from context] --title "[descriptive title]" --body "Work in progress"
 ```
 
-### GitLab (when `<gitlab_url>` is present)
+If the push is rejected as non-fast-forward (e.g. history was rewritten during the Phase 2 retries) and the branch is a Cyrus-owned worktree branch, recover with `git push --force-with-lease`. If the push still fails, stop here and surface the failure — do not open or ready a PR/MR on un-pushed code.
+
+## Phase 5: Create or update the PR/MR
+
+**Pick the platform.** `<repository_routing_context>` renders both `<github_url>` and `<gitlab_url>`; the unused one is the literal `N/A`. If `<github_url>` is a real URL (not `N/A`), follow the **GitHub** branch; otherwise follow the **GitLab** branch. Follow exactly one.
+
+Resolve the bot mention handle once: use `<github_bot_username>` / `<gitlab_bot_username>` from `<agent_context>`. `<agent_context>` is omitted when those env vars are unset, so default to `cyrusagent`. This is the bot, distinct from the PR/MR author (see attribution below).
+
+**Ready-state decision (load-bearing).** If Phase 2 ended with failing checks or Phase 1 found unmet criteria, the branch is not shippable: the PR/MR must be a draft, keep any `WIP:` / `Draft:` prefix, and surface the failures at the top of the body and in your summary. On a re-run where an existing PR/MR was previously marked ready, actively demote it back to draft (GitHub `gh pr ready --undo`; GitLab `glab mr update --draft`) — do not just leave it ready. Only mark ready when checks pass AND `<agent_guidance>` does not call for keeping drafts.
+
+### GitHub branch
+
+Create the draft if absent, otherwise reuse the existing one:
 
 ```bash
-git push -u origin HEAD
-glab mr view 2>/dev/null || glab mr create --draft --target-branch [base_branch from context] --title "[descriptive title]" --description "Work in progress"
+gh pr view --json url,number 2>/dev/null || gh pr create --draft --base <base_branch> --title "[descriptive title]" --body "Work in progress"
 ```
 
-### PR/MR Description
+Write the rendered body template to a file and set it (use `--body-file` so the multi-line template, blockquote, and marker survive shell quoting):
 
-Update the PR/MR with a comprehensive description:
-- **Assignee attribution**: If `<github_username>` is available in the assignee context, add `Assignee: @username ([Display Name](linear_profile_url))` at the top of the body. If only a linear profile URL is available, use `Assignee: [Display Name](linear_profile_url)`.
-- **Summary** of changes, implementation approach, and testing performed
-- **Link** to the Linear issue
-- **Cyrus marker**: Include `<!-- generated-by-cyrus -->` as a hidden HTML comment at the end of the body
-- **Interaction tip**: Add this at the end (before the marker), using the bot username from `<github_bot_username>` or `<gitlab_bot_username>` in the `<agent_context>` block of the system prompt. If `<agent_context>` is not present, default to `cyrusagent`:
-  ```
-  ---
-  > **Tip:** I will respond to comments that @ mention @<bot_username> on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
-  ```
+```bash
+gh pr edit --body-file <rendered-template-file>
+```
 
-Remove any "WIP:" or "Draft:" prefix from the title. Check `<agent_guidance>` — only mark the PR/MR as ready if guidance does NOT specify keeping them as drafts.
+Then apply the ready-state decision — mark ready only when allowed, or demote a now-failing PR back to draft:
 
-Verify the PR/MR targets the correct base branch from `<base_branch>` in the issue context.
+```bash
+gh pr ready          # only when checks pass and guidance allows
+gh pr ready --undo   # only to demote a previously-ready PR that is now failing
+```
+
+### GitLab branch
+
+```bash
+glab mr view 2>/dev/null || glab mr create --draft --target-branch <base_branch> --title "[descriptive title]" --description "Work in progress"
+```
+
+Set the rendered body template as the description:
+
+```bash
+glab mr update --description "<rendered template>"
+```
+
+Then apply the ready-state decision — mark ready only when allowed, or demote a now-failing MR back to draft:
+
+```bash
+glab mr update --ready   # only when checks pass and guidance allows
+glab mr update --draft   # only to demote a previously-ready MR that is now failing
+```
+
+### Body template (both platforms)
+
+Render this shape; the marker and tip are machine-detected. The assignee line follows the attribution rule below (not a literal copy). The tip text is verbatim user-facing copy — keep its first-person wording; do not rewrite it into imperative.
+
+```
+[If checks failing: ## Checks failing — not ready for review
+<one line per failing check / unmet criterion>]
+
+<Assignee line — per attribution rule below>
+
+## Summary
+<what changed, approach, testing performed>
+
+Closes <ISSUE-ID> — <linear_url>
+
+---
+
+> **Tip:** I will respond to comments that @ mention @<bot_handle> on this PR/MR. You can also leave review comments, and I will automatically wake up to address each comment.
+
+<!-- generated-by-cyrus -->
+```
+
+- **Attribution** comes from `<assignee>` inside `<linear_issue>`. On GitHub, if `<github_username>` is present use `Assignee: @<github_username> ([<linear_display_name>](<linear_profile_url>))`; on GitLab, if `<gitlab_username>` (or `<github_username>`) is present use `Assignee: @<username> ([<linear_display_name>](<linear_profile_url>))`. Otherwise `Assignee: [<linear_display_name>](<linear_profile_url>)`. Skip the line if no assignee data exists. Do not derive the bot handle from these usernames — they are the author, not the bot.
+- The `<!-- generated-by-cyrus -->` marker stays last; the interaction tip sits just before it; the checks-failing block (if any) stays first.
+- Confirm the PR/MR targets `<base_branch>` and fix the target if it drifted.

--- a/skills/verify-and-ship/SKILL.md
+++ b/skills/verify-and-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-and-ship
-description: Run all quality checks (tests, lint, typecheck), fix failures, update the changelog, commit, push, and create/update the pull request or merge request.
+description: Runs all quality checks (tests, lint, typecheck), fixes failures, updates the changelog, commits, pushes, and creates or updates the pull/merge request. Use after implementation or debug whenever code changed, before summarize. Not needed for questions or research (use investigate then summarize).
 ---
 
 # Verify and Ship


### PR DESCRIPTION
## Summary

Cold resumes past the ~50-min keep-alive window rewrite the **entire** transcript to prompt cache, which is slow and degrades response quality on very long-running issues. This PR replaces those oversized resumes with a summarize-and-restart: when a resume's estimated context exceeds an **opt-in** threshold, Cyrus summarizes the prior transcript with a one-shot **Haiku** call and starts a **fresh** session seeded with that summary instead of resuming the giant transcript.

Implements **DEV-177 — PR 5 — Cold-resume summarize-and-restart (Haiku)**.

### Locked decisions honored
- **Haiku-generated summary** (not a deterministic seed).
- **Opt-in**: unset `claudeColdResumeSummarizeThresholdTokens` = disabled; resumes behave exactly as before.
- **Never breaks a resume that would otherwise succeed**: any failure (no transcript found, estimate at/below threshold, summarization error/timeout) falls through to a normal resume.
- On success the Claude session ID is **preserved** (runner pinning + init-message rebind depend on it).

## What changed

**New modules (`packages/claude-runner`):**
- `transcript-locator.ts` — two-level scan of `~/.claude/projects/*/` for `<sessionId>.jsonl` (the on-disk slug sanitization is undocumented, so we scan rather than reconstruct the path).
- `transcript-parser.ts` — normalizes raw `.jsonl` records into conversational turns.
- `transcript-summarizer.ts` — one-shot Haiku `query()` (custom system prompt, no tools, `maxTurns: 1`, `effort: low`, `maxBudgetUsd: 0.5`, 90s timeout). Renders a compact turn log with tail-truncation that keeps the first turn as a head anchor.

**`packages/edge-worker`:**
- `EdgeWorker.resumeAgentSession` — threshold resolution (`MIN_COLD_RESUME_THRESHOLD_TOKENS = 20_000`, below-min warns and disables), context estimation (usage signal, else transcript size/4), and the summarize trigger. On success it builds a fresh session with a new `<previous_session_summary>` prompt block instead of resuming.

**Config:**
- New top-level `claudeColdResumeSummarizeThresholdTokens` field: Zod schema, `ConfigManager` merge + `globalKeys` whitelist, `docs/CONFIG_FILE.md`, and regenerated committed JSON schemas.

## Testing

- **24 new unit tests** (transcript locator/parser/summarizer, session-summary prompt assembly with full-prompt assertions per the repo mandate, and the cold-resume decision logic incl. the fall-through-on-failure paths and the "never clear claudeSessionId" invariant). All pass.
- `pnpm typecheck` — clean. `pnpm lint` — clean (pre-existing warnings only). `pnpm -r test:run` — green.

> [!NOTE]
> The `EdgeWorker.runner-selection` (2) and `EdgeWorker.screenshot-upload-hooks` (6) failures seen in a raw `pnpm -r test:run` are **pre-existing environment noise**, not a regression from this PR: they trip only when `CURSOR_API_KEY` is set in the shell (it flips default-runner auto-detection to `cursor`). With `CURSOR_API_KEY` unset, all 34 of those tests pass. This diff touches neither runner selection nor screenshot hooks.
