### PR TITLE
fix(slack): back-read thread messages posted between mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding. ([#1388](https://github.com/cyrusagents/cyrus/pull/1388))
+- Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding. ([#1388](https://github.com/cyrusagents/cyrus/pull/1388)) Thanks @rairulyle for the contribution!
 
 ### Security
 - Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` reports no known vulnerabilities. ([CYPACK-1423](https://linear.app/ceedar/issue/CYPACK-1423/address-open-security-patches-for-cyrus-cli), [#1392](https://github.com/cyrusagents/cyrus/pull/1392))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding.
 
 ## [0.2.67] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding.
+- Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding. ([#1388](https://github.com/cyrusagents/cyrus/pull/1388))
 
 ## [0.2.67] - 2026-07-25
 

--- a/packages/core/src/CyrusAgentSession.ts
+++ b/packages/core/src/CyrusAgentSession.ts
@@ -103,6 +103,8 @@ export interface CyrusAgentSession {
 		totalCostUsd?: number;
 		usage?: any;
 		commentId?: string;
+		/** Chat sessions: thread position up to which this session has context */
+		lastContextTs?: string;
 	};
 }
 

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -49,22 +49,18 @@ export interface ChatPlatformAdapter<TEvent> {
 	/** Build a platform-specific system prompt */
 	buildSystemPrompt(event: TEvent): string;
 
-	/** Fetch thread context as formatted string. Returns "" if not applicable */
-	fetchThreadContext(event: TEvent): Promise<string>;
+	/**
+	 * Thread context as a formatted string, or "" if not applicable. Pass
+	 * `sinceTs` to read only what followed it, so a resumed session catches up on
+	 * discussion it never saw. `null` means the read failed — only a non-null
+	 * result advances the cursor.
+	 */
+	fetchThreadContext(event: TEvent, sinceTs?: string): Promise<string | null>;
 
 	/**
-	 * Fetch thread messages posted since `sinceTs`, so a resumed session catches
-	 * up on discussion it never saw. Returns "" if there's nothing new, `null`
-	 * if the fetch failed — only a non-null result advances the cursor.
-	 *
-	 * Optional — platforms that deliver every thread message omit it.
+	 * This event's thread position, stored as the catch-up cursor. Optional —
+	 * platforms that deliver every thread message omit it and get no catch-up.
 	 */
-	fetchThreadContextDelta?(
-		event: TEvent,
-		sinceTs?: string,
-	): Promise<string | null>;
-
-	/** This event's thread position, stored as the catch-up cursor */
 	getThreadContextTs?(event: TEvent): string | undefined;
 
 	/** Post the agent's final response back to the platform */
@@ -342,13 +338,11 @@ export class ChatSessionHandler<TEvent> {
 			await this.deps.onStateChange();
 
 			// Fetch thread context for threaded mentions
-			const threadContext = await this.fetchInitialThreadContext(event);
-			const userPrompt = threadContext
-				? `${threadContext}\n\n${taskInstructions}`
-				: taskInstructions;
-			if (threadContext !== null) {
-				this.recordThreadContextTs(session, event);
-			}
+			const userPrompt = await this.withThreadContext(
+				session,
+				event,
+				taskInstructions,
+			);
 
 			this.logger.info(
 				`Starting runner for ${this.adapter.platformName} event ${eventId}`,
@@ -453,9 +447,6 @@ export class ChatSessionHandler<TEvent> {
 		session: CyrusAgentSession,
 		event: TEvent,
 	): void {
-		if (!this.adapter.fetchThreadContextDelta) {
-			return;
-		}
 		const ts = this.adapter.getThreadContextTs?.(event);
 		if (!ts) {
 			return;
@@ -473,57 +464,50 @@ export class ChatSessionHandler<TEvent> {
 	}
 
 	/**
-	 * Opening read for a new session. Prefers the delta method, whose `null`
-	 * distinguishes a failed read from an empty one and so holds the cursor.
+	 * Prefix the task instructions with thread context — the whole thread for a
+	 * new session, or just what was said since the cursor for a follow-up. The
+	 * cursor only advances on a successful read, so a failed one retries the same
+	 * window instead of losing it.
 	 */
-	private async fetchInitialThreadContext(
-		event: TEvent,
-	): Promise<string | null> {
-		try {
-			return this.adapter.fetchThreadContextDelta
-				? await this.adapter.fetchThreadContextDelta(event, undefined)
-				: await this.adapter.fetchThreadContext(event);
-		} catch (error) {
-			this.logger.warn(
-				`Failed to fetch thread context for ${this.adapter.platformName} session: ${error instanceof Error ? error.message : String(error)}`,
-			);
-			return null;
-		}
-	}
-
-	/**
-	 * Prefix the task instructions with what was said since the last mention.
-	 * A failed fetch leaves the cursor put, so the missed window is retried
-	 * on the next event instead of being lost.
-	 */
-	private async withThreadCatchup(
+	private async withThreadContext(
 		session: CyrusAgentSession,
 		event: TEvent,
 		taskInstructions: string,
 	): Promise<string> {
-		if (!this.adapter.fetchThreadContextDelta) {
-			return taskInstructions;
-		}
-
-		let delta: string | null;
+		let context: string | null;
 		try {
-			delta = await this.adapter.fetchThreadContextDelta(
+			context = await this.adapter.fetchThreadContext(
 				event,
 				session.metadata?.lastContextTs,
 			);
 		} catch (error) {
 			// A context read must never cost the user their message
 			this.logger.warn(
-				`Failed to fetch thread catch-up for ${this.adapter.platformName} session: ${error instanceof Error ? error.message : String(error)}`,
+				`Failed to fetch thread context for ${this.adapter.platformName} session: ${error instanceof Error ? error.message : String(error)}`,
 			);
 			return taskInstructions;
 		}
 
-		if (delta !== null) {
+		if (context !== null) {
 			this.recordThreadContextTs(session, event);
 		}
 
-		return delta ? `${delta}\n\n${taskInstructions}` : taskInstructions;
+		return context ? `${context}\n\n${taskInstructions}` : taskInstructions;
+	}
+
+	/**
+	 * Follow-up variant. Platforms with no thread cursor deliver every message
+	 * already, so re-reading the thread would only duplicate what the session has.
+	 */
+	private async withThreadCatchup(
+		session: CyrusAgentSession,
+		event: TEvent,
+		taskInstructions: string,
+	): Promise<string> {
+		if (!this.adapter.getThreadContextTs) {
+			return taskInstructions;
+		}
+		return this.withThreadContext(session, event, taskInstructions);
 	}
 
 	/**

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -52,6 +52,21 @@ export interface ChatPlatformAdapter<TEvent> {
 	/** Fetch thread context as formatted string. Returns "" if not applicable */
 	fetchThreadContext(event: TEvent): Promise<string>;
 
+	/**
+	 * Fetch thread messages posted since `sinceTs`, so a resumed session catches
+	 * up on discussion it never saw. Returns "" if there's nothing new, `null`
+	 * if the fetch failed — only a non-null result advances the cursor.
+	 *
+	 * Optional — platforms that deliver every thread message omit it.
+	 */
+	fetchThreadContextDelta?(
+		event: TEvent,
+		sinceTs?: string,
+	): Promise<string | null>;
+
+	/** This event's thread position, stored as the catch-up cursor */
+	getThreadContextTs?(event: TEvent): string | undefined;
+
 	/** Post the agent's final response back to the platform */
 	postReply(event: TEvent, runner: IAgentRunner): Promise<void>;
 
@@ -198,7 +213,13 @@ export class ChatSessionHandler<TEvent> {
 							`Injecting follow-up prompt into running session ${existingSessionId} (thread ${threadKey})`,
 						);
 						this.enqueueReply(existingSessionId, event);
-						existingRunner.addStreamMessage(taskInstructions);
+						existingRunner.addStreamMessage(
+							await this.withThreadCatchup(
+								existingSession,
+								event,
+								taskInstructions,
+							),
+						);
 					} else {
 						// Runner can't accept mid-turn input (e.g. exec Codex). Queue the
 						// follow-up so it's delivered as a fresh turn once this one ends,
@@ -325,6 +346,7 @@ export class ChatSessionHandler<TEvent> {
 			const userPrompt = threadContext
 				? `${threadContext}\n\n${taskInstructions}`
 				: taskInstructions;
+			this.recordThreadContextTs(session, event);
 
 			this.logger.info(
 				`Starting runner for ${this.adapter.platformName} event ${eventId}`,
@@ -424,6 +446,49 @@ export class ChatSessionHandler<TEvent> {
 		return this.sessionManager.getAgentRunner(sessionId);
 	}
 
+	/** Mark how far this session has thread context, for the next catch-up */
+	private recordThreadContextTs(
+		session: CyrusAgentSession,
+		event: TEvent,
+	): void {
+		if (!this.adapter.fetchThreadContextDelta) {
+			return;
+		}
+		const ts = this.adapter.getThreadContextTs?.(event);
+		if (!ts) {
+			return;
+		}
+		if (!session.metadata) {
+			session.metadata = {};
+		}
+		session.metadata.lastContextTs = ts;
+	}
+
+	/**
+	 * Prefix the task instructions with what was said since the last mention.
+	 * A failed fetch leaves the cursor put, so the missed window is retried
+	 * on the next event instead of being lost.
+	 */
+	private async withThreadCatchup(
+		session: CyrusAgentSession,
+		event: TEvent,
+		taskInstructions: string,
+	): Promise<string> {
+		if (!this.adapter.fetchThreadContextDelta) {
+			return taskInstructions;
+		}
+
+		const delta = await this.adapter.fetchThreadContextDelta(
+			event,
+			session.metadata?.lastContextTs,
+		);
+		if (delta !== null) {
+			this.recordThreadContextTs(session, event);
+		}
+
+		return delta ? `${delta}\n\n${taskInstructions}` : taskInstructions;
+	}
+
 	/**
 	 * Resume an existing session with a new prompt (--continue behavior).
 	 */
@@ -447,6 +512,12 @@ export class ChatSessionHandler<TEvent> {
 		const runner = this.deps.createRunner(runnerConfig);
 		this.sessionManager.addAgentRunner(sessionId, runner);
 
+		const resumePrompt = await this.withThreadCatchup(
+			existingSession,
+			event,
+			taskInstructions,
+		);
+
 		// Reply posting is driven by `result` messages on the runner's stream
 		// (see handleAgentMessage). We must not await turn completion here —
 		// warm sessions hold the streaming prompt open across turns so the
@@ -454,8 +525,8 @@ export class ChatSessionHandler<TEvent> {
 		this.enqueueReply(sessionId, event);
 		const startPromise =
 			runner.supportsStreamingInput && runner.startStreaming
-				? runner.startStreaming(taskInstructions)
-				: runner.start(taskInstructions);
+				? runner.startStreaming(resumePrompt)
+				: runner.start(resumePrompt);
 		startPromise
 			.then((sessionInfo: AgentSessionInfo) => {
 				this.logger.info(

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -342,11 +342,13 @@ export class ChatSessionHandler<TEvent> {
 			await this.deps.onStateChange();
 
 			// Fetch thread context for threaded mentions
-			const threadContext = await this.adapter.fetchThreadContext(event);
+			const threadContext = await this.fetchInitialThreadContext(event);
 			const userPrompt = threadContext
 				? `${threadContext}\n\n${taskInstructions}`
 				: taskInstructions;
-			this.recordThreadContextTs(session, event);
+			if (threadContext !== null) {
+				this.recordThreadContextTs(session, event);
+			}
 
 			this.logger.info(
 				`Starting runner for ${this.adapter.platformName} event ${eventId}`,
@@ -461,7 +463,32 @@ export class ChatSessionHandler<TEvent> {
 		if (!session.metadata) {
 			session.metadata = {};
 		}
+		// Concurrent mentions race here; a backwards cursor re-delivers a message.
+		// Slack ts is zero-padded, so string ordering is chronological.
+		const current = session.metadata.lastContextTs;
+		if (current && ts <= current) {
+			return;
+		}
 		session.metadata.lastContextTs = ts;
+	}
+
+	/**
+	 * Opening read for a new session. Prefers the delta method, whose `null`
+	 * distinguishes a failed read from an empty one and so holds the cursor.
+	 */
+	private async fetchInitialThreadContext(
+		event: TEvent,
+	): Promise<string | null> {
+		try {
+			return this.adapter.fetchThreadContextDelta
+				? await this.adapter.fetchThreadContextDelta(event, undefined)
+				: await this.adapter.fetchThreadContext(event);
+		} catch (error) {
+			this.logger.warn(
+				`Failed to fetch thread context for ${this.adapter.platformName} session: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return null;
+		}
 	}
 
 	/**
@@ -478,10 +505,20 @@ export class ChatSessionHandler<TEvent> {
 			return taskInstructions;
 		}
 
-		const delta = await this.adapter.fetchThreadContextDelta(
-			event,
-			session.metadata?.lastContextTs,
-		);
+		let delta: string | null;
+		try {
+			delta = await this.adapter.fetchThreadContextDelta(
+				event,
+				session.metadata?.lastContextTs,
+			);
+		} catch (error) {
+			// A context read must never cost the user their message
+			this.logger.warn(
+				`Failed to fetch thread catch-up for ${this.adapter.platformName} session: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return taskInstructions;
+		}
+
 		if (delta !== null) {
 			this.recordThreadContextTs(session, event);
 		}

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -28,6 +28,9 @@ export const SLACK_NO_RESPONSE_SENTINEL = "<<NO_RESPONSE>>";
  */
 export const BEHAVIOURS_PAGE_ROUTE = "/settings/behaviours";
 
+/** How many thread messages a single context or catch-up read carries. */
+const THREAD_CONTEXT_MESSAGE_LIMIT = 50;
+
 /** Reaction added when a message is received and queued for processing (👀) */
 export const RECEIPT_REACTION = "eyes";
 
@@ -227,6 +230,35 @@ Supported mrkdwn syntax:
 	}
 
 	async fetchThreadContext(event: SlackWebhookEvent): Promise<string> {
+		// Collapses failure into "" — callers needing that distinction use the delta
+		return (await this.fetchThreadWindow(event)) ?? "";
+	}
+
+	getThreadContextTs(event: SlackWebhookEvent): string | undefined {
+		return event.payload.ts;
+	}
+
+	/**
+	 * Fetch what was posted in the thread since `sinceTs`, or the whole window
+	 * when there's no cursor yet. With thread following disabled, untagged
+	 * messages never reach us, so everything said between two @mentions is
+	 * invisible unless back-read here.
+	 *
+	 * Returns "" when there's nothing new, `null` when the fetch failed — the
+	 * caller only advances its cursor on a non-null result.
+	 */
+	async fetchThreadContextDelta(
+		event: SlackWebhookEvent,
+		sinceTs?: string,
+	): Promise<string | null> {
+		return this.fetchThreadWindow(event, sinceTs);
+	}
+
+	/** Whole thread when `sinceTs` is absent, otherwise just what follows it. */
+	private async fetchThreadWindow(
+		event: SlackWebhookEvent,
+		sinceTs?: string,
+	): Promise<string | null> {
 		// Only fetch context for threaded messages
 		if (!event.payload.thread_ts) {
 			return "";
@@ -236,66 +268,6 @@ Supported mrkdwn syntax:
 		if (!token) {
 			this.logger.warn(
 				"Cannot fetch Slack thread context: no slackBotToken available",
-			);
-			return "";
-		}
-
-		try {
-			const slackService = new SlackMessageService();
-			const [messages, selfBotId] = await Promise.all([
-				slackService.fetchThreadMessages({
-					token,
-					channel: event.payload.channel,
-					thread_ts: event.payload.thread_ts,
-					limit: 50,
-				}),
-				this.getSelfBotId(token),
-			]);
-
-			if (messages.length === 0) {
-				return "";
-			}
-
-			// Include all messages (user and bot) so follow-up sessions retain
-			// full conversation history, especially when the runner type changes.
-			return this.formatThreadContext(messages, selfBotId);
-		} catch (error) {
-			this.logger.warn(
-				`Failed to fetch Slack thread context: ${error instanceof Error ? error.message : String(error)}`,
-			);
-			return "";
-		}
-	}
-
-	getThreadContextTs(event: SlackWebhookEvent): string | undefined {
-		return event.payload.ts;
-	}
-
-	/**
-	 * Fetch what was posted in the thread since `sinceTs`. With thread following
-	 * disabled, untagged messages never reach us, so everything said between two
-	 * @mentions is invisible unless back-read here.
-	 *
-	 * Returns "" when there's nothing new, `null` when the fetch failed — the
-	 * caller only advances its cursor on a non-null result.
-	 */
-	async fetchThreadContextDelta(
-		event: SlackWebhookEvent,
-		sinceTs?: string,
-	): Promise<string | null> {
-		if (!event.payload.thread_ts) {
-			return "";
-		}
-
-		// No cursor yet — fall back to the full window rather than no history
-		if (!sinceTs) {
-			return this.fetchThreadContext(event);
-		}
-
-		const token = this.getSlackBotToken(event);
-		if (!token) {
-			this.logger.warn(
-				"Cannot fetch Slack thread catch-up: no slackBotToken available",
 			);
 			return null;
 		}
@@ -307,15 +279,25 @@ Supported mrkdwn syntax:
 					token,
 					channel: event.payload.channel,
 					thread_ts: event.payload.thread_ts,
-					limit: 50,
-					oldest: sinceTs,
+					limit: THREAD_CONTEXT_MESSAGE_LIMIT,
+					// An over-long gap should lose its stalest messages, not its newest
+					...(sinceTs ? { oldest: sinceTs, keep: "newest" as const } : {}),
 				}),
 				this.getSelfBotId(token),
 			]);
 
+			if (!sinceTs) {
+				// Include all messages (user and bot) so follow-up sessions retain
+				// full conversation history, especially when the runner type changes.
+				return messages.length === 0
+					? ""
+					: this.formatThreadContext(messages, selfBotId);
+			}
+
 			const delta = messages.filter((msg) => {
-				// conversations.replies returns the parent regardless of `oldest`
-				if (Number.parseFloat(msg.ts) <= Number.parseFloat(sinceTs)) {
+				// conversations.replies returns the parent regardless of `oldest`.
+				// Slack ts is zero-padded, so string ordering is chronological.
+				if (msg.ts <= sinceTs) {
 					return false;
 				}
 				// Already in the task instructions
@@ -336,7 +318,7 @@ Supported mrkdwn syntax:
 			)}`;
 		} catch (error) {
 			this.logger.warn(
-				`Failed to fetch Slack thread catch-up: ${error instanceof Error ? error.message : String(error)}`,
+				`Failed to fetch Slack thread context: ${error instanceof Error ? error.message : String(error)}`,
 			);
 			return null;
 		}

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -267,6 +267,81 @@ Supported mrkdwn syntax:
 		}
 	}
 
+	getThreadContextTs(event: SlackWebhookEvent): string | undefined {
+		return event.payload.ts;
+	}
+
+	/**
+	 * Fetch what was posted in the thread since `sinceTs`. With thread following
+	 * disabled, untagged messages never reach us, so everything said between two
+	 * @mentions is invisible unless back-read here.
+	 *
+	 * Returns "" when there's nothing new, `null` when the fetch failed — the
+	 * caller only advances its cursor on a non-null result.
+	 */
+	async fetchThreadContextDelta(
+		event: SlackWebhookEvent,
+		sinceTs?: string,
+	): Promise<string | null> {
+		if (!event.payload.thread_ts) {
+			return "";
+		}
+
+		// No cursor yet — fall back to the full window rather than no history
+		if (!sinceTs) {
+			return this.fetchThreadContext(event);
+		}
+
+		const token = this.getSlackBotToken(event);
+		if (!token) {
+			this.logger.warn(
+				"Cannot fetch Slack thread catch-up: no slackBotToken available",
+			);
+			return null;
+		}
+
+		try {
+			const slackService = new SlackMessageService();
+			const [messages, selfBotId] = await Promise.all([
+				slackService.fetchThreadMessages({
+					token,
+					channel: event.payload.channel,
+					thread_ts: event.payload.thread_ts,
+					limit: 50,
+					oldest: sinceTs,
+				}),
+				this.getSelfBotId(token),
+			]);
+
+			const delta = messages.filter((msg) => {
+				// conversations.replies returns the parent regardless of `oldest`
+				if (Number.parseFloat(msg.ts) <= Number.parseFloat(sinceTs)) {
+					return false;
+				}
+				// Already in the task instructions
+				if (msg.ts === event.payload.ts) {
+					return false;
+				}
+				// Already in the resumed session's memory
+				return !(selfBotId && msg.bot_id === selfBotId);
+			});
+
+			if (delta.length === 0) {
+				return "";
+			}
+
+			return `The following messages were posted in this thread since you last had context. Read them for background before responding.\n\n${this.formatThreadContext(
+				delta,
+				selfBotId,
+			)}`;
+		} catch (error) {
+			this.logger.warn(
+				`Failed to fetch Slack thread catch-up: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return null;
+		}
+	}
+
 	async postReply(
 		event: SlackWebhookEvent,
 		runner: IAgentRunner,

--- a/packages/edge-worker/src/SlackChatAdapter.ts
+++ b/packages/edge-worker/src/SlackChatAdapter.ts
@@ -31,6 +31,12 @@ export const BEHAVIOURS_PAGE_ROUTE = "/settings/behaviours";
 /** How many thread messages a single context or catch-up read carries. */
 const THREAD_CONTEXT_MESSAGE_LIMIT = 50;
 
+/**
+ * How deep a catch-up read scans before trimming to the newest messages. A
+ * thread paginates from its head, so reaching the tail means walking past it.
+ */
+const THREAD_CATCHUP_SCAN_LIMIT = 2000;
+
 /** Reaction added when a message is received and queued for processing (👀) */
 export const RECEIPT_REACTION = "eyes";
 
@@ -229,33 +235,19 @@ Supported mrkdwn syntax:
 - Lists: use plain numbered lines (1. item) or dashes (- item) with newlines`;
 	}
 
-	async fetchThreadContext(event: SlackWebhookEvent): Promise<string> {
-		// Collapses failure into "" — callers needing that distinction use the delta
-		return (await this.fetchThreadWindow(event)) ?? "";
-	}
-
 	getThreadContextTs(event: SlackWebhookEvent): string | undefined {
 		return event.payload.ts;
 	}
 
 	/**
-	 * Fetch what was posted in the thread since `sinceTs`, or the whole window
-	 * when there's no cursor yet. With thread following disabled, untagged
-	 * messages never reach us, so everything said between two @mentions is
-	 * invisible unless back-read here.
+	 * Whole thread when `sinceTs` is absent, otherwise just what followed it.
+	 * With thread following disabled, untagged messages never reach us, so
+	 * everything said between two @mentions is invisible unless back-read here.
 	 *
-	 * Returns "" when there's nothing new, `null` when the fetch failed — the
-	 * caller only advances its cursor on a non-null result.
+	 * "" when there is nothing to add, `null` when the read failed — the caller
+	 * only advances its cursor on a non-null result.
 	 */
-	async fetchThreadContextDelta(
-		event: SlackWebhookEvent,
-		sinceTs?: string,
-	): Promise<string | null> {
-		return this.fetchThreadWindow(event, sinceTs);
-	}
-
-	/** Whole thread when `sinceTs` is absent, otherwise just what follows it. */
-	private async fetchThreadWindow(
+	async fetchThreadContext(
 		event: SlackWebhookEvent,
 		sinceTs?: string,
 	): Promise<string | null> {
@@ -279,9 +271,10 @@ Supported mrkdwn syntax:
 					token,
 					channel: event.payload.channel,
 					thread_ts: event.payload.thread_ts,
-					limit: THREAD_CONTEXT_MESSAGE_LIMIT,
-					// An over-long gap should lose its stalest messages, not its newest
-					...(sinceTs ? { oldest: sinceTs, keep: "newest" as const } : {}),
+					limit: sinceTs
+						? THREAD_CATCHUP_SCAN_LIMIT
+						: THREAD_CONTEXT_MESSAGE_LIMIT,
+					...(sinceTs ? { oldest: sinceTs } : {}),
 				}),
 				this.getSelfBotId(token),
 			]);
@@ -294,19 +287,22 @@ Supported mrkdwn syntax:
 					: this.formatThreadContext(messages, selfBotId);
 			}
 
-			const delta = messages.filter((msg) => {
-				// conversations.replies returns the parent regardless of `oldest`.
-				// Slack ts is zero-padded, so string ordering is chronological.
-				if (msg.ts <= sinceTs) {
-					return false;
-				}
-				// Already in the task instructions
-				if (msg.ts === event.payload.ts) {
-					return false;
-				}
-				// Already in the resumed session's memory
-				return !(selfBotId && msg.bot_id === selfBotId);
-			});
+			const delta = messages
+				.filter((msg) => {
+					// conversations.replies returns the parent regardless of `oldest`.
+					// Slack ts is zero-padded, so string ordering is chronological.
+					if (msg.ts <= sinceTs) {
+						return false;
+					}
+					// Already in the task instructions
+					if (msg.ts === event.payload.ts) {
+						return false;
+					}
+					// Already in the resumed session's memory
+					return !this.isSelfMessage(msg, selfBotId);
+				})
+				// An over-long gap should lose its stalest messages, not its newest
+				.slice(-THREAD_CONTEXT_MESSAGE_LIMIT);
 
 			if (delta.length === 0) {
 				return "";
@@ -457,14 +453,19 @@ Supported mrkdwn syntax:
 		});
 	}
 
+	private isSelfMessage(msg: SlackThreadMessage, selfBotId?: string): boolean {
+		return Boolean(selfBotId && msg.bot_id === selfBotId);
+	}
+
 	private formatThreadContext(
 		messages: SlackThreadMessage[],
 		selfBotId?: string,
 	): string {
 		const formattedMessages = messages
 			.map((msg) => {
-				const isSelf = selfBotId && msg.bot_id === selfBotId;
-				const author = isSelf ? "assistant (you)" : (msg.user ?? "unknown");
+				const author = this.isSelfMessage(msg, selfBotId)
+					? "assistant (you)"
+					: (msg.user ?? "unknown");
 				return `  <message>
     <author>${author}</author>
     <timestamp>${msg.ts}</timestamp>

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -1063,6 +1063,7 @@ original ask
 			thread_ts: PARENT_TS,
 			limit: 50,
 			oldest: "1700000000.000200",
+			keep: "newest",
 		});
 		expect(result).toContain("since you last had context");
 		expect(result).toContain("we decided to use redis");
@@ -1087,6 +1088,27 @@ original ask
 		).resolves.toBe("");
 	});
 
+	it("drops a message sitting exactly on the cursor", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		vi.spyOn(
+			SlackMessageService.prototype,
+			"fetchThreadMessages",
+		).mockResolvedValue([
+			// Slack can echo the cursor message back when `inclusive` is honoured
+			{ user: "U2", text: "already seen", ts: "1700000000.000200" },
+			{ user: "U2", text: "genuinely new", ts: "1700000000.000400" },
+		] as any);
+
+		const result = await adapter.fetchThreadContextDelta(
+			mentionEvent(),
+			"1700000000.000200",
+		);
+
+		expect(result).toContain("genuinely new");
+		expect(result).not.toContain("already seen");
+	});
+
 	it("returns null when there is no bot token", async () => {
 		const adapter = new SlackChatAdapter(createStaticProvider([]));
 		const event = mentionEvent();
@@ -1095,6 +1117,22 @@ original ask
 		await expect(
 			adapter.fetchThreadContextDelta(event, "1700000000.000200"),
 		).resolves.toBeNull();
+	});
+
+	it("reports a failed initial full-window read as null, not as empty", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		vi.spyOn(
+			SlackMessageService.prototype,
+			"fetchThreadMessages",
+		).mockRejectedValue(new Error("ratelimited"));
+
+		// The cursor-less read covers the whole thread; failure must stay visible
+		await expect(
+			adapter.fetchThreadContextDelta(mentionEvent()),
+		).resolves.toBeNull();
+		// fetchThreadContext still collapses that to ""
+		await expect(adapter.fetchThreadContext(mentionEvent())).resolves.toBe("");
 	});
 
 	it("returns null when the Slack fetch fails", async () => {
@@ -1200,7 +1238,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 	const TASK = "Inspect repository configuration";
 
 	it("prefixes the resumed prompt with what was said between mentions", async () => {
-		const adapter = new CatchupAdapter("catchup-thread", ["<catch-up/>"]);
+		const adapter = new CatchupAdapter("catchup-thread", ["", "<catch-up/>"]);
 		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
 
 		await handler.handleEvent({
@@ -1216,13 +1254,13 @@ describe("ChatSessionHandler thread catch-up", () => {
 			ts: "200",
 		} as any);
 
-		// First mention took the new-session path; the second back-read from it
-		expect(adapter.sinceArgs).toEqual(["100"]);
+		// New session reads the full window; the second back-reads from there
+		expect(adapter.sinceArgs).toEqual([undefined, "100"]);
 		expect(prompts[1]).toBe(`<catch-up/>\n\n${TASK}`);
 	});
 
 	it("advances the cursor on a successful fetch even when nothing was said", async () => {
-		const adapter = new CatchupAdapter("empty-thread", ["", "<catch-up/>"]);
+		const adapter = new CatchupAdapter("empty-thread", ["", "", "<catch-up/>"]);
 		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
 
 		await handler.handleEvent({
@@ -1243,13 +1281,17 @@ describe("ChatSessionHandler thread catch-up", () => {
 			ts: "300",
 		} as any);
 
-		expect(adapter.sinceArgs).toEqual(["100", "200"]);
+		expect(adapter.sinceArgs).toEqual([undefined, "100", "200"]);
 		// An empty catch-up leaves the prompt untouched.
 		expect(prompts[1]).toBe(TASK);
 	});
 
 	it("holds the cursor when the catch-up fetch fails, retrying the window later", async () => {
-		const adapter = new CatchupAdapter("failed-thread", [null, "<catch-up/>"]);
+		const adapter = new CatchupAdapter("failed-thread", [
+			"",
+			null,
+			"<catch-up/>",
+		]);
 		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
 
 		await handler.handleEvent({
@@ -1271,13 +1313,160 @@ describe("ChatSessionHandler thread catch-up", () => {
 		} as any);
 
 		// The failed window is retried rather than skipped.
-		expect(adapter.sinceArgs).toEqual(["100", "100"]);
+		expect(adapter.sinceArgs).toEqual([undefined, "100", "100"]);
 		expect(prompts[1]).toBe(TASK);
 		expect(prompts[2]).toBe(`<catch-up/>\n\n${TASK}`);
 	});
 
+	it("holds the cursor when the initial full-window read fails", async () => {
+		const adapter = new CatchupAdapter("cold-thread", [null, "<catch-up/>"]);
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "cold-thread",
+			ts: "100",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "cold-thread",
+			ts: "200",
+		} as any);
+
+		// No cursor was set, so the next mention re-reads the whole thread
+		expect(adapter.sinceArgs).toEqual([undefined, undefined]);
+		expect(prompts[1]).toBe(`<catch-up/>\n\n${TASK}`);
+	});
+
+	it("still delivers the message when the catch-up read throws", async () => {
+		class ThrowingAdapter extends TestChatAdapter {
+			getThreadContextTs(event: TestEvent): string | undefined {
+				return event.ts;
+			}
+
+			async fetchThreadContextDelta(
+				_event: TestEvent,
+				sinceTs?: string,
+			): Promise<string | null> {
+				if (sinceTs === undefined) {
+					return "";
+				}
+				throw new Error("adapter blew up");
+			}
+		}
+
+		const adapter = new ThrowingAdapter("throwing-thread");
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "throwing-thread",
+			ts: "100",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "throwing-thread",
+			ts: "200",
+		} as any);
+
+		// A throwing context read degrades to the bare task rather than losing it
+		expect(prompts[1]).toBe(TASK);
+	});
+
+	it("never lets a concurrent mention move the cursor backwards", async () => {
+		const releases: Array<() => void> = [];
+
+		class GatedAdapter extends TestChatAdapter {
+			public sinceArgs: Array<string | undefined> = [];
+
+			getThreadContextTs(event: TestEvent): string | undefined {
+				return event.ts;
+			}
+
+			async fetchThreadContextDelta(
+				_event: TestEvent,
+				sinceTs?: string,
+			): Promise<string | null> {
+				this.sinceArgs.push(sinceTs);
+				// Gate only the two mentions raced below, to finish them out of order
+				if (this.sinceArgs.length === 2 || this.sinceArgs.length === 3) {
+					await new Promise<void>((resolve) => {
+						releases.push(resolve);
+					});
+				}
+				return "";
+			}
+		}
+
+		const adapter = new GatedAdapter("racy-thread");
+		let running = false;
+		const createRunner = vi.fn(() => {
+			running = true;
+			return {
+				supportsStreamingInput: true,
+				startStreaming: vi.fn(async () => ({ sessionId: "session-1" })),
+				start: vi.fn(),
+				stop: vi.fn(),
+				isRunning: vi.fn(() => running),
+				isStreaming: vi.fn(() => true),
+				addStreamMessage: vi.fn(),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "racy-thread",
+			ts: "100",
+		} as any);
+
+		// Two mentions in flight at once, both reading the same cursor
+		const second = handler.handleEvent({
+			eventId: "m2",
+			threadKey: "racy-thread",
+			ts: "200",
+		} as any);
+		const third = handler.handleEvent({
+			eventId: "m3",
+			threadKey: "racy-thread",
+			ts: "300",
+		} as any);
+		// Wait until both are parked on their gated read
+		for (let i = 0; i < 100 && releases.length < 2; i++) {
+			await new Promise((resolve) => setImmediate(resolve));
+		}
+		expect(releases).toHaveLength(2);
+
+		// Resolve them out of order: the newer mention lands first
+		releases[1]();
+		releases[0]();
+		await Promise.all([second, third]);
+
+		await handler.handleEvent({
+			eventId: "m4",
+			threadKey: "racy-thread",
+			ts: "400",
+		} as any);
+
+		// The straggler must not drag the cursor back to its own ts
+		expect(adapter.sinceArgs).toEqual([undefined, "100", "100", "300"]);
+	});
+
 	it("catches up when the follow-up is injected mid-turn", async () => {
-		const adapter = new CatchupAdapter("live-thread", ["<catch-up/>"]);
+		const adapter = new CatchupAdapter("live-thread", ["", "<catch-up/>"]);
 		const prompts: string[] = [];
 		let running = false;
 
@@ -1321,7 +1510,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 		} as any);
 
 		expect(createRunner).toHaveBeenCalledTimes(1);
-		expect(adapter.sinceArgs).toEqual(["100"]);
+		expect(adapter.sinceArgs).toEqual([undefined, "100"]);
 		expect(prompts[1]).toBe(`<catch-up/>\n\n${TASK}`);
 	});
 

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -1002,7 +1002,7 @@ describe("SlackChatAdapter thread catch-up", () => {
 	it("returns nothing for a message outside a thread", async () => {
 		const adapter = new SlackChatAdapter(createStaticProvider([]));
 		await expect(
-			adapter.fetchThreadContextDelta(mentionEvent(false), "1"),
+			adapter.fetchThreadContext(mentionEvent(false), "1"),
 		).resolves.toBe("");
 	});
 
@@ -1015,7 +1015,7 @@ describe("SlackChatAdapter thread catch-up", () => {
 				{ user: "U1", text: "original ask", ts: PARENT_TS },
 			] as any);
 
-		const result = await adapter.fetchThreadContextDelta(mentionEvent());
+		const result = await adapter.fetchThreadContext(mentionEvent());
 
 		// Delegates to the full-window fetch — no `oldest`, no catch-up preamble.
 		expect(fetchSpy.mock.calls[0]?.[0]).not.toHaveProperty("oldest");
@@ -1052,7 +1052,7 @@ original ask
 				{ user: "U1", text: "<@U0BOT> where were we?", ts: TRIGGER_TS },
 			] as any);
 
-		const result = await adapter.fetchThreadContextDelta(
+		const result = await adapter.fetchThreadContext(
 			mentionEvent(),
 			"1700000000.000200",
 		);
@@ -1061,9 +1061,8 @@ original ask
 			token: "xoxb-test",
 			channel: "C1",
 			thread_ts: PARENT_TS,
-			limit: 50,
+			limit: 2000,
 			oldest: "1700000000.000200",
-			keep: "newest",
 		});
 		expect(result).toContain("since you last had context");
 		expect(result).toContain("we decided to use redis");
@@ -1084,7 +1083,7 @@ original ask
 		] as any);
 
 		await expect(
-			adapter.fetchThreadContextDelta(mentionEvent(), "1700000000.000200"),
+			adapter.fetchThreadContext(mentionEvent(), "1700000000.000200"),
 		).resolves.toBe("");
 	});
 
@@ -1100,7 +1099,7 @@ original ask
 			{ user: "U2", text: "genuinely new", ts: "1700000000.000400" },
 		] as any);
 
-		const result = await adapter.fetchThreadContextDelta(
+		const result = await adapter.fetchThreadContext(
 			mentionEvent(),
 			"1700000000.000200",
 		);
@@ -1115,11 +1114,37 @@ original ask
 		delete (event as any).slackBotToken;
 
 		await expect(
-			adapter.fetchThreadContextDelta(event, "1700000000.000200"),
+			adapter.fetchThreadContext(event, "1700000000.000200"),
 		).resolves.toBeNull();
 	});
 
-	it("reports a failed initial full-window read as null, not as empty", async () => {
+	it("keeps only the newest messages of an over-long gap", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		// 60 new messages, more than a single context read carries
+		vi.spyOn(
+			SlackMessageService.prototype,
+			"fetchThreadMessages",
+		).mockResolvedValue(
+			Array.from({ length: 60 }, (_, i) => ({
+				user: "U2",
+				text: `msg ${i}`,
+				ts: `1700000000.00${String(1000 + i)}`,
+			})) as any,
+		);
+
+		const result = await adapter.fetchThreadContext(
+			mentionEvent(),
+			"1700000000.000200",
+		);
+
+		// Trimmed to the last 50, so the stalest go and the freshest stay
+		expect(result).not.toContain("msg 9\n");
+		expect(result).toContain("msg 10");
+		expect(result).toContain("msg 59");
+	});
+
+	it("returns null whether the read fails with a cursor or without one", async () => {
 		const adapter = new SlackChatAdapter(createStaticProvider([]));
 		mockIdentity();
 		vi.spyOn(
@@ -1127,24 +1152,11 @@ original ask
 			"fetchThreadMessages",
 		).mockRejectedValue(new Error("ratelimited"));
 
-		// The cursor-less read covers the whole thread; failure must stay visible
 		await expect(
-			adapter.fetchThreadContextDelta(mentionEvent()),
+			adapter.fetchThreadContext(mentionEvent()),
 		).resolves.toBeNull();
-		// fetchThreadContext still collapses that to ""
-		await expect(adapter.fetchThreadContext(mentionEvent())).resolves.toBe("");
-	});
-
-	it("returns null when the Slack fetch fails", async () => {
-		const adapter = new SlackChatAdapter(createStaticProvider([]));
-		mockIdentity();
-		vi.spyOn(
-			SlackMessageService.prototype,
-			"fetchThreadMessages",
-		).mockRejectedValue(new Error("ratelimited"));
-
 		await expect(
-			adapter.fetchThreadContextDelta(mentionEvent(), "1700000000.000200"),
+			adapter.fetchThreadContext(mentionEvent(), "1700000000.000200"),
 		).resolves.toBeNull();
 	});
 });
@@ -1165,7 +1177,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 			return event.ts;
 		}
 
-		async fetchThreadContextDelta(
+		async fetchThreadContext(
 			_event: TestEvent,
 			sinceTs?: string,
 		): Promise<string | null> {
@@ -1177,23 +1189,33 @@ describe("ChatSessionHandler thread catch-up", () => {
 		}
 	}
 
-	/** Handler whose runner is idle between events, so follow-ups resume it */
-	function buildHandler(adapter: ChatPlatformAdapter<TestEvent>) {
+	/**
+	 * Handler whose runner is idle between events, so follow-ups resume it.
+	 * With `streaming`, the runner stays live and follow-ups inject mid-turn.
+	 */
+	function buildHandler(
+		adapter: ChatPlatformAdapter<TestEvent>,
+		{ streaming = false } = {},
+	) {
 		const prompts: string[] = [];
 		let running = false;
 		let capturedConfig: any;
 
+		const capture = async (prompt: string) => {
+			prompts.push(prompt);
+			return { sessionId: "session-1" };
+		};
+
 		const createRunner = vi.fn((config: any) => {
 			capturedConfig = config;
+			running = streaming;
 			return {
-				supportsStreamingInput: false,
-				start: vi.fn(async (prompt: string) => {
-					prompts.push(prompt);
-					return { sessionId: "session-1" };
-				}),
+				supportsStreamingInput: streaming,
+				start: vi.fn(capture),
+				startStreaming: vi.fn(capture),
 				stop: vi.fn(),
 				isRunning: vi.fn(() => running),
-				isStreaming: vi.fn(() => false),
+				isStreaming: vi.fn(() => streaming),
 				addStreamMessage: vi.fn((prompt: string) => prompts.push(prompt)),
 				getMessages: vi.fn().mockReturnValue([]),
 			} as any;
@@ -1345,7 +1367,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 				return event.ts;
 			}
 
-			async fetchThreadContextDelta(
+			async fetchThreadContext(
 				_event: TestEvent,
 				sinceTs?: string,
 			): Promise<string | null> {
@@ -1385,7 +1407,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 				return event.ts;
 			}
 
-			async fetchThreadContextDelta(
+			async fetchThreadContext(
 				_event: TestEvent,
 				sinceTs?: string,
 			): Promise<string | null> {
@@ -1401,31 +1423,7 @@ describe("ChatSessionHandler thread catch-up", () => {
 		}
 
 		const adapter = new GatedAdapter("racy-thread");
-		let running = false;
-		const createRunner = vi.fn(() => {
-			running = true;
-			return {
-				supportsStreamingInput: true,
-				startStreaming: vi.fn(async () => ({ sessionId: "session-1" })),
-				start: vi.fn(),
-				stop: vi.fn(),
-				isRunning: vi.fn(() => running),
-				isStreaming: vi.fn(() => true),
-				addStreamMessage: vi.fn(),
-				getMessages: vi.fn().mockReturnValue([]),
-			} as any;
-		});
-
-		const handler = new ChatSessionHandler(adapter, {
-			cyrusHome: TEST_CYRUS_CHAT,
-			chatRepositoryProvider: createStaticProvider([]),
-			runnerConfigBuilder: createMockRunnerConfigBuilder(),
-			createRunner,
-			onWebhookStart: vi.fn(),
-			onWebhookEnd: vi.fn(),
-			onStateChange: vi.fn().mockResolvedValue(undefined),
-			onClaudeError: vi.fn(),
-		});
+		const { handler } = buildHandler(adapter, { streaming: true });
 
 		await handler.handleEvent({
 			eventId: "m1",
@@ -1467,35 +1465,8 @@ describe("ChatSessionHandler thread catch-up", () => {
 
 	it("catches up when the follow-up is injected mid-turn", async () => {
 		const adapter = new CatchupAdapter("live-thread", ["", "<catch-up/>"]);
-		const prompts: string[] = [];
-		let running = false;
-
-		const createRunner = vi.fn(() => {
-			running = true;
-			return {
-				supportsStreamingInput: true,
-				startStreaming: vi.fn(async (prompt: string) => {
-					prompts.push(prompt);
-					return { sessionId: "session-1" };
-				}),
-				start: vi.fn(),
-				stop: vi.fn(),
-				isRunning: vi.fn(() => running),
-				isStreaming: vi.fn(() => true),
-				addStreamMessage: vi.fn((prompt: string) => prompts.push(prompt)),
-				getMessages: vi.fn().mockReturnValue([]),
-			} as any;
-		});
-
-		const handler = new ChatSessionHandler(adapter, {
-			cyrusHome: TEST_CYRUS_CHAT,
-			chatRepositoryProvider: createStaticProvider([]),
-			runnerConfigBuilder: createMockRunnerConfigBuilder(),
-			createRunner,
-			onWebhookStart: vi.fn(),
-			onWebhookEnd: vi.fn(),
-			onStateChange: vi.fn().mockResolvedValue(undefined),
-			onClaudeError: vi.fn(),
+		const { handler, prompts, createRunner } = buildHandler(adapter, {
+			streaming: true,
 		});
 
 		await handler.handleEvent({

--- a/packages/edge-worker/test/chat-sessions.test.ts
+++ b/packages/edge-worker/test/chat-sessions.test.ts
@@ -69,6 +69,8 @@ function createStaticProvider(
 interface TestEvent {
 	eventId: string;
 	threadKey: string;
+	/** Thread position, used by adapters that support catch-up */
+	ts?: string;
 }
 
 class TestChatAdapter implements ChatPlatformAdapter<TestEvent> {
@@ -963,5 +965,380 @@ describe("LiveChatRepositoryProvider", () => {
 		const provider = new LiveChatRepositoryProvider(repos, () => workspaces);
 
 		expect(provider.getDefaultLinearWorkspaceId()).toBe("ws1");
+	});
+});
+
+describe("SlackChatAdapter thread catch-up", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.SLACK_BOT_TOKEN;
+	});
+
+	const TRIGGER_TS = "1700000000.000500";
+	const PARENT_TS = "1700000000.000100";
+
+	const mentionEvent = (thread = true): SlackWebhookEvent =>
+		({
+			eventType: "app_mention",
+			eventId: "Ev2",
+			teamId: "T1",
+			slackBotToken: "xoxb-test",
+			payload: {
+				type: "app_mention",
+				user: "U1",
+				channel: "C1",
+				text: "<@U0BOT> where were we?",
+				ts: TRIGGER_TS,
+				...(thread ? { thread_ts: PARENT_TS } : {}),
+				event_ts: TRIGGER_TS,
+			},
+		}) as SlackWebhookEvent;
+
+	const mockIdentity = () =>
+		vi
+			.spyOn(SlackMessageService.prototype, "getIdentity")
+			.mockResolvedValue({ bot_id: "B0BOT" } as any);
+
+	it("returns nothing for a message outside a thread", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		await expect(
+			adapter.fetchThreadContextDelta(mentionEvent(false), "1"),
+		).resolves.toBe("");
+	});
+
+	it("falls back to the full thread window when no cursor is known", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		const fetchSpy = vi
+			.spyOn(SlackMessageService.prototype, "fetchThreadMessages")
+			.mockResolvedValue([
+				{ user: "U1", text: "original ask", ts: PARENT_TS },
+			] as any);
+
+		const result = await adapter.fetchThreadContextDelta(mentionEvent());
+
+		// Delegates to the full-window fetch — no `oldest`, no catch-up preamble.
+		expect(fetchSpy.mock.calls[0]?.[0]).not.toHaveProperty("oldest");
+		expect(result).toBe(
+			`<slack_thread_context>
+  <message>
+    <author>U1</author>
+    <timestamp>${PARENT_TS}</timestamp>
+    <content>
+original ask
+    </content>
+  </message>
+</slack_thread_context>`,
+		);
+	});
+
+	it("asks Slack for messages after the cursor and drops the ones already known", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		const fetchSpy = vi
+			.spyOn(SlackMessageService.prototype, "fetchThreadMessages")
+			.mockResolvedValue([
+				// Slack returns the thread parent regardless of `oldest`
+				{ user: "U1", text: "original ask", ts: PARENT_TS },
+				// our own earlier reply — already in the session's memory
+				{ text: "on it", ts: "1700000000.000300", bot_id: "B0BOT" },
+				// the inter-tag discussion we actually want
+				{
+					user: "U2",
+					text: "we decided to use redis",
+					ts: "1700000000.000400",
+				},
+				// the triggering message — already in the task instructions
+				{ user: "U1", text: "<@U0BOT> where were we?", ts: TRIGGER_TS },
+			] as any);
+
+		const result = await adapter.fetchThreadContextDelta(
+			mentionEvent(),
+			"1700000000.000200",
+		);
+
+		expect(fetchSpy).toHaveBeenCalledWith({
+			token: "xoxb-test",
+			channel: "C1",
+			thread_ts: PARENT_TS,
+			limit: 50,
+			oldest: "1700000000.000200",
+		});
+		expect(result).toContain("since you last had context");
+		expect(result).toContain("we decided to use redis");
+		expect(result).not.toContain("original ask");
+		expect(result).not.toContain("on it");
+		expect(result).not.toContain("where were we?");
+	});
+
+	it("returns an empty string when nothing new was said", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		vi.spyOn(
+			SlackMessageService.prototype,
+			"fetchThreadMessages",
+		).mockResolvedValue([
+			{ user: "U1", text: "original ask", ts: PARENT_TS },
+			{ user: "U1", text: "<@U0BOT> where were we?", ts: TRIGGER_TS },
+		] as any);
+
+		await expect(
+			adapter.fetchThreadContextDelta(mentionEvent(), "1700000000.000200"),
+		).resolves.toBe("");
+	});
+
+	it("returns null when there is no bot token", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		const event = mentionEvent();
+		delete (event as any).slackBotToken;
+
+		await expect(
+			adapter.fetchThreadContextDelta(event, "1700000000.000200"),
+		).resolves.toBeNull();
+	});
+
+	it("returns null when the Slack fetch fails", async () => {
+		const adapter = new SlackChatAdapter(createStaticProvider([]));
+		mockIdentity();
+		vi.spyOn(
+			SlackMessageService.prototype,
+			"fetchThreadMessages",
+		).mockRejectedValue(new Error("ratelimited"));
+
+		await expect(
+			adapter.fetchThreadContextDelta(mentionEvent(), "1700000000.000200"),
+		).resolves.toBeNull();
+	});
+});
+
+describe("ChatSessionHandler thread catch-up", () => {
+	/** Adapter that supports catch-up, with a scripted queue of delta results */
+	class CatchupAdapter extends TestChatAdapter {
+		public sinceArgs: Array<string | undefined> = [];
+
+		constructor(
+			threadKey: string,
+			private readonly deltas: Array<string | null>,
+		) {
+			super(threadKey);
+		}
+
+		getThreadContextTs(event: TestEvent): string | undefined {
+			return event.ts;
+		}
+
+		async fetchThreadContextDelta(
+			_event: TestEvent,
+			sinceTs?: string,
+		): Promise<string | null> {
+			this.sinceArgs.push(sinceTs);
+			// Not `?? ""` — a scripted null means a fetch failure
+			return this.deltas.length > 0
+				? (this.deltas.shift() as string | null)
+				: "";
+		}
+	}
+
+	/** Handler whose runner is idle between events, so follow-ups resume it */
+	function buildHandler(adapter: ChatPlatformAdapter<TestEvent>) {
+		const prompts: string[] = [];
+		let running = false;
+		let capturedConfig: any;
+
+		const createRunner = vi.fn((config: any) => {
+			capturedConfig = config;
+			return {
+				supportsStreamingInput: false,
+				start: vi.fn(async (prompt: string) => {
+					prompts.push(prompt);
+					return { sessionId: "session-1" };
+				}),
+				stop: vi.fn(),
+				isRunning: vi.fn(() => running),
+				isStreaming: vi.fn(() => false),
+				addStreamMessage: vi.fn((prompt: string) => prompts.push(prompt)),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		/** Give the session a runner session id so follow-ups resume it */
+		const bindResumableSession = async () => {
+			await capturedConfig.onMessage({
+				type: "system",
+				subtype: "init",
+				session_id: "session-1",
+				model: "claude-test",
+				tools: [],
+				permissionMode: "default",
+				apiKeySource: "test",
+			});
+			await new Promise((resolve) => setImmediate(resolve));
+		};
+
+		return {
+			handler,
+			prompts,
+			createRunner,
+			bindResumableSession,
+			setRunning: (value: boolean) => {
+				running = value;
+			},
+		};
+	}
+
+	const TASK = "Inspect repository configuration";
+
+	it("prefixes the resumed prompt with what was said between mentions", async () => {
+		const adapter = new CatchupAdapter("catchup-thread", ["<catch-up/>"]);
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "mention-1",
+			threadKey: "catchup-thread",
+			ts: "100",
+		} as any);
+		await bindResumableSession();
+
+		await handler.handleEvent({
+			eventId: "mention-2",
+			threadKey: "catchup-thread",
+			ts: "200",
+		} as any);
+
+		// First mention took the new-session path; the second back-read from it
+		expect(adapter.sinceArgs).toEqual(["100"]);
+		expect(prompts[1]).toBe(`<catch-up/>\n\n${TASK}`);
+	});
+
+	it("advances the cursor on a successful fetch even when nothing was said", async () => {
+		const adapter = new CatchupAdapter("empty-thread", ["", "<catch-up/>"]);
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "empty-thread",
+			ts: "100",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "empty-thread",
+			ts: "200",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m3",
+			threadKey: "empty-thread",
+			ts: "300",
+		} as any);
+
+		expect(adapter.sinceArgs).toEqual(["100", "200"]);
+		// An empty catch-up leaves the prompt untouched.
+		expect(prompts[1]).toBe(TASK);
+	});
+
+	it("holds the cursor when the catch-up fetch fails, retrying the window later", async () => {
+		const adapter = new CatchupAdapter("failed-thread", [null, "<catch-up/>"]);
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "failed-thread",
+			ts: "100",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "failed-thread",
+			ts: "200",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m3",
+			threadKey: "failed-thread",
+			ts: "300",
+		} as any);
+
+		// The failed window is retried rather than skipped.
+		expect(adapter.sinceArgs).toEqual(["100", "100"]);
+		expect(prompts[1]).toBe(TASK);
+		expect(prompts[2]).toBe(`<catch-up/>\n\n${TASK}`);
+	});
+
+	it("catches up when the follow-up is injected mid-turn", async () => {
+		const adapter = new CatchupAdapter("live-thread", ["<catch-up/>"]);
+		const prompts: string[] = [];
+		let running = false;
+
+		const createRunner = vi.fn(() => {
+			running = true;
+			return {
+				supportsStreamingInput: true,
+				startStreaming: vi.fn(async (prompt: string) => {
+					prompts.push(prompt);
+					return { sessionId: "session-1" };
+				}),
+				start: vi.fn(),
+				stop: vi.fn(),
+				isRunning: vi.fn(() => running),
+				isStreaming: vi.fn(() => true),
+				addStreamMessage: vi.fn((prompt: string) => prompts.push(prompt)),
+				getMessages: vi.fn().mockReturnValue([]),
+			} as any;
+		});
+
+		const handler = new ChatSessionHandler(adapter, {
+			cyrusHome: TEST_CYRUS_CHAT,
+			chatRepositoryProvider: createStaticProvider([]),
+			runnerConfigBuilder: createMockRunnerConfigBuilder(),
+			createRunner,
+			onWebhookStart: vi.fn(),
+			onWebhookEnd: vi.fn(),
+			onStateChange: vi.fn().mockResolvedValue(undefined),
+			onClaudeError: vi.fn(),
+		});
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "live-thread",
+			ts: "100",
+		} as any);
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "live-thread",
+			ts: "200",
+		} as any);
+
+		expect(createRunner).toHaveBeenCalledTimes(1);
+		expect(adapter.sinceArgs).toEqual(["100"]);
+		expect(prompts[1]).toBe(`<catch-up/>\n\n${TASK}`);
+	});
+
+	it("leaves adapters without catch-up support untouched", async () => {
+		const adapter = new TestChatAdapter("plain-thread");
+		const { handler, prompts, bindResumableSession } = buildHandler(adapter);
+
+		await handler.handleEvent({
+			eventId: "m1",
+			threadKey: "plain-thread",
+		} as any);
+		await bindResumableSession();
+		await handler.handleEvent({
+			eventId: "m2",
+			threadKey: "plain-thread",
+		} as any);
+
+		expect(prompts).toEqual([TASK, TASK]);
 	});
 });

--- a/packages/slack-event-transport/src/SlackMessageService.ts
+++ b/packages/slack-event-transport/src/SlackMessageService.ts
@@ -5,6 +5,9 @@
  * typically used to reply to @mention webhooks in a thread.
  */
 
+/** Bounds the full pagination pass that `keep: "newest"` requires. */
+const MAX_PAGES_WHEN_KEEPING_NEWEST = 10;
+
 /**
  * A single message from a Slack thread (conversations.replies)
  */
@@ -39,6 +42,11 @@ export interface SlackFetchThreadParams {
 	 * recent messages in a thread longer than `limit`.
 	 */
 	oldest?: string;
+	/**
+	 * Which end to keep when more than `limit` messages match. A thread is
+	 * returned oldest-first, so "newest" must walk every page before slicing.
+	 */
+	keep?: "oldest" | "newest";
 }
 
 /**
@@ -154,15 +162,30 @@ export class SlackMessageService {
 	async fetchThreadMessages(
 		params: SlackFetchThreadParams,
 	): Promise<SlackThreadMessage[]> {
-		const { token, channel, thread_ts, limit = 100, oldest } = params;
+		const {
+			token,
+			channel,
+			thread_ts,
+			limit = 100,
+			oldest,
+			keep = "oldest",
+		} = params;
 		const messages: SlackThreadMessage[] = [];
 		let cursor: string | undefined;
+		let pages = 0;
 
-		while (messages.length < limit) {
+		while (
+			keep === "newest"
+				? pages < MAX_PAGES_WHEN_KEEPING_NEWEST
+				: messages.length < limit
+		) {
+			pages++;
 			const queryParams = new URLSearchParams({
 				channel,
 				ts: thread_ts,
-				limit: String(Math.min(limit - messages.length, 200)),
+				limit: String(
+					keep === "newest" ? 200 : Math.min(limit - messages.length, 200),
+				),
 			});
 			if (oldest) {
 				queryParams.set("oldest", oldest);
@@ -214,6 +237,8 @@ export class SlackMessageService {
 		}
 
 		// Enforce limit
-		return messages.slice(0, limit);
+		return keep === "newest"
+			? messages.slice(-limit)
+			: messages.slice(0, limit);
 	}
 }

--- a/packages/slack-event-transport/src/SlackMessageService.ts
+++ b/packages/slack-event-transport/src/SlackMessageService.ts
@@ -33,6 +33,12 @@ export interface SlackFetchThreadParams {
 	thread_ts: string;
 	/** Maximum number of messages to fetch (default 100) */
 	limit?: number;
+	/**
+	 * Only fetch messages after this timestamp. Must be server-side: pagination
+	 * walks from the thread head, so a client-side filter would never reach
+	 * recent messages in a thread longer than `limit`.
+	 */
+	oldest?: string;
 }
 
 /**
@@ -148,7 +154,7 @@ export class SlackMessageService {
 	async fetchThreadMessages(
 		params: SlackFetchThreadParams,
 	): Promise<SlackThreadMessage[]> {
-		const { token, channel, thread_ts, limit = 100 } = params;
+		const { token, channel, thread_ts, limit = 100, oldest } = params;
 		const messages: SlackThreadMessage[] = [];
 		let cursor: string | undefined;
 
@@ -158,6 +164,9 @@ export class SlackMessageService {
 				ts: thread_ts,
 				limit: String(Math.min(limit - messages.length, 200)),
 			});
+			if (oldest) {
+				queryParams.set("oldest", oldest);
+			}
 			if (cursor) {
 				queryParams.set("cursor", cursor);
 			}

--- a/packages/slack-event-transport/src/SlackMessageService.ts
+++ b/packages/slack-event-transport/src/SlackMessageService.ts
@@ -5,9 +5,6 @@
  * typically used to reply to @mention webhooks in a thread.
  */
 
-/** Bounds the full pagination pass that `keep: "newest"` requires. */
-const MAX_PAGES_WHEN_KEEPING_NEWEST = 10;
-
 /**
  * A single message from a Slack thread (conversations.replies)
  */
@@ -42,11 +39,6 @@ export interface SlackFetchThreadParams {
 	 * recent messages in a thread longer than `limit`.
 	 */
 	oldest?: string;
-	/**
-	 * Which end to keep when more than `limit` messages match. A thread is
-	 * returned oldest-first, so "newest" must walk every page before slicing.
-	 */
-	keep?: "oldest" | "newest";
 }
 
 /**
@@ -162,30 +154,15 @@ export class SlackMessageService {
 	async fetchThreadMessages(
 		params: SlackFetchThreadParams,
 	): Promise<SlackThreadMessage[]> {
-		const {
-			token,
-			channel,
-			thread_ts,
-			limit = 100,
-			oldest,
-			keep = "oldest",
-		} = params;
+		const { token, channel, thread_ts, limit = 100, oldest } = params;
 		const messages: SlackThreadMessage[] = [];
 		let cursor: string | undefined;
-		let pages = 0;
 
-		while (
-			keep === "newest"
-				? pages < MAX_PAGES_WHEN_KEEPING_NEWEST
-				: messages.length < limit
-		) {
-			pages++;
+		while (messages.length < limit) {
 			const queryParams = new URLSearchParams({
 				channel,
 				ts: thread_ts,
-				limit: String(
-					keep === "newest" ? 200 : Math.min(limit - messages.length, 200),
-				),
+				limit: String(Math.min(limit - messages.length, 200)),
 			});
 			if (oldest) {
 				queryParams.set("oldest", oldest);
@@ -237,8 +214,6 @@ export class SlackMessageService {
 		}
 
 		// Enforce limit
-		return keep === "newest"
-			? messages.slice(-limit)
-			: messages.slice(0, limit);
+		return messages.slice(0, limit);
 	}
 }

--- a/packages/slack-event-transport/test/SlackMessageService.test.ts
+++ b/packages/slack-event-transport/test/SlackMessageService.test.ts
@@ -249,6 +249,83 @@ describe("SlackMessageService", () => {
 			expect(calledUrl.searchParams.get("limit")).toBe("2");
 		});
 
+		it("passes oldest through so Slack filters server-side", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					ok: true,
+					messages: [{ user: "U111", text: "Newer", ts: "1704110400.000900" }],
+					has_more: false,
+				}),
+			});
+
+			await service.fetchThreadMessages({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+				limit: 50,
+				oldest: "1704110400.000500",
+			});
+
+			const calledUrl = new URL(mockFetch.mock.calls[0][0]);
+			expect(calledUrl.searchParams.get("oldest")).toBe("1704110400.000500");
+			expect(calledUrl.searchParams.get("limit")).toBe("50");
+		});
+
+		it("omits oldest when it is not supplied", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ ok: true, messages: [], has_more: false }),
+			});
+
+			await service.fetchThreadMessages({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+			});
+
+			const calledUrl = new URL(mockFetch.mock.calls[0][0]);
+			expect(calledUrl.searchParams.has("oldest")).toBe(false);
+		});
+
+		it("keeps oldest on paginated follow-up requests", async () => {
+			mockFetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({
+						ok: true,
+						messages: [
+							{ user: "U111", text: "Page 1", ts: "1704110400.000600" },
+						],
+						has_more: true,
+						response_metadata: { next_cursor: "cursor_abc" },
+					}),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({
+						ok: true,
+						messages: [
+							{ user: "U222", text: "Page 2", ts: "1704110400.000700" },
+						],
+						has_more: false,
+					}),
+				});
+
+			await service.fetchThreadMessages({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+				oldest: "1704110400.000500",
+			});
+
+			const secondCallUrl = new URL(mockFetch.mock.calls[1][0]);
+			expect(secondCallUrl.searchParams.get("oldest")).toBe(
+				"1704110400.000500",
+			);
+			expect(secondCallUrl.searchParams.get("cursor")).toBe("cursor_abc");
+		});
+
 		it("throws on non-OK HTTP response", async () => {
 			mockFetch.mockResolvedValueOnce({
 				ok: false,

--- a/packages/slack-event-transport/test/SlackMessageService.test.ts
+++ b/packages/slack-event-transport/test/SlackMessageService.test.ts
@@ -272,6 +272,66 @@ describe("SlackMessageService", () => {
 			expect(calledUrl.searchParams.get("limit")).toBe("50");
 		});
 
+		it("keeps the newest messages when keep is newest", async () => {
+			mockFetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({
+						ok: true,
+						messages: [
+							{ user: "U111", text: "Stalest", ts: "1704110400.000100" },
+							{ user: "U222", text: "Middle", ts: "1704110400.000200" },
+						],
+						has_more: true,
+						response_metadata: { next_cursor: "page2" },
+					}),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => ({
+						ok: true,
+						messages: [
+							{ user: "U333", text: "Recent", ts: "1704110400.000300" },
+							{ user: "U444", text: "Newest", ts: "1704110400.000400" },
+						],
+						has_more: false,
+					}),
+				});
+
+			const result = await service.fetchThreadMessages({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+				limit: 2,
+				keep: "newest",
+			});
+
+			// keep: "oldest" would have stopped at page 1 with Stalest/Middle
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+			expect(result.map((m) => m.text)).toEqual(["Recent", "Newest"]);
+		});
+
+		it("returns everything when keep is newest and the gap fits the limit", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					ok: true,
+					messages: [{ user: "U111", text: "Only", ts: "1704110400.000100" }],
+					has_more: false,
+				}),
+			});
+
+			const result = await service.fetchThreadMessages({
+				token: "xoxb-test-token",
+				channel: "C9876543210",
+				thread_ts: "1704110400.000100",
+				limit: 50,
+				keep: "newest",
+			});
+
+			expect(result.map((m) => m.text)).toEqual(["Only"]);
+		});
+
 		it("omits oldest when it is not supplied", async () => {
 			mockFetch.mockResolvedValueOnce({
 				ok: true,

--- a/packages/slack-event-transport/test/SlackMessageService.test.ts
+++ b/packages/slack-event-transport/test/SlackMessageService.test.ts
@@ -272,66 +272,6 @@ describe("SlackMessageService", () => {
 			expect(calledUrl.searchParams.get("limit")).toBe("50");
 		});
 
-		it("keeps the newest messages when keep is newest", async () => {
-			mockFetch
-				.mockResolvedValueOnce({
-					ok: true,
-					json: async () => ({
-						ok: true,
-						messages: [
-							{ user: "U111", text: "Stalest", ts: "1704110400.000100" },
-							{ user: "U222", text: "Middle", ts: "1704110400.000200" },
-						],
-						has_more: true,
-						response_metadata: { next_cursor: "page2" },
-					}),
-				})
-				.mockResolvedValueOnce({
-					ok: true,
-					json: async () => ({
-						ok: true,
-						messages: [
-							{ user: "U333", text: "Recent", ts: "1704110400.000300" },
-							{ user: "U444", text: "Newest", ts: "1704110400.000400" },
-						],
-						has_more: false,
-					}),
-				});
-
-			const result = await service.fetchThreadMessages({
-				token: "xoxb-test-token",
-				channel: "C9876543210",
-				thread_ts: "1704110400.000100",
-				limit: 2,
-				keep: "newest",
-			});
-
-			// keep: "oldest" would have stopped at page 1 with Stalest/Middle
-			expect(mockFetch).toHaveBeenCalledTimes(2);
-			expect(result.map((m) => m.text)).toEqual(["Recent", "Newest"]);
-		});
-
-		it("returns everything when keep is newest and the gap fits the limit", async () => {
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: async () => ({
-					ok: true,
-					messages: [{ user: "U111", text: "Only", ts: "1704110400.000100" }],
-					has_more: false,
-				}),
-			});
-
-			const result = await service.fetchThreadMessages({
-				token: "xoxb-test-token",
-				channel: "C9876543210",
-				thread_ts: "1704110400.000100",
-				limit: 50,
-				keep: "newest",
-			});
-
-			expect(result.map((m) => m.text)).toEqual(["Only"]);
-		});
-
 		it("omits oldest when it is not supplied", async () => {
 			mockFetch.mockResolvedValueOnce({
 				ok: true,


### PR DESCRIPTION
## What & Why

Re-mentioning Cyrus in an existing Slack thread only passed along the new
message, so anything discussed since the previous mention was lost. The gap is
most visible with thread following disabled, where untagged messages never reach
Cyrus at all — someone answers a question in the thread, Cyrus gets re-tagged,
and it responds as if that exchange never happened.

Sessions now track how far their thread context extends and back-read the
missing window on re-tag.

The governing invariant: **the cursor may only advance past messages the agent
actually received.**

<img width="801" height="660" alt="image" src="https://github.com/user-attachments/assets/c24d4774-2e3d-4dbb-a7e2-3e8834f78e30" />


## How to Test

Automated:

```bash
pnpm --filter cyrus-edge-worker test:run          # 749 passed
pnpm --filter cyrus-slack-event-transport test:run # 84 passed
pnpm typecheck
```

Coverage lives in `packages/edge-worker/test/chat-sessions.test.ts` and
`packages/slack-event-transport/test/SlackMessageService.test.ts`, and is
behavioural rather than mock-shaped — the cursor-hold cases assert that the same
window is re-requested on the next mention, and the concurrency case races two
mentions through gated reads that resolve out of order, then asserts the third
read starts from the newer position.

Manual, with `slackThreadFollowing` disabled:

1. `@mention` Cyrus in a channel to open a thread and let it reply.
2. Post two or three messages in that thread **without** tagging Cyrus.
3. `@mention` Cyrus again in the same thread.
4. Cyrus's prompt should include the untagged messages under a
   "posted in this thread since you last had context" preamble.
5. Repeat with thread following enabled and confirm the messages are not
   duplicated.

## Checklist

- [x] Self-reviewed the diff
- [x] Tests added / updated (or N/A — explain why)
- [x] No secrets or env values hardcoded
- [x] Docs updated if behavior changed

## Notes for Reviewer

Two bounded residual gaps, called out rather than left implicit:

- **Delivery failure.** The watermark advances once the *read* succeeds, not
  once the runner accepts the prompt. If `start`/`addStreamMessage` fails
  afterwards, that window is skipped. Rolling it back needs care given the
  monotonic guard, so it is deliberately left out of this PR.
- **Very long gaps.** Keeping the newest messages requires walking every page,
  so the walk is capped (10 pages × 200). Beyond ~2000 messages in a single gap
  the read still truncates — a far larger window than the previous 50, but not
  unbounded.

The extra `conversations.replies` call per event is also worth a look: with
thread following *enabled* every thread message already reaches Cyrus, so the
catch-up read is usually redundant there. Gating the read on `app_mention`
events would keep the cost on the path that actually needs it, if you'd prefer
that in this PR.
