### PR TITLE
Release Cyrus CLI v0.2.68

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.68] - 2026-08-05
+
 ### Added
 - Added an on-demand, main-only Cyrus CLI release workflow using npm trusted publishing. It validates the coordinated monorepo version and changelogs, runs release gates, inspects every package tarball, publishes the complete dependency graph in order, and creates the matching git tag and GitHub release without a long-lived npm token. ([#1398](https://github.com/cyrusagents/cyrus/pull/1398))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.68] - 2026-08-05
+
 ### Added
 - `ClaudeRunnerConfig` accepts a `spawnClaudeCodeProcess` override, forwarded to the Claude Agent SDK option of the same name. Lets the Claude Code process run somewhere other than a local child process — a container, a Kubernetes pod, a remote host — without forking the runner. ([#1391](https://github.com/cyrusagents/cyrus/pull/1391))
 
@@ -13,6 +15,53 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 - Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` reports no known vulnerabilities. ([CYPACK-1423](https://linear.app/ceedar/issue/CYPACK-1423/address-open-security-patches-for-cyrus-cli), [#1392](https://github.com/cyrusagents/cyrus/pull/1392))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.68
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.68
+
+#### cyrus-core
+- cyrus-core@0.2.68
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.68
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.68
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.68
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.68
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.68
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.68
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.68
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.68
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.68
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.68
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.68
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.68
 
 ## [0.2.67] - 2026-07-25
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-08-05-cypack-1423-release-v0.2.68.md
+++ b/apps/f1/test-drives/2026-08-05-cypack-1423-release-v0.2.68.md
@@ -1,0 +1,66 @@
+# Test Drive: CYPACK-1423 Release v0.2.68
+
+**Date**: 2026-08-05
+**Goal**: Validate the local F1 issue, Codex session, and activity-rendering flow before publishing v0.2.68.
+**Test Repo**: `/tmp/f1-release-v0.2.68-uUGoFB/repo`
+**F1 Port**: `3600`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Session started
+- [x] Worktree created
+- [x] Activities tracked
+- [x] Codex processed the issue successfully
+
+### Renderer
+- [x] Activity format correct
+- [x] Pagination works
+- [ ] Search works (the F1 CLI has no session-search command)
+
+## Session Log
+
+```bash
+apps/f1/f1 init-test-repo --path /tmp/f1-release-v0.2.68-uUGoFB/repo
+CYRUS_PORT=3600 CYRUS_DEFAULT_RUNNER=codex \
+  CYRUS_REPO_PATH=/tmp/f1-release-v0.2.68-uUGoFB/repo \
+  bun run apps/f1/server.ts
+CYRUS_PORT=3600 apps/f1/f1 ping
+CYRUS_PORT=3600 apps/f1/f1 status
+```
+
+Result: the fresh test repository was initialized, the server started on port 3600, ping returned healthy, and status returned `ready`.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 create-issue \
+  --title "Release v0.2.68 F1 validation" \
+  --description $'[agent=codex]\nValidate the Cyrus v0.2.68 release by inspecting the configured repository and reporting its current implementation status. Do not edit files.'
+CYRUS_PORT=3600 apps/f1/f1 start-session --issue-id issue-1
+CYRUS_PORT=3600 apps/f1/f1 prompt-session \
+  --session-id session-1 \
+  --message "Use the configured test repository for this issue."
+```
+
+Result: F1 created `issue-1` / `DEF-1` and `session-1`. After repository selection, EdgeWorker created the issue worktree, selected the Codex runner, and reported model `gpt-5.5`.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 10 --offset 20
+```
+
+Result: the Codex-backed investigation completed successfully. The session rendered 32 coherent activities, including elicitation, prompt, thought, action, and final response activity. Pagination returned the requested 10-row window and displayed continuation guidance.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 stop-session --session-id session-1
+```
+
+Result: the session stopped successfully, and SIGINT shut down EdgeWorker and the shared application server gracefully.
+
+## Final Retrospective
+
+F1 validated the full local server, issue tracker, repository-selection recovery, worktree creation, Codex app-server execution, activity rendering, pagination, successful final response, session stop, and graceful server shutdown paths for v0.2.68. The generated test repository intentionally has unfinished algorithms and tests; the agent correctly performed an inspection-only task without modifying it.

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"repository": {
 		"type": "git",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Configuration update handlers for Cyrus agent",
 	"repository": {
 		"type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Core business logic for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"repository": {
 		"type": "git",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Simple agent runner for enumerated responses",
 	"repository": {
 		"type": "git",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.67",
+	"version": "0.2.68",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- cut public and internal changelogs for v0.2.68
- bump all 15 coordinated npm packages to 0.2.68
- add passing Codex-backed F1 release evidence

## Verification
- `node scripts/release-packages.mjs validate 0.2.68`
- `pnpm test:packages:run` (1,609 passed)
- `pnpm typecheck`
- `pnpm build`
- `pnpm audit` (zero advisories)
- F1 issue/session/activity test drive