### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you've built a versatile AI agent for various platforms,  making development workflows more streamlined. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Subagent granted the built-in Bash tool
   File: .claude/agents/f1-test-drive.md
   What it means: This subagent's frontmatter grants the built-in `Bash` tool, letting it run arbitrary shell commands.

2. [HIGH] Subagent granted filesystem-write or web-fetch built-ins
   File: .claude/agents/f1-test-drive.md
   What it means: This subagent's frontmatter grants a filesystem-write (`Write`/`Edit`) or web-fetch (`WebFetch`) built-in.

3. [HIGH] Model-invocable skill grants side-effecting tools
   File: .claude/skills/google/SKILL.md
   What it means: Claude can auto-invoke this skill (disable-model-invocation is not set) and it pre-approves a side-effecting or exfiltration-capable tool (Bash / Write / Edit / WebFetch / NotebookEdit).

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)