### PR TITLE
fix: use repository name for Linear repo-selection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Repository selection prompts in Linear now use the configured repository name as the option value instead of the git URL. Previously, when a repository's configured GitHub/GitLab URL exceeded Linear's 100-character limit on option values — common when the URL embeds an access token — the selection prompt failed to post and the session stalled with an error. Using the repository name also keeps credential-bearing URLs out of the data sent to Linear. ([#1](https://github.com/oduist/cyrus/pull/1))
+- Repository selection prompts in Linear now use the configured repository name as the option value instead of the git URL. Previously, when a repository's configured GitHub/GitLab URL exceeded Linear's 100-character limit on option values — common when the URL embeds an access token — the selection prompt failed to post and the session stalled with an error. Using the repository name also keeps credential-bearing URLs out of the data sent to Linear. ([#1379](https://github.com/cyrusagents/cyrus/pull/1379))
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Repository selection prompts in Linear now use the configured repository name as the option value instead of the git URL. Previously, when a repository's configured GitHub/GitLab URL exceeded Linear's 100-character limit on option values — common when the URL embeds an access token — the selection prompt failed to post and the session stalled with an error. Using the repository name also keeps credential-bearing URLs out of the data sent to Linear.
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Repository selection prompts in Linear now use the configured repository name as the option value instead of the git URL. Previously, when a repository's configured GitHub/GitLab URL exceeded Linear's 100-character limit on option values — common when the URL embeds an access token — the selection prompt failed to post and the session stalled with an error. Using the repository name also keeps credential-bearing URLs out of the data sent to Linear.
+- Repository selection prompts in Linear now use the configured repository name as the option value instead of the git URL. Previously, when a repository's configured GitHub/GitLab URL exceeded Linear's 100-character limit on option values — common when the URL embeds an access token — the selection prompt failed to post and the session stalled with an error. Using the repository name also keeps credential-bearing URLs out of the data sent to Linear. ([#1](https://github.com/oduist/cyrus/pull/1))
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/packages/edge-worker/src/RepositoryRouter.ts
+++ b/packages/edge-worker/src/RepositoryRouter.ts
@@ -10,6 +10,11 @@ import {
 } from "cyrus-core";
 
 /**
+ * Linear rejects select-signal option values longer than 100 characters.
+ */
+const MAX_SELECT_OPTION_VALUE_LENGTH = 100;
+
+/**
  * Repository routing result types
  */
 export type RepositoryRoutingResult =
@@ -576,7 +581,7 @@ export class RepositoryRouter {
 
 				const fullIssue = await issueTracker.fetchIssue(issueId);
 				const project = await fullIssue?.project;
-				if (!project || !project.name) {
+				if (!project?.name) {
 					this.logger.debug(
 						`No project name found for issue ${issueId} in repository ${repo.name}`,
 					);
@@ -644,9 +649,11 @@ export class RepositoryRouter {
 			return;
 		}
 
-		// Create repository options
+		// Create repository options. Use the configured repository name, never
+		// git URLs: configured URLs may embed credentials (which must not be
+		// sent to Linear) and can exceed Linear's option value length limit.
 		const options = workspaceRepos.map((repo) => ({
-			value: repo.githubUrl || repo.gitlabUrl || repo.name,
+			value: repo.name.slice(0, MAX_SELECT_OPTION_VALUE_LENGTH),
 		}));
 
 		// Post elicitation activity
@@ -729,12 +736,15 @@ export class RepositoryRouter {
 		// Remove from pending map
 		this.pendingSelections.delete(agentSessionId);
 
-		// Find selected repository by GitHub/GitLab URL or name
+		// Find selected repository by name (option values are names, possibly
+		// truncated to Linear's length limit), falling back to GitHub/GitLab URL
 		const selectedRepo = pendingData.workspaceRepos.find(
 			(repo) =>
+				repo.name === selectedRepositoryName ||
+				repo.name.slice(0, MAX_SELECT_OPTION_VALUE_LENGTH) ===
+					selectedRepositoryName ||
 				repo.githubUrl === selectedRepositoryName ||
-				repo.gitlabUrl === selectedRepositoryName ||
-				repo.name === selectedRepositoryName,
+				repo.gitlabUrl === selectedRepositoryName,
 		);
 
 		// Fallback to first repository if not found

--- a/packages/edge-worker/test/RepositoryRouter.test.ts
+++ b/packages/edge-worker/test/RepositoryRouter.test.ts
@@ -1472,7 +1472,7 @@ describe("RepositoryRouter", () => {
 				// When: Eliciting user selection
 				await env.router.elicitUserRepositorySelection(webhook, [repo1, repo2]);
 
-				// Then: Should post elicitation with correct options
+				// Then: Should post elicitation with repository names as options
 				expect(env.mockLinearClient.createAgentActivity).toHaveBeenCalledWith({
 					agentSessionId: "session-123",
 					content: {
@@ -1481,10 +1481,7 @@ describe("RepositoryRouter", () => {
 					},
 					signal: AgentActivitySignal.Select,
 					signalMetadata: {
-						options: [
-							{ value: "https://github.com/org/frontend" },
-							{ value: "https://github.com/org/backend" },
-						],
+						options: [{ value: "Frontend Repo" }, { value: "Backend Repo" }],
 					},
 				});
 			});
@@ -1506,6 +1503,61 @@ describe("RepositoryRouter", () => {
 						},
 					}),
 				);
+			});
+
+			it("should never send credential-bearing git URLs as option values", async () => {
+				// Given: Repository whose git URL embeds a PAT
+				const repo = env
+					.repository("repo-1", "Mirage Pools")
+					.withGithubUrl(
+						"https://user:github_pat_secret123@github.com/org/mirage-pools",
+					)
+					.build();
+
+				const webhook = env.webhook().build();
+
+				// When: Eliciting user selection
+				await env.router.elicitUserRepositorySelection(webhook, [repo]);
+
+				// Then: Option value is the repository name, not the URL
+				expect(env.mockLinearClient.createAgentActivity).toHaveBeenCalledWith(
+					expect.objectContaining({
+						signalMetadata: {
+							options: [{ value: "Mirage Pools" }],
+						},
+					}),
+				);
+				const payload = JSON.stringify(
+					(env.mockLinearClient.createAgentActivity as any).mock.calls,
+				);
+				expect(payload).not.toContain("github_pat_secret123");
+			});
+
+			it("should truncate option values to Linear's 100 character limit", async () => {
+				// Given: Repository with a name longer than 100 characters
+				const longName = "a".repeat(150);
+				const repo = env.repository("repo-1", longName).build();
+
+				const webhook = env.webhook().withSession("session-123").build();
+
+				// When: Eliciting user selection
+				await env.router.elicitUserRepositorySelection(webhook, [repo]);
+
+				// Then: Option value is truncated to 100 characters
+				expect(env.mockLinearClient.createAgentActivity).toHaveBeenCalledWith(
+					expect.objectContaining({
+						signalMetadata: {
+							options: [{ value: "a".repeat(100) }],
+						},
+					}),
+				);
+
+				// And: Selecting via the truncated value resolves the repository
+				const result = await env.router.selectRepositoryFromResponse(
+					"session-123",
+					"a".repeat(100),
+				);
+				expect(result).toBe(repo);
 			});
 
 			it("should store pending selection for later processing", async () => {


### PR DESCRIPTION
## Problem

When no routing rule matches an issue, `RepositoryRouter` posts a repository-selection elicitation to Linear with the configured git URL (`githubUrl`/`gitlabUrl`) as the select-signal option value. Linear rejects option values longer than 100 characters, so for repositories whose configured URL embeds an access token (e.g. `https://user:github_pat_...@github.com/org/repo`), the elicitation always fails and the session stalls with an error:

```
Invalid signal metadata for "select" with activity type "elicitation": [options.0.value]: Value length cannot exceed 100 characters.
```

Worse, this transmitted credential-bearing git URLs to Linear as part of the mutation payload, and the resulting SDK error logged them in plaintext.

## Fix

- Option values now use the configured repository `name` (a required config field, and what users should see anyway), truncated to Linear's 100-character limit. Git URLs are never sent to Linear.
- `selectRepositoryFromResponse` resolves names first (including the truncated form) and keeps URL matching for compatibility.

## Testing

- Updated existing elicitation tests to expect repository names as option values.
- Added a test asserting credential-bearing URLs never appear in the payload sent to Linear.
- Added a test for the 100-character truncation round trip (option value → selection resolution).
- `pnpm test:packages:run` and `pnpm typecheck` pass.