### PR TITLE
fix(core): add Linear's new webhook source IPs to allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - `ClaudeRunnerConfig` accepts a `spawnClaudeCodeProcess` override, forwarded to the Claude Agent SDK option of the same name. Lets the Claude Code process run somewhere other than a local child process — a container, a Kubernetes pod, a remote host — without forking the runner. ([#1391](https://github.com/cyrusagents/cyrus/pull/1391))
 
 ### Fixed
+- Linear webhooks sent from Linear's three newly added delivery IPs are no longer rejected. Instances validating webhook source IPs were intermittently dropping agent mentions (the agent appeared to randomly not respond) after Linear expanded its documented egress IP list on 2026-08-04. ([#1395](https://github.com/cyrusagents/cyrus/pull/1395))
 - Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding. ([#1388](https://github.com/cyrusagents/cyrus/pull/1388)) Thanks @rairulyle for the contribution!
 
 ### Security

--- a/packages/core/src/security/WebhookIpValidator.ts
+++ b/packages/core/src/security/WebhookIpValidator.ts
@@ -19,10 +19,13 @@ import { createLogger, type ILogger } from "../logging/index.js";
 export const LINEAR_WEBHOOK_IPS = [
 	"35.231.147.226",
 	"35.243.134.228",
+	"35.196.141.51",
 	"34.140.253.14",
 	"34.38.87.206",
+	"34.62.119.29",
 	"34.134.222.122",
 	"35.222.25.142",
+	"34.60.255.158",
 ] as const;
 
 /**

--- a/packages/core/test/security/WebhookIpValidator.test.ts
+++ b/packages/core/test/security/WebhookIpValidator.test.ts
@@ -148,8 +148,8 @@ describe("IP utility functions", () => {
 });
 
 describe("Known provider allowlists", () => {
-	it("has 6 Linear webhook IPs", () => {
-		expect(LINEAR_WEBHOOK_IPS).toHaveLength(6);
+	it("has 9 Linear webhook IPs", () => {
+		expect(LINEAR_WEBHOOK_IPS).toHaveLength(9);
 	});
 
 	it("all Linear IPs are valid IPv4", () => {


### PR DESCRIPTION
## Summary

Linear added three webhook egress IPs to their documented source list
(https://linear.app/developers/webhooks#securing-webhooks):

- `35.196.141.51`
- `34.62.119.29`
- `34.60.255.158`

`LINEAR_WEBHOOK_IPS` in `cyrus-core` still has the previous 6, so instances
running direct Linear webhooks with IP validation enabled reject deliveries
from the new IPs with 403 — dropping agent mentions intermittently (only when
Linear happens to route via a new IP), which presents as the agent randomly
not responding.

Observed in production starting 2026-08-04 ~22:28 UTC:

    [WARN] [LinearEventTransport] Rejected Linear webhook from unauthorized IP: 35.196.141.51

## Why this happened (and will happen again)

Linear delivers webhooks from a small set of Google Cloud egress IPs and their
docs explicitly say the list may grow ("We may occasionally update this list
to add new IP addresses"). Cyrus hardcodes the list, so every published
release goes stale the moment Linear scales out their delivery infrastructure
— any instance with IP validation enabled then silently drops a fraction of
webhooks. Nothing changed on the operator's side; this is purely an upstream
provider IP rotation, and it will recur for all Cyrus deployments each time
Linear adds IPs.

## Changes

- Add the 3 new IPs to `LINEAR_WEBHOOK_IPS` (now 9, matching Linear's docs order)
- Update the allowlist-length test assertion (6 → 9)

HMAC signature verification runs after the IP check, so this does not loosen
authentication.

## Follow-up idea (out of scope here)

Since the list will go stale again, longer-term it may be worth refreshing it
dynamically (like `refreshGitHubAllowlist()` does via GitHub `/meta` — though
Linear offers no machine-readable endpoint, only the docs page) or allowing
operators to extend the allowlist via env/config, so a stale constant can't
silently drop webhooks.

## Testing

- `vitest run packages/core/test/security/WebhookIpValidator.test.ts` — 42/42 pass
- Deployed the same change to our production instance (0.2.67): rejections
  stopped, Linear webhooks from `35.196.141.51` now accepted and
  signature-verified.
