### PR TITLE
Fall back to Codex when Claude quota is exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - `ClaudeRunnerConfig` accepts a `spawnClaudeCodeProcess` override, forwarded to the Claude Agent SDK option of the same name. Lets the Claude Code process run somewhere other than a local child process — a container, a Kubernetes pod, a remote host — without forking the runner. ([#1391](https://github.com/cyrusagents/cyrus/pull/1391))
+- Claude sessions can now continue automatically with a configured Codex fallback when selected subscription quota limits are exhausted, while preserving the current worktree and session context. ([MEL-187](https://linear.app/melodymaifafafa/issue/MEL-187/claude-%E4%BC%9A%E8%AF%9D%E9%A2%9D%E5%BA%A6%E8%80%97%E5%B0%BD%E6%97%B6%E8%87%AA%E5%8A%A8%E5%88%87%E6%8D%A2%E5%88%B0-codex-runner), [#1396](https://github.com/cyrusagents/cyrus/pull/1396))
 
 ### Fixed
 - Cyrus now catches up on what was said in a Slack thread between mentions. Previously, @mentioning Cyrus again in a thread it had already replied to passed along only your new message, so anything the team discussed since the last mention was invisible to it — most noticeably with automatic thread listening turned off, where untagged messages are never delivered. Cyrus now back-reads the messages posted since it last had context and reads them before responding. ([#1388](https://github.com/cyrusagents/cyrus/pull/1388)) Thanks @rairulyle for the contribution!

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -235,6 +235,7 @@ export class WorkerService {
 					| "codex"
 					| "cursor"
 					| undefined) || edgeConfig.defaultRunner,
+			runnerFallbacks: edgeConfig.runnerFallbacks,
 			issueUpdateTrigger: edgeConfig.issueUpdateTrigger,
 			prReviewTrigger: edgeConfig.prReviewTrigger,
 			promptDefaults: edgeConfig.promptDefaults,

--- a/apps/f1/server.ts
+++ b/apps/f1/server.ts
@@ -21,12 +21,17 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getAllTools } from "cyrus-claude-runner";
+import { getAllTools, type SDKMessage } from "cyrus-claude-runner";
 import {
+	type AgentRunnerConfig,
+	type AgentSessionInfo,
 	type EdgeWorkerConfig,
 	getDefaultReposDir,
 	getDefaultWorktreesDir,
+	type IAgentRunner,
+	type IMessageFormatter,
 	type RepositoryConfig,
+	type RunnerType,
 } from "cyrus-core";
 import { EdgeWorker } from "cyrus-edge-worker";
 import type { SlackWebhookEvent } from "cyrus-slack-event-transport";
@@ -44,6 +49,127 @@ const DEFAULT_WORKTREES_BASE_DIR = getDefaultWorktreesDir(CYRUS_HOME);
 // Optional second repository path for multi-repo orchestration testing
 const CYRUS_REPO_PATH_2 = process.env.CYRUS_REPO_PATH_2;
 const MULTI_REPO_MODE = Boolean(CYRUS_REPO_PATH_2);
+const REPLAY_CLAUDE_QUOTA = process.env.CYRUS_REPLAY_CLAUDE_QUOTA === "1";
+
+abstract class ReplayRunner implements IAgentRunner {
+	readonly supportsStreamingInput = true;
+	protected running = false;
+
+	constructor(protected readonly config: AgentRunnerConfig) {}
+
+	abstract start(prompt: string): Promise<AgentSessionInfo>;
+
+	startStreaming(prompt?: string): Promise<AgentSessionInfo> {
+		return this.start(prompt ?? "");
+	}
+
+	stop(): void {
+		this.running = false;
+	}
+
+	isRunning(): boolean {
+		return this.running;
+	}
+
+	getMessages(): SDKMessage[] {
+		return [];
+	}
+
+	getFormatter(): IMessageFormatter {
+		throw new Error("Replay runners do not emit tool events");
+	}
+
+	protected async emitMessage(message: SDKMessage): Promise<void> {
+		await this.config.onMessage?.(message);
+	}
+}
+
+class ClaudeQuotaReplayRunner extends ReplayRunner {
+	async start(_prompt: string): Promise<AgentSessionInfo> {
+		this.running = true;
+		await this.emitMessage({
+			type: "rate_limit_event",
+			session_id: "f1-replay-claude-session",
+			uuid: "f1-replay-rate-limit",
+			rate_limit_info: {
+				status: "rejected",
+				rateLimitType: "five_hour",
+				resetsAt: 1_800_000_000,
+			},
+		} as unknown as SDKMessage);
+		await this.emitMessage({
+			type: "result",
+			subtype: "success",
+			session_id: "f1-replay-claude-session",
+			is_error: false,
+			result: "This Claude result must be suppressed",
+			total_cost_usd: 0,
+			usage: {},
+		} as unknown as SDKMessage);
+		this.running = false;
+		return {
+			sessionId: "f1-replay-claude-session",
+			startedAt: new Date(),
+			isRunning: false,
+		};
+	}
+}
+
+// The exact class name intentionally matches the production runner discriminator.
+class CodexRunner extends ReplayRunner {
+	async isAvailable(): Promise<boolean> {
+		return true;
+	}
+
+	async start(_prompt: string): Promise<AgentSessionInfo> {
+		this.running = true;
+		void this.emitMessage({
+			type: "system",
+			subtype: "init",
+			session_id: "f1-replay-codex-session",
+			model: "gpt-5.5",
+			tools: [],
+			permissionMode: "never",
+			apiKeySource: "f1-replay",
+		} as unknown as SDKMessage);
+		void this.emitMessage({
+			type: "assistant",
+			session_id: "f1-replay-codex-session",
+			message: {
+				content: [
+					{
+						type: "text",
+						text: "Codex completed the replayed fallback work item.",
+					},
+				],
+			},
+		} as unknown as SDKMessage);
+		void this.emitMessage({
+			type: "result",
+			subtype: "success",
+			session_id: "f1-replay-codex-session",
+			is_error: false,
+			result: "Codex completed the replayed fallback work item.",
+			total_cost_usd: 0,
+			usage: {},
+		} as unknown as SDKMessage);
+		this.running = false;
+		return {
+			sessionId: "f1-replay-codex-session",
+			startedAt: new Date(),
+			isRunning: false,
+		};
+	}
+}
+
+function createReplayRunner(
+	runnerType: RunnerType,
+	config: AgentRunnerConfig,
+): IAgentRunner {
+	if (runnerType === "claude") return new ClaudeQuotaReplayRunner(config);
+	if (runnerType === "codex") return new CodexRunner(config);
+	throw new Error(`F1 quota replay does not support ${runnerType}`);
+}
 
 // Validate port
 if (Number.isNaN(CYRUS_PORT) || CYRUS_PORT < 1 || CYRUS_PORT > 65535) {
@@ -166,12 +292,25 @@ function createEdgeWorkerConfig(): EdgeWorkerConfig {
 		claudeDefaultFallbackModel: "haiku",
 		// Env-gated runner selection for harness validation (default unchanged).
 		// e.g. CYRUS_DEFAULT_RUNNER=codex to exercise the Codex (app-server) path.
-		...(process.env.CYRUS_DEFAULT_RUNNER && {
-			defaultRunner: process.env.CYRUS_DEFAULT_RUNNER as
-				| "claude"
-				| "gemini"
-				| "codex"
-				| "cursor",
+		...(process.env.CYRUS_DEFAULT_RUNNER &&
+			!REPLAY_CLAUDE_QUOTA && {
+				defaultRunner: process.env.CYRUS_DEFAULT_RUNNER as
+					| "claude"
+					| "gemini"
+					| "codex"
+					| "cursor",
+			}),
+		...(REPLAY_CLAUDE_QUOTA && {
+			defaultRunner: "claude" as const,
+			runnerFallbacks: {
+				claude: {
+					runners: ["codex" as const],
+					rateLimitTypes: ["five_hour" as const],
+				},
+			},
+			handlers: {
+				createRunner: createReplayRunner,
+			},
 		}),
 		codexDefaultModel: process.env.CODEX_MODEL || "gpt-5.5",
 		// Enable all tools including Edit(**), Bash, etc. for full testing capability

--- a/apps/f1/test-drives/2026-08-05-mel-187-claude-codex-runner-fallback.md
+++ b/apps/f1/test-drives/2026-08-05-mel-187-claude-codex-runner-fallback.md
@@ -1,0 +1,84 @@
+# Test Drive: MEL-187 Claude-to-Codex Quota Fallback
+
+**Date**: 2026-08-05
+**Goal**: Verify that a replayed rejected Claude quota event transitions the same Cyrus work item to Codex and posts one final response.
+**Test Repo**: `/tmp/f1-mel-187.yaBy5N/repo`
+
+## Verification Results
+
+### Issue-Tracker
+
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible
+
+### EdgeWorker
+
+- [x] Session started
+- [x] Worktree created
+- [x] Replayed `five_hour` rejected quota event triggered Codex
+- [x] Follow-up prompt resumed the Codex session
+- [x] Session stopped cleanly
+
+### Renderer
+
+- [x] Transition thought appeared before Codex activity
+- [x] Reset time was present in the transition thought
+- [x] Exactly one final response was posted for the fallback turn
+- [x] The superseded Claude success result was absent
+- [x] Pagination and activity search worked
+
+## Session Log
+
+The F1 server used `CYRUS_REPLAY_CLAUDE_QUOTA=1`, which configures an implicit Claude default, a `five_hour` Claude-to-Codex fallback policy, and deterministic replay runners.
+
+```text
+CYRUS_REPLAY_CLAUDE_QUOTA=1 CYRUS_PORT=3600 \
+  CYRUS_REPO_PATH=/tmp/f1-mel-187.yaBy5N/repo \
+  bun run apps/f1/server.ts
+
+CYRUS_PORT=3600 ./f1 create-issue \
+  --title "MEL-187 replayed Claude quota fallback" \
+  --description "Verify rejected five_hour quota transitions from implicit Claude default to Codex with one final response." \
+  --labels primary
+
+Issue ID: issue-2
+Identifier: DEF-2
+
+CYRUS_PORT=3600 ./f1 start-session --issue-id issue-2
+Session ID: session-2
+```
+
+The first-page activity order was:
+
+```text
+thought   I've received your request and I'm starting to work on it.
+thought   Routing (Label routing) — F1 Test Repository → main
+thought   Claude quota exhausted (five_hour); continuing with Codex. Quota resets at ...
+thought   Using model: gpt-5.5
+response  Codex completed the replayed fallback work item.
+```
+
+Search verification:
+
+```text
+search "Codex"                         -> 2 activities
+search "Claude result must be suppressed" -> 0 activities
+```
+
+Continuation verification:
+
+```text
+CYRUS_PORT=3600 ./f1 prompt-session \
+  --session-id session-2 \
+  --message "Continue with Codex"
+
+resumeSessionId=f1-replay-codex-session
+response  Codex completed the replayed fallback work item.
+```
+
+The server stopped gracefully after `./f1 stop-session --session-id session-2`.
+
+## Final Retrospective
+
+The replay validated the complete CLI issue-tracker, EdgeWorker, worktree, runner transition, activity rendering, and continuation path. The initial unlabeled issue intentionally demonstrated that F1 routing requires a matching repository label; the successful drive used the existing `primary` routing label. The test repository has no `origin`, so Git fetch logged its expected local-branch fallback before creating the worktree.

--- a/packages/codex-runner/src/CodexRunner.ts
+++ b/packages/codex-runner/src/CodexRunner.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
+import { promisify } from "node:util";
 import type { IAgentRunner, IMessageFormatter, SDKMessage } from "cyrus-core";
 import { AppServerCodexBackend } from "./backend/AppServerCodexBackend.js";
 import type {
@@ -73,6 +75,21 @@ export class CodexRunner extends EventEmitter implements IAgentRunner {
 		if (config.onMessage) this.on("message", config.onMessage);
 		if (config.onError) this.on("error", config.onError);
 		if (config.onComplete) this.on("complete", config.onComplete);
+	}
+
+	/** Verify the CLI exists and has credentials before an automatic fallback. */
+	async isAvailable(): Promise<boolean> {
+		if (process.env.OPENAI_API_KEY) return true;
+		try {
+			const { stdout, stderr } = await promisify(execFile)(
+				this.config.codexPath || "codex",
+				["login", "status"],
+				{ timeout: 5_000 },
+			);
+			return /^logged in\b/im.test(stdout + stderr);
+		} catch {
+			return false;
+		}
 	}
 
 	async start(prompt: string): Promise<CodexSessionInfo> {

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -543,6 +543,46 @@
 			"type": "string",
 			"enum": ["claude", "gemini", "codex", "cursor"]
 		},
+		"runnerFallbacks": {
+			"type": "object",
+			"propertyNames": {
+				"type": "string",
+				"enum": ["claude", "gemini", "codex", "cursor"]
+			},
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"runners": {
+						"minItems": 1,
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["claude", "gemini", "codex", "cursor"]
+						}
+					},
+					"rateLimitTypes": {
+						"minItems": 1,
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": [
+								"five_hour",
+								"seven_day",
+								"seven_day_opus",
+								"seven_day_sonnet",
+								"seven_day_overage_included",
+								"overage"
+							]
+						}
+					},
+					"overrideExplicitSelectors": {
+						"type": "boolean"
+					}
+				},
+				"required": ["runners", "rateLimitTypes"],
+				"additionalProperties": false
+			}
+		},
 		"defaultModel": {
 			"type": "string"
 		},

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -537,6 +537,46 @@
 			"type": "string",
 			"enum": ["claude", "gemini", "codex", "cursor"]
 		},
+		"runnerFallbacks": {
+			"type": "object",
+			"propertyNames": {
+				"type": "string",
+				"enum": ["claude", "gemini", "codex", "cursor"]
+			},
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"runners": {
+						"minItems": 1,
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["claude", "gemini", "codex", "cursor"]
+						}
+					},
+					"rateLimitTypes": {
+						"minItems": 1,
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": [
+								"five_hour",
+								"seven_day",
+								"seven_day_opus",
+								"seven_day_sonnet",
+								"seven_day_overage_included",
+								"overage"
+							]
+						}
+					},
+					"overrideExplicitSelectors": {
+						"type": "boolean"
+					}
+				},
+				"required": ["runners", "rateLimitTypes"],
+				"additionalProperties": false
+			}
+		},
 		"defaultModel": {
 			"type": "string"
 		},

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -222,6 +222,13 @@ export interface IMessageFormatter {
  */
 export interface IAgentRunner {
 	/**
+	 * Optional preflight used before an automatic cross-provider fallback.
+	 * Runners without a probe are assumed available and surface startup errors
+	 * through their normal result stream.
+	 */
+	isAvailable?(): Promise<boolean>;
+
+	/**
 	 * Indicates whether this runner supports streaming input
 	 *
 	 * When true, the runner supports `startStreaming()`, `addStreamMessage()`, and `completeStream()`.

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -6,6 +6,43 @@ import { z } from "zod";
 export const RunnerTypeSchema = z.enum(["claude", "gemini", "codex", "cursor"]);
 export type RunnerType = z.infer<typeof RunnerTypeSchema>;
 
+/** Claude subscription quota buckets exposed by the Agent SDK. */
+export const ClaudeRateLimitTypeSchema = z.enum([
+	"five_hour",
+	"seven_day",
+	"seven_day_opus",
+	"seven_day_sonnet",
+	"seven_day_overage_included",
+	"overage",
+]);
+
+/**
+ * Cross-provider recovery policy for one source runner.
+ *
+ * Fallbacks are deliberately opt-in per quota bucket. This prevents auth,
+ * tool, warning, and ordinary provider errors from silently changing the
+ * runner selected by the user.
+ */
+export const RunnerFallbackPolicySchema = z.object({
+	runners: z.array(RunnerTypeSchema).min(1),
+	rateLimitTypes: z.array(ClaudeRateLimitTypeSchema).min(1),
+	overrideExplicitSelectors: z.boolean().optional(),
+});
+
+export const RunnerFallbacksSchema = z
+	.partialRecord(RunnerTypeSchema, RunnerFallbackPolicySchema)
+	.superRefine((fallbacks, context) => {
+		for (const [source, policy] of Object.entries(fallbacks)) {
+			if (policy?.runners.includes(source as RunnerType)) {
+				context.addIssue({
+					code: "custom",
+					path: [source, "runners"],
+					message: `Runner "${source}" cannot fall back directly to itself`,
+				});
+			}
+		}
+	});
+
 /**
  * User identifier for access control matching.
  * Supports multiple formats for flexibility:
@@ -367,6 +404,12 @@ export const EdgeConfigSchema = z.object({
 	defaultRunner: RunnerTypeSchema.optional(),
 
 	/**
+	 * Quota-specific cross-provider recovery policies keyed by source runner.
+	 * Example: `{ claude: { runners: ["codex"], rateLimitTypes: ["five_hour"] } }`.
+	 */
+	runnerFallbacks: RunnerFallbacksSchema.optional(),
+
+	/**
 	 * @deprecated Use claudeDefaultModel instead.
 	 * Legacy field retained for backwards compatibility and migrated on load.
 	 */
@@ -606,6 +649,9 @@ export type UserAccessControlConfig = z.infer<
 export type LinearWorkspaceConfig = z.infer<typeof LinearWorkspaceConfigSchema>;
 export type RepositoryConfig = z.infer<typeof RepositoryConfigSchema>;
 export type EdgeConfig = z.infer<typeof EdgeConfigSchema>;
+export type ClaudeRateLimitType = z.infer<typeof ClaudeRateLimitTypeSchema>;
+export type RunnerFallbackPolicy = z.infer<typeof RunnerFallbackPolicySchema>;
+export type RunnerFallbacks = z.infer<typeof RunnerFallbacksSchema>;
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
 export type NetworkPolicy = z.infer<typeof NetworkPolicySchema>;
 export type RepositoryConfigPayload = z.infer<

--- a/packages/core/src/config-types.ts
+++ b/packages/core/src/config-types.ts
@@ -1,13 +1,20 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { AgentRunnerConfig, IAgentRunner } from "./agent-runner-types.js";
 import type { Workspace } from "./CyrusAgentSession.js";
 // Import types for use in this file
-import type { EdgeConfig, RepositoryConfig } from "./config-schemas.js";
+import type {
+	EdgeConfig,
+	RepositoryConfig,
+	RunnerType,
+} from "./config-schemas.js";
 import type { Issue } from "./issue-tracker/types.js";
 
 // Re-export schemas and types from config-schemas
 export {
+	type ClaudeRateLimitType,
+	ClaudeRateLimitTypeSchema,
 	type EdgeConfig,
 	type EdgeConfigPayload,
 	EdgeConfigPayloadSchema,
@@ -21,6 +28,10 @@ export {
 	type RepositoryConfigPayload,
 	RepositoryConfigPayloadSchema,
 	RepositoryConfigSchema,
+	type RunnerFallbackPolicy,
+	RunnerFallbackPolicySchema,
+	type RunnerFallbacks,
+	RunnerFallbacksSchema,
 	type RunnerType,
 	RunnerTypeSchema,
 	requireLinearWorkspaceId,
@@ -141,6 +152,12 @@ export interface EdgeWorkerRuntimeConfig {
 	 * These are callback functions that cannot be serialized to JSON.
 	 */
 	handlers?: {
+		/** Optional runner factory used by harnesses that replay provider streams. */
+		createRunner?: (
+			runnerType: RunnerType,
+			config: AgentRunnerConfig,
+		) => IAgentRunner;
+
 		/** Called when workspace needs to be created. Accepts array of repositories for multi-repo workspaces. */
 		createWorkspace?: (
 			issue: Issue,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export type {
 } from "./CyrusAgentSession.js";
 // Configuration types
 export type {
+	ClaudeRateLimitType,
 	EdgeConfig,
 	EdgeConfigPayload,
 	EdgeWorkerConfig,
@@ -84,12 +85,15 @@ export type {
 	RepoSetupHookStatus,
 	RepositoryConfig,
 	RepositoryConfigPayload,
+	RunnerFallbackPolicy,
+	RunnerFallbacks,
 	RunnerType,
 	SandboxConfig,
 	UserAccessControlConfig,
 	UserIdentifier,
 } from "./config-types.js";
 export {
+	ClaudeRateLimitTypeSchema,
 	EdgeConfigPayloadSchema,
 	// Zod schemas for runtime validation
 	EdgeConfigSchema,
@@ -98,6 +102,8 @@ export {
 	NetworkPolicySchema,
 	RepositoryConfigPayloadSchema,
 	RepositoryConfigSchema,
+	RunnerFallbackPolicySchema,
+	RunnerFallbacksSchema,
 	RunnerTypeSchema,
 	requireLinearWorkspaceId,
 	resolvePath,

--- a/packages/core/test/json-schema-export.test.ts
+++ b/packages/core/test/json-schema-export.test.ts
@@ -44,6 +44,7 @@ describe("JSON Schema export", () => {
 				"geminiDefaultModel",
 				"codexDefaultModel",
 				"defaultRunner",
+				"runnerFallbacks",
 				"defaultModel",
 				"defaultFallbackModel",
 				"global_setup_script",

--- a/packages/core/test/runner-fallback-config.test.ts
+++ b/packages/core/test/runner-fallback-config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { EdgeConfigSchema } from "../src/config-schemas.js";
+
+const baseConfig = {
+	repositories: [],
+};
+
+describe("runner fallback config", () => {
+	it("accepts a typed Claude quota fallback policy", () => {
+		const result = EdgeConfigSchema.safeParse({
+			...baseConfig,
+			runnerFallbacks: {
+				claude: {
+					runners: ["codex"],
+					rateLimitTypes: ["five_hour", "seven_day"],
+				},
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects unknown quota categories", () => {
+		const result = EdgeConfigSchema.safeParse({
+			...baseConfig,
+			runnerFallbacks: {
+				claude: {
+					runners: ["codex"],
+					rateLimitTypes: ["authentication_error"],
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a direct fallback loop", () => {
+		const result = EdgeConfigSchema.safeParse({
+			...baseConfig,
+			runnerFallbacks: {
+				claude: {
+					runners: ["claude"],
+					rateLimitTypes: ["five_hour"],
+				},
+			},
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/edge-worker/src/AgentSessionManager.ts
+++ b/packages/edge-worker/src/AgentSessionManager.ts
@@ -21,6 +21,7 @@ import {
 	type ILogger,
 	type IssueMinimal,
 	type RepositoryContext,
+	type RunnerType,
 	type SerializedCyrusAgentSession,
 	type SerializedCyrusAgentSessionEntry,
 	type Workspace,
@@ -89,6 +90,11 @@ export class AgentSessionManager extends EventEmitter {
 	// deferred tools like ToolSearch, where a tool_use and its tool_result can
 	// arrive back-to-back in the same microtask batch).
 	private messageProcessingQueues: Map<string, Promise<void>> = new Map();
+	private suppressedRunnerSessions: Map<string, Set<string>> = new Map();
+	private rateLimitFallbackHandler?: (
+		sessionId: string,
+		message: SDKRateLimitEvent,
+	) => Promise<boolean>;
 	private getParentSessionId?: (childSessionId: string) => string | undefined;
 	private resumeParentSession?: (
 		parentSessionId: string,
@@ -117,6 +123,15 @@ export class AgentSessionManager extends EventEmitter {
 	 */
 	setActivitySink(sessionId: string, sink: IActivitySink): void {
 		this.activitySinks.set(sessionId, sink);
+	}
+
+	setRateLimitFallbackHandler(
+		handler: (
+			sessionId: string,
+			message: SDKRateLimitEvent,
+		) => Promise<boolean>,
+	): void {
+		this.rateLimitFallbackHandler = handler;
 	}
 
 	/**
@@ -517,6 +532,15 @@ export class AgentSessionManager extends EventEmitter {
 	): Promise<void> {
 		const log = this.sessionLog(sessionId);
 		try {
+			const runnerSessionId = (message as { session_id?: string }).session_id;
+			if (
+				runnerSessionId &&
+				this.suppressedRunnerSessions.get(sessionId)?.has(runnerSessionId)
+			) {
+				log.debug(`Ignoring superseded runner message ${message.type}`);
+				return;
+			}
+
 			switch (message.type) {
 				case "system":
 					if (message.subtype === "init") {
@@ -598,7 +622,10 @@ export class AgentSessionManager extends EventEmitter {
 					break;
 
 				case "rate_limit_event":
-					this.handleRateLimitEvent(sessionId, message as SDKRateLimitEvent);
+					await this.handleRateLimitEvent(
+						sessionId,
+						message as SDKRateLimitEvent,
+					);
 					break;
 
 				default:
@@ -629,14 +656,23 @@ export class AgentSessionManager extends EventEmitter {
 	/**
 	 * Handle rate limit events from Claude runners
 	 */
-	private handleRateLimitEvent(
+	private async handleRateLimitEvent(
 		sessionId: string,
 		message: SDKRateLimitEvent,
-	): void {
+	): Promise<void> {
 		const log = this.sessionLog(sessionId);
 		const info = message.rate_limit_info;
 
 		if (info.status === "rejected") {
+			if (this.rateLimitFallbackHandler) {
+				try {
+					if (await this.rateLimitFallbackHandler(sessionId, message)) {
+						return;
+					}
+				} catch (error) {
+					log.error("Runner fallback handler failed:", error);
+				}
+			}
 			const resetsAt = info.resetsAt
 				? new Date(info.resetsAt * 1000).toISOString()
 				: "unknown";
@@ -1359,6 +1395,49 @@ export class AgentSessionManager extends EventEmitter {
 		log.debug(`Added agent runner`);
 	}
 
+	/** Ignore all remaining messages from a provider attempt being replaced. */
+	suppressRunnerSession(sessionId: string, runnerSessionId: string): void {
+		const suppressed =
+			this.suppressedRunnerSessions.get(sessionId) ?? new Set();
+		suppressed.add(runnerSessionId);
+		this.suppressedRunnerSessions.set(sessionId, suppressed);
+	}
+
+	/** Replace the active provider while keeping the Cyrus/Linear session intact. */
+	switchAgentRunner(
+		sessionId: string,
+		agentRunner: IAgentRunner,
+		runnerType: RunnerType,
+	): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) return;
+
+		session.agentRunner?.stop();
+		session.agentRunner = agentRunner;
+		session.status = AgentSessionStatus.Active;
+		session.updatedAt = Date.now();
+		session.claudeSessionId = undefined;
+		session.geminiSessionId = undefined;
+		session.codexSessionId = undefined;
+		session.cursorSessionId = undefined;
+
+		this.activeTasksBySession.delete(sessionId);
+		this.lastAssistantBodyBySession.delete(sessionId);
+		this.lastAssistantBodyIsToolInputBySession.delete(sessionId);
+		this.bufferedAssistantEntryBySession.delete(sessionId);
+		this.sessionLog(sessionId).info(`Switched active runner to ${runnerType}`);
+	}
+
+	/** End a failed fallback without replacing the actionable quota error. */
+	async failRunnerFallback(sessionId: string, body: string): Promise<void> {
+		this.activeTasksBySession.delete(sessionId);
+		this.lastAssistantBodyBySession.delete(sessionId);
+		this.lastAssistantBodyIsToolInputBySession.delete(sessionId);
+		this.bufferedAssistantEntryBySession.delete(sessionId);
+		await this.updateSessionStatus(sessionId, AgentSessionStatus.Error);
+		await this.createErrorActivity(sessionId, body);
+	}
+
 	/**
 	 *  Get all agent runners
 	 */
@@ -1642,6 +1721,7 @@ export class AgentSessionManager extends EventEmitter {
 		this.lastAssistantBodyBySession.delete(sessionId);
 		this.bufferedAssistantEntryBySession.delete(sessionId);
 		this.messageProcessingQueues.delete(sessionId);
+		this.suppressedRunnerSessions.delete(sessionId);
 		log.debug("Removed session");
 	}
 

--- a/packages/edge-worker/src/ConfigManager.ts
+++ b/packages/edge-worker/src/ConfigManager.ts
@@ -1,7 +1,12 @@
 import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import { watch as chokidarWatch, type FSWatcher } from "chokidar";
-import type { EdgeWorkerConfig, ILogger, RepositoryConfig } from "cyrus-core";
+import {
+	type EdgeWorkerConfig,
+	type ILogger,
+	type RepositoryConfig,
+	RunnerFallbacksSchema,
+} from "cyrus-core";
 
 /**
  * Describes the set of repository-level changes detected after a config
@@ -196,6 +201,20 @@ export class ConfigManager extends EventEmitter {
 
 			const configContent = await readFile(this.configPath, "utf-8");
 			const parsedConfig = JSON.parse(configContent);
+			let runnerFallbacks = this.config.runnerFallbacks;
+			if (parsedConfig.runnerFallbacks !== undefined) {
+				const fallbackResult = RunnerFallbacksSchema.safeParse(
+					parsedConfig.runnerFallbacks,
+				);
+				if (!fallbackResult.success) {
+					this.logger.error(
+						"❌ Invalid runnerFallbacks config:",
+						fallbackResult.error,
+					);
+					return null;
+				}
+				runnerFallbacks = fallbackResult.data;
+			}
 
 			// Merge with current EdgeWorker config structure
 			const newConfig: EdgeWorkerConfig = {
@@ -225,6 +244,7 @@ export class ConfigManager extends EventEmitter {
 					parsedConfig.cursorDefaultFallbackModel ||
 					this.config.cursorDefaultFallbackModel,
 				defaultRunner: parsedConfig.defaultRunner || this.config.defaultRunner,
+				runnerFallbacks,
 				promptDefaults:
 					parsedConfig.promptDefaults || this.config.promptDefaults,
 				// Preserve legacy fields while rolling out new config keys.
@@ -338,6 +358,7 @@ export class ConfigManager extends EventEmitter {
 	private detectGlobalConfigChanges(newConfig: EdgeWorkerConfig): boolean {
 		const globalKeys: Array<keyof EdgeWorkerConfig> = [
 			"defaultRunner",
+			"runnerFallbacks",
 			"claudeDefaultModel",
 			"claudeDefaultFallbackModel",
 			"geminiDefaultModel",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -168,6 +168,7 @@ import {
 	RunnerConfigBuilder,
 	resolveIssueMcpConfigPath,
 } from "./RunnerConfigBuilder.js";
+import { RunnerFallbackController } from "./RunnerFallbackController.js";
 import { RunnerSelectionService } from "./RunnerSelectionService.js";
 import { SharedApplicationServer } from "./SharedApplicationServer.js";
 import {
@@ -206,6 +207,7 @@ export class EdgeWorker extends EventEmitter {
 	private config: EdgeWorkerConfig;
 	private repositories: Map<string, RepositoryConfig> = new Map(); // repository 'id' (internal, stored in config.json) mapped to the full repo config
 	private agentSessionManager: AgentSessionManager; // Single instance managing all agent sessions across repositories
+	private runnerFallbackController: RunnerFallbackController;
 	private activitySinks: Map<string, IActivitySink> = new Map(); // Maps Linear workspace ID to activity sink (one per workspace, mirrors issueTrackers)
 	private sessionRepositories: Map<string, string> = new Map(); // Maps session ID to repository ID
 	private lastStopTimeBySession: Map<string, number> = new Map(); // Maps session ID to timestamp of last stop signal (for double-stop detection)
@@ -487,6 +489,16 @@ export class EdgeWorker extends EventEmitter {
 					childSessionId,
 				);
 			},
+		);
+		this.runnerFallbackController = new RunnerFallbackController({
+			getConfig: () => this.config,
+			sessionManager: this.agentSessionManager,
+			createRunner: (runnerType, runnerConfig) =>
+				this.createRunnerForType(runnerType, runnerConfig),
+		});
+		this.agentSessionManager.setRateLimitFallbackHandler?.(
+			(sessionId, message) =>
+				this.runnerFallbackController.handleRateLimit(sessionId, message),
 		);
 
 		// Initialize repositories with path resolution
@@ -3401,6 +3413,7 @@ ${taskSection}`;
 				`Session stopped — ${message.workItemIdentifier} was marked as Done or Canceled.`,
 			);
 			this.agentSessionManager.removeSession(session.id);
+			this.runnerFallbackController.removeSession(session.id);
 		}
 
 		// Build the set of repositories involved with this issue so per-repo
@@ -4547,28 +4560,57 @@ ${taskSection}`;
 
 			// Create agent runner with system prompt from assembly
 			// buildAgentRunnerConfig now determines runner type from labels internally
-			const { config: runnerConfig, runnerType } =
-				await this.buildAgentRunnerConfig(
-					session,
-					primaryRepo,
-					sessionId,
-					assembly.systemPrompt,
-					allowedTools,
-					allowedDirectories,
-					disallowedTools,
-					undefined, // resumeSessionId
-					labels, // Pass labels for runner selection and model override
-					fullIssue.description || undefined, // Description tags can override label selectors
-					undefined, // maxTurns
-					linearWorkspaceId,
-					this.buildSkillSessionContext(primaryRepo, fullIssue, session),
-				);
+			const {
+				config: runnerConfig,
+				runnerType,
+				selectionWasExplicit,
+			} = await this.buildAgentRunnerConfig(
+				session,
+				primaryRepo,
+				sessionId,
+				assembly.systemPrompt,
+				allowedTools,
+				allowedDirectories,
+				disallowedTools,
+				undefined, // resumeSessionId
+				labels, // Pass labels for runner selection and model override
+				fullIssue.description || undefined, // Description tags can override label selectors
+				undefined, // maxTurns
+				linearWorkspaceId,
+				this.buildSkillSessionContext(primaryRepo, fullIssue, session),
+			);
 
 			log.debug(
 				`Label-based runner selection for new session: ${runnerType} (session ${sessionId})`,
 			);
 
 			const runner = this.createRunnerForType(runnerType, runnerConfig);
+			this.runnerFallbackController.registerTurn({
+				sessionId,
+				runnerType,
+				selectionWasExplicit,
+				prompt: assembly.userPrompt,
+				buildConfig: async (fallbackType) =>
+					(
+						await this.buildAgentRunnerConfig(
+							session,
+							primaryRepo,
+							sessionId,
+							assembly.systemPrompt,
+							allowedTools,
+							allowedDirectories,
+							disallowedTools,
+							undefined,
+							labels,
+							fullIssue.description || undefined,
+							undefined,
+							linearWorkspaceId,
+							this.buildSkillSessionContext(primaryRepo, fullIssue, session),
+							"linear",
+							fallbackType,
+						)
+					).config,
+			});
 
 			// Store runner by comment ID
 			agentSessionManager.addAgentRunner(sessionId, runner);
@@ -5337,6 +5379,9 @@ ${taskSection}`;
 		runnerType: "claude" | "gemini" | "codex" | "cursor",
 		config: AgentRunnerConfig,
 	): IAgentRunner {
+		if (this.config.handlers?.createRunner) {
+			return this.config.handlers.createRunner(runnerType, config);
+		}
 		switch (runnerType) {
 			case "claude": {
 				// Inject the hosted SessionStore at the last moment so it only
@@ -6443,7 +6488,12 @@ ${input.userComment}
 		 * Defaults to `"linear"` (the pre-platform-aware behavior).
 		 */
 		sessionPlatform: "linear" | "github" | "gitlab" = "linear",
-	): Promise<{ config: AgentRunnerConfig; runnerType: RunnerType }> {
+		runnerTypeOverride?: RunnerType,
+	): Promise<{
+		config: AgentRunnerConfig;
+		runnerType: RunnerType;
+		selectionWasExplicit: boolean;
+	}> {
 		const log = this.logger.withContext({
 			sessionId,
 			platform: session.issueContext?.trackerId,
@@ -6493,6 +6543,7 @@ ${input.userComment}
 			skills: allowedSkillNames,
 			sandboxSettings: this.sdkSandboxSettings ?? undefined,
 			egressCaCertPath: this.egressCaCertPath ?? undefined,
+			runnerTypeOverride,
 			onMessage: (message: SDKMessage) => {
 				this.handleClaudeMessage(sessionId, message, repository.id);
 			},
@@ -7262,22 +7313,25 @@ ${input.userComment}
 		// Create runner configuration
 		// buildAgentRunnerConfig determines runner type from labels for new sessions
 		// For existing sessions, we still need labels for model override but ignore runner type
-		const { config: runnerConfig, runnerType } =
-			await this.buildAgentRunnerConfig(
-				session,
-				repository,
-				sessionId,
-				systemPrompt,
-				allowedTools,
-				allowedDirectories,
-				disallowedTools,
-				resumeSessionId,
-				labels, // Always pass labels to preserve model override
-				fullIssue.description || undefined, // Description tags can override label selectors
-				maxTurns, // Pass maxTurns if specified
-				resolvedWorkspaceId,
-				this.buildSkillSessionContext(repository, fullIssue, session),
-			);
+		const {
+			config: runnerConfig,
+			runnerType,
+			selectionWasExplicit,
+		} = await this.buildAgentRunnerConfig(
+			session,
+			repository,
+			sessionId,
+			systemPrompt,
+			allowedTools,
+			allowedDirectories,
+			disallowedTools,
+			resumeSessionId,
+			labels, // Always pass labels to preserve model override
+			fullIssue.description || undefined, // Description tags can override label selectors
+			maxTurns, // Pass maxTurns if specified
+			resolvedWorkspaceId,
+			this.buildSkillSessionContext(repository, fullIssue, session),
+		);
 
 		// Create the appropriate runner based on session state
 		const runner = this.createRunnerForType(runnerType, runnerConfig);
@@ -7299,6 +7353,32 @@ ${input.userComment}
 			commentAuthor,
 			commentTimestamp,
 		);
+		this.runnerFallbackController.registerTurn({
+			sessionId,
+			runnerType,
+			selectionWasExplicit,
+			prompt: fullPrompt,
+			buildConfig: async (fallbackType) =>
+				(
+					await this.buildAgentRunnerConfig(
+						session,
+						repository,
+						sessionId,
+						systemPrompt,
+						allowedTools,
+						allowedDirectories,
+						disallowedTools,
+						undefined,
+						labels,
+						fullIssue.description || undefined,
+						maxTurns,
+						resolvedWorkspaceId,
+						this.buildSkillSessionContext(repository, fullIssue, session),
+						"linear",
+						fallbackType,
+					)
+				).config,
+		});
 
 		// Start session - use streaming mode if supported for ability to add messages later
 		try {

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -59,6 +59,7 @@ export interface IRunnerSelector {
 		runnerType: RunnerType;
 		modelOverride?: string;
 		fallbackModelOverride?: string;
+		selectionWasExplicit?: boolean;
 	};
 	getDefaultModelForRunner(runnerType: RunnerType): string;
 	getDefaultFallbackModelForRunner(runnerType: RunnerType): string;
@@ -158,6 +159,8 @@ export interface IssueRunnerConfigInput {
 	sandboxSettings?: SandboxSettings;
 	/** CA cert path for MITM TLS termination — passed via child process env */
 	egressCaCertPath?: string;
+	/** Force a provider for a cross-runner fallback attempt. */
+	runnerTypeOverride?: RunnerType;
 }
 
 export function resolveIssueMcpConfigPath(
@@ -303,6 +306,7 @@ export class RunnerConfigBuilder {
 	buildIssueConfig(input: IssueRunnerConfigInput): {
 		config: AgentRunnerConfig;
 		runnerType: RunnerType;
+		selectionWasExplicit: boolean;
 	} {
 		const log = input.logger;
 
@@ -329,24 +333,46 @@ export class RunnerConfigBuilder {
 		let runnerType = runnerSelection.runnerType;
 		let modelOverride = runnerSelection.modelOverride;
 		let fallbackModelOverride = runnerSelection.fallbackModelOverride;
+		if (input.runnerTypeOverride) {
+			runnerType = input.runnerTypeOverride;
+			modelOverride = this.runnerSelector.getDefaultModelForRunner(runnerType);
+			fallbackModelOverride =
+				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType);
+		}
 
 		// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
-		if (input.session.claudeSessionId && runnerType !== "claude") {
+		if (
+			!input.runnerTypeOverride &&
+			input.session.claudeSessionId &&
+			runnerType !== "claude"
+		) {
 			runnerType = "claude";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("claude");
 			fallbackModelOverride =
 				this.runnerSelector.getDefaultFallbackModelForRunner("claude");
-		} else if (input.session.geminiSessionId && runnerType !== "gemini") {
+		} else if (
+			!input.runnerTypeOverride &&
+			input.session.geminiSessionId &&
+			runnerType !== "gemini"
+		) {
 			runnerType = "gemini";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("gemini");
 			fallbackModelOverride =
 				this.runnerSelector.getDefaultFallbackModelForRunner("gemini");
-		} else if (input.session.codexSessionId && runnerType !== "codex") {
+		} else if (
+			!input.runnerTypeOverride &&
+			input.session.codexSessionId &&
+			runnerType !== "codex"
+		) {
 			runnerType = "codex";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("codex");
 			fallbackModelOverride =
 				this.runnerSelector.getDefaultFallbackModelForRunner("codex");
-		} else if (input.session.cursorSessionId && runnerType !== "cursor") {
+		} else if (
+			!input.runnerTypeOverride &&
+			input.session.cursorSessionId &&
+			runnerType !== "cursor"
+		) {
 			runnerType = "cursor";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("cursor");
 			fallbackModelOverride =
@@ -483,7 +509,11 @@ export class RunnerConfigBuilder {
 			config.maxTurns = input.maxTurns;
 		}
 
-		return { config, runnerType };
+		return {
+			config,
+			runnerType,
+			selectionWasExplicit: runnerSelection.selectionWasExplicit === true,
+		};
 	}
 
 	/**

--- a/packages/edge-worker/src/RunnerFallbackController.ts
+++ b/packages/edge-worker/src/RunnerFallbackController.ts
@@ -1,0 +1,154 @@
+import type { SDKRateLimitEvent } from "cyrus-claude-runner";
+import type {
+	AgentRunnerConfig,
+	EdgeWorkerConfig,
+	IAgentRunner,
+	RunnerType,
+} from "cyrus-core";
+import type { AgentSessionManager } from "./AgentSessionManager.js";
+
+export interface RunnerFallbackTurn {
+	sessionId: string;
+	runnerType: RunnerType;
+	selectionWasExplicit: boolean;
+	prompt: string;
+	buildConfig: (runnerType: RunnerType) => Promise<AgentRunnerConfig>;
+}
+
+interface RunnerFallbackContext extends RunnerFallbackTurn {
+	attemptedRunners: Set<RunnerType>;
+}
+
+export interface RunnerFallbackControllerDependencies {
+	getConfig: () => EdgeWorkerConfig;
+	sessionManager: AgentSessionManager;
+	createRunner: (
+		runnerType: RunnerType,
+		config: AgentRunnerConfig,
+	) => IAgentRunner;
+}
+
+/** Coordinates a bounded provider transition without replacing Cyrus state. */
+export class RunnerFallbackController {
+	private readonly contexts = new Map<string, RunnerFallbackContext>();
+
+	constructor(
+		private readonly dependencies: RunnerFallbackControllerDependencies,
+	) {}
+
+	registerTurn(turn: RunnerFallbackTurn): void {
+		this.contexts.set(turn.sessionId, {
+			...turn,
+			attemptedRunners: new Set([turn.runnerType]),
+		});
+	}
+
+	removeSession(sessionId: string): void {
+		this.contexts.delete(sessionId);
+	}
+
+	async handleRateLimit(
+		sessionId: string,
+		message: SDKRateLimitEvent,
+	): Promise<boolean> {
+		const context = this.contexts.get(sessionId);
+		const info = message.rate_limit_info;
+		if (!context || info.status !== "rejected" || !info.rateLimitType) {
+			return false;
+		}
+
+		const policy =
+			this.dependencies.getConfig().runnerFallbacks?.[context.runnerType];
+		if (!policy?.rateLimitTypes.includes(info.rateLimitType)) {
+			return false;
+		}
+		if (context.selectionWasExplicit && !policy.overrideExplicitSelectors) {
+			return false;
+		}
+
+		// Drop the failed provider's trailing assistant/result messages immediately.
+		// Otherwise they can race the replacement runner and post a false success.
+		this.dependencies.sessionManager.suppressRunnerSession(
+			sessionId,
+			message.session_id,
+		);
+
+		for (const fallbackType of policy.runners) {
+			if (context.attemptedRunners.has(fallbackType)) continue;
+			context.attemptedRunners.add(fallbackType);
+
+			let runner: IAgentRunner;
+			try {
+				const config = await context.buildConfig(fallbackType);
+				runner = this.dependencies.createRunner(fallbackType, config);
+				if (runner.isAvailable && !(await runner.isAvailable())) {
+					continue;
+				}
+			} catch {
+				continue;
+			}
+
+			await this.dependencies.sessionManager.createThoughtActivity(
+				sessionId,
+				this.formatTransition(context.runnerType, fallbackType, message),
+			);
+			this.dependencies.sessionManager.switchAgentRunner(
+				sessionId,
+				runner,
+				fallbackType,
+			);
+			context.runnerType = fallbackType;
+
+			try {
+				if (runner.supportsStreamingInput && runner.startStreaming) {
+					await runner.startStreaming(context.prompt);
+				} else {
+					await runner.start(context.prompt);
+				}
+			} catch (error) {
+				runner.stop();
+				await this.dependencies.sessionManager.failRunnerFallback(
+					sessionId,
+					`${this.formatQuota(message)} The ${this.displayName(fallbackType)} fallback failed to start: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			return true;
+		}
+
+		this.dependencies.sessionManager.getAgentRunner(sessionId)?.stop();
+		await this.dependencies.sessionManager.failRunnerFallback(
+			sessionId,
+			`${this.formatQuota(message)} The configured fallback runner is unavailable or unauthenticated, so execution could not continue.`,
+		);
+		return true;
+	}
+
+	private formatTransition(
+		source: RunnerType,
+		target: RunnerType,
+		message: SDKRateLimitEvent,
+	): string {
+		return `${this.displayName(source)} quota exhausted (${message.rate_limit_info.rateLimitType}); continuing with ${this.displayName(target)}.${this.formatReset(message)}`;
+	}
+
+	private formatQuota(message: SDKRateLimitEvent): string {
+		return `Claude quota exhausted (${message.rate_limit_info.rateLimitType ?? "unknown"}).${this.formatReset(message)}`;
+	}
+
+	private formatReset(message: SDKRateLimitEvent): string {
+		const resetsAt = message.rate_limit_info.resetsAt;
+		return resetsAt
+			? ` Quota resets at ${new Date(resetsAt * 1000).toISOString()}.`
+			: "";
+	}
+
+	private displayName(runnerType: RunnerType): string {
+		return runnerType === "codex"
+			? "Codex"
+			: runnerType === "claude"
+				? "Claude"
+				: runnerType === "gemini"
+					? "Gemini"
+					: "Cursor";
+	}
+}

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -129,6 +129,7 @@ export class RunnerSelectionService {
 		runnerType: RunnerType;
 		modelOverride?: string;
 		fallbackModelOverride?: string;
+		selectionWasExplicit: boolean;
 	} {
 		const normalizedLabels = (labels || []).map((label) => label.toLowerCase());
 		const normalizedDescription = issueDescription || "";
@@ -321,6 +322,12 @@ export class RunnerSelectionService {
 			runnerType,
 			modelOverride: resolvedModelOverride,
 			fallbackModelOverride,
+			selectionWasExplicit: Boolean(
+				resolvedAgentFromDescription ||
+					resolvedAgentFromLabels ||
+					modelFromDescription ||
+					modelFromLabels,
+			),
 		};
 	}
 }

--- a/packages/edge-worker/test/ConfigManager.runner-fallbacks.test.ts
+++ b/packages/edge-worker/test/ConfigManager.runner-fallbacks.test.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import type { EdgeWorkerConfig, ILogger } from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigManager } from "../src/ConfigManager.js";
+
+vi.mock("node:fs/promises");
+
+describe("ConfigManager runnerFallbacks hot reload", () => {
+	let logger: ILogger;
+	const baseConfig = {
+		proxyUrl: "http://localhost:3000",
+		cyrusHome: "/tmp/cyrus-home",
+		repositories: [
+			{
+				id: "repo-1",
+				name: "Repo 1",
+				repositoryPath: "/test/repo",
+				baseBranch: "main",
+				workspaceBaseDir: "/test/workspaces",
+			},
+		],
+	} as unknown as EdgeWorkerConfig;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as ILogger;
+	});
+
+	function manager(config = baseConfig): ConfigManager {
+		return new ConfigManager(
+			config,
+			logger,
+			"/tmp/cyrus-home/config.json",
+			new Map(config.repositories.map((repo) => [repo.id, repo])),
+		);
+	}
+
+	it("merges and detects a valid runnerFallbacks change", async () => {
+		const fallbackPolicy = {
+			claude: {
+				runners: ["codex"],
+				rateLimitTypes: ["five_hour"],
+			},
+		};
+		const configManager = manager();
+		vi.mocked(readFile).mockResolvedValue(
+			JSON.stringify({
+				repositories: baseConfig.repositories,
+				runnerFallbacks: fallbackPolicy,
+			}) as never,
+		);
+
+		const reloaded = await (configManager as any).loadConfigSafely();
+
+		expect(reloaded.runnerFallbacks).toEqual(fallbackPolicy);
+		expect((configManager as any).detectGlobalConfigChanges(reloaded)).toBe(
+			true,
+		);
+	});
+
+	it("rejects an invalid runnerFallbacks change", async () => {
+		const configManager = manager();
+		vi.mocked(readFile).mockResolvedValue(
+			JSON.stringify({
+				repositories: baseConfig.repositories,
+				runnerFallbacks: {
+					claude: {
+						runners: ["codex"],
+						rateLimitTypes: ["not_a_quota"],
+					},
+				},
+			}) as never,
+		);
+
+		expect(await (configManager as any).loadConfigSafely()).toBeNull();
+		expect(logger.error).toHaveBeenCalledWith(
+			expect.stringContaining("runnerFallbacks"),
+			expect.anything(),
+		);
+	});
+});

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
@@ -70,6 +70,52 @@ function buildCodexConfig(sandboxSettings?: Record<string, unknown>) {
 }
 
 describe("RunnerConfigBuilder Codex sandbox plumbing", () => {
+	it("forces Codex for fallback while preserving the Claude turn context", () => {
+		const session = makeSession();
+		session.claudeSessionId = "claude-session";
+		const { config, runnerType } = makeCodexBuilder().buildIssueConfig({
+			session,
+			repository: {
+				id: "repo-a",
+				name: "Repo A",
+				repositoryPath: "/repos/repo-a",
+				allowedTools: [],
+			} as unknown as RepositoryConfig,
+			sessionId: "sess-1",
+			systemPrompt: "same system prompt",
+			allowedTools: ["Read(**)", "Bash(*)"],
+			allowedDirectories: ["/ws/root/attachments", "/repos/repo-a"],
+			disallowedTools: ["Bash(rm *)"],
+			platformMcpConfigOverrides: ["/tmp/linear-mcp.json"],
+			cyrusHome: "/tmp/cyrus-home",
+			linearWorkspaceId: "ws-1",
+			logger: silentLogger,
+			onMessage: () => {},
+			onError: () => {},
+			requireLinearWorkspaceId: () => "ws-1",
+			sandboxSettings: { enabled: true },
+			runnerTypeOverride: "codex",
+		});
+
+		expect(runnerType).toBe("codex");
+		expect(config).toEqual(
+			expect.objectContaining({
+				workingDirectory: "/ws/root",
+				allowedTools: ["Read(**)", "Bash(*)"],
+				allowedDirectories: ["/ws/root/attachments", "/repos/repo-a"],
+				disallowedTools: ["Bash(rm *)"],
+				mcpConfigPath: "/tmp/linear-mcp.json",
+				model: "gpt-5.5",
+				fallbackModel: "gpt-5.4",
+				sandboxSettings: {
+					allowWrite: ["/ws/root"],
+					allowRead: ["/ws/root", "/ws/root/attachments", "/repos/repo-a"],
+				},
+			}),
+		);
+		expect(config.resumeSessionId).toBeUndefined();
+	});
+
 	it("translates the egress sandbox into a Codex filesystem allow-list", () => {
 		// Plumbs both write (worktree) and read (worktree + allowed dirs) roots;
 		// the Codex runner turns these into a per-thread permission profile.

--- a/packages/edge-worker/test/RunnerFallbackController.test.ts
+++ b/packages/edge-worker/test/RunnerFallbackController.test.ts
@@ -1,0 +1,281 @@
+import type { SDKMessage, SDKRateLimitEvent } from "cyrus-claude-runner";
+import {
+	type AgentRunnerConfig,
+	AgentSessionStatus,
+	type EdgeWorkerConfig,
+	type IAgentRunner,
+} from "cyrus-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSessionManager } from "../src/AgentSessionManager.js";
+import { RunnerFallbackController } from "../src/RunnerFallbackController.js";
+import type { IActivitySink } from "../src/sinks/IActivitySink.js";
+
+class FakeRunner {
+	readonly supportsStreamingInput = true;
+	readonly startStreaming = vi.fn(async () => ({
+		sessionId: "codex-session",
+		startedAt: new Date(),
+		isRunning: false,
+	}));
+	readonly start = vi.fn();
+	readonly stop = vi.fn();
+	readonly isAvailable = vi.fn(async () => true);
+	getFormatter = vi.fn();
+}
+
+const rejectedRateLimit = {
+	type: "rate_limit_event",
+	session_id: "claude-session",
+	uuid: "rate-limit-1",
+	rate_limit_info: {
+		status: "rejected",
+		rateLimitType: "five_hour",
+		resetsAt: 1_800_000_000,
+	},
+} as SDKRateLimitEvent;
+
+describe("RunnerFallbackController", () => {
+	let manager: AgentSessionManager;
+	let sink: IActivitySink;
+	let oldRunner: FakeRunner;
+	let codexRunner: FakeRunner;
+	let config: EdgeWorkerConfig;
+	let createRunner: ReturnType<typeof vi.fn>;
+	const sessionId = "linear-session";
+
+	beforeEach(() => {
+		config = {
+			repositories: [],
+			runnerFallbacks: {
+				claude: {
+					runners: ["codex"],
+					rateLimitTypes: ["five_hour"],
+				},
+			},
+		} as unknown as EdgeWorkerConfig;
+		manager = new AgentSessionManager();
+		sink = {
+			id: "linear",
+			postActivity: vi.fn().mockResolvedValue({ activityId: "activity-id" }),
+			createAgentSession: vi.fn(),
+		};
+		manager.createCyrusAgentSession(
+			sessionId,
+			"issue-1",
+			{ id: "issue-1", identifier: "MEL-187", title: "Fallback" },
+			{ path: "/tmp/worktree", isGitWorktree: true },
+		);
+		manager.setActivitySink(sessionId, sink);
+		oldRunner = new FakeRunner();
+		codexRunner = new FakeRunner();
+		Object.defineProperty(codexRunner, "constructor", {
+			value: { name: "CodexRunner" },
+		});
+		manager.addAgentRunner(sessionId, oldRunner as unknown as IAgentRunner);
+		manager.getSession(sessionId)!.claudeSessionId = "claude-session";
+		createRunner = vi.fn(() => codexRunner as unknown as IAgentRunner);
+	});
+
+	function register(selectionWasExplicit = false): RunnerFallbackController {
+		const controller = new RunnerFallbackController({
+			getConfig: () => config,
+			sessionManager: manager,
+			createRunner,
+		});
+		controller.registerTurn({
+			sessionId,
+			runnerType: "claude",
+			selectionWasExplicit,
+			prompt: "original prompt with attachments",
+			buildConfig: vi.fn(
+				async () =>
+					({
+						workingDirectory: "/tmp/worktree",
+						allowedTools: ["Bash"],
+						mcpConfig: { linear: { type: "sdk", name: "linear" } },
+					}) as unknown as AgentRunnerConfig,
+			),
+		});
+		manager.setRateLimitFallbackHandler((id, event) =>
+			controller.handleRateLimit(id, event),
+		);
+		return controller;
+	}
+
+	it("switches an implicit Claude turn to Codex and suppresses Claude completion", async () => {
+		register();
+
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+		await manager.handleClaudeMessage(sessionId, {
+			type: "result",
+			subtype: "success",
+			session_id: "claude-session",
+			is_error: false,
+			result: "misleading Claude success",
+			total_cost_usd: 0,
+			usage: {},
+		} as unknown as SDKMessage);
+		await manager.handleClaudeMessage(sessionId, {
+			type: "assistant",
+			session_id: "codex-session",
+			message: {
+				content: [{ type: "text", text: "Codex finished the work" }],
+			},
+		} as unknown as SDKMessage);
+		await manager.handleClaudeMessage(sessionId, {
+			type: "result",
+			subtype: "success",
+			session_id: "codex-session",
+			is_error: false,
+			result: "Codex finished the work",
+			total_cost_usd: 0,
+			usage: {},
+		} as unknown as SDKMessage);
+
+		expect(oldRunner.stop).toHaveBeenCalledOnce();
+		expect(codexRunner.startStreaming).toHaveBeenCalledWith(
+			"original prompt with attachments",
+		);
+		expect(createRunner).toHaveBeenCalledWith(
+			"codex",
+			expect.objectContaining({
+				workingDirectory: "/tmp/worktree",
+				allowedTools: ["Bash"],
+				mcpConfig: expect.objectContaining({ linear: expect.any(Object) }),
+			}),
+		);
+		expect(manager.getSession(sessionId)?.agentRunner).toBe(codexRunner);
+		expect(manager.getSession(sessionId)?.claudeSessionId).toBeUndefined();
+		expect(sink.postActivity).toHaveBeenCalledTimes(2);
+		expect(sink.postActivity).toHaveBeenCalledWith(
+			sessionId,
+			expect.objectContaining({
+				type: "thought",
+				body: expect.stringMatching(/Claude quota.*continuing with Codex/i),
+			}),
+			{},
+		);
+		expect(vi.mocked(sink.postActivity).mock.calls[1]?.[1]).toEqual({
+			type: "response",
+			body: "Codex finished the work",
+		});
+		expect(
+			vi
+				.mocked(sink.postActivity)
+				.mock.calls.some((call) =>
+					JSON.stringify(call).includes("misleading Claude success"),
+				),
+		).toBe(false);
+	});
+
+	it("preserves an explicit Claude selector by default", async () => {
+		register(true);
+
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+
+		expect(createRunner).not.toHaveBeenCalled();
+		expect(oldRunner.stop).not.toHaveBeenCalled();
+	});
+
+	it("allows explicit selectors when the policy opts in", async () => {
+		config.runnerFallbacks!.claude!.overrideExplicitSelectors = true;
+		register(true);
+
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+
+		expect(createRunner).toHaveBeenCalledWith("codex", expect.any(Object));
+	});
+
+	it("does not fall back for warnings or unconfigured quota categories", async () => {
+		register();
+
+		await manager.handleClaudeMessage(sessionId, {
+			...rejectedRateLimit,
+			rate_limit_info: {
+				...rejectedRateLimit.rate_limit_info,
+				status: "allowed_warning",
+			},
+		} as SDKRateLimitEvent);
+		await manager.handleClaudeMessage(sessionId, {
+			...rejectedRateLimit,
+			rate_limit_info: {
+				...rejectedRateLimit.rate_limit_info,
+				rateLimitType: "seven_day",
+			},
+		} as SDKRateLimitEvent);
+
+		expect(createRunner).not.toHaveBeenCalled();
+	});
+
+	it("does not fall back for authentication or ordinary provider errors", async () => {
+		register();
+
+		await manager.handleClaudeMessage(sessionId, {
+			type: "assistant",
+			session_id: "claude-session",
+			error: "authentication_failed",
+			message: { content: [{ type: "text", text: "Please sign in" }] },
+		} as unknown as SDKMessage);
+		await manager.handleClaudeMessage(sessionId, {
+			type: "result",
+			subtype: "error_during_execution",
+			session_id: "claude-session",
+			is_error: true,
+			errors: ["ordinary provider failure"],
+			total_cost_usd: 0,
+			usage: {},
+		} as unknown as SDKMessage);
+
+		expect(createRunner).not.toHaveBeenCalled();
+	});
+
+	it("keeps an actionable quota error when Codex is unavailable", async () => {
+		codexRunner.isAvailable.mockResolvedValue(false);
+		register();
+
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+
+		expect(codexRunner.startStreaming).not.toHaveBeenCalled();
+		expect(manager.getSession(sessionId)?.agentRunner).toBe(oldRunner);
+		expect(manager.getSession(sessionId)?.status).toBe(
+			AgentSessionStatus.Error,
+		);
+		expect(sink.postActivity).toHaveBeenCalledWith(
+			sessionId,
+			expect.objectContaining({
+				type: "error",
+				body: expect.stringMatching(/quota.*unavailable or unauthenticated/i),
+			}),
+			{},
+		);
+	});
+
+	it("attempts each provider at most once", async () => {
+		config.runnerFallbacks!.claude!.runners = ["codex", "claude"];
+		codexRunner.isAvailable.mockResolvedValue(false);
+		register();
+
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+
+		expect(createRunner).toHaveBeenCalledTimes(1);
+		expect(createRunner).toHaveBeenCalledWith("codex", expect.any(Object));
+	});
+
+	it("stores the Codex session id so later prompts continue with Codex", async () => {
+		register();
+		await manager.handleClaudeMessage(sessionId, rejectedRateLimit);
+
+		await manager.handleClaudeMessage(sessionId, {
+			type: "system",
+			subtype: "init",
+			session_id: "codex-session",
+			model: "gpt-5.5",
+			tools: ["Bash"],
+			permissionMode: "never",
+			apiKeySource: "chatgpt",
+		} as unknown as SDKMessage);
+
+		expect(manager.getSession(sessionId)?.claudeSessionId).toBeUndefined();
+		expect(manager.getSession(sessionId)?.codexSessionId).toBe("codex-session");
+	});
+});

--- a/packages/edge-worker/test/RunnerSelectionService.fallback.test.ts
+++ b/packages/edge-worker/test/RunnerSelectionService.fallback.test.ts
@@ -1,0 +1,31 @@
+import type { EdgeWorkerConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import { RunnerSelectionService } from "../src/RunnerSelectionService.js";
+
+function service(): RunnerSelectionService {
+	return new RunnerSelectionService({
+		repositories: [],
+		defaultRunner: "claude",
+	} as unknown as EdgeWorkerConfig);
+}
+
+describe("RunnerSelectionService fallback selector semantics", () => {
+	it("marks defaultRunner selection as implicit", () => {
+		expect(
+			service().determineRunnerSelection([], "").selectionWasExplicit,
+		).toBe(false);
+	});
+
+	it("marks an agent description selector as explicit", () => {
+		expect(
+			service().determineRunnerSelection([], "[agent=claude]")
+				.selectionWasExplicit,
+		).toBe(true);
+	});
+
+	it("marks an agent label as explicit", () => {
+		expect(
+			service().determineRunnerSelection(["claude"]).selectionWasExplicit,
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- add validated `runnerFallbacks` configuration with hot-reload support
- fall back from Claude to Codex only for configured Claude quota rejection categories
- preserve the active worktree, original prompt, attachments, MCP/tool permissions, and sandbox settings
- suppress superseded Claude completion messages and continue later prompts in the Codex session
- surface an actionable quota error when Codex is unavailable

## Configuration

```json
{
  "runnerFallbacks": {
    "claude": {
      "runners": ["codex"],
      "rateLimitTypes": ["five_hour", "seven_day"],
      "overrideExplicitSelectors": false
    }
  }
}
```

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors; 11 pre-existing warnings)
- `pnpm test:packages:run` (all 14 package suites passed)
- `pnpm --filter './apps/*' test:run` (94 CLI tests passed; F1 has no unit files)
- F1 replay: Claude quota rejection → one Codex transition → one Codex response → follow-up resumes the Codex session
- `git diff --check`

Linear: https://linear.app/melodymaifafafa/issue/MEL-187/claude-%E4%BC%9A%E8%AF%9D%E9%A2%9D%E5%BA%A6%E8%80%97%E5%B0%BD%E6%97%B6%E8%87%AA%E5%8A%A8%E5%88%87%E6%8D%A2%E5%88%B0-codex-runner

Tip: mention `@cyrusagent` in a PR comment to request changes.

<!-- generated-by-cyrus -->