### PR TITLE
Fix release workflow runner path initialization

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -43,7 +43,6 @@ jobs:
       REQUESTED_VERSION: ${{ inputs.version }}
       DIST_TAG: ${{ inputs.dist_tag }}
       DRY_RUN: ${{ inputs.dry_run }}
-      RELEASE_ARTIFACTS: ${{ runner.temp }}/cyrus-release
 
     steps:
       - name: Require the main branch
@@ -53,6 +52,10 @@ jobs:
             echo "Cyrus releases must be dispatched from main; received $GITHUB_REF." >&2
             exit 1
           fi
+
+      - name: Initialize release paths
+        shell: bash
+        run: echo "RELEASE_ARTIFACTS=$RUNNER_TEMP/cyrus-release" >> "$GITHUB_ENV"
 
       - name: Check out the release source
         uses: actions/checkout@v6

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -30,6 +30,12 @@ describe("trusted Cyrus release workflow", () => {
 		expect(workflow).toContain('"refs/heads/main"');
 		expect(workflow).toContain("group: release-cyrus-cli");
 		expect(workflow).toContain("cancel-in-progress: false");
+		expect(workflow).not.toContain(
+			`RELEASE_ARTIFACTS: \${{ runner.temp }}/cyrus-release`,
+		);
+		expect(workflow).toContain(
+			'echo "RELEASE_ARTIFACTS=$RUNNER_TEMP/cyrus-release" >> "$GITHUB_ENV"',
+		);
 	});
 
 	it("uses npm OIDC without a long-lived publish token", () => {


### PR DESCRIPTION
## Summary
- initialize release artifact paths after the GitHub-hosted runner starts
- prevent invalid job-level use of the `runner` expression context
- add a regression assertion for workflow path initialization

## Validation
- reproduced the HTTP 422 dispatch failure with the merged workflow
- `pnpm --filter cyrus-ai test:run` (100 tests)
- `pnpm test:packages:run`
- `pnpm typecheck`
- `pnpm build`
- changed-file Biome check

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->