### PR TITLE
feat(edge-worker): load external local plugins from ~/.cyrus/plugins

### DIFF
--- a/packages/claude-runner/src/session-env.ts
+++ b/packages/claude-runner/src/session-env.ts
@@ -26,8 +26,12 @@ const AUTH_ENV_KEYS = [
  *
  * - MCP_CONNECTION_NONBLOCKING lets MCP servers connect in the background so
  *   both cold-start and pre-warm sessions return faster.
+ * - CYRUS_AGENT_SESSION marks the session as a headless Cyrus agent session so
+ *   skills and tooling can detect agent mode deterministically (e.g. relax
+ *   interactive approval checkpoints that would otherwise stall unattended runs).
  */
 export const CYRUS_SESSION_ENV = {
+	CYRUS_AGENT_SESSION: "1",
 	CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1",
 	CLAUDE_CODE_ENABLE_TASKS: "true",
 	CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1",

--- a/packages/edge-worker/src/SkillsPluginResolver.ts
+++ b/packages/edge-worker/src/SkillsPluginResolver.ts
@@ -35,20 +35,26 @@ interface SkillScope {
 /**
  * Resolves skills plugins for agent sessions.
  *
- * Two plugin sources are supported:
+ * Three plugin sources are supported:
  * 1. Internal plugin — default Cyrus workflow skills deployed to ~/.cyrus/cyrus-skills-plugin/
  *    (editable by the user)
  * 2. User skills plugin — custom skills managed by the CYHOST UI at ~/.cyrus/user-skills-plugin/
+ * 3. External plugins — full Claude Code plugins (skills, agents, commands) dropped
+ *    into ~/.cyrus/plugins/<name>/, each identified by its own
+ *    .claude-plugin/plugin.json manifest. A directory entry may be a symlink to a
+ *    plugin repo cloned elsewhere on the host.
  *
- * Both live outside the repository so they are never committed to the user's repo.
+ * All live outside the repository so they are never committed to the user's repo.
  *
- * Plugin ordering: user plugin is loaded before internal plugin so that
- * user-defined skills take precedence over internal skills with the same name.
+ * Plugin ordering: user plugin, then external plugins (alphabetical), then the
+ * internal plugin, so user-defined skills take precedence over external ones and
+ * both take precedence over internal skills with the same name.
  */
 export class SkillsPluginResolver {
 	private readonly internalPluginPath: string;
 	private readonly userPluginPath: string;
 	private readonly userSkillsDir: string;
+	private readonly externalPluginsDir: string;
 
 	constructor(
 		private readonly cyrusHome: string,
@@ -57,6 +63,7 @@ export class SkillsPluginResolver {
 		this.internalPluginPath = join(this.cyrusHome, "cyrus-skills-plugin");
 		this.userPluginPath = join(this.cyrusHome, "user-skills-plugin");
 		this.userSkillsDir = join(this.userPluginPath, "skills");
+		this.externalPluginsDir = join(this.cyrusHome, "plugins");
 	}
 
 	/**
@@ -119,11 +126,13 @@ export class SkillsPluginResolver {
 	async resolve(): Promise<SdkPluginConfig[]> {
 		const plugins: SdkPluginConfig[] = [];
 
-		// User plugin first — user skills override internal skills
+		// User plugin first — user skills override external and internal skills
 		const user = await this.resolveUserPlugin();
 		if (user) {
 			plugins.push(user);
 		}
+
+		plugins.push(...(await this.resolveExternalPlugins()));
 
 		const internal = await this.resolveInternalPlugin();
 		if (internal) {
@@ -363,6 +372,47 @@ export class SkillsPluginResolver {
 		return null;
 	}
 
+	/**
+	 * Discover external plugins under `~/.cyrus/plugins/`.
+	 *
+	 * Each immediate subdirectory (or symlink) holding a
+	 * `.claude-plugin/plugin.json` manifest is treated as a full local plugin —
+	 * the SDK loads its skills, agents, and commands under the name declared in
+	 * that manifest. Entries without a manifest are skipped with a warning so a
+	 * half-copied plugin fails loudly rather than silently. Returned in
+	 * alphabetical order for deterministic precedence.
+	 */
+	private async resolveExternalPlugins(): Promise<SdkPluginConfig[]> {
+		let entries: string[];
+		try {
+			const dirents = await readdir(this.externalPluginsDir, {
+				withFileTypes: true,
+			});
+			entries = dirents
+				.filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+				.map((entry) => entry.name)
+				.sort();
+		} catch {
+			// ~/.cyrus/plugins/ doesn't exist — external plugins not in use
+			return [];
+		}
+
+		const plugins: SdkPluginConfig[] = [];
+		for (const name of entries) {
+			const pluginPath = join(this.externalPluginsDir, name);
+			const manifestPath = join(pluginPath, ".claude-plugin", "plugin.json");
+			if (!(await this.exists(manifestPath))) {
+				this.logger.warn(
+					`Ignoring ${pluginPath}: no .claude-plugin/plugin.json manifest`,
+				);
+				continue;
+			}
+			this.logger.debug(`Using external plugin at ${pluginPath}`);
+			plugins.push({ type: "local", path: pluginPath });
+		}
+		return plugins;
+	}
+
 	private async resolveUserPlugin(): Promise<SdkPluginConfig | null> {
 		const manifestPath = join(
 			this.userPluginPath,
@@ -378,36 +428,35 @@ export class SkillsPluginResolver {
 	}
 
 	/**
-	 * Detect and log skill name conflicts between user and internal plugins.
+	 * Detect and log skill name conflicts across plugins. Earlier plugins in
+	 * the resolved order shadow later ones (user > external > internal).
 	 */
 	private async logConflicts(plugins: SdkPluginConfig[]): Promise<void> {
 		if (plugins.length < 2) {
 			return;
 		}
 
-		const skillSets: string[][] = [];
+		const seen = new Set<string>();
 		for (const plugin of plugins) {
 			const skillsDir = join(plugin.path, "skills");
+			let names: string[] = [];
 			try {
 				const entries = await readdir(skillsDir, { withFileTypes: true });
-				skillSets.push(
-					entries
-						.filter((e) => e.isDirectory() || e.isSymbolicLink())
-						.map((e) => e.name),
-				);
+				names = entries
+					.filter((e) => e.isDirectory() || e.isSymbolicLink())
+					.map((e) => e.name);
 			} catch {
-				skillSets.push([]);
+				// no skills dir — nothing to conflict
 			}
-		}
 
-		// First set is user, second is internal — find overlap
-		if (skillSets.length >= 2 && skillSets[0] && skillSets[1]) {
-			const userSkills = new Set(skillSets[0]);
-			const conflicts = skillSets[1].filter((s) => userSkills.has(s));
+			const conflicts = names.filter((s) => seen.has(s));
 			if (conflicts.length > 0) {
 				this.logger.info(
-					`User skills override internal skills: ${conflicts.join(", ")}`,
+					`Skills in ${plugin.path} are shadowed by an earlier plugin: ${conflicts.join(", ")}`,
 				);
+			}
+			for (const name of names) {
+				seen.add(name);
 			}
 		}
 	}

--- a/packages/edge-worker/test/SkillsPluginResolver.external.test.ts
+++ b/packages/edge-worker/test/SkillsPluginResolver.external.test.ts
@@ -1,0 +1,159 @@
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ILogger } from "cyrus-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SkillsPluginResolver } from "../src/SkillsPluginResolver.js";
+
+function createTestLogger(): ILogger {
+	return {
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		debug: () => {},
+		withContext: () => createTestLogger(),
+	} as unknown as ILogger;
+}
+
+async function writeUserPluginManifest(cyrusHome: string): Promise<void> {
+	const manifestDir = join(cyrusHome, "user-skills-plugin", ".claude-plugin");
+	await mkdir(manifestDir, { recursive: true });
+	await writeFile(
+		join(manifestDir, "plugin.json"),
+		JSON.stringify({ name: "user-skills", description: "" }),
+		"utf-8",
+	);
+}
+
+async function writeSkill(pluginRoot: string, name: string): Promise<void> {
+	const skillDir = join(pluginRoot, "skills", name);
+	await mkdir(skillDir, { recursive: true });
+	await writeFile(
+		join(skillDir, "SKILL.md"),
+		`---\nname: ${name}\ndescription: test ${name}\n---\n\nbody\n`,
+		"utf-8",
+	);
+}
+
+/**
+ * Create an external plugin at `<cyrusHome>/plugins/<dirName>` with a
+ * `.claude-plugin/plugin.json` manifest, unless `withManifest` is false.
+ */
+async function writeExternalPlugin(
+	cyrusHome: string,
+	dirName: string,
+	options: { withManifest?: boolean; skills?: string[] } = {},
+): Promise<string> {
+	const { withManifest = true, skills = [] } = options;
+	const pluginRoot = join(cyrusHome, "plugins", dirName);
+	await mkdir(pluginRoot, { recursive: true });
+	if (withManifest) {
+		const manifestDir = join(pluginRoot, ".claude-plugin");
+		await mkdir(manifestDir, { recursive: true });
+		await writeFile(
+			join(manifestDir, "plugin.json"),
+			JSON.stringify({ name: dirName, description: `test ${dirName}` }),
+			"utf-8",
+		);
+	}
+	for (const skill of skills) {
+		await writeSkill(pluginRoot, skill);
+	}
+	return pluginRoot;
+}
+
+describe("SkillsPluginResolver external plugin discovery", () => {
+	let home: string;
+	let outside: string;
+	let resolver: SkillsPluginResolver;
+
+	beforeEach(async () => {
+		const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		home = join(tmpdir(), `cyrus-external-home-${stamp}`);
+		outside = join(tmpdir(), `cyrus-external-outside-${stamp}`);
+		await mkdir(home, { recursive: true });
+		await mkdir(outside, { recursive: true });
+		resolver = new SkillsPluginResolver(home, createTestLogger());
+	});
+
+	afterEach(async () => {
+		for (const dir of [home, outside]) {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves plugins from ~/.cyrus/plugins that carry a manifest", async () => {
+		const pluginRoot = await writeExternalPlugin(home, "sesai", {
+			skills: ["plan-writing"],
+		});
+
+		const plugins = await resolver.resolve();
+
+		expect(plugins.map((p) => p.path)).toContain(pluginRoot);
+	});
+
+	it("includes external plugin skills in the discovered skill names", async () => {
+		await writeExternalPlugin(home, "sesai", {
+			skills: ["plan-writing", "linear-workflow"],
+		});
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins, {
+			repositoryId: "repo-a",
+		});
+
+		expect(names).toContain("plan-writing");
+		expect(names).toContain("linear-workflow");
+	});
+
+	it("skips directories without a plugin manifest", async () => {
+		const pluginRoot = await writeExternalPlugin(home, "half-copied", {
+			withManifest: false,
+			skills: ["orphan-skill"],
+		});
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins);
+
+		expect(plugins.map((p) => p.path)).not.toContain(pluginRoot);
+		expect(names).not.toContain("orphan-skill");
+	});
+
+	it("resolves no external plugins when ~/.cyrus/plugins is absent", async () => {
+		const plugins = await resolver.resolve();
+
+		expect(plugins).toEqual([]);
+	});
+
+	it("follows a symlinked plugin directory", async () => {
+		const realRoot = join(outside, "sesai-clone");
+		await mkdir(join(realRoot, ".claude-plugin"), { recursive: true });
+		await writeFile(
+			join(realRoot, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "sesai", description: "" }),
+			"utf-8",
+		);
+		await writeSkill(realRoot, "plan-writing");
+		await mkdir(join(home, "plugins"), { recursive: true });
+		await symlink(realRoot, join(home, "plugins", "sesai"));
+
+		const plugins = await resolver.resolve();
+		const names = await resolver.discoverSkillNames(plugins);
+
+		expect(names).toContain("plan-writing");
+	});
+
+	it("orders plugins user, then external alphabetically, then internal", async () => {
+		await writeUserPluginManifest(home);
+		await writeExternalPlugin(home, "zeta");
+		await writeExternalPlugin(home, "alpha");
+
+		const plugins = await resolver.resolve();
+
+		expect(plugins.map((p) => p.path)).toEqual([
+			join(home, "user-skills-plugin"),
+			join(home, "plugins", "alpha"),
+			join(home, "plugins", "zeta"),
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Cyrus currently loads exactly two plugins — `~/.cyrus/cyrus-skills-plugin` and `~/.cyrus/user-skills-plugin` — and passes the SDK a `skills` whitelist built only from those (plus repo-local `.claude/skills`). Because unlisted skills are hidden from the model and rejected by the Skill tool, there is no way to give agent sessions a full organization-owned Claude Code plugin (skills + agents + commands): marketplace installs via repo `.claude/settings.json` load the plugin but its skills stay blocked by the whitelist.

This adds a third plugin source: any directory (or symlink) under `~/.cyrus/plugins/` carrying a `.claude-plugin/plugin.json` manifest is loaded as a full local plugin, and its skills join the session whitelist. Entries without a manifest are skipped with a warning. Precedence: user plugin > external plugins (alphabetical) > internal plugin; `logConflicts` is generalized to log shadowing across any number of plugins.

Also adds `CYRUS_AGENT_SESSION=1` to the session env so skills/tooling can deterministically detect they are running under a headless Cyrus session (e.g. to relax interactive approval checkpoints written for terminal use).

## Test plan

- New `SkillsPluginResolver.external.test.ts` (6 tests): manifest discovery, skill whitelisting, manifest-less dirs skipped, absent dir no-op, symlinked plugin dirs, ordering.
- Existing `SkillsPluginResolver` scope/repoLocal suites still pass (23 tests total).
- `tsc --noEmit` clean on `edge-worker` and `claude-runner`.
- Verified end-to-end against a real plugin repo symlinked into `~/.cyrus/plugins/`: its skills resolve into the session whitelist and load in the SDK session.