### PR TITLE
Expose spawnClaudeCodeProcess on ClaudeRunnerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- `ClaudeRunnerConfig` accepts a `spawnClaudeCodeProcess` override, forwarded to the Claude Agent SDK option of the same name. Lets the Claude Code process run somewhere other than a local child process — a container, a Kubernetes pod, a remote host — without forking the runner. ([#1391](https://github.com/cyrusagents/cyrus/pull/1391))
 
 ## [0.2.67] - 2026-07-25
 

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -194,6 +194,8 @@ function buildSanitizedQueryOptions(
 	out.hasExtraArgs = !!o.extraArgs;
 	out.hasPathToClaudeCodeExecutable =
 		typeof o.pathToClaudeCodeExecutable === "string";
+	out.hasSpawnClaudeCodeProcess =
+		typeof o.spawnClaudeCodeProcess === "function";
 
 	return out;
 }
@@ -736,6 +738,9 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					...(this.config.sandbox && { sandbox: this.config.sandbox }),
 					...(this.config.extraArgs && { extraArgs: this.config.extraArgs }),
 					...(pathToClaudeCodeExecutable && { pathToClaudeCodeExecutable }),
+					...(this.config.spawnClaudeCodeProcess && {
+						spawnClaudeCodeProcess: this.config.spawnClaudeCodeProcess,
+					}),
 				},
 			};
 

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -12,6 +12,8 @@ import type {
 	SDKUserMessage,
 	SdkPluginConfig,
 	SessionStore,
+	SpawnedProcess,
+	SpawnOptions,
 	WarmQuery,
 } from "@anthropic-ai/claude-agent-sdk";
 import type { ILogger, OnAskUserQuestion } from "cyrus-core";
@@ -72,6 +74,13 @@ export interface ClaudeRunnerConfig {
 	/** Additional environment variables to pass to the Claude child process (merged after process.env) */
 	additionalEnv?: Record<string, string>;
 	pathToClaudeCodeExecutable?: string; // Explicit path to Claude Code CLI executable (auto-resolved if not set)
+	/**
+	 * Override how the Claude Code process is spawned. Forwarded to the SDK's
+	 * `query()` option of the same name. Lets the CLI run somewhere other than a
+	 * local child process — a container, a pod, a remote host — as long as the
+	 * returned object proxies stdin/stdout and exit.
+	 */
+	spawnClaudeCodeProcess?: (options: SpawnOptions) => SpawnedProcess;
 	extraArgs?: Record<string, string | null>; // Additional CLI arguments to pass to Claude Code (e.g., { 'output-format': 'json' } for --output-format=json, or { verbose: null } for boolean flags)
 	/**
 	 * Callback for handling AskUserQuestion tool invocations.

--- a/packages/claude-runner/test/spawn-claude-code-process.test.ts
+++ b/packages/claude-runner/test/spawn-claude-code-process.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Claude SDK
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+	query: vi.fn(),
+}));
+
+// Mock file system operations
+vi.mock("fs", () => ({
+	mkdirSync: vi.fn(),
+	existsSync: vi.fn(() => false),
+	readFileSync: vi.fn(() => ""),
+	createWriteStream: vi.fn(() => ({
+		write: vi.fn(),
+		end: vi.fn(),
+		on: vi.fn(),
+	})),
+}));
+
+// Mock os module
+vi.mock("os", () => ({
+	homedir: vi.fn(() => "/mock/home"),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeRunner } from "../src/ClaudeRunner";
+import type { ClaudeRunnerConfig } from "../src/types";
+
+describe("spawnClaudeCodeProcess", () => {
+	let mockQuery: any;
+
+	const baseConfig: ClaudeRunnerConfig = {
+		workingDirectory: "/tmp/test",
+		cyrusHome: "/tmp/test-cyrus-home",
+	};
+
+	function mockSuccessfulQuery() {
+		mockQuery.mockImplementation(async function* () {
+			yield {
+				type: "assistant",
+				message: { content: [{ type: "text", text: "Done" }] },
+				parent_tool_use_id: null,
+				session_id: "test-session",
+			} as any;
+		});
+	}
+
+	function getQueryOptions(): Record<string, unknown> {
+		const call = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
+		return call[0].options;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockQuery = vi.mocked(query);
+	});
+
+	it("should forward the spawn override to the SDK when configured", async () => {
+		const spawnClaudeCodeProcess = vi.fn() as unknown as NonNullable<
+			ClaudeRunnerConfig["spawnClaudeCodeProcess"]
+		>;
+
+		mockSuccessfulQuery();
+		const runner = new ClaudeRunner({ ...baseConfig, spawnClaudeCodeProcess });
+		await runner.start("test");
+
+		expect(getQueryOptions().spawnClaudeCodeProcess).toBe(
+			spawnClaudeCodeProcess,
+		);
+	});
+
+	it("should omit the spawn override when not configured", async () => {
+		mockSuccessfulQuery();
+		const runner = new ClaudeRunner(baseConfig);
+		await runner.start("test");
+
+		expect(getQueryOptions()).not.toHaveProperty("spawnClaudeCodeProcess");
+	});
+});


### PR DESCRIPTION
The Agent SDK has a `spawnClaudeCodeProcess` option for overriding how the CLI subprocess is created, but `ClaudeRunner` never forwards it — so in practice Claude Code can only run as a local child of the Cyrus process.

**Why I want it.** I'm running Cyrus on Kubernetes. Today that means a single pod hosting every concurrent session: all worktrees on one volume, every `claude` child sharing a HOME, and scaling up means a bigger node rather than more pods. With this option I can pass a function that creates a pod per issue — its own PVC, its own gVisor runtime class — and proxies stdio to it, so each Linear issue gets a real isolation boundary and the cluster does the scheduling. That's a couple hundred lines against `@kubernetes/client-node` on my side and no other changes to Cyrus. The same hook covers remote hosts or a VM pool for anyone who wants sessions off the box running the edge worker.

The change is a straight passthrough: the option is only added to the query when set, so nothing changes if you don't use it. I also added a presence flag to the Sentry option sanitiser, matching how the other opaque fields are handled.

Tests cover the forwarded and absent cases. `tsc --noEmit`, `biome check` and the claude-runner suite (119 tests) pass locally.