### PR TITLE
fix(cli): pass cursor default model config through to EdgeWorker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- The Cursor runner now respects `cursorDefaultModel` and `cursorDefaultFallbackModel` from `config.json` (and the `CYRUS_CURSOR_DEFAULT_MODEL` environment variable). Previously these settings were silently ignored and every Cursor session fell back to the built-in default model regardless of configuration.
 
 ## [0.2.67] - 2026-07-25
 

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -228,6 +228,9 @@ export class WorkerService {
 				process.env.CYRUS_GEMINI_DEFAULT_MODEL || edgeConfig.geminiDefaultModel,
 			codexDefaultModel:
 				process.env.CYRUS_CODEX_DEFAULT_MODEL || edgeConfig.codexDefaultModel,
+			cursorDefaultModel:
+				process.env.CYRUS_CURSOR_DEFAULT_MODEL || edgeConfig.cursorDefaultModel,
+			cursorDefaultFallbackModel: edgeConfig.cursorDefaultFallbackModel,
 			defaultRunner:
 				(process.env.CYRUS_DEFAULT_RUNNER as
 					| "claude"


### PR DESCRIPTION
## Problem

Setting `cursorDefaultModel` (and `cursorDefaultFallbackModel`) in `~/.cyrus/config.json` had no effect — every Cursor runner session used the built-in default model (`composer-2`) regardless of configuration.

## Root cause

`WorkerService.startEdgeWorker()` assembles the `EdgeWorkerConfig` object field by field. It passes `claudeDefaultModel`, `geminiDefaultModel`, `codexDefaultModel`, and `defaultRunner` from `edgeConfig`, but **omits `cursorDefaultModel` and `cursorDefaultFallbackModel`**. So although these fields exist in the config schema, in `ConfigManager`, and are consumed by `RunnerSelectionService.getDefaultModelForRunner("cursor")`, the value never reaches the runtime — `this.config.cursorDefaultModel` is always `undefined` and the resolver falls back to `"composer-2"`.

The description-tag workaround (`[model=...]`) does not help either: a `claude-*` model string is inferred as the `claude` runner, conflicts with the `cursor` runner, and gets reset — so Claude-family Cursor models can only be set via config, which was the broken path.

## Fix

Add `cursorDefaultModel` and `cursorDefaultFallbackModel` to the config assembly, mirroring the existing codex/claude passthrough (env var takes precedence over config file). Introduces `CYRUS_CURSOR_DEFAULT_MODEL` for parity with `CYRUS_CODEX_DEFAULT_MODEL`.

## Testing

- `pnpm build` and `pnpm typecheck` pass across the monorepo (also enforced by the pre-commit hook).
- `pnpm --filter cyrus-edge-worker test:run` — 733 passed.
- `pnpm --filter cyrus-ai test:run` — 94 passed.

## Note on coverage

`WorkerService.startEdgeWorker()` has no unit coverage today — the config object is built inline within a large method with git/oauth closures, so no existing test asserts the codex/claude passthrough either. A regression test would require extracting the config assembly into a pure function; I kept this PR surgical and did not add a resolver-level test that would pass regardless of the bug. Flagging the gap for maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)