### PR TITLE
Make CLI releases safely resumable

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,5 +1,5 @@
 name: 'Install Dependencies'
-description: 'Sets up Node.js and pnpm, then installs dependencies'
+description: 'Sets up pnpm and installs locked dependencies'
 runs:
   using: 'composite'
   steps:
@@ -15,7 +15,10 @@ runs:
         echo "Installing pnpm version: $PNPM_VERSION"
     
     - name: Install dependencies with pnpm
-      uses: wyvox/action-setup-pnpm@v3
+      uses: pnpm/action-setup@v6
       with:
-        pnpm-version: ${{ env.PNPM_VERSION }}
-        args: --frozen-lockfile --strict-peer-dependencies
+        version: ${{ env.PNPM_VERSION }}
+
+    - name: Install locked dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --strict-peer-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,25 @@ on:
       - main
       - 'cypack-*'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
+        package-manager-cache: false
     
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
@@ -48,8 +53,9 @@ jobs:
       run: pnpm -r test:run
     
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v7
       continue-on-error: true
       with:
         directory: ./coverage/
         fail_ci_if_error: false
+        use_oidc: true

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -95,8 +95,10 @@ jobs:
             if npm view "${package_name}@${REQUESTED_VERSION}" version >/dev/null 2>&1; then
               if [[ "$DRY_RUN" == "true" ]]; then
                 echo "::warning::${package_name}@${REQUESTED_VERSION} is already published; continuing because this is a dry run."
+              elif [[ "$(npm view "$package_name" "dist-tags.${DIST_TAG}" 2>/dev/null || true)" == "$REQUESTED_VERSION" ]]; then
+                echo "::warning::${package_name}@${REQUESTED_VERSION} is already published with npm tag ${DIST_TAG}; continuing this partial release."
               else
-                echo "${package_name}@${REQUESTED_VERSION} is already published." >&2
+                echo "${package_name}@${REQUESTED_VERSION} is already published without npm tag ${DIST_TAG}." >&2
                 exit 1
               fi
             fi
@@ -190,11 +192,35 @@ jobs:
         if: ${{ !inputs.dry_run }}
         shell: bash
         run: |
+          verify_registry_version() {
+            local package_name="$1"
+            local published=""
+            local tagged=""
+
+            for attempt in {1..12}; do
+              published="$(npm view "${package_name}@${REQUESTED_VERSION}" version 2>/dev/null || true)"
+              tagged="$(npm view "$package_name" "dist-tags.${DIST_TAG}" 2>/dev/null || true)"
+              if [[ "$published" == "$REQUESTED_VERSION" && "$tagged" == "$REQUESTED_VERSION" ]]; then
+                return 0
+              fi
+              if [[ "$attempt" -lt 12 ]]; then
+                echo "Waiting for ${package_name}@${REQUESTED_VERSION} with npm tag ${DIST_TAG} to become visible (attempt ${attempt}/12)."
+                sleep 5
+              fi
+            done
+
+            echo "${package_name}@${REQUESTED_VERSION} is not consistently visible with npm tag ${DIST_TAG}." >&2
+            return 1
+          }
+
           while IFS=$'\t' read -r directory package_name; do
             tarball="$RELEASE_ARTIFACTS/${package_name}-${REQUESTED_VERSION}.tgz"
-            npm publish "$tarball" --access public --tag "$DIST_TAG"
-            published="$(npm view "${package_name}@${REQUESTED_VERSION}" version)"
-            test "$published" = "$REQUESTED_VERSION"
+            if npm view "${package_name}@${REQUESTED_VERSION}" version >/dev/null 2>&1; then
+              echo "Skipping immutable ${package_name}@${REQUESTED_VERSION}; verifying npm tag ${DIST_TAG}."
+            else
+              npm publish "$tarball" --access public --tag "$DIST_TAG"
+            fi
+            verify_registry_version "$package_name"
           done < <(node scripts/release-packages.mjs list)
 
       - name: Tag the release

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -58,14 +58,14 @@ jobs:
         run: echo "RELEASE_ARTIFACTS=$RUNNER_TEMP/cyrus-release" >> "$GITHUB_ENV"
 
       - name: Check out the release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node and npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "22.14.0"
+          node-version: "24.18.0"
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Upload inspected release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cyrus-${{ inputs.version }}-packages
           path: ${{ runner.temp }}/cyrus-release/*.tgz

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -188,8 +188,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: npm install --global npm@11.18.0
 
-      - name: Publish packages in dependency order
-        if: ${{ !inputs.dry_run }}
+      - name: Verify and publish packages in dependency order
         shell: bash
         run: |
           verify_registry_version() {
@@ -213,13 +212,38 @@ jobs:
             return 1
           }
 
+          tarball_integrity() {
+            TARBALL_PATH="$1" node <<'NODE'
+          const { createHash } = require("node:crypto");
+          const { readFileSync } = require("node:fs");
+
+          const digest = createHash("sha512")
+            .update(readFileSync(process.env.TARBALL_PATH))
+            .digest("base64");
+          process.stdout.write(`sha512-${digest}`);
+          NODE
+          }
+
           while IFS=$'\t' read -r directory package_name; do
             tarball="$RELEASE_ARTIFACTS/${package_name}-${REQUESTED_VERSION}.tgz"
             if npm view "${package_name}@${REQUESTED_VERSION}" version >/dev/null 2>&1; then
+              verify_registry_version "$package_name"
+              registry_integrity="$(npm view "${package_name}@${REQUESTED_VERSION}" dist.integrity)"
+              packed_integrity="$(tarball_integrity "$tarball")"
+              if [[ "$registry_integrity" != "$packed_integrity" ]]; then
+                echo "${package_name}@${REQUESTED_VERSION} does not match the artifact packed by this run; refusing a mixed-commit release." >&2
+                exit 1
+              fi
               echo "Skipping immutable ${package_name}@${REQUESTED_VERSION}; verifying npm tag ${DIST_TAG}."
-            else
-              npm publish "$tarball" --access public --tag "$DIST_TAG"
+              continue
             fi
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Dry run would publish ${package_name}@${REQUESTED_VERSION} with npm tag ${DIST_TAG}."
+              continue
+            fi
+
+            npm publish "$tarball" --access public --tag "$DIST_TAG"
             verify_registry_version "$package_name"
           done < <(node scripts/release-packages.mjs list)
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -10,7 +10,7 @@ This changelog documents internal development changes, refactors, tooling update
 - Added an on-demand, main-only Cyrus CLI release workflow using npm trusted publishing. It validates the coordinated monorepo version and changelogs, runs release gates, inspects every package tarball, publishes the complete dependency graph in order, and creates the matching git tag and GitHub release without a long-lived npm token. ([#1398](https://github.com/cyrusagents/cyrus/pull/1398))
 
 ### Fixed
-- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag. ([#1401](https://github.com/cyrusagents/cyrus/pull/1401))
+- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag or whose published tarballs differ from the recovery run. ([#1401](https://github.com/cyrusagents/cyrus/pull/1401))
 
 ## [0.2.67] - 2026-07-25
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -9,6 +9,9 @@ This changelog documents internal development changes, refactors, tooling update
 ### Added
 - Added an on-demand, main-only Cyrus CLI release workflow using npm trusted publishing. It validates the coordinated monorepo version and changelogs, runs release gates, inspects every package tarball, publishes the complete dependency graph in order, and creates the matching git tag and GitHub release without a long-lived npm token. ([#1398](https://github.com/cyrusagents/cyrus/pull/1398))
 
+### Fixed
+- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag.
+
 ## [0.2.67] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -10,7 +10,7 @@ This changelog documents internal development changes, refactors, tooling update
 - Added an on-demand, main-only Cyrus CLI release workflow using npm trusted publishing. It validates the coordinated monorepo version and changelogs, runs release gates, inspects every package tarball, publishes the complete dependency graph in order, and creates the matching git tag and GitHub release without a long-lived npm token. ([#1398](https://github.com/cyrusagents/cyrus/pull/1398))
 
 ### Fixed
-- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag or whose published tarballs differ from the recovery run. ([#1401](https://github.com/cyrusagents/cyrus/pull/1401))
+- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag or whose published tarballs differ from the recovery run. CI now tests supported Node.js 22 and 24 releases, and CI/release actions run on their current Node.js 24-based majors. ([#1401](https://github.com/cyrusagents/cyrus/pull/1401))
 
 ## [0.2.67] - 2026-07-25
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -10,7 +10,7 @@ This changelog documents internal development changes, refactors, tooling update
 - Added an on-demand, main-only Cyrus CLI release workflow using npm trusted publishing. It validates the coordinated monorepo version and changelogs, runs release gates, inspects every package tarball, publishes the complete dependency graph in order, and creates the matching git tag and GitHub release without a long-lived npm token. ([#1398](https://github.com/cyrusagents/cyrus/pull/1398))
 
 ### Fixed
-- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag.
+- Made CLI releases safely resumable after a partial npm publish and tolerant of short registry visibility delays, while still rejecting existing versions that do not carry the requested distribution tag. ([#1401](https://github.com/cyrusagents/cyrus/pull/1401))
 
 ## [0.2.67] - 2026-07-25
 

--- a/apps/cli/RELEASING.md
+++ b/apps/cli/RELEASING.md
@@ -78,14 +78,19 @@ gh workflow run release-cli.yml \
 ```
 
 The workflow refuses non-`main` refs, duplicate live releases, version drift,
-and an existing release tag. It performs a frozen install and audit, runs lint,
-tests, type checks, and the full build, then packs every package using pnpm so
+and an existing release tag. If a run stops after publishing only part of the
+package graph, rerun the same version and distribution tag: the workflow skips
+immutable versions that are already published with that tag, verifies them,
+and resumes publishing the remaining packages. It will not resume when an
+existing version points at a different distribution tag. It performs a frozen
+install and audit, runs lint, tests, type checks, and the full build, then packs every package using pnpm so
 `workspace:*` references become exact published versions. It inspects each
 tarball, installs all local release tarballs together so the CLI smoke test does
 not depend on unpublished internal versions, verifies `cyrus --version`, and
-publishes the same inspected artifacts through npm's OIDC-capable CLI. After all
-packages are visible on npm, it creates `v<version>` and the matching GitHub
-release.
+publishes the same inspected artifacts through npm's OIDC-capable CLI. npm
+registry visibility is retried before advancing to the next package. After all
+packages are visible on npm with the requested tag, it creates `v<version>` and
+the matching GitHub release.
 
 ## Post-release
 

--- a/apps/cli/RELEASING.md
+++ b/apps/cli/RELEASING.md
@@ -80,17 +80,21 @@ gh workflow run release-cli.yml \
 The workflow refuses non-`main` refs, duplicate live releases, version drift,
 and an existing release tag. If a run stops after publishing only part of the
 package graph, rerun the same version and distribution tag: the workflow skips
-immutable versions that are already published with that tag, verifies them,
-and resumes publishing the remaining packages. It will not resume when an
-existing version points at a different distribution tag. It performs a frozen
-install and audit, runs lint, tests, type checks, and the full build, then packs every package using pnpm so
-`workspace:*` references become exact published versions. It inspects each
-tarball, installs all local release tarballs together so the CLI smoke test does
-not depend on unpublished internal versions, verifies `cyrus --version`, and
-publishes the same inspected artifacts through npm's OIDC-capable CLI. npm
-registry visibility is retried before advancing to the next package. After all
-packages are visible on npm with the requested tag, it creates `v<version>` and
-the matching GitHub release.
+immutable versions only when the published tarball is byte-for-byte identical
+to the artifact packed by the recovery run and already carries that tag, then
+resumes publishing the remaining packages. It will not resume when an existing
+version points at a different distribution tag or has different integrity,
+which prevents one release from combining package artifacts from different
+commits. Dry runs exercise these recovery comparisons and report which missing
+packages a live run would publish. The workflow performs a frozen install and
+audit, runs lint, tests, type checks, and the full build, then packs every
+package using pnpm so `workspace:*` references become exact published versions.
+It inspects each tarball, installs all local release tarballs together so the
+CLI smoke test does not depend on unpublished internal versions, verifies
+`cyrus --version`, and publishes the same inspected artifacts through npm's
+OIDC-capable CLI. npm registry visibility is retried before advancing to the
+next package. After all packages are visible on npm with the requested tag, it
+creates `v<version>` and the matching GitHub release.
 
 ## Post-release
 

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -122,6 +122,17 @@ describe("trusted Cyrus release workflow", () => {
 		}
 	});
 
+	it("recovers safely from partially published npm releases", () => {
+		expect(workflow).toContain("verify_registry_version() {");
+		expect(workflow).toContain("for attempt in {1..12}; do");
+		expect(workflow).toContain(
+			`Skipping immutable \${package_name}@\${REQUESTED_VERSION}; verifying npm tag \${DIST_TAG}.`,
+		);
+		expect(workflow).toContain(
+			`\${package_name}@\${REQUESTED_VERSION} is not consistently visible with npm tag \${DIST_TAG}.`,
+		);
+	});
+
 	it("finishes a live release with a tag and GitHub release", () => {
 		expect(workflow).toMatch(/git tag --annotate "v\$\{REQUESTED_VERSION\}"/);
 		expect(workflow).toMatch(/git push origin "v\$\{REQUESTED_VERSION\}"/);

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -124,9 +124,18 @@ describe("trusted Cyrus release workflow", () => {
 
 	it("recovers safely from partially published npm releases", () => {
 		expect(workflow).toContain("verify_registry_version() {");
+		expect(workflow).toContain("tarball_integrity() {");
 		expect(workflow).toContain("for attempt in {1..12}; do");
+		expect(workflow).toContain("dist.integrity");
+		expect(workflow).toContain('createHash("sha512")');
 		expect(workflow).toContain(
 			`Skipping immutable \${package_name}@\${REQUESTED_VERSION}; verifying npm tag \${DIST_TAG}.`,
+		);
+		expect(workflow).toContain(
+			`\${package_name}@\${REQUESTED_VERSION} does not match the artifact packed by this run; refusing a mixed-commit release.`,
+		);
+		expect(workflow).toContain(
+			`Dry run would publish \${package_name}@\${REQUESTED_VERSION} with npm tag \${DIST_TAG}.`,
 		);
 		expect(workflow).toContain(
 			`\${package_name}@\${REQUESTED_VERSION} is not consistently visible with npm tag \${DIST_TAG}.`,

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -7,6 +7,14 @@ const workflow = readFileSync(
 	resolve(repositoryRoot, ".github/workflows/release-cli.yml"),
 	"utf8",
 );
+const ciWorkflow = readFileSync(
+	resolve(repositoryRoot, ".github/workflows/ci.yml"),
+	"utf8",
+);
+const installDependenciesAction = readFileSync(
+	resolve(repositoryRoot, ".github/actions/install-dependencies/action.yml"),
+	"utf8",
+);
 const releaseGuide = readFileSync(
 	resolve(repositoryRoot, "apps/cli/RELEASING.md"),
 	"utf8",
@@ -42,13 +50,27 @@ describe("trusted Cyrus release workflow", () => {
 		expect(workflow).toContain("id-token: write");
 		expect(workflow).toContain("contents: write");
 		expect(workflow).toContain("runs-on: ubuntu-latest");
-		expect(workflow).toContain('node-version: "22.14.0"');
+		expect(workflow).toContain("actions/checkout@v7");
+		expect(workflow).toContain("actions/setup-node@v7");
+		expect(workflow).toContain("actions/upload-artifact@v7");
+		expect(workflow).toContain('node-version: "24.18.0"');
 		expect(workflow).toContain("npm@11.18.0");
 		expect(workflow).toContain("registry.npmjs.org");
 		expect(workflow).not.toMatch(/NPM_TOKEN|NODE_AUTH_TOKEN|_authToken/);
 		expect(workflow.indexOf("pnpm install --frozen-lockfile")).toBeLessThan(
 			workflow.indexOf("npm install --global npm@11.18.0"),
 		);
+	});
+
+	it("uses supported Node releases and Node 24-based CI actions", () => {
+		expect(ciWorkflow).toContain("node-version: [22.x, 24.x]");
+		expect(ciWorkflow).toContain("actions/checkout@v7");
+		expect(ciWorkflow).toContain("actions/setup-node@v7");
+		expect(ciWorkflow).toContain("codecov/codecov-action@v7");
+		expect(ciWorkflow).toContain("use_oidc: true");
+		expect(ciWorkflow).not.toContain("20.x");
+		expect(installDependenciesAction).toContain("pnpm/action-setup@v6");
+		expect(installDependenciesAction).not.toContain("wyvox/action-setup-pnpm");
 	});
 
 	it("gates publishing on audit, tests, types, build, and package inspection", () => {


### PR DESCRIPTION
## Summary
- resume a partially published coordinated npm release without republishing immutable versions
- verify skipped npm tarballs are byte-identical to artifacts packed by the recovery run
- retry npm registry visibility before advancing or tagging
- upgrade CI to supported Node.js 22/24 and current Node 24-based GitHub Actions
- move releases to Node.js 24.18.0 and exercise recovery integrity during dry runs

## Validation
- `pnpm -r test:run` (1,628 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm build`
- `pnpm audit --audit-level low`
- `node scripts/release-packages.mjs validate 0.2.68`
- workflow/action YAML parse
- tracked-source Biome check (pre-existing warnings only)
- `git diff --check`

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->